### PR TITLE
feat(ui): skeleton loaders in locker + redesigned mod overlay

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -7,6 +7,11 @@ import {
   ExternalLink,
   AlertTriangle,
   Clock,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  FileArchive,
+  CheckCircle2,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type { GameBananaModDetails, GameBananaComment } from '../types/gamebanana';
@@ -14,6 +19,7 @@ import { isModOutdated, formatDate } from '../types/gamebanana';
 import { getModComments } from '../lib/api';
 import ModThumbnail from './ModThumbnail';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
+import { Skeleton } from './common/Skeleton';
 
 interface ModDetailsModalProps {
   mod: GameBananaModDetails;
@@ -84,10 +90,15 @@ export default function ModDetailsModal({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
+      if (images.length > 1) {
+        if (e.key === 'ArrowLeft') goToPrevious();
+        if (e.key === 'ArrowRight') goToNext();
+      }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onClose, images.length]);
 
   const currentImage = images[currentImageIndex];
   const currentImageUrl = currentImage
@@ -108,274 +119,363 @@ export default function ModDetailsModal({
     return 'Install';
   };
 
+  const totalDownloads = (mod.files ?? []).reduce((sum, f) => sum + f.downloadCount, 0);
+  const outdated = dateModified ? isModOutdated(dateModified) : false;
+
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-fade-in"
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 z-50 animate-fade-in"
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={mod.name}
     >
       <div
-        className="bg-bg-secondary rounded-lg max-w-2xl w-full max-h-[80vh] overflow-auto"
+        className="relative bg-bg-secondary rounded-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col border border-border shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="sticky top-0 bg-bg-secondary border-b border-border p-4 flex items-center justify-between">
-          <div className="flex items-center gap-2 min-w-0">
-            <h2 className="text-xl font-bold truncate">{mod.name}</h2>
-            {updateAvailable && (
-              <span className="rounded-full bg-accent/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
-                Update Available
-              </span>
-            )}
-            {installed && !updateAvailable && (
-              <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
-                Installed
-              </span>
-            )}
-          </div>
-          <button
-            onClick={onClose}
-            className="p-2 hover:bg-bg-tertiary rounded-lg transition-colors cursor-pointer"
-          >
-            ✕
-          </button>
-        </div>
+        {/* Close button — floats over the hero so it's always reachable */}
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute top-3 right-3 z-20 p-2 rounded-full bg-black/60 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/10 transition-colors cursor-pointer"
+        >
+          <X className="w-4 h-4" />
+        </button>
 
-        {dateModified && isModOutdated(dateModified) && (
-          <div className="mx-4 mt-4 flex items-center gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-yellow-200 text-sm">
-            <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0" />
-            <span>This mod was last updated on {formatDate(dateModified)} and may not be compatible with the current version of Deadlock.</span>
+        {/* Hero area: image carousel with title overlay */}
+        {images.length > 0 ? (
+          <div className="relative w-full aspect-[16/9] max-h-[45vh] bg-black flex-shrink-0 overflow-hidden">
+            <ModThumbnail
+              src={currentImageUrl}
+              alt={`${mod.name} - Image ${currentImageIndex + 1}`}
+              nsfw={mod.nsfw}
+              hideNsfw={hideNsfwPreviews}
+              className={`w-full h-full object-contain transition-opacity duration-200 ${imageLoading ? 'opacity-0' : 'opacity-100'}`}
+            />
+            {/* Hidden probe img drives load/error signal */}
+            {currentImageUrl && (
+              <img
+                key={currentImageUrl}
+                ref={(el) => {
+                  if (el && el.complete && el.naturalWidth > 0) {
+                    setImageLoading(false);
+                  }
+                }}
+                src={currentImageUrl}
+                alt=""
+                aria-hidden
+                className="hidden"
+                onLoad={() => setImageLoading(false)}
+                onError={() => setImageLoading(false)}
+              />
+            )}
+            {imageLoading && (
+              <Skeleton className="absolute inset-0" rounded="none" />
+            )}
+
+            {/* Bottom gradient for title readability */}
+            <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-black/95 via-black/60 to-transparent pointer-events-none" />
+
+            {/* Carousel controls */}
+            {images.length > 1 && (
+              <>
+                <button
+                  onClick={goToPrevious}
+                  aria-label="Previous image"
+                  className="absolute left-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer backdrop-blur-sm border border-white/10"
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                </button>
+                <button
+                  onClick={goToNext}
+                  aria-label="Next image"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer backdrop-blur-sm border border-white/10"
+                >
+                  <ChevronRight className="w-5 h-5" />
+                </button>
+                <div className="absolute top-3 left-3 px-2 py-1 rounded-md bg-black/60 backdrop-blur-sm text-white/90 text-xs border border-white/10">
+                  {currentImageIndex + 1} / {images.length}
+                </div>
+                <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 z-10">
+                  {images.map((_, index) => (
+                    <button
+                      key={index}
+                      onClick={() => setCurrentImageIndex(index)}
+                      className={`h-1.5 rounded-full transition-all cursor-pointer ${
+                        index === currentImageIndex
+                          ? 'w-6 bg-white'
+                          : 'w-1.5 bg-white/40 hover:bg-white/60'
+                      }`}
+                      aria-label={`Go to image ${index + 1}`}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {/* Title + badges overlay */}
+            <div className="absolute inset-x-0 bottom-0 p-5 flex items-end justify-between gap-4 z-[5]">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap mb-1.5">
+                  {updateAvailable && (
+                    <span className="rounded-full bg-accent/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent border border-accent/40">
+                      Update Available
+                    </span>
+                  )}
+                  {installed && !updateAvailable && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-500/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-300 border border-green-500/40">
+                      <CheckCircle2 className="w-2.5 h-2.5" />
+                      Installed
+                    </span>
+                  )}
+                  {outdated && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-300 border border-yellow-500/40">
+                      <AlertTriangle className="w-2.5 h-2.5" />
+                      Outdated
+                    </span>
+                  )}
+                </div>
+                <h2 className="text-2xl font-bold text-white leading-tight drop-shadow-lg truncate">
+                  {mod.name}
+                </h2>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="p-6 border-b border-border flex-shrink-0">
+            <div className="flex items-center gap-2 flex-wrap mb-2">
+              {updateAvailable && (
+                <span className="rounded-full bg-accent/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+                  Update Available
+                </span>
+              )}
+              {installed && !updateAvailable && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
+                  <CheckCircle2 className="w-2.5 h-2.5" />
+                  Installed
+                </span>
+              )}
+            </div>
+            <h2 className="text-2xl font-bold">{mod.name}</h2>
           </div>
         )}
 
-        <div className="p-4 space-y-4">
-          {(dateAdded || dateModified) && (
-            <div className="flex items-center gap-4 text-xs text-text-secondary">
-              {dateAdded && dateAdded > 0 && (
-                <span className="flex items-center gap-1">
-                  <Clock className="w-3 h-3" />
-                  Added: {formatDate(dateAdded)}
-                </span>
-              )}
-              {dateModified && dateModified > 0 && (
-                <span className={`flex items-center gap-1 ${isModOutdated(dateModified) ? 'text-yellow-400' : ''}`}>
-                  <Clock className="w-3 h-3" />
-                  Updated: {formatDate(dateModified)}
-                </span>
-              )}
-            </div>
-          )}
-
-          {images.length > 0 && (
-            <div className="relative w-full rounded-lg overflow-hidden border border-border">
-              <div className="relative">
-                <ModThumbnail
-                  src={currentImageUrl}
-                  alt={`${mod.name} - Image ${currentImageIndex + 1}`}
-                  nsfw={mod.nsfw}
-                  hideNsfw={hideNsfwPreviews}
-                  className={`w-full max-h-[60vh] object-contain bg-bg-tertiary transition-opacity duration-200 ${imageLoading ? 'opacity-40' : 'opacity-100'}`}
-                />
-                {/* Hidden probe img drives the load/error signal without
-                    requiring ModThumbnail to expose onLoad. The ref callback
-                    checks img.complete on attach so already-cached images
-                    never flash the loading overlay. */}
-                {currentImageUrl && (
-                  <img
-                    key={currentImageUrl}
-                    ref={(el) => {
-                      if (el && el.complete && el.naturalWidth > 0) {
-                        setImageLoading(false);
-                      }
-                    }}
-                    src={currentImageUrl}
-                    alt=""
-                    aria-hidden
-                    className="hidden"
-                    onLoad={() => setImageLoading(false)}
-                    onError={() => setImageLoading(false)}
-                  />
-                )}
-                {imageLoading && (
-                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                    <div className="flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-sm px-3 py-1.5 text-xs text-white/90 border border-white/10 shadow animate-fade-in">
-                      <Loader2 className="w-4 h-4 animate-spin text-accent" />
-                      Loading image…
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {images.length > 1 && (
-                <>
-                  <button
-                    onClick={goToPrevious}
-                    className="absolute left-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer"
-                    aria-label="Previous image"
-                  >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                    </svg>
-                  </button>
-                  <button
-                    onClick={goToNext}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer"
-                    aria-label="Next image"
-                  >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </button>
-
-                  <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1.5">
-                    {images.map((_, index) => (
-                      <button
-                        key={index}
-                        onClick={() => setCurrentImageIndex(index)}
-                        className={`w-2 h-2 rounded-full transition-colors cursor-pointer ${index === currentImageIndex
-                          ? 'bg-white'
-                          : 'bg-white/40 hover:bg-white/60'
-                          }`}
-                        aria-label={`Go to image ${index + 1}`}
-                      />
-                    ))}
-                  </div>
-
-                  <div className="absolute top-2 right-2 px-2 py-1 rounded bg-black/50 text-white/80 text-xs">
-                    {currentImageIndex + 1} / {images.length}
-                  </div>
-                </>
-              )}
-            </div>
-          )}
-
-          {audioPreviewUrl && (
-            <div className="relative rounded-lg overflow-hidden border border-border bg-gradient-to-br from-bg-tertiary via-bg-secondary to-bg-tertiary p-4">
-              <div className="flex items-center gap-3 mb-3">
-                <Volume2 className="w-5 h-5 text-accent" />
-                <h3 className="font-medium text-text-primary">Audio Preview</h3>
-              </div>
-              <div className="flex items-end justify-center gap-0.5 mb-3 h-12">
-                {[3, 5, 8, 12, 16, 20, 16, 12, 18, 14, 10, 6, 9, 14, 18, 14, 11, 7, 4, 6, 10, 14, 18, 14, 8, 5, 3].map((h, i) => (
-                  <div
-                    key={i}
-                    className="w-1.5 bg-accent/50 rounded-full transition-all"
-                    style={{ height: `${h * 2}px` }}
-                  />
-                ))}
-              </div>
-              <div className="backdrop-blur-md bg-bg-primary/50 rounded-lg border border-white/10 p-1">
-                <AudioPreviewPlayer
-                  src={audioPreviewUrl}
-                  className="w-full"
-                />
-              </div>
-            </div>
-          )}
-
-          {section === 'Sound' && !audioPreviewUrl && images.length === 0 && (
-            <div className="flex items-center justify-center p-8 rounded-lg border border-border bg-bg-tertiary">
-              <div className="flex flex-col items-center gap-2 text-text-secondary">
-                <Volume2 className="w-12 h-12 text-accent/60" />
-                <span className="text-sm">Sound Mod</span>
-                <span className="text-xs opacity-60">No audio preview available</span>
-              </div>
-            </div>
-          )}
-
-          {mod.description && (
-            <div className="text-sm text-text-secondary">
-              <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(mod.description) }} />
-            </div>
-          )}
-
-          {mod.files && mod.files.length > 0 && (
-            <div className="space-y-2">
-              <h3 className="font-medium">Files</h3>
-              {mod.files.map((file) => (
-                <div
-                  key={file.id}
-                  className="flex items-center justify-between p-3 bg-bg-tertiary rounded-lg"
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="font-medium truncate">{file.fileName}</p>
-                    <p className="text-xs text-text-secondary">
-                      {(file.fileSize / 1024 / 1024).toFixed(2)} MB •{' '}
-                      {file.downloadCount.toLocaleString()} downloads
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => onDownload(file.id, file.fileName)}
-                    disabled={downloadingFileId !== null}
-                    className="flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors ml-4 cursor-pointer"
-                  >
-                    {downloadingFileId === file.id ? (
-                      <>
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                        {extracting
-                          ? 'Extracting...'
-                          : progress && progress.total > 0
-                            ? `${Math.round((progress.downloaded / progress.total) * 100)}%`
-                            : 'Downloading...'}
-                      </>
-                    ) : (
-                      <>
-                        <Download className="w-4 h-4" />
-                        {actionLabel(file.id)}
-                      </>
-                    )}
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <h3 className="font-medium flex items-center gap-2">
-              <MessageSquare className="w-4 h-4" />
-              Comments {commentsTotalCount > 0 && <span className="text-xs text-text-secondary">({commentsTotalCount})</span>}
-            </h3>
-            {commentsLoading ? (
-              <div className="flex items-center gap-2 text-text-secondary text-sm py-2">
-                <Loader2 className="w-4 h-4 animate-spin" />
-                Loading comments...
-              </div>
-            ) : comments.length === 0 ? (
-              <p className="text-sm text-text-secondary py-2">No comments yet</p>
-            ) : (
-              <div className="space-y-3 max-h-80 overflow-y-auto">
-                {comments.map((comment) => (
-                  <div key={comment.id} className="flex gap-3 p-3 bg-bg-tertiary rounded-lg">
-                    {comment.poster.avatarUrl && (
-                      <img
-                        src={comment.poster.avatarUrl}
-                        alt={comment.poster.name}
-                        className="w-8 h-8 rounded-full flex-shrink-0"
-                      />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-sm font-medium">{comment.poster.name}</span>
-                        <span className="text-[11px] text-text-secondary">{formatDate(comment.dateAdded)}</span>
-                      </div>
-                      <div
-                        className="text-sm text-text-secondary [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
-                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
+        {/* Metadata strip */}
+        {(dateAdded || dateModified || totalDownloads > 0) && (
+          <div className="flex items-center gap-4 px-5 py-3 border-b border-border bg-bg-primary/30 text-xs text-text-secondary flex-shrink-0 flex-wrap">
+            {dateAdded && dateAdded > 0 && (
+              <span className="flex items-center gap-1.5">
+                <Clock className="w-3 h-3" />
+                Added <span className="text-text-primary">{formatDate(dateAdded)}</span>
+              </span>
+            )}
+            {dateModified && dateModified > 0 && (
+              <span className={`flex items-center gap-1.5 ${outdated ? 'text-yellow-400' : ''}`}>
+                <Clock className="w-3 h-3" />
+                Updated <span className={outdated ? 'text-yellow-300' : 'text-text-primary'}>{formatDate(dateModified)}</span>
+              </span>
+            )}
+            {totalDownloads > 0 && (
+              <span className="flex items-center gap-1.5">
+                <Download className="w-3 h-3" />
+                <span className="text-text-primary">{totalDownloads.toLocaleString()}</span> downloads
+              </span>
             )}
           </div>
+        )}
 
-          <a
-            href={`https://gamebanana.com/mods/${mod.id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
-          >
-            <ExternalLink className="w-4 h-4" />
-            View on GameBanana
-          </a>
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="p-5 space-y-5">
+            {outdated && (
+              <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2.5 text-yellow-200 text-sm">
+                <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" />
+                <span>This mod was last updated on {formatDate(dateModified!)} and may not be compatible with the current version of Deadlock.</span>
+              </div>
+            )}
+
+            {audioPreviewUrl && (
+              <div className="relative rounded-lg overflow-hidden border border-border bg-gradient-to-br from-bg-tertiary via-bg-secondary to-bg-tertiary p-4">
+                <div className="flex items-center gap-3 mb-3">
+                  <Volume2 className="w-5 h-5 text-accent" />
+                  <h3 className="font-medium text-text-primary">Audio Preview</h3>
+                </div>
+                <div className="flex items-end justify-center gap-0.5 mb-3 h-12">
+                  {[3, 5, 8, 12, 16, 20, 16, 12, 18, 14, 10, 6, 9, 14, 18, 14, 11, 7, 4, 6, 10, 14, 18, 14, 8, 5, 3].map((h, i) => (
+                    <div
+                      key={i}
+                      className="w-1.5 bg-accent/50 rounded-full transition-all"
+                      style={{ height: `${h * 2}px` }}
+                    />
+                  ))}
+                </div>
+                <div className="backdrop-blur-md bg-bg-primary/50 rounded-lg border border-white/10 p-1">
+                  <AudioPreviewPlayer
+                    src={audioPreviewUrl}
+                    className="w-full"
+                  />
+                </div>
+              </div>
+            )}
+
+            {section === 'Sound' && !audioPreviewUrl && images.length === 0 && (
+              <div className="flex items-center justify-center p-8 rounded-lg border border-border bg-bg-tertiary">
+                <div className="flex flex-col items-center gap-2 text-text-secondary">
+                  <Volume2 className="w-12 h-12 text-accent/60" />
+                  <span className="text-sm">Sound Mod</span>
+                  <span className="text-xs opacity-60">No audio preview available</span>
+                </div>
+              </div>
+            )}
+
+            {mod.description && (
+              <div className="text-sm text-text-secondary [&_p]:mb-2 [&_a]:text-accent [&_a]:hover:underline [&_img]:rounded-md [&_img]:my-2">
+                <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(mod.description) }} />
+              </div>
+            )}
+
+            {mod.files && mod.files.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="font-semibold text-sm uppercase tracking-wide text-text-secondary">
+                  Files {mod.files.length > 1 && <span className="text-text-secondary/70 normal-case tracking-normal">({mod.files.length})</span>}
+                </h3>
+                <div className="space-y-2">
+                  {mod.files.map((file) => {
+                    const isInstalled = installedFileIds.has(file.id);
+                    const isUpdate = updateAvailable && isInstalled;
+                    const isDownloadingThis = downloadingFileId === file.id;
+                    const pct = progress && progress.total > 0
+                      ? Math.round((progress.downloaded / progress.total) * 100)
+                      : null;
+                    return (
+                      <div
+                        key={file.id}
+                        className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                          isUpdate
+                            ? 'border-accent/40 bg-accent/5'
+                            : isInstalled
+                              ? 'border-green-500/30 bg-green-500/5'
+                              : 'border-border bg-bg-tertiary'
+                        }`}
+                      >
+                        <div className={`flex-shrink-0 w-10 h-10 rounded-md flex items-center justify-center ${
+                          isUpdate
+                            ? 'bg-accent/15 text-accent'
+                            : isInstalled
+                              ? 'bg-green-500/15 text-green-400'
+                              : 'bg-bg-secondary text-text-secondary'
+                        }`}>
+                          <FileArchive className="w-5 h-5" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
+                          <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
+                            <span>{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
+                            <span className="opacity-50">•</span>
+                            <span>{file.downloadCount.toLocaleString()} downloads</span>
+                          </div>
+                          {isDownloadingThis && pct !== null && (
+                            <div className="mt-2 h-1 w-full rounded-full bg-bg-secondary overflow-hidden">
+                              <div
+                                className="h-full bg-accent transition-all duration-200"
+                                style={{ width: `${pct}%` }}
+                              />
+                            </div>
+                          )}
+                        </div>
+                        <button
+                          onClick={() => onDownload(file.id, file.fileName)}
+                          disabled={downloadingFileId !== null}
+                          className={`flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2 min-w-[110px] text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
+                            isUpdate
+                              ? 'bg-accent hover:bg-accent-hover text-white'
+                              : isInstalled
+                                ? 'bg-bg-secondary hover:bg-bg-primary text-text-primary border border-border'
+                                : 'bg-accent hover:bg-accent-hover text-white'
+                          }`}
+                        >
+                          {isDownloadingThis ? (
+                            <>
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                              {extracting ? 'Extracting…' : pct !== null ? `${pct}%` : 'Starting'}
+                            </>
+                          ) : (
+                            <>
+                              <Download className="w-4 h-4" />
+                              {actionLabel(file.id)}
+                            </>
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <h3 className="font-semibold text-sm uppercase tracking-wide text-text-secondary flex items-center gap-2">
+                <MessageSquare className="w-4 h-4" />
+                Comments {commentsTotalCount > 0 && <span className="normal-case tracking-normal text-text-secondary/70">({commentsTotalCount})</span>}
+              </h3>
+              {commentsLoading ? (
+                <div className="space-y-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="flex gap-3 p-3 bg-bg-tertiary rounded-lg">
+                      <Skeleton className="w-8 h-8 flex-shrink-0" rounded="full" />
+                      <div className="flex-1 space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Skeleton className="h-3 w-24" />
+                          <Skeleton className="h-2.5 w-16" />
+                        </div>
+                        <Skeleton className="h-2.5 w-full" />
+                        <Skeleton className="h-2.5 w-2/3" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : comments.length === 0 ? (
+                <p className="text-sm text-text-secondary py-2">No comments yet</p>
+              ) : (
+                <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+                  {comments.map((comment) => (
+                    <div key={comment.id} className="flex gap-3 p-3 bg-bg-tertiary rounded-lg">
+                      {comment.poster.avatarUrl ? (
+                        <img
+                          src={comment.poster.avatarUrl}
+                          alt={comment.poster.name}
+                          className="w-8 h-8 rounded-full flex-shrink-0"
+                        />
+                      ) : (
+                        <div className="w-8 h-8 rounded-full flex-shrink-0 bg-bg-secondary" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-sm font-medium">{comment.poster.name}</span>
+                          <span className="text-[11px] text-text-secondary">{formatDate(comment.dateAdded)}</span>
+                        </div>
+                        <div
+                          className="text-sm text-text-secondary [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
+                          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <a
+              href={`https://gamebanana.com/mods/${mod.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
+            >
+              <ExternalLink className="w-4 h-4" />
+              View on GameBanana
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,45 @@
+import { type CSSProperties } from 'react';
+
+interface SkeletonProps {
+  className?: string;
+  style?: CSSProperties;
+  rounded?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+}
+
+const roundedClass: Record<NonNullable<SkeletonProps['rounded']>, string> = {
+  none: '',
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  full: 'rounded-full',
+};
+
+export function Skeleton({ className = '', style, rounded = 'md' }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden
+      className={`bg-bg-tertiary skeleton-shimmer ${roundedClass[rounded]} ${className}`}
+      style={style}
+    />
+  );
+}
+
+interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+  lineClassName?: string;
+}
+
+export function SkeletonText({ lines = 3, className = '', lineClassName = '' }: SkeletonTextProps) {
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className={`h-3 ${i === lines - 1 ? 'w-2/3' : 'w-full'} ${lineClassName}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/locker/DownloadableSkinsSection.tsx
+++ b/src/components/locker/DownloadableSkinsSection.tsx
@@ -6,6 +6,7 @@ import { getModThumbnail, getPrimaryFile, formatDate, isModOutdated } from '../.
 import type { CachedMod } from '../../types/electron';
 import type { GameBananaMod } from '../../types/gamebanana';
 import ModThumbnail from '../ModThumbnail';
+import { Skeleton } from '../common/Skeleton';
 import { useAppStore } from '../../stores/appStore';
 
 interface DownloadableSkinsSectionProps {
@@ -345,9 +346,28 @@ export default function DownloadableSkinsSection({
 
             <div className="flex-1 overflow-y-auto p-5">
               {loadState === 'loading' && (
-                <div className="flex flex-col items-center justify-center py-16 gap-3">
-                  <Loader2 className="w-8 h-8 animate-spin text-accent" />
-                  <span className="text-sm text-text-secondary">Loading skins…</span>
+                <div
+                  className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4"
+                  aria-busy="true"
+                  aria-live="polite"
+                >
+                  {Array.from({ length: 8 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="flex flex-col gap-2 p-2 bg-bg-tertiary rounded-lg border border-transparent"
+                    >
+                      <Skeleton className="aspect-video w-full" rounded="md" />
+                      <div className="space-y-1.5">
+                        <Skeleton className="h-3 w-full" />
+                        <Skeleton className="h-3 w-3/4" />
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <Skeleton className="h-2.5 w-1/3" />
+                        <Skeleton className="h-2.5 w-1/4" />
+                      </div>
+                      <Skeleton className="h-7 w-full" rounded="md" />
+                    </div>
+                  ))}
                 </div>
               )}
 

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -2,6 +2,7 @@ import type { Mod } from '../../types/mod';
 import type { MinaPreset, MinaSelection, MinaVariant } from '../../lib/lockerUtils';
 import ModThumbnail from '../ModThumbnail';
 import DownloadableSkinsSection from './DownloadableSkinsSection';
+import { Skeleton } from '../common/Skeleton';
 
 interface HeroSkinsPanelProps {
   mods: Mod[];
@@ -125,9 +126,12 @@ export default function HeroSkinsPanel({
               </button>
             </div>
           ) : minaArchivePath === 'Downloading...' ? (
-            <div className="flex items-center gap-2 text-xs text-text-secondary">
-              <div className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-              <span>Downloading variations archive... (this may take a few minutes)</span>
+            <div className="space-y-2" aria-busy="true" aria-live="polite">
+              <div className="flex items-center gap-2 text-xs text-text-secondary">
+                <div className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+                <span>Downloading variations archive... (this may take a few minutes)</span>
+              </div>
+              <Skeleton className="h-2 w-full" rounded="full" />
             </div>
           ) : (
             <>
@@ -155,6 +159,16 @@ export default function HeroSkinsPanel({
                     ? `${minaVariants.length} presets found`
                     : 'Click Load to scan for presets.'}
               </div>
+              {minaVariantsLoading && (
+                <div className="space-y-1.5" aria-busy="true">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <Skeleton className="h-6 w-6" rounded="sm" />
+                      <Skeleton className="h-2.5 flex-1" />
+                    </div>
+                  ))}
+                </div>
+              )}
             </>
           )}
           {minaVariantsError && <div className="text-xs text-red-400">{minaVariantsError}</div>}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -79,6 +79,7 @@ export default function Installed() {
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const [detailsUpdateAvailable, setDetailsUpdateAvailable] = useState(false);
   const [detailsInstalledFileIds, setDetailsInstalledFileIds] = useState<Set<number>>(new Set());
+  const [detailsDates, setDetailsDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   // Local id of the installed mod that triggered the overlay. On download we
   // delete this entry first so Update/Reinstall replaces the old VPK instead
   // of installing a second copy alongside it.
@@ -98,9 +99,16 @@ export default function Installed() {
     setDetailsSourceModId(m.id);
     setDetailsInstalledFileIds(m.gameBananaFileId ? new Set([m.gameBananaFileId]) : new Set());
     setDetailsUpdateAvailable(updatesAvailable.has(m.id));
+    setDetailsDates(null);
     try {
-      const details = await getModDetails(m.gameBananaId, section);
+      const [details, cached] = await Promise.all([
+        getModDetails(m.gameBananaId, section),
+        window.electronAPI.getCachedMod(m.gameBananaId).catch(() => null),
+      ]);
       setDetailsMod(details);
+      if (cached) {
+        setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
+      }
     } catch (err) {
       setDetailsError(String(err));
     } finally {
@@ -113,6 +121,7 @@ export default function Installed() {
     setDetailsError(null);
     setDetailsUpdateAvailable(false);
     setDetailsSourceModId(null);
+    setDetailsDates(null);
   };
 
   const handleDetailsDownload = async (fileId: number, fileName: string) => {
@@ -546,6 +555,8 @@ export default function Installed() {
           extracting={false}
           progress={null}
           hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          dateAdded={detailsDates?.dateAdded}
+          dateModified={detailsDates?.dateModified}
           updateAvailable={detailsUpdateAvailable}
           onClose={closeModDetails}
           onDownload={handleDetailsDownload}

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -834,32 +834,30 @@ function HeroGalleryCard({
       <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.06),_transparent_55%)] opacity-60 transition-opacity duration-300 group-hover:opacity-100" />
       <div className="relative aspect-[3/4]">
-        {renderSrc ? (
-          <>
-            {!renderLoaded && (
-              <div className="absolute inset-0 skeleton-shimmer bg-bg-tertiary" aria-hidden />
-            )}
-            <img
-              src={renderSrc}
-              alt={hero.name}
-              ref={(el) => {
-                if (el && el.complete && el.naturalWidth > 0 && !renderLoaded) {
-                  setRenderLoaded(true);
-                }
-              }}
-              className={`absolute inset-0 h-full w-full object-cover transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-[1.06] ${isActive ? 'scale-[1.12]' : 'scale-100'} ${renderLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity`}
-              style={{
-                objectPosition: `${facePositionX}% 20%`,
-                imageRendering: 'auto',
-                transform: isActive ? undefined : 'translateZ(0)',
-              }}
-              loading="lazy"
-              decoding="async"
-              onLoad={() => setRenderLoaded(true)}
-              onError={handleRenderError}
-            />
-          </>
-        ) : (
+        {/* Shimmer shows whenever the image hasn't decoded yet or we're
+            still waiting for the IntersectionObserver to reveal the card.
+            Always painted at least once because we don't short-circuit
+            onLoad based on img.complete — locally-bundled images would
+            otherwise skip the skeleton entirely. */}
+        {!renderLoaded && fallbackStep < 3 && (
+          <div className="absolute inset-0 skeleton-shimmer bg-bg-tertiary" aria-hidden />
+        )}
+        {renderSrc && fallbackStep < 3 && (
+          <img
+            src={renderSrc}
+            alt={hero.name}
+            className={`absolute inset-0 h-full w-full object-cover will-change-transform backface-visibility-hidden group-hover:scale-[1.06] ${isActive ? 'scale-[1.12]' : 'scale-100'} ${renderLoaded ? 'opacity-100' : 'opacity-0'} transition-[opacity,transform] duration-500`}
+            style={{
+              objectPosition: `${facePositionX}% 20%`,
+              imageRendering: 'auto',
+              transform: isActive ? undefined : 'translateZ(0)',
+            }}
+            decoding="async"
+            onLoad={() => setRenderLoaded(true)}
+            onError={handleRenderError}
+          />
+        )}
+        {fallbackStep === 3 && (
           <div className="absolute inset-0 flex items-center justify-center text-text-secondary">
             {hero.name}
           </div>
@@ -883,21 +881,15 @@ function HeroGalleryCard({
         {nameFailed ? (
           <div className="text-sm font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">{hero.name}</div>
         ) : (
-          <div className="relative w-[70%] h-6 sm:h-7">
+          <div className="relative w-[70%] h-6 sm:h-7 ml-auto">
             {!nameLoaded && (
-              <div className="absolute inset-0 skeleton-shimmer bg-bg-tertiary/40 rounded-sm ml-auto" aria-hidden />
+              <div className="absolute inset-0 skeleton-shimmer bg-white/10 rounded-sm" aria-hidden />
             )}
             <img
               src={namePath}
               alt={hero.name}
-              ref={(el) => {
-                if (el && el.complete && el.naturalWidth > 0 && !nameLoaded) {
-                  setNameLoaded(true);
-                }
-              }}
-              className={`w-full h-auto max-h-6 sm:max-h-7 object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-105 ${isActive ? 'scale-110' : 'scale-100'} ${nameLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity`}
+              className={`absolute inset-0 w-full h-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] will-change-transform backface-visibility-hidden group-hover:scale-105 ${isActive ? 'scale-110' : 'scale-100'} ${nameLoaded ? 'opacity-100' : 'opacity-0'} transition-[opacity,transform] duration-500`}
               style={{ transform: isActive ? undefined : 'translateZ(0)' }}
-              loading="lazy"
               decoding="async"
               onLoad={() => setNameLoaded(true)}
               onError={() => setNameFailed(true)}

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -767,6 +767,8 @@ function HeroGalleryCard({
   const [fallbackStep, setFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [renderLoaded, setRenderLoaded] = useState(false);
+  const [nameLoaded, setNameLoaded] = useState(false);
   const cardRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
@@ -800,6 +802,7 @@ function HeroGalleryCard({
   }, [isVisible, renderLocal]);
 
   const handleRenderError = () => {
+    setRenderLoaded(false);
     if (fallbackStep === 0) {
       setRenderSrc(wikiUrl);
       setFallbackStep(1);
@@ -832,20 +835,30 @@ function HeroGalleryCard({
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.06),_transparent_55%)] opacity-60 transition-opacity duration-300 group-hover:opacity-100" />
       <div className="relative aspect-[3/4]">
         {renderSrc ? (
-          <img
-            src={renderSrc}
-            alt={hero.name}
-            className={`absolute inset-0 h-full w-full object-cover transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-[1.06] ${isActive ? 'scale-[1.12]' : 'scale-100'
-              }`}
-            style={{
-              objectPosition: `${facePositionX}% 20%`,
-              imageRendering: 'auto',
-              transform: isActive ? undefined : 'translateZ(0)',
-            }}
-            loading="lazy"
-            decoding="async"
-            onError={handleRenderError}
-          />
+          <>
+            {!renderLoaded && (
+              <div className="absolute inset-0 skeleton-shimmer bg-bg-tertiary" aria-hidden />
+            )}
+            <img
+              src={renderSrc}
+              alt={hero.name}
+              ref={(el) => {
+                if (el && el.complete && el.naturalWidth > 0 && !renderLoaded) {
+                  setRenderLoaded(true);
+                }
+              }}
+              className={`absolute inset-0 h-full w-full object-cover transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-[1.06] ${isActive ? 'scale-[1.12]' : 'scale-100'} ${renderLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity`}
+              style={{
+                objectPosition: `${facePositionX}% 20%`,
+                imageRendering: 'auto',
+                transform: isActive ? undefined : 'translateZ(0)',
+              }}
+              loading="lazy"
+              decoding="async"
+              onLoad={() => setRenderLoaded(true)}
+              onError={handleRenderError}
+            />
+          </>
         ) : (
           <div className="absolute inset-0 flex items-center justify-center text-text-secondary">
             {hero.name}
@@ -870,16 +883,26 @@ function HeroGalleryCard({
         {nameFailed ? (
           <div className="text-sm font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">{hero.name}</div>
         ) : (
-          <img
-            src={namePath}
-            alt={hero.name}
-            className={`w-[70%] h-auto max-h-6 sm:max-h-7 object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-105 ${isActive ? 'scale-110' : 'scale-100'
-              }`}
-            style={{ transform: isActive ? undefined : 'translateZ(0)' }}
-            loading="lazy"
-            decoding="async"
-            onError={() => setNameFailed(true)}
-          />
+          <div className="relative w-[70%] h-6 sm:h-7">
+            {!nameLoaded && (
+              <div className="absolute inset-0 skeleton-shimmer bg-bg-tertiary/40 rounded-sm ml-auto" aria-hidden />
+            )}
+            <img
+              src={namePath}
+              alt={hero.name}
+              ref={(el) => {
+                if (el && el.complete && el.naturalWidth > 0 && !nameLoaded) {
+                  setNameLoaded(true);
+                }
+              }}
+              className={`w-full h-auto max-h-6 sm:max-h-7 object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] transition-transform duration-500 will-change-transform backface-visibility-hidden group-hover:scale-105 ${isActive ? 'scale-110' : 'scale-100'} ${nameLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity`}
+              style={{ transform: isActive ? undefined : 'translateZ(0)' }}
+              loading="lazy"
+              decoding="async"
+              onLoad={() => setNameLoaded(true)}
+              onError={() => setNameFailed(true)}
+            />
+          </div>
         )}
         {skinCount > 0 && (
           <div className="mt-1 text-[10px] text-white/70">

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -13,6 +13,7 @@ import ModThumbnail from '../components/ModThumbnail';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { Mod } from '../types/mod';
 import { PageHeader, ViewModeToggle, EmptyState, SectionHeader } from '../components/common/PageComponents';
+import { Skeleton } from '../components/common/Skeleton';
 import {
   MINA_ARCHIVE_DEFAULT,
   buildHeroList,
@@ -740,10 +741,11 @@ interface HeroGalleryCardProps {
 function HeroGallerySkeleton() {
   return (
     <div className="relative overflow-hidden rounded-2xl border border-border bg-bg-secondary">
-      <div className="relative aspect-[3/4] skeleton-shimmer bg-bg-tertiary" />
+      <Skeleton className="relative aspect-[3/4]" rounded="none" />
+      <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/70 to-transparent" />
       <div className="absolute bottom-0 left-0 right-0 p-3 space-y-1.5">
-        <div className="h-3 w-2/3 rounded bg-bg-tertiary skeleton-shimmer" />
-        <div className="h-2 w-1/3 rounded bg-bg-tertiary/80 skeleton-shimmer" />
+        <Skeleton className="h-3 w-2/3" rounded="sm" />
+        <Skeleton className="h-2 w-1/3" rounded="sm" />
       </div>
     </div>
   );

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Layers, Loader2, Star } from 'lucide-react';
+import { ArrowLeft, Layers, Star } from 'lucide-react';
+import { Skeleton } from '../components/common/Skeleton';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import {
@@ -220,11 +221,7 @@ export default function LockerHero() {
   }
 
   if (modsLoading || categoriesLoading) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <Loader2 className="w-8 h-8 animate-spin text-accent" />
-      </div>
-    );
+    return <LockerHeroSkeleton />;
   }
 
   if (modsError || categoriesError) {
@@ -359,6 +356,49 @@ export default function LockerHero() {
 
         {/* Bottom gradient for depth */}
         <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
+      </div>
+    </div>
+  );
+}
+
+function LockerHeroSkeleton() {
+  return (
+    <div className="flex h-full" aria-busy="true" aria-live="polite">
+      {/* Left panel — mirrors HeroSkinsPanel layout */}
+      <div className="w-full lg:w-[400px] xl:w-[450px] flex-shrink-0 overflow-hidden border-r border-border bg-bg-secondary animate-slide-in-left">
+        <div className="p-6 space-y-6">
+          <div className="flex items-center justify-between gap-3">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-4" rounded="full" />
+          </div>
+          <div className="space-y-3">
+            <Skeleton className="h-7 w-2/3" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+          <div className="space-y-3 pt-2">
+            <Skeleton className="h-3 w-24" />
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-10 w-10" rounded="md" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3 w-3/4" />
+                  <Skeleton className="h-2 w-1/3" />
+                </div>
+                <Skeleton className="h-5 w-10" rounded="full" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Right panel — hero portrait placeholder */}
+      <div className="flex-1 relative overflow-hidden bg-bg-primary animate-hero-zoom-in">
+        <Skeleton className="absolute inset-0" rounded="none" />
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
+        <div className="absolute bottom-8 left-8 space-y-3">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-40" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add reusable `<Skeleton />` primitive (`src/components/common/Skeleton.tsx`) wrapping the existing `.skeleton-shimmer` class
- Replace bare spinners in Locker views (hero page, downloadable skins grid, Mina variant scan, archive download) with layout-matching skeletons
- Redesign `ModDetailsModal`: wider layout, hero image carousel with title and state badges overlaid, floating close button, metadata strip (dates + download count), richer file cards with inline download progress, skeletons for image and comments loading, arrow-key carousel navigation
- `Installed.tsx` now fetches `dateAdded` / `dateModified` from the cached mod in parallel with details, so the overlay shows the same metadata on Installed as on Browse

## Test plan
- [x] Open Locker while mods/categories are loading — hero portrait + side panel skeleton renders instead of centered spinner
- [x] Expand the downloadable skins section on a hero — 8-card skeleton grid renders during fetch
- [x] Click a mod in Browse — new overlay renders with hero image carousel, title overlaid, metadata strip
- [x] Click a mod in Installed — overlay shows Installed / Update Available / Outdated badges correctly, dates populate from cache
- [x] Start a download from the overlay — inline progress bar in the file card updates, button shows percent
- [x] Arrow keys / dot indicators navigate the image carousel
- [x] Comments skeleton rows appear while comments load

🤖 Generated with [Claude Code](https://claude.com/claude-code)