### PR TITLE
feat: installer polish, mod reorder, custom imports, vanilla launch

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,6 @@ linux:
 win:
   target:
     - nsis
-    - portable
   icon: resources/icon.ico
 mac:
   target:
@@ -47,7 +46,11 @@ mac:
   icon: resources/icon.icns
 nsis:
   oneClick: false
+  perMachine: false
   allowToChangeInstallationDirectory: true
+  createDesktopShortcut: true
+  createStartMenuShortcut: true
+  menuCategory: true
+  shortcutName: Grimoire
+  uninstallDisplayName: Grimoire Mod Manager
   artifactName: "${productName}-Setup-${version}.${ext}"
-portable:
-  artifactName: "${productName}-${version}.${ext}"

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -13,8 +13,10 @@ import './ipc/modDatabase';
 import './ipc/crosshairPresets';
 import './ipc/stats';
 import './ipc/updater';
+import './ipc/launch';
 
 import { initUpdater, checkForUpdates } from './services/updater';
+import { runStartupRecovery } from './ipc/launch';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -110,6 +112,10 @@ if (!gotTheLock) {
         }
 
         createWindow();
+
+        // Recover from any half-finished vanilla launch (app was closed mid-session,
+        // or grimoire crashed while the user was playing vanilla). Runs in background.
+        void runStartupRecovery();
 
         // Initialize auto-updater (production only)
         if (!is.dev && mainWindow) {

--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -1,0 +1,89 @@
+import { ipcMain } from 'electron';
+import { loadSettings } from '../services/settings';
+import {
+    launchModded,
+    launchVanilla,
+    readStash,
+    restoreFromStash,
+    recoverFromStashOnStartup,
+    type RestoreResult,
+} from '../services/launch';
+import { getMainWindow } from '../index';
+
+function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+function emitRestore(result: RestoreResult): void {
+    const win = getMainWindow();
+    win?.webContents.send('vanilla-restore-complete', result);
+}
+
+ipcMain.handle('launch-modded', async (): Promise<void> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    await launchModded({ deadlockPath, onRestoreComplete: emitRestore });
+});
+
+ipcMain.handle('launch-vanilla', async (): Promise<void> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    await launchVanilla({ deadlockPath, onRestoreComplete: emitRestore });
+});
+
+ipcMain.handle('get-vanilla-stash-status', async (): Promise<{
+    active: boolean;
+    startedAt?: string;
+    modCount?: number;
+}> => {
+    const stash = await readStash();
+    if (!stash) return { active: false };
+    return {
+        active: true,
+        startedAt: stash.startedAt,
+        modCount: stash.mods.length,
+    };
+});
+
+ipcMain.handle('restore-vanilla-stash', async (): Promise<RestoreResult> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const stash = await readStash();
+    if (!stash) {
+        return { restored: 0, skipped: 0, failed: [] };
+    }
+    return restoreFromStash(deadlockPath, stash);
+});
+
+/**
+ * Called from main on app startup to auto-recover a half-finished vanilla
+ * session. Exposed here so index.ts has somewhere to hang the call.
+ */
+export async function runStartupRecovery(): Promise<void> {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) return;
+    try {
+        const result = await recoverFromStashOnStartup(deadlockPath);
+        if (result) {
+            console.log('[launch] Startup recovery:', result);
+            // Notify the renderer once it's ready.
+            const win = getMainWindow();
+            if (win) {
+                // Delay slightly so renderer has mounted listeners.
+                setTimeout(() => emitRestore(result), 2000);
+            }
+        }
+    } catch (err) {
+        console.error('[launch] Startup recovery failed:', err);
+    }
+}

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,4 +1,6 @@
 import { ipcMain } from 'electron';
+import { promises as fs, existsSync } from 'fs';
+import { basename, dirname, extname, join } from 'path';
 import { loadSettings } from '../services/settings';
 import {
     scanMods,
@@ -8,9 +10,11 @@ import {
     setModPriority,
     reorderMods,
     swapModPriority,
+    findNextAvailablePriority,
     Mod,
 } from '../services/mods';
-import { getModMetadata, loadMetadata } from '../services/metadata';
+import { getAddonsPath } from '../services/deadlock';
+import { getModMetadata, loadMetadata, setModMetadata } from '../services/metadata';
 
 /**
  * Get the active deadlock path from settings
@@ -120,6 +124,109 @@ ipcMain.handle(
             throw new Error('No Deadlock path configured');
         }
         await swapModPriority(deadlockPath, modIdA, modIdB);
+        const mods = await scanMods(deadlockPath);
+        return mods.map(enrichMod);
+    }
+);
+
+interface ImportCustomModArgs {
+    vpkPath: string;
+    name: string;
+    thumbnailDataUrl?: string;
+    nsfw?: boolean;
+}
+
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+};
+
+async function readImageAsDataUrl(imagePath: string): Promise<string> {
+    const ext = extname(imagePath).toLowerCase();
+    const mime = IMAGE_MIME_BY_EXT[ext];
+    if (!mime) {
+        throw new Error(`Unsupported image type: ${ext}`);
+    }
+    const buf = await fs.readFile(imagePath);
+    return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+// read-image-data-url
+// Used by the custom-mod import modal to preview a local image file. The renderer can't
+// fetch file:// URLs under webSecurity; main reads and hands back a base64 data URL.
+ipcMain.handle('read-image-data-url', async (_, imagePath: string): Promise<string> => {
+    if (!imagePath || !existsSync(imagePath)) {
+        throw new Error('Image file not found');
+    }
+    return readImageAsDataUrl(imagePath);
+});
+
+// import-custom-mod
+// The Deadlock engine requires strict `pakXX_dir.vpk` naming (see apply-mina-variant),
+// so custom imports always get a naked `pakNN_dir.vpk` filename — no slug. The
+// human-readable name lives in metadata.modName and is shown in the UI instead.
+// Multi-file VPKs keep their numbered siblings, remapped as `pakNN_000.vpk` etc.
+ipcMain.handle(
+    'import-custom-mod',
+    async (_, args: ImportCustomModArgs): Promise<Mod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+
+        const { vpkPath, name, thumbnailDataUrl, nsfw } = args;
+
+        if (!vpkPath || !existsSync(vpkPath)) {
+            throw new Error('VPK file not found');
+        }
+        if (!vpkPath.toLowerCase().endsWith('.vpk')) {
+            throw new Error('Selected file is not a .vpk');
+        }
+        if (!name?.trim()) {
+            throw new Error('A name is required');
+        }
+
+        const addonsPath = getAddonsPath(deadlockPath);
+        if (!existsSync(addonsPath)) {
+            await fs.mkdir(addonsPath, { recursive: true });
+        }
+
+        const priority = await findNextAvailablePriority(deadlockPath);
+        const priorityStr = String(priority).padStart(2, '0');
+        const newDirFileName = `pak${priorityStr}_dir.vpk`;
+
+        const srcDir = dirname(vpkPath);
+        const srcName = basename(vpkPath);
+
+        if (srcName.toLowerCase().endsWith('_dir.vpk')) {
+            const srcBase = srcName.slice(0, -'_dir.vpk'.length);
+            const entries = await fs.readdir(srcDir);
+            const siblings = entries.filter(
+                (e) => e.startsWith(`${srcBase}_`) && e.toLowerCase().endsWith('.vpk')
+            );
+            if (siblings.length === 0) {
+                await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
+            } else {
+                for (const s of siblings) {
+                    const dstName = s === srcName
+                        ? newDirFileName
+                        : `pak${priorityStr}${s.slice(srcBase.length)}`;
+                    await fs.copyFile(join(srcDir, s), join(addonsPath, dstName));
+                }
+            }
+        } else {
+            await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
+        }
+
+        setModMetadata(newDirFileName, {
+            modName: name.trim(),
+            thumbnailUrl: thumbnailDataUrl,
+            nsfw: !!nsfw,
+        });
+
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);
     }

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -6,6 +6,8 @@ import {
     disableMod,
     deleteMod,
     setModPriority,
+    reorderMods,
+    swapModPriority,
     Mod,
 } from '../services/mods';
 import { getModMetadata, loadMetadata } from '../services/metadata';
@@ -92,6 +94,34 @@ ipcMain.handle(
         }
         const mod = await setModPriority(deadlockPath, modId, priority);
         return enrichMod(mod);
+    }
+);
+
+// reorder-mods
+ipcMain.handle(
+    'reorder-mods',
+    async (_, orderedFileNames: string[]): Promise<Mod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        await reorderMods(deadlockPath, orderedFileNames);
+        const mods = await scanMods(deadlockPath);
+        return mods.map(enrichMod);
+    }
+);
+
+// swap-mod-priority
+ipcMain.handle(
+    'swap-mod-priority',
+    async (_, modIdA: string, modIdB: string): Promise<Mod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        await swapModPriority(deadlockPath, modIdA, modIdB);
+        const mods = await scanMods(deadlockPath);
+        return mods.map(enrichMod);
     }
 );
 

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -17,6 +17,7 @@ interface OpenDialogOptions {
     directory?: boolean;
     title?: string;
     defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
 }
 
 interface SetMinaPresetArgs {
@@ -53,6 +54,7 @@ ipcMain.handle(
             properties: options.directory ? ['openDirectory'] : ['openFile'],
             title: options.title,
             defaultPath: options.defaultPath,
+            filters: options.filters,
         });
         return result.canceled ? null : result.filePaths[0] || null;
     }

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { ipcMain, dialog, BrowserWindow, shell } from 'electron';
 import { getMainWindow } from '../index';
 import { loadSettings } from '../services/settings';
 import {
@@ -57,6 +57,19 @@ ipcMain.handle(
         return result.canceled ? null : result.filePaths[0] || null;
     }
 );
+
+// open-mods-folder
+ipcMain.handle('open-mods-folder', async (): Promise<void> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const addonsPath = getAddonsPath(deadlockPath);
+    const error = await shell.openPath(addonsPath);
+    if (error) {
+        throw new Error(error);
+    }
+});
 
 // cleanup-addons
 ipcMain.handle('cleanup-addons', (): CleanupResult => {

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -1,0 +1,375 @@
+import { promises as fs, existsSync } from 'fs';
+import { join } from 'path';
+import { spawn } from 'child_process';
+import { shell } from 'electron';
+import { getUserDataPath } from '../utils/paths';
+import { getAddonsPath, getDisabledPath } from './deadlock';
+
+// Deadlock's Steam AppID — used for the steam://rungameid/... URI scheme.
+const DEADLOCK_STEAM_APP_ID = 1422450;
+
+// How long we wait for Deadlock.exe to appear after triggering a Steam launch
+// before restoring anyway (Steam not installed, user cancelled the prompt, etc.).
+const GAME_START_TIMEOUT_MS = 60_000;
+
+// How long we wait after the game process appears before moving VPKs back.
+// Gives Source 2 time to finish mounting the (empty) addons folder so the
+// restored files don't get picked up in the current session.
+const POST_START_GRACE_MS = 10_000;
+
+// Retry configuration for Windows file-lock EBUSY/EACCES errors on rename.
+const RESTORE_MAX_ATTEMPTS = 3;
+const RESTORE_RETRY_DELAY_MS = 500;
+
+/**
+ * On-disk record of a vanilla-launch-in-progress. Written before any files
+ * move so that if grimoire crashes mid-move we can still recover on restart.
+ *
+ * Lifecycle:
+ *   - 'pending'  → we intend to move these files but haven't finished yet.
+ *                  On recovery we assume some may already be moved and try to
+ *                  restore whatever's in disabled/.
+ *   - 'active'   → all files successfully stashed; the user is playing vanilla.
+ *                  Normal restore path applies.
+ */
+export interface VanillaStash {
+    version: 1;
+    status: 'pending' | 'active';
+    startedAt: string;
+    mods: Array<{ fileName: string }>;
+}
+
+function getStashPath(): string {
+    return join(getUserDataPath(), 'vanilla-stash.json');
+}
+
+/**
+ * Atomic JSON write (write to temp, then rename) so a crash mid-write can't
+ * leave a corrupt stash file.
+ */
+async function writeStash(stash: VanillaStash): Promise<void> {
+    const path = getStashPath();
+    const tmp = `${path}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(stash, null, 2), 'utf-8');
+    await fs.rename(tmp, path);
+}
+
+export async function readStash(): Promise<VanillaStash | null> {
+    const path = getStashPath();
+    if (!existsSync(path)) return null;
+    try {
+        const content = await fs.readFile(path, 'utf-8');
+        const parsed = JSON.parse(content) as VanillaStash;
+        if (parsed?.version !== 1 || !Array.isArray(parsed.mods)) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+async function deleteStash(): Promise<void> {
+    const path = getStashPath();
+    if (existsSync(path)) {
+        await fs.unlink(path).catch(() => { /* ignore */ });
+    }
+}
+
+export async function hasActiveVanillaStash(): Promise<boolean> {
+    return !!(await readStash());
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check whether Deadlock.exe is currently running. Platform-specific; we only
+ * implement Windows (the game is effectively Windows-only; on other platforms
+ * we conservatively assume "not running" so restore proceeds after the grace
+ * period).
+ */
+async function isDeadlockRunning(): Promise<boolean> {
+    if (process.platform !== 'win32') return false;
+    return new Promise<boolean>((resolve) => {
+        const proc = spawn('tasklist.exe', ['/FI', 'IMAGENAME eq deadlock.exe', '/NH'], {
+            windowsHide: true,
+        });
+        let stdout = '';
+        proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+        proc.on('close', () => {
+            resolve(/deadlock\.exe/i.test(stdout));
+        });
+        proc.on('error', () => resolve(false));
+    });
+}
+
+/**
+ * Stash every VPK currently in the addons folder: record them to the stash
+ * file first (so a crash mid-move leaves a recoverable breadcrumb), then move
+ * the files into disabled/. Mark the stash 'active' only once all moves succeed.
+ *
+ * If a move fails mid-operation, we leave the stash at 'pending' and rethrow.
+ * The caller (or next app startup) can then invoke restoreFromStash to
+ * reassemble whatever state made it to disk.
+ */
+async function stashEnabledMods(deadlockPath: string): Promise<VanillaStash> {
+    const addonsPath = getAddonsPath(deadlockPath);
+    const disabledPath = getDisabledPath(deadlockPath);
+
+    const entries = await fs.readdir(addonsPath);
+    // Stash only VPK files (addons folder may contain other junk).
+    const vpks = entries.filter((e) => e.toLowerCase().endsWith('.vpk'));
+
+    const stash: VanillaStash = {
+        version: 1,
+        status: 'pending',
+        startedAt: new Date().toISOString(),
+        mods: vpks.map((fileName) => ({ fileName })),
+    };
+    await writeStash(stash);
+
+    for (const fileName of vpks) {
+        const from = join(addonsPath, fileName);
+        const to = join(disabledPath, fileName);
+        if (existsSync(to)) {
+            // Disabled folder already has a file with this name. This shouldn't
+            // happen in normal operation (enable/disable handles collisions),
+            // but be safe: skip rather than overwrite the disabled copy.
+            continue;
+        }
+        await fs.rename(from, to);
+    }
+
+    stash.status = 'active';
+    await writeStash(stash);
+    return stash;
+}
+
+export interface RestoreResult {
+    restored: number;
+    skipped: number;
+    failed: string[];
+}
+
+/**
+ * Move stashed VPKs from disabled/ back to addons/, with retries for transient
+ * Windows file locks. Deletes the stash only if every file is accounted for.
+ *
+ * Hazard notes:
+ * - If the game is still running and holds a handle on the _dir.vpk, Windows
+ *   will fail the rename with EBUSY/EPERM. We retry a few times then give up
+ *   and leave the stash in place so the user can hit "Restore now" after they
+ *   quit the game.
+ * - If a stashed file is already back in addons/ (user manually moved it),
+ *   we skip rather than clobber.
+ * - If the stashed file vanished from disabled/ (user deleted it), we skip.
+ */
+export async function restoreFromStash(
+    deadlockPath: string,
+    stash: VanillaStash
+): Promise<RestoreResult> {
+    const addonsPath = getAddonsPath(deadlockPath);
+    const disabledPath = getDisabledPath(deadlockPath);
+
+    let restored = 0;
+    let skipped = 0;
+    const failed: string[] = [];
+
+    for (const { fileName } of stash.mods) {
+        const from = join(disabledPath, fileName);
+        const to = join(addonsPath, fileName);
+
+        if (!existsSync(from)) {
+            skipped++;
+            continue;
+        }
+        if (existsSync(to)) {
+            // Collision — don't clobber whatever's already there.
+            skipped++;
+            continue;
+        }
+
+        let ok = false;
+        let lastErr: unknown;
+        for (let attempt = 0; attempt < RESTORE_MAX_ATTEMPTS; attempt++) {
+            try {
+                await fs.rename(from, to);
+                ok = true;
+                break;
+            } catch (err) {
+                lastErr = err;
+                if (attempt < RESTORE_MAX_ATTEMPTS - 1) {
+                    await sleep(RESTORE_RETRY_DELAY_MS);
+                }
+            }
+        }
+        if (ok) {
+            restored++;
+        } else {
+            console.error(`[launch] Failed to restore ${fileName}:`, lastErr);
+            failed.push(fileName);
+        }
+    }
+
+    if (failed.length === 0) {
+        await deleteStash();
+    }
+
+    return { restored, skipped, failed };
+}
+
+/**
+ * In-memory single-flight lock. Prevents the user from rapidly double-clicking
+ * a launch button or interleaving modded/vanilla launches while a prior one's
+ * state is still mutating.
+ */
+let launchInFlight = false;
+
+/**
+ * Background task: wait for the game to actually start (polls tasklist), then
+ * wait a grace period, then restore. Deliberately fire-and-forget — callers
+ * shouldn't await this because we're still technically "done" once Steam has
+ * been asked to launch.
+ */
+function scheduleMidLaunchRestore(
+    deadlockPath: string,
+    onComplete?: (result: RestoreResult) => void
+): void {
+    void (async () => {
+        const started = Date.now();
+        let sawGame = false;
+        while (Date.now() - started < GAME_START_TIMEOUT_MS) {
+            if (await isDeadlockRunning()) {
+                sawGame = true;
+                break;
+            }
+            await sleep(1000);
+        }
+
+        // Whether or not the game appeared, grace, then restore. If the user
+        // never launched (Steam closed, cancelled the prompt), restoring after
+        // the timeout just undoes the stash — that's the correct recovery.
+        if (sawGame) {
+            await sleep(POST_START_GRACE_MS);
+        }
+
+        const stash = await readStash();
+        if (!stash) return; // Already restored (e.g. user clicked Restore now).
+
+        const result = await restoreFromStash(deadlockPath, stash);
+        onComplete?.(result);
+    })();
+}
+
+/**
+ * Trigger Steam to launch Deadlock. Doesn't wait for the game to actually start.
+ */
+async function triggerSteamLaunch(): Promise<void> {
+    await shell.openExternal(`steam://rungameid/${DEADLOCK_STEAM_APP_ID}`);
+}
+
+export interface LaunchOptions {
+    deadlockPath: string;
+    onRestoreComplete?: (result: RestoreResult) => void;
+}
+
+/**
+ * Launch the game with mods active. If a previous vanilla-launch stash is
+ * still on disk (e.g. grimoire crashed during a prior vanilla session), we
+ * restore mods first so the user actually gets a modded session.
+ */
+export async function launchModded({
+    deadlockPath,
+    onRestoreComplete,
+}: LaunchOptions): Promise<void> {
+    if (launchInFlight) {
+        throw new Error('Another launch is already in progress');
+    }
+    launchInFlight = true;
+    try {
+        const stash = await readStash();
+        if (stash) {
+            const result = await restoreFromStash(deadlockPath, stash);
+            onRestoreComplete?.(result);
+            if (result.failed.length > 0) {
+                throw new Error(
+                    `Couldn't restore ${result.failed.length} mod(s) — make sure Deadlock is fully closed and try again.`
+                );
+            }
+        }
+        await triggerSteamLaunch();
+    } finally {
+        launchInFlight = false;
+    }
+}
+
+/**
+ * Launch the game WITHOUT any mods active. Stashes every VPK in addons/,
+ * triggers Steam, then schedules a background restore after the game mounts.
+ *
+ * If the Steam launch itself fails, we immediately restore from the stash
+ * we just wrote, leaving the user in exactly the state they were in before.
+ */
+export async function launchVanilla({
+    deadlockPath,
+    onRestoreComplete,
+}: LaunchOptions): Promise<void> {
+    if (launchInFlight) {
+        throw new Error('Another launch is already in progress');
+    }
+    launchInFlight = true;
+
+    // If there's already a stash on disk, don't stack. Caller should restore first.
+    const existing = await readStash();
+    if (existing) {
+        launchInFlight = false;
+        throw new Error(
+            'A previous vanilla launch is still pending restore. Restore or retry first.'
+        );
+    }
+
+    let stash: VanillaStash;
+    try {
+        stash = await stashEnabledMods(deadlockPath);
+    } catch (err) {
+        // Mid-stash failure — try to restore whatever made it into disabled/
+        // before rethrowing, so we don't leave the user with half-moved files.
+        const current = await readStash();
+        if (current) {
+            await restoreFromStash(deadlockPath, current);
+        }
+        launchInFlight = false;
+        throw err;
+    }
+
+    try {
+        await triggerSteamLaunch();
+    } catch (err) {
+        // Steam URL failed — immediately restore so the user isn't left with
+        // no mods AND no game.
+        await restoreFromStash(deadlockPath, stash);
+        launchInFlight = false;
+        throw err;
+    }
+
+    // Release the lock now; the background restore is independent.
+    launchInFlight = false;
+    scheduleMidLaunchRestore(deadlockPath, onRestoreComplete);
+}
+
+/**
+ * Called on app startup. If a stash exists:
+ *   - If Deadlock isn't running, restore immediately. Most common case: user
+ *     quit grimoire during a vanilla session, then reopened it after closing
+ *     the game.
+ *   - If Deadlock IS running, the game has already mounted the (empty) addons
+ *     folder, so it's safe to restore now — the restored files won't be seen
+ *     until the next game launch. We still retry if Windows locks the files.
+ */
+export async function recoverFromStashOnStartup(
+    deadlockPath: string
+): Promise<RestoreResult | null> {
+    const stash = await readStash();
+    if (!stash) return null;
+    return restoreFromStash(deadlockPath, stash);
+}

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -81,3 +81,38 @@ export function removeModMetadata(fileName: string): void {
 
 // Alias for removeModMetadata
 export const deleteModMetadata = removeModMetadata;
+
+/**
+ * Atomically migrate metadata for a batch of rename operations.
+ *
+ * Why batched: when several mods are renamed in one operation (e.g. reorder),
+ * a naive loop of setModMetadata(new) + removeModMetadata(old) can clobber
+ * values whenever one mod's new name equals another mod's old name. This
+ * happens whenever priorities compact (pak03 → pak01 while pak01 → pak02).
+ *
+ * Snapshot all source values first, delete all old keys, then write all new
+ * keys in one load/save cycle.
+ */
+export function migrateModMetadata(
+    migrations: Array<{ from: string; to: string }>
+): void {
+    if (migrations.length === 0) return;
+
+    const metadata = loadMetadata();
+
+    const pending = migrations
+        .filter((m) => m.from !== m.to)
+        .map((m) => ({ from: m.from, to: m.to, data: metadata[m.from] }))
+        .filter((m) => m.data !== undefined);
+
+    if (pending.length === 0) return;
+
+    for (const m of pending) {
+        delete metadata[m.from];
+    }
+    for (const m of pending) {
+        metadata[m.to] = m.data!;
+    }
+
+    saveMetadata(metadata);
+}

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { createHash, randomBytes } from 'crypto';
 import { getAddonsPath, getDisabledPath } from './deadlock';
-import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
 
 /** Minimum VPK priority number */
 const MIN_VPK_PRIORITY = 1;
@@ -439,14 +439,12 @@ export async function reorderMods(
         throw err;
     }
 
-    for (const { mod, newFileName } of assignments) {
-        if (newFileName === mod.fileName) continue;
-        const oldMeta = getModMetadata(mod.fileName);
-        if (oldMeta) {
-            setModMetadata(newFileName, oldMeta);
-            removeModMetadata(mod.fileName);
-        }
-    }
+    migrateModMetadata(
+        assignments.map(({ mod, newFileName }) => ({
+            from: mod.fileName,
+            to: newFileName,
+        }))
+    );
 }
 
 /**
@@ -516,17 +514,8 @@ async function directSwap(a: Mod, b: Mod): Promise<void> {
     for (const step of steps) await fs.rename(step.from, step.tmp);
     for (const step of steps) await fs.rename(step.tmp, step.final);
 
-    const aMeta = getModMetadata(a.fileName);
-    const bMeta = getModMetadata(b.fileName);
-    const aNew = renameWithPriority(a.fileName, b.priority);
-    const bNew = renameWithPriority(b.fileName, a.priority);
-
-    if (aMeta) {
-        setModMetadata(aNew, aMeta);
-        if (aNew !== a.fileName) removeModMetadata(a.fileName);
-    }
-    if (bMeta) {
-        setModMetadata(bNew, bMeta);
-        if (bNew !== b.fileName) removeModMetadata(b.fileName);
-    }
+    migrateModMetadata([
+        { from: a.fileName, to: renameWithPriority(a.fileName, b.priority) },
+        { from: b.fileName, to: renameWithPriority(b.fileName, a.priority) },
+    ]);
 }

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
-import { join } from 'path';
-import { createHash } from 'crypto';
+import { join, dirname } from 'path';
+import { createHash, randomBytes } from 'crypto';
 import { getAddonsPath, getDisabledPath } from './deadlock';
+import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 
 /** Minimum VPK priority number */
 const MIN_VPK_PRIORITY = 1;
@@ -270,7 +271,25 @@ export async function deleteMod(deadlockPath: string, modId: string): Promise<vo
 }
 
 /**
- * Set the priority of a mod by renaming it (async)
+ * Find all VPK sibling files for a given _dir.vpk (e.g. pak05_foo_000.vpk, pak05_foo_001.vpk)
+ */
+async function findVpkSiblings(parentDir: string, dirFileName: string): Promise<string[]> {
+    const baseName = dirFileName.replace(/_dir\.vpk$/, '');
+    const entries = await fs.readdir(parentDir);
+    return entries.filter((e) => e.startsWith(`${baseName}_`) && e.endsWith('.vpk'));
+}
+
+/**
+ * Replace the pak## prefix in a VPK filename with a new priority.
+ */
+function renameWithPriority(fileName: string, priority: number): string {
+    const priorityStr = String(Math.min(MAX_VPK_PRIORITY, priority)).padStart(2, '0');
+    return fileName.replace(/^pak\d{2}_/, `pak${priorityStr}_`);
+}
+
+/**
+ * Set the priority of a mod by renaming it and all its VPK siblings (async).
+ * Also migrates metadata to the new filename.
  */
 export async function setModPriority(
     deadlockPath: string,
@@ -284,26 +303,230 @@ export async function setModPriority(
         throw new Error(`Mod not found: ${modId}`);
     }
 
-    const parentDir = join(targetMod.path, '..');
-    const priorityStr = String(Math.min(MAX_VPK_PRIORITY, newPriority)).padStart(2, '0');
+    const parentDir = dirname(targetMod.path);
+    const newFileName = renameWithPriority(targetMod.fileName, newPriority);
 
-    // Preserve the mod name by only replacing the priority prefix
-    // e.g., pak05_cool_skin_dir.vpk -> pak10_cool_skin_dir.vpk
-    const newFileName = targetMod.fileName.replace(/^pak\d{2}_/, `pak${priorityStr}_`);
-    const destPath = join(parentDir, newFileName);
-
-    // Check if destination already exists
-    if (existsSync(destPath) && destPath !== targetMod.path) {
-        throw new Error(`Priority ${newPriority} is already in use`);
+    if (newFileName === targetMod.fileName) {
+        return targetMod;
     }
 
-    await fs.rename(targetMod.path, destPath);
+    const siblings = await findVpkSiblings(parentDir, targetMod.fileName);
+
+    // Collision check across all siblings
+    for (const sibling of siblings) {
+        const newSiblingName = renameWithPriority(sibling, newPriority);
+        if (newSiblingName === sibling) continue;
+        if (existsSync(join(parentDir, newSiblingName))) {
+            throw new Error(`Priority ${newPriority} is already in use`);
+        }
+    }
+
+    for (const sibling of siblings) {
+        const newSiblingName = renameWithPriority(sibling, newPriority);
+        if (newSiblingName === sibling) continue;
+        await fs.rename(join(parentDir, sibling), join(parentDir, newSiblingName));
+    }
+
+    const oldMeta = getModMetadata(targetMod.fileName);
+    if (oldMeta) {
+        setModMetadata(newFileName, oldMeta);
+        removeModMetadata(targetMod.fileName);
+    }
 
     return {
         ...targetMod,
         priority: newPriority,
         fileName: newFileName,
-        path: destPath,
+        path: join(parentDir, newFileName),
         id: generateModId(newFileName),
     };
+}
+
+/**
+ * Reorder mods by rewriting their pak## priorities to match the given order (async).
+ * - Assigns priorities 1, 2, 3, … to orderedFileNames, skipping priority numbers
+ *   already held by mods NOT in the list (so disabled mods keep their slots).
+ * - Uses two-phase rename (temp prefix → final) so collisions between target
+ *   priorities can't happen mid-operation.
+ * - Migrates metadata for every renamed _dir.vpk.
+ */
+export async function reorderMods(
+    deadlockPath: string,
+    orderedFileNames: string[]
+): Promise<void> {
+    const allMods = await scanMods(deadlockPath);
+    const modByFileName = new Map(allMods.map((m) => [m.fileName, m]));
+
+    for (const fn of orderedFileNames) {
+        if (!modByFileName.has(fn)) {
+            throw new Error(`Mod not in list: ${fn}`);
+        }
+    }
+
+    const targetSet = new Set(orderedFileNames);
+    const reserved = new Set(
+        allMods.filter((m) => !targetSet.has(m.fileName)).map((m) => m.priority)
+    );
+
+    const assignments: { mod: Mod; newPriority: number; newFileName: string }[] = [];
+    let cursor = MIN_VPK_PRIORITY;
+    for (const fileName of orderedFileNames) {
+        while (reserved.has(cursor) && cursor <= MAX_VPK_PRIORITY) cursor++;
+        if (cursor > MAX_VPK_PRIORITY) {
+            throw new Error('No available priority slots (all 1-99 are used)');
+        }
+        const mod = modByFileName.get(fileName)!;
+        const newFileName = renameWithPriority(fileName, cursor);
+        if (mod.priority !== cursor || newFileName !== fileName) {
+            assignments.push({ mod, newPriority: cursor, newFileName });
+        }
+        cursor++;
+    }
+
+    if (assignments.length === 0) return;
+
+    const tmpId = randomBytes(4).toString('hex');
+    type RenameStep = { fromPath: string; tmpPath: string; finalPath: string };
+    const steps: RenameStep[] = [];
+
+    for (const { mod, newPriority } of assignments) {
+        const parentDir = dirname(mod.path);
+        const siblings = await findVpkSiblings(parentDir, mod.fileName);
+
+        for (const sibling of siblings) {
+            const finalName = renameWithPriority(sibling, newPriority);
+            if (finalName === sibling) continue;
+            steps.push({
+                fromPath: join(parentDir, sibling),
+                tmpPath: join(parentDir, `tmp${tmpId}_${sibling}`),
+                finalPath: join(parentDir, finalName),
+            });
+        }
+    }
+
+    const phase1Done: RenameStep[] = [];
+    try {
+        for (const step of steps) {
+            await fs.rename(step.fromPath, step.tmpPath);
+            phase1Done.push(step);
+        }
+    } catch (err) {
+        for (const done of phase1Done.reverse()) {
+            try {
+                await fs.rename(done.tmpPath, done.fromPath);
+            } catch { /* best-effort rollback */ }
+        }
+        throw err;
+    }
+
+    const phase2Done: RenameStep[] = [];
+    try {
+        for (const step of steps) {
+            await fs.rename(step.tmpPath, step.finalPath);
+            phase2Done.push(step);
+        }
+    } catch (err) {
+        for (const done of phase2Done.reverse()) {
+            try {
+                await fs.rename(done.finalPath, done.tmpPath);
+            } catch { /* ignore */ }
+        }
+        for (const step of steps) {
+            try {
+                await fs.rename(step.tmpPath, step.fromPath);
+            } catch { /* ignore */ }
+        }
+        throw err;
+    }
+
+    for (const { mod, newFileName } of assignments) {
+        if (newFileName === mod.fileName) continue;
+        const oldMeta = getModMetadata(mod.fileName);
+        if (oldMeta) {
+            setModMetadata(newFileName, oldMeta);
+            removeModMetadata(mod.fileName);
+        }
+    }
+}
+
+/**
+ * Swap the priorities of two mods (async).
+ */
+export async function swapModPriority(
+    deadlockPath: string,
+    modIdA: string,
+    modIdB: string
+): Promise<void> {
+    const mods = await scanMods(deadlockPath);
+    const a = mods.find((m) => m.id === modIdA);
+    const b = mods.find((m) => m.id === modIdB);
+
+    if (!a || !b) {
+        throw new Error('Mod not found for swap');
+    }
+    if (a.priority === b.priority) {
+        throw new Error('Cannot swap mods with identical priorities');
+    }
+
+    // Build a new ordered list where A and B's positions are swapped.
+    // We only reorder enabled mods to avoid touching disabled-mod priorities.
+    const enabled = mods.filter((m) => m.enabled).sort((x, y) => x.priority - y.priority);
+    const aIdx = enabled.findIndex((m) => m.id === modIdA);
+    const bIdx = enabled.findIndex((m) => m.id === modIdB);
+
+    if (aIdx === -1 || bIdx === -1) {
+        // At least one mod is disabled — fall back to direct priority swap via temp
+        await directSwap(a, b);
+        return;
+    }
+
+    const orderedFileNames = enabled.map((m) => m.fileName);
+    [orderedFileNames[aIdx], orderedFileNames[bIdx]] = [orderedFileNames[bIdx], orderedFileNames[aIdx]];
+    await reorderMods(deadlockPath, orderedFileNames);
+}
+
+/**
+ * Direct swap of two mods' pak## priorities via a temp name.
+ * Used when one or both mods live in the disabled folder.
+ */
+async function directSwap(a: Mod, b: Mod): Promise<void> {
+    const parentA = dirname(a.path);
+    const parentB = dirname(b.path);
+    const aSiblings = await findVpkSiblings(parentA, a.fileName);
+    const bSiblings = await findVpkSiblings(parentB, b.fileName);
+
+    const tmpId = randomBytes(4).toString('hex');
+    const steps: { from: string; tmp: string; final: string }[] = [];
+
+    for (const s of aSiblings) {
+        steps.push({
+            from: join(parentA, s),
+            tmp: join(parentA, `tmp${tmpId}_${s}`),
+            final: join(parentA, renameWithPriority(s, b.priority)),
+        });
+    }
+    for (const s of bSiblings) {
+        steps.push({
+            from: join(parentB, s),
+            tmp: join(parentB, `tmp${tmpId}_${s}`),
+            final: join(parentB, renameWithPriority(s, a.priority)),
+        });
+    }
+
+    for (const step of steps) await fs.rename(step.from, step.tmp);
+    for (const step of steps) await fs.rename(step.tmp, step.final);
+
+    const aMeta = getModMetadata(a.fileName);
+    const bMeta = getModMetadata(b.fileName);
+    const aNew = renameWithPriority(a.fileName, b.priority);
+    const bNew = renameWithPriority(b.fileName, a.priority);
+
+    if (aMeta) {
+        setModMetadata(aNew, aMeta);
+        if (aNew !== a.fileName) removeModMetadata(a.fileName);
+    }
+    if (bMeta) {
+        setModMetadata(bNew, bMeta);
+        if (bNew !== b.fileName) removeModMetadata(b.fileName);
+    }
 }

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -186,7 +186,7 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
         throw new Error(`Profile not found: ${profileId}`);
     }
 
-    // 1. Apply Mods
+    // 1. Apply Mods (enable/disable state)
     const currentMods = await scanMods(deadlockPath);
     const profileModMap = new Map<string, ProfileMod>();
     for (const profileMod of profile.mods) {
@@ -208,6 +208,21 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
             // Mod wasn't in the profile - disable it
             if (mod.enabled) {
                 await disableMod(deadlockPath, mod.id);
+            }
+        }
+    }
+
+    // 1b. Apply priority order - rescan so we have up-to-date IDs/paths after enable/disable
+    const refreshedMods = await scanMods(deadlockPath);
+    const byFileName = new Map(refreshedMods.map((m) => [m.fileName, m]));
+    const orderedProfileMods = [...profile.mods].sort((a, b) => a.priority - b.priority);
+    for (const profileMod of orderedProfileMods) {
+        const current = byFileName.get(profileMod.fileName);
+        if (current && current.priority !== profileMod.priority) {
+            try {
+                await setModPriority(deadlockPath, current.id, profileMod.priority);
+            } catch (err) {
+                console.warn(`[applyProfile] Could not restore priority for ${profileMod.fileName}:`, err);
             }
         }
     }

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -7,6 +7,7 @@ export interface AppSettings {
     devMode: boolean;
     devDeadlockPath: string | null;
     hideNsfwPreviews: boolean;
+    hideOutdatedMods: boolean;       // Hide GameBanana mods flagged as outdated in Browse
     activeProfileId: string | null;  // Currently active profile
     autoSaveProfile: boolean;        // Auto-save when mods change
     experimentalStats: boolean;
@@ -19,6 +20,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     devMode: false,
     devDeadlockPath: null,
     hideNsfwPreviews: false,
+    hideOutdatedMods: false,
     activeProfileId: null,
     autoSaveProfile: false,
     experimentalStats: false,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -20,6 +20,13 @@ export interface ElectronAPI {
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
 
+    // Launch
+    launchModded: () => Promise<void>;
+    launchVanilla: () => Promise<void>;
+    getVanillaStashStatus: () => Promise<VanillaStashStatus>;
+    restoreVanillaStash: () => Promise<VanillaRestoreResult>;
+    onVanillaRestoreComplete: (callback: (result: VanillaRestoreResult) => void) => () => void;
+
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
     getModDetails: (args: GetModDetailsArgs) => Promise<GameBananaModDetails>;
@@ -353,6 +360,18 @@ interface ImportCustomModArgs {
     nsfw?: boolean;
 }
 
+interface VanillaStashStatus {
+    active: boolean;
+    startedAt?: string;
+    modCount?: number;
+}
+
+interface VanillaRestoreResult {
+    restored: number;
+    skipped: number;
+    failed: string[];
+}
+
 interface DownloadProgressData {
     modId: number;
     fileId: number;
@@ -599,6 +618,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('import-custom-mod', args),
     readImageDataUrl: (imagePath: string) =>
         ipcRenderer.invoke('read-image-data-url', imagePath),
+
+    // Launch
+    launchModded: () => ipcRenderer.invoke('launch-modded'),
+    launchVanilla: () => ipcRenderer.invoke('launch-vanilla'),
+    getVanillaStashStatus: () => ipcRenderer.invoke('get-vanilla-stash-status'),
+    restoreVanillaStash: () => ipcRenderer.invoke('restore-vanilla-stash'),
+    onVanillaRestoreComplete: (callback: (result: VanillaRestoreResult) => void) => {
+        const handler = (_event: Electron.IpcRendererEvent, result: VanillaRestoreResult) =>
+            callback(result);
+        ipcRenderer.on('vanilla-restore-complete', handler);
+        return () => ipcRenderer.removeListener('vanilla-restore-complete', handler);
+    },
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => ipcRenderer.invoke('browse-mods', args),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -34,6 +34,7 @@ export interface ElectronAPI {
     cleanupAddons: () => Promise<CleanupResult>;
     getGameinfoStatus: () => Promise<GameinfoStatus>;
     fixGameinfo: () => Promise<GameinfoStatus>;
+    openModsFolder: () => Promise<void>;
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => Promise<boolean>;
@@ -592,6 +593,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     cleanupAddons: () => ipcRenderer.invoke('cleanup-addons'),
     getGameinfoStatus: () => ipcRenderer.invoke('get-gameinfo-status'),
     fixGameinfo: () => ipcRenderer.invoke('fix-gameinfo'),
+    openModsFolder: () => ipcRenderer.invoke('open-mods-folder'),
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => ipcRenderer.invoke('set-always-on-top', enabled),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -17,6 +17,8 @@ export interface ElectronAPI {
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
+    importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
+    readImageDataUrl: (imagePath: string) => Promise<string>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
@@ -341,6 +343,14 @@ interface OpenDialogOptions {
     directory?: boolean;
     title?: string;
     defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+}
+
+interface ImportCustomModArgs {
+    vpkPath: string;
+    name: string;
+    thumbnailDataUrl?: string;
+    nsfw?: boolean;
 }
 
 interface DownloadProgressData {
@@ -585,6 +595,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('reorder-mods', orderedFileNames),
     swapModPriority: (modIdA: string, modIdB: string) =>
         ipcRenderer.invoke('swap-mod-priority', modIdA, modIdB),
+    importCustomMod: (args: ImportCustomModArgs) =>
+        ipcRenderer.invoke('import-custom-mod', args),
+    readImageDataUrl: (imagePath: string) =>
+        ipcRenderer.invoke('read-image-data-url', imagePath),
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => ipcRenderer.invoke('browse-mods', args),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -15,6 +15,8 @@ export interface ElectronAPI {
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
+    reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
+    swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
@@ -235,6 +237,12 @@ interface AppSettings {
     devMode: boolean;
     devDeadlockPath: string | null;
     hideNsfwPreviews: boolean;
+    hideOutdatedMods: boolean;
+    activeProfileId: string | null;
+    autoSaveProfile: boolean;
+    experimentalStats: boolean;
+    experimentalCrosshair: boolean;
+    hasCompletedSetup: boolean;
 }
 
 interface Mod {
@@ -573,6 +581,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     deleteMod: (modId: string) => ipcRenderer.invoke('delete-mod', modId),
     setModPriority: (modId: string, priority: number) =>
         ipcRenderer.invoke('set-mod-priority', modId, priority),
+    reorderMods: (orderedFileNames: string[]) =>
+        ipcRenderer.invoke('reorder-mods', orderedFileNames),
+    swapModPriority: (modIdA: string, modIdB: string) =>
+        ipcRenderer.invoke('swap-mod-priority', modIdA, modIdB),
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => ipcRenderer.invoke('browse-mods', args),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import {
   Package,
@@ -11,8 +11,20 @@ import {
   Terminal,
   BarChart3,
   Download,
+  Play,
+  RotateCcw,
+  Loader2,
 } from 'lucide-react';
-import { getConflicts } from '../lib/api';
+import {
+  getConflicts,
+  getVanillaStashStatus,
+  launchModded,
+  launchVanilla,
+  onVanillaRestoreComplete,
+  restoreVanillaStash,
+  type VanillaStashStatus,
+  type VanillaRestoreResult,
+} from '../lib/api';
 
 import { useAppStore } from '../stores/appStore';
 
@@ -21,23 +33,28 @@ export default function Sidebar() {
   const [appVersion, setAppVersion] = useState('');
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const settings = useAppStore((state) => state.settings);
+  const loadMods = useAppStore((state) => state.loadMods);
   const navigate = useNavigate();
 
-  // Load app version and check for updates on mount
+  const [stashStatus, setStashStatus] = useState<VanillaStashStatus>({ active: false });
+  const [launchPending, setLaunchPending] = useState<'modded' | 'vanilla' | null>(null);
+  const [restorePending, setRestorePending] = useState(false);
+  const [toast, setToast] = useState<{ kind: 'info' | 'error'; text: string } | null>(null);
+
+  const refreshStashStatus = useCallback(async () => {
+    try {
+      setStashStatus(await getVanillaStashStatus());
+    } catch {
+      setStashStatus({ active: false });
+    }
+  }, []);
+
   useEffect(() => {
     window.electronAPI.updater.getVersion().then(v => setAppVersion(`v${v}`)).catch(() => setAppVersion('v???'));
-
-    // Check for updates silently on app start
     window.electronAPI.updater.checkForUpdates().catch(() => { });
-
-    // Get initial status
     window.electronAPI.updater.getStatus().then(status => {
-      if (status) {
-        setUpdateAvailable(status.available || status.downloaded);
-      }
+      if (status) setUpdateAvailable(status.available || status.downloaded);
     });
-
-    // Listen for update status changes
     const unsub = window.electronAPI.updater.onStatus((status) => {
       setUpdateAvailable(status.available || status.downloaded);
     });
@@ -53,13 +70,42 @@ export default function Sidebar() {
         setConflictCount(0);
       }
     };
-
     loadConflicts();
-
-    // Refresh conflict count every 10 seconds
     const interval = setInterval(loadConflicts, 10000);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    refreshStashStatus();
+    // Poll so the indicator disappears once the background restore finishes.
+    const interval = setInterval(refreshStashStatus, 5000);
+    return () => clearInterval(interval);
+  }, [refreshStashStatus]);
+
+  useEffect(() => {
+    const unsub = onVanillaRestoreComplete((result: VanillaRestoreResult) => {
+      if (result.failed.length > 0) {
+        setToast({
+          kind: 'error',
+          text: `Couldn't restore ${result.failed.length} mod(s). Make sure Deadlock is closed, then retry.`,
+        });
+      } else if (result.restored > 0) {
+        setToast({
+          kind: 'info',
+          text: `Restored ${result.restored} mod${result.restored === 1 ? '' : 's'} after vanilla launch.`,
+        });
+      }
+      refreshStashStatus();
+      loadMods();
+    });
+    return unsub;
+  }, [refreshStashStatus, loadMods]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 6000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   const navItems = useMemo(() => {
     const items = [
@@ -81,9 +127,69 @@ export default function Sidebar() {
     });
   }, [settings?.experimentalStats, settings?.experimentalCrosshair, conflictCount]);
 
+  const handleLaunchModded = async () => {
+    if (launchPending) return;
+    setLaunchPending('modded');
+    setToast(null);
+    try {
+      await launchModded();
+      if (stashStatus.active) {
+        // Modded path did an auto-restore as part of the launch.
+        loadMods();
+      }
+    } catch (err) {
+      setToast({ kind: 'error', text: String(err).replace(/^Error:\s*/, '') });
+    } finally {
+      setLaunchPending(null);
+      refreshStashStatus();
+    }
+  };
+
+  const handleLaunchVanilla = async () => {
+    if (launchPending) return;
+    setLaunchPending('vanilla');
+    setToast(null);
+    try {
+      await launchVanilla();
+      refreshStashStatus();
+      loadMods();
+    } catch (err) {
+      setToast({ kind: 'error', text: String(err).replace(/^Error:\s*/, '') });
+    } finally {
+      setLaunchPending(null);
+    }
+  };
+
+  const handleRestoreNow = async () => {
+    if (restorePending) return;
+    setRestorePending(true);
+    setToast(null);
+    try {
+      const result = await restoreVanillaStash();
+      if (result.failed.length > 0) {
+        setToast({
+          kind: 'error',
+          text: `Couldn't restore ${result.failed.length} mod(s). Is Deadlock still running?`,
+        });
+      } else {
+        setToast({
+          kind: 'info',
+          text: `Restored ${result.restored} mod${result.restored === 1 ? '' : 's'}.`,
+        });
+      }
+    } catch (err) {
+      setToast({ kind: 'error', text: String(err).replace(/^Error:\s*/, '') });
+    } finally {
+      setRestorePending(false);
+      refreshStashStatus();
+      loadMods();
+    }
+  };
+
+  const canLaunch = !!settings?.deadlockPath || !!settings?.devDeadlockPath;
+
   return (
     <aside className="w-56 bg-bg-secondary border-r border-border flex flex-col">
-      {/* Logo */}
       <div className="px-3 pt-4 pb-3 border-b border-border text-center">
         <span
           className="text-4xl text-accent block leading-none"
@@ -96,17 +202,17 @@ export default function Sidebar() {
         </span>
       </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 p-2">
+      <nav className="flex-1 p-2 overflow-y-auto">
         <ul className="space-y-1">
           {navItems.map(({ to, icon: Icon, label, badge }) => (
             <li key={to}>
               <NavLink
                 to={to}
                 className={({ isActive }) =>
-                  `flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${isActive
-                    ? 'bg-accent text-white'
-                    : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
+                  `flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
+                    isActive
+                      ? 'bg-accent text-white'
+                      : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
                   }`
                 }
               >
@@ -123,20 +229,94 @@ export default function Sidebar() {
         </ul>
       </nav>
 
-      {/* Footer */}
-      <div className="p-4 border-t border-border text-xs text-text-secondary">
+      <div className="border-t border-border p-3 space-y-2.5">
+        {stashStatus.active && (
+          <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-2 text-[11px] text-yellow-200 flex items-center gap-2">
+            <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+            <span className="flex-1 leading-tight">
+              Vanilla — {stashStatus.modCount ?? 0} stashed
+            </span>
+            <button
+              onClick={handleRestoreNow}
+              disabled={restorePending}
+              title="Restore stashed mods now"
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-yellow-500/20 hover:bg-yellow-500/30 disabled:opacity-60 transition-colors cursor-pointer disabled:cursor-not-allowed font-medium"
+            >
+              {restorePending ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <RotateCcw className="w-3 h-3" />
+              )}
+              Restore
+            </button>
+          </div>
+        )}
+
+        {toast && (
+          <div
+            className={`rounded-md px-2.5 py-1.5 text-[11px] leading-snug ${
+              toast.kind === 'error'
+                ? 'border border-red-500/40 bg-red-500/10 text-red-300'
+                : 'border border-accent/40 bg-accent/10 text-accent'
+            }`}
+          >
+            {toast.text}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-1.5">
+          <button
+            onClick={handleLaunchModded}
+            disabled={!canLaunch || !!launchPending}
+            title={
+              !canLaunch
+                ? 'Configure your Deadlock path in Settings first'
+                : stashStatus.active
+                  ? 'Restores stashed mods first, then launches Deadlock via Steam'
+                  : 'Launch Deadlock with mods active'
+            }
+            className="flex items-center justify-center gap-2 h-10 rounded-lg bg-accent hover:bg-accent-hover text-white text-sm font-semibold transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {launchPending === 'modded' ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Play className="w-4 h-4 fill-current" />
+            )}
+            Launch Modded
+          </button>
+
+          <button
+            onClick={handleLaunchVanilla}
+            disabled={!canLaunch || !!launchPending || stashStatus.active}
+            title={
+              !canLaunch
+                ? 'Configure your Deadlock path in Settings first'
+                : stashStatus.active
+                  ? 'A vanilla session is already active — restore mods first'
+                  : 'Temporarily stash mods, launch Deadlock via Steam, then auto-restore after the game starts'
+            }
+            className="flex items-center justify-center gap-2 h-9 rounded-lg bg-bg-tertiary hover:bg-white/10 text-text-secondary hover:text-text-primary border border-white/5 text-xs font-medium transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {launchPending === 'vanilla' ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Play className="w-3.5 h-3.5" />
+            )}
+            Launch Vanilla
+          </button>
+        </div>
+
         <button
           onClick={() => updateAvailable && navigate('/settings')}
-          className={`flex items-center gap-2 w-full ${updateAvailable ? 'cursor-pointer hover:text-accent transition-colors' : 'cursor-default'}`}
+          className={`flex items-center justify-center gap-2 w-full pt-1 text-[11px] text-text-secondary ${
+            updateAvailable ? 'cursor-pointer hover:text-accent transition-colors' : 'cursor-default'
+          }`}
           title={updateAvailable ? 'Update available! Click to view' : ''}
         >
           <span>{appVersion || 'v...'}</span>
-          {updateAvailable && (
-            <Download className="w-4 h-4 text-accent animate-pulse" />
-          )}
+          {updateAvailable && <Download className="w-3 h-3 text-accent animate-pulse" />}
         </button>
       </div>
     </aside>
   );
 }
-

--- a/src/components/locker/DownloadableSkinsSection.tsx
+++ b/src/components/locker/DownloadableSkinsSection.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { ChevronDown, Download, Loader2, RefreshCw, AlertTriangle } from 'lucide-react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { Download, Loader2, RefreshCw, AlertTriangle, Search, X } from 'lucide-react';
 import { browseMods, getModDetails, downloadMod } from '../../lib/api';
 import { getModThumbnail, getPrimaryFile, formatDate, isModOutdated } from '../../types/gamebanana';
 import type { CachedMod } from '../../types/electron';
 import type { GameBananaMod } from '../../types/gamebanana';
 import ModThumbnail from '../ModThumbnail';
+import { useAppStore } from '../../stores/appStore';
 
 interface DownloadableSkinsSectionProps {
   categoryId: number;
@@ -55,7 +57,9 @@ export default function DownloadableSkinsSection({
   const [downloading, setDownloading] = useState<{ modId: number; fileId: number } | null>(null);
   const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
   const [extracting, setExtracting] = useState(false);
+  const [query, setQuery] = useState('');
 
+  const hideOutdated = useAppStore((s) => s.settings?.hideOutdatedMods) ?? false;
 
   // Track categoryId to reset on change
   const prevCategoryRef = useRef(categoryId);
@@ -68,13 +72,27 @@ export default function DownloadableSkinsSection({
       setMods([]);
       setLoadState('idle');
       setError(null);
-
+      setQuery('');
     }
   }, [categoryId]);
 
-  // Filter out installed mods from display (use Set internally for O(1) lookup)
-  const installedSet = new Set(installedModIds);
-  const availableMods = mods.filter((mod) => !installedSet.has(mod.id));
+  const installedSet = useMemo(() => new Set(installedModIds), [installedModIds]);
+
+  const availableMods = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    return mods.filter((mod) => {
+      if (installedSet.has(mod.id)) return false;
+      if (hideOutdated && mod.dateModified && isModOutdated(mod.dateModified)) return false;
+      if (trimmedQuery && !mod.name.toLowerCase().includes(trimmedQuery)) return false;
+      return true;
+    });
+  }, [mods, installedSet, hideOutdated, query]);
+
+  const rawAvailableCount = useMemo(
+    () => mods.filter((m) => !installedSet.has(m.id)).length,
+    [mods, installedSet]
+  );
+  const filteredOutCount = rawAvailableCount - availableMods.length;
 
   const loadMods = useCallback(async () => {
     setLoadState('loading');
@@ -254,102 +272,179 @@ export default function DownloadableSkinsSection({
   };
 
   return (
-    <div className="border-t border-border pt-3 mt-3 relative">
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full text-xs text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
-      >
-        <ChevronDown
-          className={`w-4 h-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
-        />
-        <span>Download More</span>
-      </button>
+    <>
+      <div className="border-t border-border pt-3 mt-3">
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-lg bg-accent hover:bg-accent-hover text-white text-sm font-semibold transition-colors cursor-pointer"
+        >
+          <Download className="w-4 h-4" />
+          Download More
+        </button>
+      </div>
 
-      {expanded && (
-        <div className="mt-3 space-y-2">
-          {loadState === 'loading' && (
-            <div className="flex items-center justify-center py-4">
-              <Loader2 className="w-5 h-5 animate-spin text-accent" />
-            </div>
-          )}
-
-          {loadState === 'error' && (
-            <div className="flex items-center justify-between text-xs text-red-400">
-              <span>{error || 'Failed to load'}</span>
+      {expanded && createPortal(
+        <div
+          className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
+          onClick={() => setExpanded(false)}
+        >
+          <div
+            className="w-full max-w-5xl max-h-[90vh] flex flex-col bg-bg-secondary border border-border rounded-xl shadow-2xl overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border">
+              <div className="flex items-center gap-2">
+                <Download className="w-5 h-5 text-accent" />
+                <h2 className="text-lg font-semibold text-text-primary">Download More Skins</h2>
+                {loadState === 'loaded' && (
+                  <span className="text-xs text-text-secondary ml-2">
+                    {availableMods.length}
+                    {filteredOutCount > 0 ? ` of ${rawAvailableCount}` : ''}
+                  </span>
+                )}
+              </div>
               <button
                 type="button"
-                onClick={handleRetry}
-                className="flex items-center gap-1 px-2 py-1 hover:bg-bg-tertiary rounded transition-colors cursor-pointer"
+                onClick={() => setExpanded(false)}
+                className="p-1.5 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
+                aria-label="Close"
               >
-                <RefreshCw className="w-3 h-3" />
-                Retry
+                <X className="w-5 h-5" />
               </button>
             </div>
-          )}
 
-          {loadState === 'loaded' && availableMods.length === 0 && (
-            <div className="text-xs text-text-secondary text-center py-2">
-              No additional skins available
-            </div>
-          )}
-
-          {loadState === 'loaded' && availableMods.length > 0 && (
-            <div className="grid grid-cols-2 gap-2">
-              {availableMods.map((mod) => {
-                const isDownloading = downloading?.modId === mod.id;
-                return (
-                  <div
-                    key={mod.id}
-                    className="flex flex-col gap-1.5 p-2 bg-bg-tertiary rounded-lg"
+            <div className="px-5 py-3 border-b border-border">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search skins…"
+                  autoFocus
+                  className="w-full pl-9 pr-9 py-2 text-sm bg-bg-tertiary border border-border rounded-lg text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent/60"
+                />
+                {query && (
+                  <button
+                    type="button"
+                    onClick={() => setQuery('')}
+                    aria-label="Clear search"
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 text-text-secondary hover:text-text-primary cursor-pointer"
                   >
-                    <div className="aspect-video rounded overflow-hidden bg-black/20">
-                      <ModThumbnail
-                        src={getModThumbnail(mod)}
-                        alt={mod.name}
-                        nsfw={mod.nsfw}
-                        hideNsfw={hideNsfwPreviews}
-                        className="w-full h-full"
-                      />
-                    </div>
-                    <div className="text-xs font-medium truncate" title={mod.name}>
-                      {mod.name}
-                    </div>
-                    {mod.dateModified > 0 && isModOutdated(mod.dateModified) && (
-                      <div className="flex items-center gap-1 text-[10px] text-yellow-400">
-                        <AlertTriangle className="w-2.5 h-2.5 flex-shrink-0" />
-                        <span>Outdated · {formatDate(mod.dateModified)}</span>
-                      </div>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => initiateDownload(mod)}
-                      disabled={downloading !== null}
-                      className="flex items-center justify-center gap-1 px-2 py-1 text-xs bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white rounded transition-colors cursor-pointer"
-                    >
-                      {isDownloading ? (
-                        <>
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                          {extracting
-                            ? 'Extracting'
-                            : downloadProgress !== null
-                              ? `${downloadProgress}%`
-                              : 'Starting'}
-                        </>
-                      ) : (
-                        <>
-                          <Download className="w-3 h-3" />
-                          Install
-                        </>
-                      )}
-                    </button>
-                  </div>
-                );
-              })}
+                    <X className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+              {hideOutdated && filteredOutCount > 0 && (
+                <div className="mt-1.5 text-[11px] text-text-secondary">
+                  {filteredOutCount} outdated skin{filteredOutCount === 1 ? '' : 's'} hidden by your Settings preference.
+                </div>
+              )}
             </div>
-          )}
-        </div>
+
+            <div className="flex-1 overflow-y-auto p-5">
+              {loadState === 'loading' && (
+                <div className="flex flex-col items-center justify-center py-16 gap-3">
+                  <Loader2 className="w-8 h-8 animate-spin text-accent" />
+                  <span className="text-sm text-text-secondary">Loading skins…</span>
+                </div>
+              )}
+
+              {loadState === 'error' && (
+                <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
+                  <div className="text-sm text-red-400 max-w-md">{error || 'Failed to load'}</div>
+                  <button
+                    type="button"
+                    onClick={handleRetry}
+                    className="flex items-center gap-2 px-4 py-2 rounded-md bg-bg-tertiary hover:bg-bg-secondary text-sm transition-colors cursor-pointer"
+                  >
+                    <RefreshCw className="w-4 h-4" />
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {loadState === 'loaded' && availableMods.length === 0 && (
+                <div className="text-sm text-text-secondary text-center py-12">
+                  {rawAvailableCount === 0
+                    ? 'No additional skins available for this hero.'
+                    : query.trim()
+                      ? `No matches for "${query.trim()}"${filteredOutCount > 0 ? ` (${filteredOutCount} hidden by filters)` : ''}.`
+                      : `All ${rawAvailableCount} available skins are hidden by your filters.`}
+                </div>
+              )}
+
+              {loadState === 'loaded' && availableMods.length > 0 && (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                  {availableMods.map((mod) => {
+                    const isDownloading = downloading?.modId === mod.id;
+                    return (
+                      <div
+                        key={mod.id}
+                        className="flex flex-col gap-2 p-2 bg-bg-tertiary rounded-lg border border-transparent hover:border-accent/40 transition-colors"
+                      >
+                        <div className="aspect-video rounded-md overflow-hidden bg-black/30">
+                          <ModThumbnail
+                            src={getModThumbnail(mod)}
+                            alt={mod.name}
+                            nsfw={mod.nsfw}
+                            hideNsfw={hideNsfwPreviews}
+                            className="w-full h-full"
+                          />
+                        </div>
+                        <div className="text-sm font-medium leading-tight line-clamp-2 min-h-[2.5rem]" title={mod.name}>
+                          {mod.name}
+                        </div>
+                        <div className="flex items-center justify-between text-[11px] text-text-secondary">
+                          <span>{mod.submitter?.name ?? ''}</span>
+                          {mod.dateModified > 0 && (
+                            <span
+                              className={
+                                isModOutdated(mod.dateModified)
+                                  ? 'text-yellow-400 flex items-center gap-1'
+                                  : ''
+                              }
+                            >
+                              {isModOutdated(mod.dateModified) && (
+                                <AlertTriangle className="w-3 h-3 flex-shrink-0" />
+                              )}
+                              {formatDate(mod.dateModified)}
+                            </span>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => initiateDownload(mod)}
+                          disabled={downloading !== null}
+                          className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-md transition-colors cursor-pointer"
+                        >
+                          {isDownloading ? (
+                            <>
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                              {extracting
+                                ? 'Extracting'
+                                : downloadProgress !== null
+                                  ? `${downloadProgress}%`
+                                  : 'Starting'}
+                            </>
+                          ) : (
+                            <>
+                              <Download className="w-3.5 h-3.5" />
+                              Install
+                            </>
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body
       )}
-    </div>
+    </>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,6 +67,19 @@ export async function swapModPriority(modIdA: string, modIdB: string): Promise<M
   return window.electronAPI.swapModPriority(modIdA, modIdB);
 }
 
+export async function importCustomMod(args: {
+  vpkPath: string;
+  name: string;
+  thumbnailDataUrl?: string;
+  nsfw?: boolean;
+}): Promise<Mod[]> {
+  return window.electronAPI.importCustomMod(args);
+}
+
+export async function readImageDataUrl(imagePath: string): Promise<string> {
+  return window.electronAPI.readImageDataUrl(imagePath);
+}
+
 // GameBanana
 export async function browseMods(
   page: number,
@@ -156,6 +169,7 @@ export async function showOpenDialog(options: {
   directory?: boolean;
   title?: string;
   defaultPath?: string;
+  filters?: Array<{ name: string; extensions: string[] }>;
 }): Promise<string | null> {
   return window.electronAPI.showOpenDialog(options);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -80,6 +80,44 @@ export async function readImageDataUrl(imagePath: string): Promise<string> {
   return window.electronAPI.readImageDataUrl(imagePath);
 }
 
+// =====================
+// Launch API
+// =====================
+
+export interface VanillaStashStatus {
+  active: boolean;
+  startedAt?: string;
+  modCount?: number;
+}
+
+export interface VanillaRestoreResult {
+  restored: number;
+  skipped: number;
+  failed: string[];
+}
+
+export async function launchModded(): Promise<void> {
+  return window.electronAPI.launchModded();
+}
+
+export async function launchVanilla(): Promise<void> {
+  return window.electronAPI.launchVanilla();
+}
+
+export async function getVanillaStashStatus(): Promise<VanillaStashStatus> {
+  return window.electronAPI.getVanillaStashStatus();
+}
+
+export async function restoreVanillaStash(): Promise<VanillaRestoreResult> {
+  return window.electronAPI.restoreVanillaStash();
+}
+
+export function onVanillaRestoreComplete(
+  callback: (result: VanillaRestoreResult) => void
+): () => void {
+  return window.electronAPI.onVanillaRestoreComplete(callback);
+}
+
 // GameBanana
 export async function browseMods(
   page: number,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,6 +59,14 @@ export async function setModPriority(modId: string, priority: number): Promise<M
   return window.electronAPI.setModPriority(modId, priority);
 }
 
+export async function reorderMods(orderedFileNames: string[]): Promise<Mod[]> {
+  return window.electronAPI.reorderMods(orderedFileNames);
+}
+
+export async function swapModPriority(modIdA: string, modIdB: string): Promise<Mod[]> {
+  return window.electronAPI.swapModPriority(modIdA, modIdB);
+}
+
 // GameBanana
 export async function browseMods(
   page: number,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -139,6 +139,10 @@ export async function fixGameinfo(): Promise<{ configured: boolean; message: str
   return window.electronAPI.fixGameinfo();
 }
 
+export async function openModsFolder(): Promise<void> {
+  return window.electronAPI.openModsFolder();
+}
+
 // Dialog helper for Settings page
 export async function showOpenDialog(options: {
   directory?: boolean;

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -709,8 +709,11 @@ export default function Browse() {
     return ids;
   }, [installedMods]);
 
-  // Just use all loaded mods - infinite scroll handles pagination
-  const displayMods = mods;
+  // Just use all loaded mods - infinite scroll handles pagination.
+  // Hide outdated mods if the user has opted in.
+  const displayMods = settings?.hideOutdatedMods
+    ? mods.filter((m) => !m.dateModified || !isModOutdated(m.dateModified))
+    : mods;
 
   if (!activeDeadlockPath) {
     return (

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1102,13 +1102,19 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
         )}
       </div>
 
-      {/* Gradient overlay for text readability */}
-      <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/30 to-transparent pointer-events-none" />
+      {/* Single gradient: transparent at top, strongest darkness at the label band */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'linear-gradient(to top, rgba(0,0,0,0.95) 0%, rgba(0,0,0,0.7) 22%, rgba(0,0,0,0.25) 55%, transparent 80%)',
+        }}
+      />
 
       {/* Info overlaid at bottom */}
       <div className={`absolute bottom-0 left-0 right-0 ${isCompact ? 'p-2.5' : 'p-3'}`}>
-        <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.8)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
-        <div className={`flex items-center gap-3 text-white/80 mt-1 ${isCompact ? 'text-xs' : 'text-sm'}`}>
+        <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
+        <div className={`flex items-center gap-3 text-white/90 mt-1 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${isCompact ? 'text-xs' : 'text-sm'}`}>
           <span className="flex items-center gap-1"><ThumbsUp className={isCompact ? 'w-3 h-3' : 'w-3.5 h-3.5'} />{mod.likeCount}</span>
           <span className="flex items-center gap-1"><Eye className={isCompact ? 'w-3 h-3' : 'w-3.5 h-3.5'} />{mod.viewCount}</span>
           {mod.submitter && <span className="truncate">by {mod.submitter.name}</span>}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Package, Loader2, Settings, Trash2, ToggleLeft, ToggleRight, AlertTriangle, FolderOpen } from 'lucide-react';
+import { Package, Loader2, Settings, Trash2, ToggleLeft, ToggleRight, AlertTriangle, FolderOpen, ChevronUp, ChevronDown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
@@ -20,7 +20,7 @@ function formatBytes(bytes: number): string {
 
 export default function Installed() {
   const navigate = useNavigate();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, deleteMod } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, deleteMod, swapModPriority } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
@@ -130,8 +130,8 @@ export default function Installed() {
     );
   }
 
-  // Mod list
-  const enabledMods = mods.filter((m) => m.enabled);
+  // Mod list (enabled sorted by priority so chevron-reorder matches visual order)
+  const enabledMods = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
   const disabledMods = mods.filter((m) => !m.enabled);
   const conflictCount = conflictMap.size > 0 ? new Set([...conflictMap.keys()]).size : 0;
 
@@ -186,7 +186,7 @@ export default function Installed() {
                 : 'space-y-2'
             }
           >
-            {enabledMods.map((mod) => (
+            {enabledMods.map((mod, index) => (
               <ModCard
                 key={mod.id}
                 mod={mod}
@@ -195,6 +195,8 @@ export default function Installed() {
                 conflicts={conflictMap.get(mod.id) || []}
                 onToggle={() => toggleMod(mod.id)}
                 onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
+                onMoveUp={index > 0 ? () => swapModPriority(mod.id, enabledMods[index - 1].id) : undefined}
+                onMoveDown={index < enabledMods.length - 1 ? () => swapModPriority(mod.id, enabledMods[index + 1].id) : undefined}
               />
             ))}
           </div>
@@ -261,9 +263,11 @@ interface ModCardProps {
   conflicts: ModConflict[];
   onToggle: () => void;
   onDelete: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
 }
 
-function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelete }: ModCardProps) {
+function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelete, onMoveUp, onMoveDown }: ModCardProps) {
   const hasConflicts = conflicts.length > 0;
 
   return (
@@ -328,6 +332,30 @@ function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelet
             </span>
           </div>
         </div>
+
+        {/* Reorder (enabled mods only) */}
+        {(onMoveUp || onMoveDown) && (
+          <div className="flex flex-col">
+            <button
+              onClick={onMoveUp}
+              disabled={!onMoveUp}
+              className="p-0.5 text-text-secondary hover:text-text-primary disabled:opacity-30 disabled:hover:text-text-secondary transition-colors cursor-pointer disabled:cursor-not-allowed"
+              title="Move up (higher priority)"
+              aria-label="Move up"
+            >
+              <ChevronUp className="w-5 h-5" />
+            </button>
+            <button
+              onClick={onMoveDown}
+              disabled={!onMoveDown}
+              className="p-0.5 text-text-secondary hover:text-text-primary disabled:opacity-30 disabled:hover:text-text-secondary transition-colors cursor-pointer disabled:cursor-not-allowed"
+              title="Move down (lower priority)"
+              aria-label="Move down"
+            >
+              <ChevronDown className="w-5 h-5" />
+            </button>
+          </div>
+        )}
 
         {/* Delete */}
         <button

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -212,7 +212,6 @@ export default function Installed() {
             )}
             <Button
               variant="secondary"
-              size="sm"
               onClick={() => setImportOpen(true)}
               icon={FilePlus}
               title="Import a VPK from disk with a custom name and thumbnail"
@@ -221,7 +220,6 @@ export default function Installed() {
             </Button>
             <Button
               variant="secondary"
-              size="sm"
               onClick={() => openModsFolder().catch(() => {})}
               icon={FolderOpen}
               title="Open mods folder"

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,14 +1,27 @@
-import { useEffect, useState } from 'react';
-import { Package, Loader2, Settings, Trash2, ToggleLeft, ToggleRight, AlertTriangle, FolderOpen, ChevronUp, ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import {
+  Package,
+  Loader2,
+  Settings,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+  AlertTriangle,
+  FolderOpen,
+  GripVertical,
+  FilePlus,
+  X,
+  ImagePlus,
+  Search,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import ModThumbnail from '../components/ModThumbnail';
 import { Button } from '../components/common/ui';
 import { PageHeader, ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
-import { Search } from 'lucide-react';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -18,14 +31,32 @@ function formatBytes(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
 }
 
+type DropPosition = 'before' | 'after';
+
 export default function Installed() {
   const navigate = useNavigate();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, deleteMod, swapModPriority } =
-    useAppStore();
+  const {
+    settings,
+    mods,
+    modsLoading,
+    modsError,
+    loadSettings,
+    loadMods,
+    toggleMod,
+    deleteMod,
+    reorderMods,
+    importCustomMod,
+  } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
   const [modToDelete, setModToDelete] = useState<{ id: string; name: string } | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
+
+  // Drag-and-drop reorder state
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [dropPosition, setDropPosition] = useState<DropPosition | null>(null);
 
   const handleDeleteConfirm = async () => {
     if (modToDelete) {
@@ -44,37 +75,29 @@ export default function Installed() {
     }
   }, [activeDeadlockPath, loadMods]);
 
-  // Load conflicts and build a map of mod ID -> conflicts
   useEffect(() => {
     const loadConflictData = async () => {
       try {
         const conflicts = await getConflicts();
         const map = new Map<string, ModConflict[]>();
-
         for (const conflict of conflicts) {
-          // Add to modA's conflicts
           const existingA = map.get(conflict.modA) || [];
           existingA.push(conflict);
           map.set(conflict.modA, existingA);
-
-          // Add to modB's conflicts
           const existingB = map.get(conflict.modB) || [];
           existingB.push(conflict);
           map.set(conflict.modB, existingB);
         }
-
         setConflictMap(map);
       } catch {
         setConflictMap(new Map());
       }
     };
-
     if (mods.length > 0) {
       loadConflictData();
     }
   }, [mods]);
 
-  // No path configured
   if (!activeDeadlockPath) {
     return (
       <EmptyState
@@ -90,7 +113,6 @@ export default function Installed() {
     );
   }
 
-  // Loading
   if (modsLoading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -99,7 +121,6 @@ export default function Installed() {
     );
   }
 
-  // Error
   if (modsError) {
     return (
       <EmptyState
@@ -107,33 +128,69 @@ export default function Installed() {
         title="Error Loading Mods"
         description={modsError ?? undefined}
         variant="error"
-        action={
-          <Button onClick={() => loadMods()}>Retry</Button>
-        }
+        action={<Button onClick={() => loadMods()}>Retry</Button>}
       />
     );
   }
 
-  // No mods found
-  if (mods.length === 0) {
-    return (
-      <EmptyState
-        icon={Package}
-        title="No Mods Found"
-        description="No mods installed yet. Download mods from the Browse tab or manually place VPK files in your addons folder."
-        action={
-          <Button onClick={() => navigate('/browse')} icon={Search}>
-            Browse Mods
-          </Button>
-        }
-      />
-    );
-  }
-
-  // Mod list (enabled sorted by priority so chevron-reorder matches visual order)
   const enabledMods = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
   const disabledMods = mods.filter((m) => !m.enabled);
   const conflictCount = conflictMap.size > 0 ? new Set([...conflictMap.keys()]).size : 0;
+
+  const resetDragState = () => {
+    setDraggingId(null);
+    setDropTargetId(null);
+    setDropPosition(null);
+  };
+
+  const applyReorder = (sourceId: string, targetId: string, position: DropPosition) => {
+    if (sourceId === targetId) return;
+    const sourceIdx = enabledMods.findIndex((m) => m.id === sourceId);
+    if (sourceIdx === -1) return;
+
+    const working = enabledMods.slice();
+    const [moved] = working.splice(sourceIdx, 1);
+    const adjustedTargetIdx = working.findIndex((m) => m.id === targetId);
+    if (adjustedTargetIdx === -1) return;
+    const insertAt = position === 'before' ? adjustedTargetIdx : adjustedTargetIdx + 1;
+    working.splice(insertAt, 0, moved);
+
+    const unchanged = working.every((m, i) => m.id === enabledMods[i].id);
+    if (unchanged) return;
+
+    reorderMods(working.map((m) => m.fileName));
+  };
+
+  // No mods at all
+  if (mods.length === 0) {
+    return (
+      <>
+        <EmptyState
+          icon={Package}
+          title="No Mods Found"
+          description="No mods installed yet. Download mods from the Browse tab, import a custom VPK, or manually place VPK files in your addons folder."
+          action={
+            <div className="flex items-center gap-3">
+              <Button onClick={() => navigate('/browse')} icon={Search}>
+                Browse Mods
+              </Button>
+              <Button variant="secondary" onClick={() => setImportOpen(true)} icon={FilePlus}>
+                Import Custom Mod
+              </Button>
+            </div>
+          }
+        />
+        {importOpen && (
+          <ImportCustomModModal
+            onClose={() => setImportOpen(false)}
+            onImport={async (args) => {
+              await importCustomMod(args);
+            }}
+          />
+        )}
+      </>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -156,6 +213,15 @@ export default function Installed() {
             <Button
               variant="secondary"
               size="sm"
+              onClick={() => setImportOpen(true)}
+              icon={FilePlus}
+              title="Import a VPK from disk with a custom name and thumbnail"
+            >
+              Add Custom Mod
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => openModsFolder().catch(() => {})}
               icon={FolderOpen}
               title="Open mods folder"
@@ -175,7 +241,6 @@ export default function Installed() {
         className="mb-6"
       />
 
-      {/* Enabled Mods */}
       {enabledMods.length > 0 && (
         <div className="mb-6">
           <SectionHeader count={enabledMods.length}>Enabled</SectionHeader>
@@ -186,7 +251,7 @@ export default function Installed() {
                 : 'space-y-2'
             }
           >
-            {enabledMods.map((mod, index) => (
+            {enabledMods.map((mod) => (
               <ModCard
                 key={mod.id}
                 mod={mod}
@@ -195,15 +260,36 @@ export default function Installed() {
                 conflicts={conflictMap.get(mod.id) || []}
                 onToggle={() => toggleMod(mod.id)}
                 onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
-                onMoveUp={index > 0 ? () => swapModPriority(mod.id, enabledMods[index - 1].id) : undefined}
-                onMoveDown={index < enabledMods.length - 1 ? () => swapModPriority(mod.id, enabledMods[index + 1].id) : undefined}
+                draggable
+                isDragging={draggingId === mod.id}
+                isDropTarget={dropTargetId === mod.id}
+                dropPosition={dropTargetId === mod.id ? dropPosition : null}
+                onDragStart={() => setDraggingId(mod.id)}
+                onDragOver={(pos) => {
+                  if (!draggingId || draggingId === mod.id) return;
+                  setDropTargetId(mod.id);
+                  setDropPosition(pos);
+                }}
+                onDragLeaveCard={() => {
+                  // Only clear if we're still targeting this card
+                  if (dropTargetId === mod.id) {
+                    setDropTargetId(null);
+                    setDropPosition(null);
+                  }
+                }}
+                onDrop={() => {
+                  if (draggingId && dropTargetId && dropPosition) {
+                    applyReorder(draggingId, dropTargetId, dropPosition);
+                  }
+                  resetDragState();
+                }}
+                onDragEnd={resetDragState}
               />
             ))}
           </div>
         </div>
       )}
 
-      {/* Disabled Mods */}
       {disabledMods.length > 0 && (
         <div>
           <SectionHeader count={disabledMods.length}>Disabled</SectionHeader>
@@ -223,19 +309,21 @@ export default function Installed() {
                 conflicts={conflictMap.get(mod.id) || []}
                 onToggle={() => toggleMod(mod.id)}
                 onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
+                draggable={false}
               />
             ))}
           </div>
         </div>
       )}
 
-      {/* Delete Confirmation Modal */}
       <ConfirmModal
         isOpen={!!modToDelete}
         title="Delete Mod?"
         message={
           <>
-            Are you sure you want to delete <span className="font-medium text-text-primary">{modToDelete?.name}</span>? This action cannot be undone.
+            Are you sure you want to delete{' '}
+            <span className="font-medium text-text-primary">{modToDelete?.name}</span>? This action
+            cannot be undone.
           </>
         }
         confirmLabel="Delete"
@@ -243,6 +331,15 @@ export default function Installed() {
         onConfirm={handleDeleteConfirm}
         onCancel={() => setModToDelete(null)}
       />
+
+      {importOpen && (
+        <ImportCustomModModal
+          onClose={() => setImportOpen(false)}
+          onImport={async (args) => {
+            await importCustomMod(args);
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -263,22 +360,110 @@ interface ModCardProps {
   conflicts: ModConflict[];
   onToggle: () => void;
   onDelete: () => void;
-  onMoveUp?: () => void;
-  onMoveDown?: () => void;
+  draggable?: boolean;
+  isDragging?: boolean;
+  isDropTarget?: boolean;
+  dropPosition?: DropPosition | null;
+  onDragStart?: () => void;
+  onDragOver?: (position: DropPosition) => void;
+  onDragLeaveCard?: () => void;
+  onDrop?: () => void;
+  onDragEnd?: () => void;
 }
 
-function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelete, onMoveUp, onMoveDown }: ModCardProps) {
+function ModCard({
+  mod,
+  viewMode,
+  hideNsfwPreviews,
+  conflicts,
+  onToggle,
+  onDelete,
+  draggable,
+  isDragging,
+  isDropTarget,
+  dropPosition,
+  onDragStart,
+  onDragOver,
+  onDragLeaveCard,
+  onDrop,
+  onDragEnd,
+}: ModCardProps) {
   const hasConflicts = conflicts.length > 0;
+  const handleDownRef = useRef<boolean>(false);
+
+  const indicatorClasses = (() => {
+    if (!isDropTarget || !dropPosition) return '';
+    const base = 'absolute bg-accent pointer-events-none rounded-full';
+    if (viewMode === 'list') {
+      return dropPosition === 'before'
+        ? `${base} left-2 right-2 -top-[3px] h-[3px]`
+        : `${base} left-2 right-2 -bottom-[3px] h-[3px]`;
+    }
+    return dropPosition === 'before'
+      ? `${base} top-2 bottom-2 -left-[3px] w-[3px]`
+      : `${base} top-2 bottom-2 -right-[3px] w-[3px]`;
+  })();
 
   return (
     <div
-      className={`rounded-lg border transition-colors ${hasConflicts
-        ? 'bg-yellow-500/5 border-yellow-500/50'
-        : mod.enabled
-          ? 'bg-bg-secondary border-accent/30'
-          : 'bg-bg-tertiary border-border grayscale-[50%]'
-        } ${viewMode === 'grid' ? 'p-3 flex flex-col gap-3' : 'flex items-center gap-4 p-4'}`}
+      className={`relative rounded-lg border transition-colors ${
+        hasConflicts
+          ? 'bg-yellow-500/5 border-yellow-500/50'
+          : mod.enabled
+            ? 'bg-bg-secondary border-accent/30'
+            : 'bg-bg-tertiary border-border grayscale-[50%]'
+      } ${viewMode === 'grid' ? 'p-3 flex flex-col gap-3' : 'flex items-center gap-4 p-4'} ${
+        isDragging ? 'opacity-40' : ''
+      }`}
+      draggable={draggable}
+      onDragStart={(e) => {
+        if (!draggable || !onDragStart) {
+          e.preventDefault();
+          return;
+        }
+        // Require drag to originate from the grip handle so clicks on toggle/delete don't start a drag
+        if (!handleDownRef.current) {
+          e.preventDefault();
+          return;
+        }
+        handleDownRef.current = false;
+        e.dataTransfer.effectAllowed = 'move';
+        // Firefox needs setData to start a drag
+        try {
+          e.dataTransfer.setData('text/plain', mod.id);
+        } catch {
+          // ignore
+        }
+        onDragStart();
+      }}
+      onDragOver={(e) => {
+        if (!draggable || !onDragOver) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        const rect = e.currentTarget.getBoundingClientRect();
+        if (viewMode === 'list') {
+          const mid = rect.top + rect.height / 2;
+          onDragOver(e.clientY < mid ? 'before' : 'after');
+        } else {
+          const mid = rect.left + rect.width / 2;
+          onDragOver(e.clientX < mid ? 'before' : 'after');
+        }
+      }}
+      onDragLeave={(e) => {
+        // Only count leaves where we're exiting the card itself
+        const related = e.relatedTarget as Node | null;
+        if (related && e.currentTarget.contains(related)) return;
+        onDragLeaveCard?.();
+      }}
+      onDrop={(e) => {
+        if (!draggable || !onDrop) return;
+        e.preventDefault();
+        onDrop();
+      }}
+      onDragEnd={() => onDragEnd?.()}
     >
+      {indicatorClasses && <div className={indicatorClasses} />}
+
       {viewMode === 'grid' && (
         <div className="relative w-full aspect-video bg-bg-tertiary rounded-md overflow-hidden">
           <ModThumbnail
@@ -289,7 +474,10 @@ function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelet
             className="w-full h-full"
           />
           {hasConflicts && (
-            <div className="absolute top-2 right-2 p-1.5 bg-yellow-500 rounded-full" title={conflicts.map(c => c.details).join(', ')}>
+            <div
+              className="absolute top-2 right-2 p-1.5 bg-yellow-500 rounded-full"
+              title={conflicts.map((c) => c.details).join(', ')}
+            >
               <AlertTriangle className="w-3 h-3 text-black" />
             </div>
           )}
@@ -297,23 +485,34 @@ function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelet
       )}
 
       <div className={viewMode === 'grid' ? 'flex items-center gap-3' : 'contents'}>
-        {/* Toggle */}
+        {draggable && (
+          <div
+            onMouseDown={() => {
+              handleDownRef.current = true;
+            }}
+            onMouseUp={() => {
+              handleDownRef.current = false;
+            }}
+            className="p-1 text-text-secondary hover:text-text-primary cursor-grab active:cursor-grabbing select-none"
+            title="Drag to reorder"
+            aria-label="Drag to reorder"
+          >
+            <GripVertical className="w-5 h-5" />
+          </div>
+        )}
+
         <button
           onClick={onToggle}
           aria-pressed={mod.enabled}
           aria-label={mod.enabled ? 'Disable mod' : 'Enable mod'}
-          className={`transition-colors cursor-pointer ${mod.enabled ? 'text-accent' : 'text-text-secondary hover:text-text-primary'
-            }`}
+          className={`transition-colors cursor-pointer ${
+            mod.enabled ? 'text-accent' : 'text-text-secondary hover:text-text-primary'
+          }`}
           title={mod.enabled ? 'Disable mod' : 'Enable mod'}
         >
-          {mod.enabled ? (
-            <ToggleRight className="w-8 h-8" />
-          ) : (
-            <ToggleLeft className="w-8 h-8" />
-          )}
+          {mod.enabled ? <ToggleRight className="w-8 h-8" /> : <ToggleLeft className="w-8 h-8" />}
         </button>
 
-        {/* Info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <h3 className="font-medium truncate">{mod.name}</h3>
@@ -333,31 +532,6 @@ function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelet
           </div>
         </div>
 
-        {/* Reorder (enabled mods only) */}
-        {(onMoveUp || onMoveDown) && (
-          <div className="flex flex-col">
-            <button
-              onClick={onMoveUp}
-              disabled={!onMoveUp}
-              className="p-0.5 text-text-secondary hover:text-text-primary disabled:opacity-30 disabled:hover:text-text-secondary transition-colors cursor-pointer disabled:cursor-not-allowed"
-              title="Move up (higher priority)"
-              aria-label="Move up"
-            >
-              <ChevronUp className="w-5 h-5" />
-            </button>
-            <button
-              onClick={onMoveDown}
-              disabled={!onMoveDown}
-              className="p-0.5 text-text-secondary hover:text-text-primary disabled:opacity-30 disabled:hover:text-text-secondary transition-colors cursor-pointer disabled:cursor-not-allowed"
-              title="Move down (lower priority)"
-              aria-label="Move down"
-            >
-              <ChevronDown className="w-5 h-5" />
-            </button>
-          </div>
-        )}
-
-        {/* Delete */}
         <button
           onClick={onDelete}
           className="p-2 text-text-secondary hover:text-red-500 transition-colors cursor-pointer"
@@ -365,6 +539,196 @@ function ModCard({ mod, viewMode, hideNsfwPreviews, conflicts, onToggle, onDelet
         >
           <Trash2 className="w-5 h-5" />
         </button>
+      </div>
+    </div>
+  );
+}
+
+interface ImportCustomModModalProps {
+  onClose: () => void;
+  onImport: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
+}
+
+function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) {
+  const [vpkPath, setVpkPath] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [imagePath, setImagePath] = useState<string>('');
+  const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string>('');
+  const [nsfw, setNsfw] = useState<boolean>(false);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pickVpk = async () => {
+    const picked = await showOpenDialog({
+      title: 'Select VPK file',
+      filters: [{ name: 'VPK files', extensions: ['vpk'] }],
+    });
+    if (picked) {
+      setVpkPath(picked);
+      if (!name) {
+        const base = picked.split(/[\\/]/).pop() ?? '';
+        const cleaned = base
+          .replace(/_dir\.vpk$/i, '')
+          .replace(/\.vpk$/i, '')
+          .replace(/^pak\d{2}_/, '')
+          .replace(/[_-]+/g, ' ');
+        setName(cleaned.trim());
+      }
+    }
+  };
+
+  const pickImage = async () => {
+    const picked = await showOpenDialog({
+      title: 'Select thumbnail image',
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
+    });
+    if (!picked) return;
+    setImagePath(picked);
+    setError(null);
+    try {
+      const dataUrl = await readImageDataUrl(picked);
+      setThumbnailDataUrl(dataUrl);
+    } catch (err) {
+      setThumbnailDataUrl('');
+      setError(`Couldn't read image: ${String(err)}`);
+    }
+  };
+
+  const canSubmit = !!vpkPath && !!name.trim() && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onImport({
+        vpkPath,
+        name: name.trim(),
+        thumbnailDataUrl: thumbnailDataUrl || undefined,
+        nsfw,
+      });
+      onClose();
+    } catch (err) {
+      setError(String(err));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-bg-secondary border border-border rounded-xl w-full max-w-lg">
+        <div className="flex items-center justify-between p-5 border-b border-border">
+          <h3 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+            <FilePlus className="w-5 h-5" />
+            Import Custom Mod
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-text-primary rounded cursor-pointer"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1.5">
+              VPK file <span className="text-red-400">*</span>
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={vpkPath}
+                readOnly
+                placeholder="No file selected"
+                className="flex-1 min-w-0 px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none truncate"
+              />
+              <button
+                onClick={pickVpk}
+                className="px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm hover:bg-bg-secondary transition-colors cursor-pointer"
+              >
+                Choose…
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-text-secondary">
+              The file will be copied into your addons folder and renamed with the next available pak## priority.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1.5">
+              Mod name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My awesome skin"
+              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1.5">
+              Thumbnail image <span className="text-text-secondary font-normal">(optional)</span>
+            </label>
+            <div className="flex items-start gap-3">
+              <div className="w-24 aspect-video bg-bg-tertiary rounded-md overflow-hidden flex items-center justify-center text-text-secondary flex-shrink-0">
+                {thumbnailDataUrl ? (
+                  <img src={thumbnailDataUrl} alt="Thumbnail preview" className="w-full h-full object-cover" />
+                ) : (
+                  <ImagePlus className="w-5 h-5" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0 flex flex-col gap-2">
+                <button
+                  onClick={pickImage}
+                  className="px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm hover:bg-bg-secondary transition-colors cursor-pointer w-fit"
+                >
+                  {imagePath ? 'Change image…' : 'Choose image…'}
+                </button>
+                {imagePath && (
+                  <span className="text-xs text-text-secondary font-mono truncate">{imagePath}</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={nsfw}
+              onChange={(e) => setNsfw(e.target.checked)}
+              className="w-4 h-4 accent-accent cursor-pointer"
+            />
+            Mark as NSFW
+          </label>
+
+          {error && (
+            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg p-2">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 p-5 border-t border-border">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-4 py-2 bg-accent hover:bg-accent-hover text-white rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+            Import
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Package, Loader2, Settings, Trash2, ToggleLeft, ToggleRight, AlertTriangle } from 'lucide-react';
+import { Package, Loader2, Settings, Trash2, ToggleLeft, ToggleRight, AlertTriangle, FolderOpen } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts } from '../lib/api';
+import { getConflicts, openModsFolder } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import ModThumbnail from '../components/ModThumbnail';
 import { Button } from '../components/common/ui';
@@ -153,6 +153,15 @@ export default function Installed() {
                 {conflictMap.size / 2} conflicts
               </Button>
             )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => openModsFolder().catch(() => {})}
+              icon={FolderOpen}
+              title="Open mods folder"
+            >
+              Open Folder
+            </Button>
             <ViewModeToggle
               value={viewMode}
               options={[

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -156,6 +156,12 @@ export default function Settings() {
     }
   };
 
+  const handleHideOutdatedChange = async (checked: boolean) => {
+    if (settings) {
+      await saveSettings({ ...settings, hideOutdatedMods: checked });
+    }
+  };
+
   const handleDevModeChange = async (checked: boolean) => {
     if (!settings) return;
     if (checked) {
@@ -504,6 +510,15 @@ export default function Settings() {
               onChange={handleHideNsfwChange}
               label="Hide NSFW Content"
               description="Blur thumbnail images for mods marked as NSFW."
+            />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.hideOutdatedMods ?? false}
+              onChange={handleHideOutdatedChange}
+              label="Hide Outdated Mods"
+              description="Hide mods in Browse that haven't been updated since the current game version cutoff."
             />
 
             <div className="h-px bg-white/5" />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -38,6 +38,8 @@ interface AppState {
   deleteMod: (modId: string) => Promise<void>;
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
+  reorderMods: (orderedFileNames: string[]) => Promise<void>;
+  importCustomMod: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
 
   // Download counts cache actions
   getDownloadCount: (modId: number) => number | undefined;
@@ -154,6 +156,28 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ mods: updated });
     } catch (err) {
       set({ modsError: String(err) });
+    }
+  },
+
+  // Reorder mods via drag-and-drop. Accepts the target enabled-list order as filenames.
+  // Rolls back to a fresh scan on error so the UI can't desync from disk.
+  reorderMods: async (orderedFileNames: string[]) => {
+    try {
+      const updated = await api.reorderMods(orderedFileNames);
+      set({ mods: updated });
+    } catch (err) {
+      set({ modsError: String(err) });
+      get().loadMods();
+    }
+  },
+
+  importCustomMod: async (args) => {
+    try {
+      const updated = await api.importCustomMod(args);
+      set({ mods: updated });
+    } catch (err) {
+      set({ modsError: String(err) });
+      throw err;
     }
   },
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -37,6 +37,7 @@ interface AppState {
   toggleMod: (modId: string) => Promise<void>;
   deleteMod: (modId: string) => Promise<void>;
   setModPriority: (modId: string, priority: number) => Promise<void>;
+  swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
 
   // Download counts cache actions
   getDownloadCount: (modId: number) => number | undefined;
@@ -141,6 +142,16 @@ export const useAppStore = create<AppState>((set, get) => ({
           .mods.map((m) => (m.id === modId ? updatedMod : m))
           .sort((a, b) => a.priority - b.priority),
       });
+    } catch (err) {
+      set({ modsError: String(err) });
+    }
+  },
+
+  // Swap the priority of two mods (mod IDs change after rename, so we replace the full list)
+  swapModPriority: async (modIdA: string, modIdB: string) => {
+    try {
+      const updated = await api.swapModPriority(modIdA, modIdB);
+      set({ mods: updated });
     } catch (err) {
       set({ modsError: String(err) });
     }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -64,6 +64,14 @@ export interface OpenDialogOptions {
     directory?: boolean;
     title?: string;
     defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+}
+
+export interface ImportCustomModArgs {
+    vpkPath: string;
+    name: string;
+    thumbnailDataUrl?: string;
+    nsfw?: boolean;
 }
 
 export interface DownloadProgressData {
@@ -203,6 +211,8 @@ export interface ElectronAPI {
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
+    importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
+    readImageDataUrl: (imagePath: string) => Promise<string>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -74,6 +74,18 @@ export interface ImportCustomModArgs {
     nsfw?: boolean;
 }
 
+export interface VanillaStashStatus {
+    active: boolean;
+    startedAt?: string;
+    modCount?: number;
+}
+
+export interface VanillaRestoreResult {
+    restored: number;
+    skipped: number;
+    failed: string[];
+}
+
 export interface DownloadProgressData {
     modId: number;
     fileId: number;
@@ -213,6 +225,13 @@ export interface ElectronAPI {
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
+
+    // Launch
+    launchModded: () => Promise<void>;
+    launchVanilla: () => Promise<void>;
+    getVanillaStashStatus: () => Promise<VanillaStashStatus>;
+    restoreVanillaStash: () => Promise<VanillaRestoreResult>;
+    onVanillaRestoreComplete: (callback: (result: VanillaRestoreResult) => void) => () => void;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -201,6 +201,8 @@ export interface ElectronAPI {
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
+    reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
+    swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -219,6 +219,7 @@ export interface ElectronAPI {
     cleanupAddons: () => Promise<CleanupResult>;
     getGameinfoStatus: () => Promise<GameinfoStatus>;
     fixGameinfo: () => Promise<GameinfoStatus>;
+    openModsFolder: () => Promise<void>;
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => Promise<boolean>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -40,6 +40,7 @@ export interface AppSettings {
   devMode: boolean;
   devDeadlockPath: string | null;
   hideNsfwPreviews: boolean;
+  hideOutdatedMods: boolean;
   activeProfileId: string | null;
   autoSaveProfile: boolean;
   experimentalStats: boolean;


### PR DESCRIPTION
Closes #1

Addresses all three suggestions from @ZenZenXDz and bundles several related fixes that came up while testing.

## Summary

### For issue #1
- **Change mod order / priority** — drag-and-drop reorder on the Installed page with a grip handle + edge drop indicator. Replaces the chevron up/down buttons.
- **Open mods folder** — one-click button in the Installed page header (`shell.openPath` on the enabled addons folder).
- **Windows-searchable install** — NSIS target now creates Desktop + Start Menu shortcuts with a named uninstaller entry and per-user install (no UAC). The bare portable `.exe` target was dropped to avoid the Setup.exe vs portable-.exe confusion.

### Other improvements on this branch
- **Launch Modded / Launch Vanilla** buttons in the sidebar footer. Vanilla stashes all enabled VPKs to `disabled/`, launches Steam, polls `tasklist` for `deadlock.exe`, then auto-restores after a grace period. State file is atomically written so a crash / force-quit mid-session is recoverable on next app start.
- **Import Custom Mod** — add a local VPK with a custom name and thumbnail, stored under strict `pakNN_dir.vpk` naming at the next free priority. Optional NSFW flag.
- **Locker "Download More" modal** — replaces the collapsed dropdown with a centered overlay (portal'd so `position: fixed` isn't trapped by LockerHero's `transform` ancestor) with search + responsive 2/3/4-column grid. Now also honors the `hideOutdatedMods` setting, which it previously ignored.
- **Bug fix: reorder was wiping thumbnails/names** — `reorderMods` and `directSwap` migrated metadata one mod at a time, which clobbered sibling entries when new filenames collided with another mod's still-current filename. New batched `migrateModMetadata()` snapshots all source entries, deletes old keys, writes new keys in a single atomic pass.
- **UI polish** — outdated mod warnings, sticky browse header, overlay mod cards, Browse card gradient redone to improve label contrast without a horizontal seam, header button sizes tightened up.

## Test plan

- [x] Reorder a few enabled mods via drag handle; thumbnails + names survive
- [x] Import a custom VPK (single-file and multi-file) with custom name + thumbnail
- [x] Launch Vanilla → verify mods move to `disabled/`, auto-restore after game starts
- [x] Launch Vanilla → force-quit game immediately → mods still get restored
- [x] Quit grimoire during vanilla session → restart grimoire → stash auto-restores on startup
- [x] Open Mods Folder button opens the addons folder
- [x] Locker → Download More opens centered modal, search filters results, outdated hidden when Settings toggle on
- [ ] Install Setup.exe → Desktop shortcut works, "Grimoire" appears in Start search

---

CI note for reviewers: this repo's `release.yml` only runs on tag pushes, so this PR intentionally has no automated checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)