### PR TITLE
Bundle RAR/7z extractors and add audio preview on installed sound mods

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,7 @@ files:
   - node_modules/file-uri-to-path/**/*
   - node_modules/node-7z/**/*
   - node_modules/node-unrar-js/**/*
+  - node_modules/7zip-bin/**/*
   - node_modules/cross-spawn/**/*
   - node_modules/shebang-command/**/*
   - node_modules/shebang-regex/**/*
@@ -27,6 +28,7 @@ files:
 asarUnpack:
   - node_modules/better-sqlite3/**/*
   - node_modules/node-unrar-js/**/*
+  - node_modules/7zip-bin/**/*
 linux:
   target:
     - AppImage

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -38,6 +38,7 @@ function enrichMod(mod: Mod): Mod {
             // Use the stored mod name from GameBanana if available
             name: metadata.modName || mod.name,
             thumbnailUrl: metadata.thumbnailUrl,
+            audioUrl: metadata.audioUrl,
             gameBananaId: metadata.gameBananaId,
             gameBananaFileId: metadata.gameBananaFileId,
             categoryId: metadata.categoryId,

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -370,6 +370,7 @@ async function executeDownload(
         categoryId: details.category?.id,  // Get category from mod details, not filter
         categoryName: details.category?.name,  // Also store category name for display
         thumbnailUrl,
+        audioUrl: details.previewMedia?.metadata?.audioUrl,  // Persist for Sound mod preview
         sourceSection: section,
         nsfw: details.nsfw,  // Use actual NSFW flag from GameBanana
     };
@@ -393,20 +394,23 @@ async function executeDownload(
         } catch (extractError) {
             const errorMsg = extractError instanceof Error ? extractError.message : String(extractError);
 
-            // Check if this is a 7-Zip related error
+            // The bundled extractors should handle virtually all archives; if they
+            // failed, the archive is likely corrupt or uses an exotic format. We
+            // still surface 7-Zip as a fallback users can try.
             const is7zError = errorMsg.includes("7z") ||
                 errorMsg.includes("7-Zip") ||
                 errorMsg.includes("p7zip") ||
-                errorMsg.includes("unrar");
+                errorMsg.includes("unrar") ||
+                errorMsg.includes("RAR extraction failed");
 
-            // Emit download-error event with structured info
             mainWindow?.webContents.send('download-error', {
                 modId,
                 fileId,
                 errorCode: is7zError ? 'MISSING_7ZIP' : 'EXTRACTION_FAILED',
                 message: is7zError
-                    ? '7-Zip is required to extract this mod. Please install it from https://7-zip.org and restart the app.'
+                    ? "Couldn't extract this mod. Install 7-Zip from https://7-zip.org and try again."
                     : `Failed to extract mod: ${errorMsg}`,
+                helpUrl: is7zError ? 'https://7-zip.org' : undefined,
             });
 
             // Clean up failed download

--- a/electron/main/services/extract.ts
+++ b/electron/main/services/extract.ts
@@ -1,28 +1,44 @@
-import { existsSync, mkdirSync, readdirSync, copyFileSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, copyFileSync, unlinkSync, writeFileSync, readFileSync, rmdirSync } from 'fs';
 import { join, extname, basename } from 'path';
 import { randomBytes } from 'crypto';
 import AdmZip from 'adm-zip';
 import { spawn } from 'child_process';
+import { createExtractorFromData } from 'node-unrar-js';
+import { path7za as bundled7zaPath } from '7zip-bin';
 
 /**
- * Find 7z executable path on Windows, checking common installation paths
+ * Resolve a node_modules binary path to its asar.unpacked location when packaged.
+ * electron-builder rewrites __dirname inside the asar, so bundled binaries
+ * (which must be executable on disk) live at app.asar.unpacked instead.
+ */
+function resolveUnpackedPath(p: string): string {
+    return p.replace(/app\.asar([\\/])/, 'app.asar.unpacked$1');
+}
+
+/**
+ * Find 7z executable paths, preferring the bundled binary over system installs.
  */
 function find7zPath(): string[] {
     const candidates: string[] = [];
 
-    // Check common Windows installation paths first
+    // 1. Bundled 7za (ships with the app, no user install required)
+    const bundled = resolveUnpackedPath(bundled7zaPath);
+    if (existsSync(bundled)) {
+        candidates.push(bundled);
+    }
+
+    // 2. Common Windows install paths (faster for huge archives)
     const windowsPaths = [
         'C:\\Program Files\\7-Zip\\7z.exe',
         'C:\\Program Files (x86)\\7-Zip\\7z.exe',
     ];
-
     for (const p of windowsPaths) {
         if (existsSync(p)) {
             candidates.push(p);
         }
     }
 
-    // Also try PATH-based commands as fallback
+    // 3. PATH fallback
     candidates.push('7z', '7za');
 
     return candidates;
@@ -85,14 +101,12 @@ function extractZip(archivePath: string, destDir: string): string[] {
 }
 
 /**
- * Extract a 7z archive using system 7z command
+ * Extract a 7z archive using the bundled 7za binary (falls back to system 7z).
  */
 async function extract7z(archivePath: string, destDir: string): Promise<string[]> {
-    // Create temp directory for extraction
     const tempDir = createTempDir('modmanager-7z');
 
     try {
-        // Try common 7z paths (Windows install dirs + PATH fallback)
         for (const tool of find7zPath()) {
             try {
                 await runCommand(tool, ['x', '-y', `-o${tempDir}`, archivePath]);
@@ -105,10 +119,9 @@ async function extract7z(archivePath: string, destDir: string): Promise<string[]
         }
 
         throw new Error(
-            "Failed to extract 7z. Install '7z' (p7zip-full) or '7za' and try again."
+            "Failed to extract 7z archive. The bundled extractor failed and no system 7-Zip was found. Please install 7-Zip from https://7-zip.org and try again."
         );
     } finally {
-        // Cleanup temp directory
         try {
             rmDirRecursive(tempDir);
         } catch {
@@ -118,13 +131,43 @@ async function extract7z(archivePath: string, destDir: string): Promise<string[]
 }
 
 /**
- * Extract a RAR archive using system unrar or 7z command
+ * Extract a RAR archive. Uses node-unrar-js (pure JS, no external binary) by
+ * default; falls back to the bundled 7za or system unrar if the in-process
+ * extractor fails (e.g. RAR5-specific features it can't handle).
  */
 async function extractRar(archivePath: string, destDir: string): Promise<string[]> {
-    const tempDir = createTempDir('modmanager-rar');
-
+    // Primary path: pure-JS in-process RAR extractor (no install required).
     try {
-        // Try common 7z paths, then unrar as fallback
+        const data = readFileSync(archivePath);
+        // Create an ArrayBuffer copy (node-unrar-js expects ArrayBuffer, not Buffer)
+        const ab = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+        const extractor = await createExtractorFromData({ data: ab });
+
+        const extracted = extractor.extract({
+            files: (header) => !header.flags.directory && extname(header.name).toLowerCase() === '.vpk',
+        });
+
+        const extractedVpks: string[] = [];
+        for (const file of extracted.files) {
+            if (!file.extraction) continue;
+            const fileName = basename(file.fileHeader.name);
+            const destPath = join(destDir, fileName);
+            writeFileSync(destPath, Buffer.from(file.extraction));
+            extractedVpks.push(destPath);
+        }
+
+        if (extractedVpks.length > 0) {
+            return extractedVpks;
+        }
+        // No VPKs found via in-process — fall through to 7za/unrar in case of
+        // odd RAR5 solid archives that node-unrar-js can't iterate.
+    } catch (err) {
+        console.warn('[extractRar] node-unrar-js failed, falling back to system tools:', err);
+    }
+
+    // Fallback path: bundled 7za, system 7z, or system unrar.
+    const tempDir = createTempDir('modmanager-rar');
+    try {
         for (const tool of [...find7zPath(), 'unrar']) {
             try {
                 if (tool === 'unrar') {
@@ -141,7 +184,7 @@ async function extractRar(archivePath: string, destDir: string): Promise<string[
         }
 
         throw new Error(
-            "RAR extraction failed. Install '7z' or 'unrar' and try again."
+            "RAR extraction failed. The bundled extractor could not read this archive. Please install 7-Zip from https://7-zip.org and try again."
         );
     } finally {
         try {
@@ -267,8 +310,6 @@ function rmDirRecursive(dir: string): void {
         }
     }
 
-    // Remove the directory itself
-    const { rmdirSync } = require('fs');
     rmdirSync(dir);
 }
 

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -4,6 +4,7 @@ import { getMetadataPath } from '../utils/paths';
 export interface ModMetadata {
     modName?: string;      // The human-readable mod name from GameBanana
     thumbnailUrl?: string;
+    audioUrl?: string;     // GameBanana audio preview URL (Sound mods)
     gameBananaId?: number;
     gameBananaFileId?: number; // The specific file ID that was downloaded
     categoryId?: number;

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -23,6 +23,7 @@ export interface Mod {
     installedAt: string;
     description?: string;
     thumbnailUrl?: string;
+    audioUrl?: string;
     gameBananaId?: number;
     gameBananaFileId?: number;
     categoryId?: number;

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -389,6 +389,7 @@ interface DownloadErrorData {
     fileId: number;
     errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
     message: string;
+    helpUrl?: string;
 }
 
 interface DownloadQueueItem {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "package:mac": "electron-vite build && electron-builder --mac"
   },
   "dependencies": {
+    "7zip-bin": "^5.2.0",
     "@compai/font-unifraktur-maguntia": "^0.0.3",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      7zip-bin:
+        specifier: ^5.2.0
+        version: 5.2.0
       '@compai/font-unifraktur-maguntia':
         specifier: ^0.0.3
         version: 0.0.3
@@ -587,56 +590,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -709,24 +723,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1581,7 +1599,7 @@ packages:
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -1848,24 +1866,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -84,6 +84,27 @@ function flattenCategories(
   return results;
 }
 
+// Render an error string with any embedded https:// URLs as clickable links.
+function renderErrorWithLinks(text: string): React.ReactNode {
+  const parts = text.split(/(https?:\/\/[^\s)]+)/g);
+  return parts.map((part, i) => {
+    if (/^https?:\/\//.test(part)) {
+      return (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="underline text-accent hover:text-accent-hover"
+        >
+          {part}
+        </a>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
 function findCategoryByName(
   nodes: GameBananaCategoryNode[],
   name: string
@@ -460,8 +481,11 @@ export default function Browse() {
         setDownloading(null);
         setDownloadProgress(null);
         setExtracting(false);
-        // Show user-friendly error message
-        setError(data.message);
+        const fullMessage =
+          data.helpUrl && !data.message.includes(data.helpUrl)
+            ? `${data.message} ${data.helpUrl}`
+            : data.message;
+        setError(fullMessage);
       }
     });
 
@@ -883,7 +907,7 @@ export default function Browse() {
           </div>
         ) : error ? (
           <div className="flex flex-col items-center justify-center h-full text-text-secondary">
-            <p className="text-red-400">{error}</p>
+            <p className="text-red-400 max-w-xl text-center">{renderErrorWithLinks(error)}</p>
             <button
               onClick={fetchMods}
               className="mt-4 px-4 py-2 bg-accent hover:bg-accent-hover text-white rounded-lg transition-colors cursor-pointer"

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -20,6 +20,7 @@ import { getActiveDeadlockPath } from '../lib/appSettings';
 import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import ModThumbnail from '../components/ModThumbnail';
+import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { Button } from '../components/common/ui';
 import { PageHeader, ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
 
@@ -46,6 +47,7 @@ export default function Installed() {
     deleteMod,
     reorderMods,
     importCustomMod,
+    soundVolume,
   } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
@@ -256,6 +258,7 @@ export default function Installed() {
                 viewMode={viewMode}
                 hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
                 conflicts={conflictMap.get(mod.id) || []}
+                soundVolume={soundVolume}
                 onToggle={() => toggleMod(mod.id)}
                 onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
                 draggable
@@ -305,6 +308,7 @@ export default function Installed() {
                 viewMode={viewMode}
                 hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
                 conflicts={conflictMap.get(mod.id) || []}
+                soundVolume={soundVolume}
                 onToggle={() => toggleMod(mod.id)}
                 onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
                 draggable={false}
@@ -351,11 +355,14 @@ interface ModCardProps {
     priority: number;
     size: number;
     thumbnailUrl?: string;
+    audioUrl?: string;
+    sourceSection?: string;
     nsfw?: boolean;
   };
   viewMode: ViewMode;
   hideNsfwPreviews: boolean;
   conflicts: ModConflict[];
+  soundVolume: number;
   onToggle: () => void;
   onDelete: () => void;
   draggable?: boolean;
@@ -374,6 +381,7 @@ function ModCard({
   viewMode,
   hideNsfwPreviews,
   conflicts,
+  soundVolume,
   onToggle,
   onDelete,
   draggable,
@@ -538,6 +546,10 @@ function ModCard({
           <Trash2 className="w-5 h-5" />
         </button>
       </div>
+
+      {mod.sourceSection === 'Sound' && mod.audioUrl && viewMode === 'grid' && (
+        <AudioPreviewPlayer src={mod.audioUrl} compact volume={soundVolume} className="w-full" />
+      )}
     </div>
   );
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -103,6 +103,7 @@ export interface DownloadErrorData {
     fileId: number;
     errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
     message: string;
+    helpUrl?: string;
 }
 
 export interface DownloadQueueItem {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -9,6 +9,7 @@ export interface Mod {
   installedAt: string;
   description?: string;
   thumbnailUrl?: string;
+  audioUrl?: string;
   gameBananaId?: number;
   gameBananaFileId?: number;
   categoryId?: number;


### PR DESCRIPTION
## Summary
- **Fixes extraction for users without 7-Zip installed** (the blocker normies are hitting). RAR now uses `node-unrar-js` (pure JS, already in `package.json` + `asarUnpack`) in-process first; `.7z` uses bundled `7zip-bin`. System `7z`/`unrar` remain as fallbacks for power users.
- **Better error surface**: `download-error` IPC now carries a `helpUrl`; Browse renders any URLs in the error banner as clickable links so the 7-Zip download page is one click away if the bundled extractors ever fail.
- **Audio play button on installed Sound mods**: `audioUrl` is now persisted at download time and rendered via the existing `AudioPreviewPlayer` on installed grid cards (`sourceSection === 'Sound'`). Shares the same global `soundVolume` used on Browse.

Deliberately **not** grouping multi-pak mods (Part 2 of the original plan) — the migration cost on already-installed mods isn't worth it for most users.

## Test plan
- [ ] Fresh machine without 7-Zip installed: download a `.rar` mod (e.g. "Taiki Shuttle over Holliday"). Extraction should succeed without any error dialog.
- [ ] Same machine: download a `.7z` mod (e.g. "Smart Falcon voice over Celeste"). Extraction should succeed.
- [ ] Simulate extractor failure (corrupt archive): confirm the error banner in Browse shows the 7-Zip link as a clickable anchor.
- [ ] Download a Sound-section mod. On the Installed page (grid view), confirm the audio player renders below the mod card and plays when clicked.
- [ ] Legacy installed sound mods (downloaded before this change) should render without a player — no regression.
- [ ] Machine with 7-Zip installed: system binary still works (power-user fallback path).
- [ ] Packaged build (`pnpm package:win`): `7zip-bin` binaries end up in `app.asar.unpacked/node_modules/7zip-bin/win/x64/7za.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)