### PR TITLE
UI polish: WCAG pass, page modernization, drag-drop import

### DIFF
--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
 // Type definitions for the exposed API
 export interface ElectronAPI {
@@ -53,6 +53,10 @@ export interface ElectronAPI {
 
     // Dialogs
     showOpenDialog: (options: OpenDialogOptions) => Promise<string | null>;
+
+    // Drag & drop — resolves a native filesystem path for a dropped File.
+    // Needed because Electron 32+ removed `File.path` from the DataTransfer API.
+    getDroppedFilePath: (file: File) => string;
 
     // Events
     onDownloadProgress: (callback: (data: DownloadProgressData) => void) => () => void;
@@ -659,6 +663,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     // Dialogs
     showOpenDialog: (options: OpenDialogOptions) => ipcRenderer.invoke('show-open-dialog', options),
+
+    // Drag & drop
+    getDroppedFilePath: (file: File) => webUtils.getPathForFile(file),
 
     // Events - return unsubscribe function
     onDownloadProgress: (callback: (data: DownloadProgressData) => void) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -446,7 +446,7 @@ interface ModConflict {
     modAName: string;
     modB: string;
     modBName: string;
-    conflictType: 'priority' | 'samefile';
+    conflictType: 'priority' | 'file';
     details: string;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import Installed from './pages/Installed';
@@ -13,6 +14,18 @@ import Stats from './pages/Stats';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
 
 export default function App() {
+  // Swallow stray file drops so Electron doesn't navigate the window to the
+  // dropped file:// URL. Registered drop zones still handle their own events.
+  useEffect(() => {
+    const swallow = (e: DragEvent) => e.preventDefault();
+    window.addEventListener('dragover', swallow);
+    window.addEventListener('drop', swallow);
+    return () => {
+      window.removeEventListener('dragover', swallow);
+      window.removeEventListener('drop', swallow);
+    };
+  }, []);
+
   return (
     <HashRouter>
       <ErrorBoundary>

--- a/src/components/AudioPreviewPlayer.tsx
+++ b/src/components/AudioPreviewPlayer.tsx
@@ -217,6 +217,7 @@ export default function AudioPreviewPlayer({
             {!compact && (
                 <button
                     onClick={toggleMute}
+                    aria-label={isMuted ? 'Unmute' : 'Mute'}
                     className="flex-shrink-0 text-text-secondary hover:text-text-primary transition-colors"
                     title={isMuted ? 'Unmute' : 'Mute'}
                 >

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -111,7 +111,7 @@ export default function Layout() {
             </div>
           </div>
         )}
-        <div key={location.pathname} className="animate-fade-in">
+        <div key={location.pathname} className="animate-fade-in h-full">
           <Outlet />
         </div>
       </main>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -258,7 +258,7 @@ export default function Sidebar() {
 
       <div className="flex-shrink-0 border-t border-border p-3 space-y-2.5">
         {stashStatus.active && (
-          <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-2 text-[11px] text-yellow-200 flex items-center gap-2">
+          <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-2 text-xs text-yellow-200 flex items-center gap-2">
             <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
             <span className="flex-1 leading-tight">
               Vanilla — {stashStatus.modCount ?? 0} stashed
@@ -281,7 +281,7 @@ export default function Sidebar() {
 
         {toast && (
           <div
-            className={`rounded-md px-2.5 py-1.5 text-[11px] leading-snug ${
+            className={`rounded-md px-2.5 py-1.5 text-xs leading-snug ${
               toast.kind === 'error'
                 ? 'border border-red-500/40 bg-red-500/10 text-red-300'
                 : 'border border-accent/40 bg-accent/10 text-accent'
@@ -322,7 +322,7 @@ export default function Sidebar() {
                   ? 'A vanilla session is already active — restore mods first'
                   : 'Temporarily stash mods, launch Deadlock via Steam, then auto-restore after the game starts'
             }
-            className="flex w-full items-center gap-3 h-11 px-3 rounded-lg text-text-primary/70 hover:text-text-primary hover:bg-bg-tertiary text-sm font-medium tracking-wide transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            className="flex w-full items-center gap-3 h-11 px-3 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-tertiary text-sm font-medium tracking-wide transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {launchPending === 'vanilla' ? (
               <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" />
@@ -335,7 +335,7 @@ export default function Sidebar() {
 
         <button
           onClick={() => navigate('/settings')}
-          className="flex items-center justify-center gap-2 w-full pt-1 text-[11px] text-text-secondary cursor-pointer hover:text-accent transition-colors"
+          className="flex items-center justify-center gap-2 w-full pt-1 text-xs text-text-secondary cursor-pointer hover:text-accent transition-colors"
           title={updateAvailable ? 'Update available! Click to view' : 'Open Settings'}
         >
           <span>{appVersion || 'v...'}</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
 } from '../lib/api';
 
 import { useAppStore } from '../stores/appStore';
+import UpdateModal from './UpdateModal';
 
 export default function Sidebar() {
   const [conflictCount, setConflictCount] = useState(0);
@@ -43,6 +44,7 @@ export default function Sidebar() {
   const [launchPending, setLaunchPending] = useState<'modded' | 'vanilla' | null>(null);
   const [restorePending, setRestorePending] = useState(false);
   const [toast, setToast] = useState<{ kind: 'info' | 'error'; text: string } | null>(null);
+  const [updateModalOpen, setUpdateModalOpen] = useState(false);
 
   const refreshStashStatus = useCallback(async () => {
     try {
@@ -334,14 +336,19 @@ export default function Sidebar() {
         </div>
 
         <button
-          onClick={() => navigate('/settings')}
+          onClick={() => {
+            if (updateAvailable) setUpdateModalOpen(true);
+            else navigate('/settings');
+          }}
           className="flex items-center justify-center gap-2 w-full pt-1 text-xs text-text-secondary cursor-pointer hover:text-accent transition-colors"
-          title={updateAvailable ? 'Update available! Click to view' : 'Open Settings'}
+          title={updateAvailable ? 'Update available — click to view release notes' : 'Open Settings'}
         >
           <span>{appVersion || 'v...'}</span>
           {updateAvailable && <Download className="w-3 h-3 text-accent animate-pulse" />}
         </button>
       </div>
+
+      {updateModalOpen && <UpdateModal onClose={() => setUpdateModalOpen(false)} />}
     </aside>
   );
 }

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { X, Download, ArrowDownCircle, RefreshCw, Sparkles, AlertTriangle } from 'lucide-react';
+import DOMPurify from 'dompurify';
+import { Button } from './common/ui';
+
+interface UpdateInfo {
+    version: string;
+    releaseDate?: string;
+    releaseNotes?: string | { version: string; note: string | null }[] | null;
+}
+
+interface UpdateStatus {
+    checking: boolean;
+    available: boolean;
+    downloading: boolean;
+    downloaded: boolean;
+    error: string | null;
+    progress: number;
+    updateInfo: UpdateInfo | null;
+}
+
+interface Props {
+    onClose: () => void;
+}
+
+export default function UpdateModal({ onClose }: Props) {
+    const [appVersion, setAppVersion] = useState('');
+    const [status, setStatus] = useState<UpdateStatus | null>(null);
+    const [checkedOnce, setCheckedOnce] = useState(false);
+
+    useEffect(() => {
+        window.electronAPI.updater.getVersion().then(setAppVersion);
+        window.electronAPI.updater.getStatus().then(setStatus);
+        const unsub = window.electronAPI.updater.onStatus((s) => {
+            setStatus(s);
+            if (!s.checking) setCheckedOnce(true);
+        });
+        return unsub;
+    }, []);
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    const handleCheck = async () => {
+        setCheckedOnce(false);
+        try {
+            await window.electronAPI.updater.checkForUpdates();
+        } catch (err) {
+            console.error('Update check failed:', err);
+        }
+    };
+
+    const handleDownload = async () => {
+        try {
+            await window.electronAPI.updater.downloadUpdate();
+        } catch (err) {
+            console.error('Update download failed:', err);
+        }
+    };
+
+    const handleInstall = () => {
+        window.electronAPI.updater.installUpdate();
+    };
+
+    const releaseNotes = status?.updateInfo?.releaseNotes;
+    const hasNotes = Array.isArray(releaseNotes) ? releaseNotes.length > 0 : Boolean(releaseNotes);
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="update-modal-title"
+            onClick={onClose}
+        >
+            <div
+                className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-start justify-between p-6 border-b border-white/10">
+                    <div className="min-w-0">
+                        <h2 id="update-modal-title" className="text-xl font-bold text-text-primary">
+                            {status?.downloaded
+                                ? `v${status.updateInfo?.version} ready to install`
+                                : status?.available
+                                    ? `Update available — v${status.updateInfo?.version}`
+                                    : 'App Updates'}
+                        </h2>
+                        <p className="text-sm text-text-secondary mt-1">
+                            You're on <span className="font-mono text-text-primary">v{appVersion || '...'}</span>
+                            {status?.updateInfo?.releaseDate && status.available && (
+                                <> — released {new Date(status.updateInfo.releaseDate).toLocaleDateString()}</>
+                            )}
+                        </p>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+                        aria-label="Close"
+                    >
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                <div className="p-6 overflow-y-auto flex-1 min-h-0">
+                    {status?.error && (
+                        <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm mb-4">
+                            <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                            <span>{status.error}</span>
+                        </div>
+                    )}
+
+                    {status?.downloading && (
+                        <div className="mb-4">
+                            <div className="flex justify-between text-xs text-text-secondary mb-1">
+                                <span>Downloading update…</span>
+                                <span className="tabular-nums">{Math.round(status.progress)}%</span>
+                            </div>
+                            <div className="w-full bg-bg-tertiary rounded-full h-1.5 overflow-hidden">
+                                <div
+                                    className="bg-accent h-full rounded-full transition-all duration-300 ease-out"
+                                    style={{ width: `${status.progress}%` }}
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    {status?.downloaded && !status.downloading && (
+                        <div className="flex items-center gap-2 p-3 rounded-lg bg-state-success/10 border border-state-success/30 text-state-success text-sm mb-4">
+                            <Sparkles className="w-4 h-4 flex-shrink-0" />
+                            <span>Download complete. Click Install &amp; Restart to apply.</span>
+                        </div>
+                    )}
+
+                    {!status?.available && !status?.downloaded && !status?.checking && checkedOnce && !status?.error && (
+                        <div className="flex items-center gap-2 p-3 rounded-lg bg-state-success/10 border border-state-success/30 text-state-success text-sm mb-4">
+                            <Sparkles className="w-4 h-4 flex-shrink-0" />
+                            <span>You're on the latest version.</span>
+                        </div>
+                    )}
+
+                    {hasNotes ? (
+                        <>
+                            <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">
+                                What's new
+                            </h3>
+                            {typeof releaseNotes === 'string' ? (
+                                <div
+                                    className="prose prose-invert prose-sm max-w-none"
+                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(releaseNotes) }}
+                                />
+                            ) : (
+                                <div className="space-y-4">
+                                    {(releaseNotes as { version: string; note: string | null }[]).map((note, idx) => (
+                                        <div key={idx}>
+                                            <h4 className="font-semibold text-accent">v{note.version}</h4>
+                                            {note.note && (
+                                                <div
+                                                    className="prose prose-invert prose-sm max-w-none mt-1"
+                                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(note.note) }}
+                                                />
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    ) : !status?.available && !status?.checking && (
+                        <p className="text-sm text-text-secondary">
+                            Updates are delivered automatically through GitHub Releases. Click Check for Updates to look now.
+                        </p>
+                    )}
+                </div>
+
+                <div className="flex justify-end gap-3 p-6 border-t border-white/10">
+                    <Button onClick={onClose} variant="secondary">
+                        Close
+                    </Button>
+                    {status?.downloaded ? (
+                        <Button onClick={handleInstall} icon={ArrowDownCircle}>
+                            Install &amp; Restart
+                        </Button>
+                    ) : status?.available && !status.downloading ? (
+                        <Button onClick={handleDownload} icon={Download}>
+                            Download Update
+                        </Button>
+                    ) : (
+                        <Button
+                            onClick={handleCheck}
+                            disabled={status?.checking || status?.downloading}
+                            isLoading={status?.checking}
+                            icon={RefreshCw}
+                        >
+                            {status?.checking ? 'Checking…' : 'Check for Updates'}
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -145,24 +145,33 @@ export function ConfirmModal({
     if (!isOpen) return null;
 
     const confirmClass = variant === 'danger'
-        ? 'bg-red-500 hover:bg-red-600 text-white'
-        : 'bg-accent hover:bg-accent-hover text-white';
+        ? 'bg-red-600 hover:bg-red-500 text-white focus-visible:ring-red-400'
+        : 'bg-accent hover:bg-accent-hover text-black focus-visible:ring-accent';
 
     return (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div className="bg-bg-secondary border border-border rounded-xl p-6 max-w-md mx-4">
-                <h3 className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
+        <div
+            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-modal-title"
+            onClick={onCancel}
+        >
+            <div
+                className="bg-bg-secondary border border-border rounded-xl p-6 max-w-md w-full"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
                 <div className="text-text-secondary mb-4">{message}</div>
                 <div className="flex justify-end gap-3">
                     <button
                         onClick={onCancel}
-                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer"
+                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                     >
                         {cancelLabel}
                     </button>
                     <button
                         onClick={onConfirm}
-                        className={`px-4 py-2 rounded-lg transition-colors cursor-pointer ${confirmClass}`}
+                        className={`px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
                     >
                         {confirmLabel}
                     </button>

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -105,7 +105,7 @@ export function Tag({
     return (
         <span
             title={title}
-            className={`inline-flex items-center gap-1 rounded-md px-1.5 py-[2px] text-[10.5px] font-semibold leading-none ${surface} ${className}`}
+            className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-semibold leading-none ${surface} ${className}`}
         >
             {Icon && <Icon className="w-3 h-3" />}
             {children}
@@ -193,7 +193,7 @@ export function Toggle({ checked, onChange, label, description, className = '', 
                     onChange={(e) => !disabled && onChange(e.target.checked)}
                     disabled={disabled}
                 />
-                <div className="w-11 h-6 bg-bg-tertiary peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-accent border border-white/5"></div>
+                <div className="w-11 h-6 bg-bg-tertiary peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-bg-primary rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-accent border border-white/5"></div>
             </div>
             <div>
                 {label && <span className="block text-sm font-medium text-text-primary group-hover:text-white transition-colors">{label}</span>}
@@ -223,12 +223,12 @@ export function Button({
     const baseStyles = 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
 
     const variants = {
-        primary: 'bg-accent hover:bg-accent-hover text-white focus:ring-accent',
-        secondary: 'bg-bg-tertiary hover:bg-white/10 text-text-primary border border-white/5 focus:ring-white/20',
+        primary: 'bg-accent hover:bg-accent-hover text-black focus:ring-accent',
+        secondary: 'bg-bg-tertiary hover:bg-white/10 text-text-primary border border-white/5 focus:ring-white/60',
         danger: 'bg-red-500/10 hover:bg-red-500/20 text-red-500 border border-red-500/20 focus:ring-red-500',
         success: 'bg-green-500/10 hover:bg-green-500/20 text-green-400 border border-green-500/20 focus:ring-green-500',
         warning: 'bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-400 border border-yellow-500/20 focus:ring-yellow-500',
-        ghost: 'hover:bg-white/5 text-text-secondary hover:text-text-primary',
+        ghost: 'hover:bg-white/5 text-text-secondary hover:text-text-primary focus:ring-white/40',
     };
 
     const sizes = {

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -112,7 +112,7 @@ export default function HeroSkinsPanel({
                 onClick={async () => {
                   try {
                     onMinaArchivePathChange?.('Downloading...');
-                    const path = await window.api.downloadMinaVariations();
+                    const path = await window.electronAPI.downloadMinaVariations();
                     onMinaArchivePathChange?.(path);
                     onLoadMinaVariants?.();
                   } catch (err) {

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,7 @@
   --color-accent-hover: #ea580c;
   --color-text-primary: #ffffff;
   --color-text-secondary: #a1a1aa;
+  --color-text-tertiary: #8a8a94;
   --color-border: #2d2d2d;
 
   /* Semantic state tokens. Use these for card states, toasts, badges —
@@ -188,9 +189,19 @@ body {
   background-image: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(255, 255, 255, 0.04) 50%,
+    rgba(255, 255, 255, 0.09) 50%,
     transparent 100%
   );
   background-size: 200% 100%;
   animation: skeletonShimmer 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-in-left,
+  .animate-hero-zoom-in,
+  .animate-fade-in,
+  .skeleton-shimmer {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -221,7 +221,7 @@ export interface ModConflict {
   modAName: string;
   modB: string;
   modBName: string;
-  conflictType: 'priority' | 'samefile';
+  conflictType: 'priority' | 'file';
   details: string;
 }
 

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle } from 'lucide-react';
 import { getSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
+import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
 
 // Popular Deadlock autoexec command presets
 const COMMAND_PRESETS = [
@@ -79,6 +80,7 @@ export default function Autoexec() {
     const [isSaving, setIsSaving] = useState(false);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
     const [hasUnsaved, setHasUnsaved] = useState(false);
+    const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
     // Load game path, autoexec status, and existing commands
     useEffect(() => {
@@ -157,22 +159,19 @@ export default function Autoexec() {
         }
     };
 
-    const handleClear = () => {
+    const confirmClear = () => {
         setCommands([]);
         setHasUnsaved(true);
+        setClearConfirmOpen(false);
     };
 
     return (
         <div className="flex flex-col min-h-0 flex-1 p-6 space-y-6 overflow-auto">
-            <div className="flex items-center gap-3 shrink-0">
-                <div className="p-3 bg-accent/10 rounded-xl">
-                    <Terminal className="w-8 h-8 text-accent" />
-                </div>
-                <div>
-                    <h1 className="text-3xl font-bold font-reaver tracking-wide">Autoexec Commands</h1>
-                    <p className="text-text-secondary">Manage startup commands and game configuration</p>
-                </div>
-            </div>
+            <PageHeader
+                title="Autoexec Commands"
+                description="Manage startup commands and game configuration"
+                className="shrink-0"
+            />
 
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
                 {/* Left Panel - Command Presets */}
@@ -248,7 +247,7 @@ export default function Autoexec() {
                         icon={Terminal}
                         action={
                             <div className="flex gap-2">
-                                <Button size="sm" variant="secondary" onClick={handleClear} disabled={commands.length === 0} icon={RefreshCw}>
+                                <Button size="sm" variant="secondary" onClick={() => setClearConfirmOpen(true)} disabled={commands.length === 0} icon={RefreshCw}>
                                     Clear
                                 </Button>
                                 <Button size="sm" variant="secondary" onClick={handleCopy} disabled={commands.length === 0} icon={copied ? Check : Copy}>
@@ -283,7 +282,7 @@ export default function Autoexec() {
                             </div>
                         )}
 
-                        <div className="overflow-y-auto space-y-2 pr-1 custom-scrollbar flex-1 min-h-0">
+                        <div className="overflow-y-auto space-y-2 pr-1 flex-1 min-h-0">
                             {commands.length > 0 ? (
                                 commands.map((cmd, i) => (
                                     <div
@@ -340,6 +339,16 @@ export default function Autoexec() {
                     </Card>
                 </div>
             </div>
+
+            <ConfirmModal
+                isOpen={clearConfirmOpen}
+                onCancel={() => setClearConfirmOpen(false)}
+                onConfirm={confirmClear}
+                title="Clear all commands?"
+                message={`Remove all ${commands.length} command${commands.length === 1 ? '' : 's'} from the list? Your saved autoexec.cfg won't change until you click Save.`}
+                confirmLabel="Clear"
+                variant="danger"
+            />
         </div>
     );
 }

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -13,6 +13,9 @@ import {
   List,
   AlertTriangle,
   Clock,
+  Package,
+  Music,
+  SlidersHorizontal,
 } from 'lucide-react';
 import {
   browseMods,
@@ -167,11 +170,32 @@ export default function Browse() {
   const [playingModId, setPlayingModId] = useState<number | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const filtersRef = useRef<HTMLDivElement>(null);
 
   // Load settings on mount (needed for hideNsfwPreviews)
   useEffect(() => {
     loadSettings();
   }, [loadSettings]);
+
+  // Close the filters popover on outside click or Escape
+  useEffect(() => {
+    if (!filtersOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (filtersRef.current && !filtersRef.current.contains(e.target as Node)) {
+        setFiltersOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFiltersOpen(false);
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [filtersOpen]);
 
   // Check if local cache is available for search
   const [hasLocalCache, setHasLocalCache] = useState(false);
@@ -859,12 +883,34 @@ export default function Browse() {
             {/* Divider */}
             <div className="w-px h-6 bg-border" />
 
-            {/* Filters */}
-            <DynamicSelect
-              value={section}
-              onChange={(val) => setSection(val)}
-              options={sections.map((entry) => ({ value: entry.modelName, label: entry.pluralTitle }))}
-            />
+            {/* Section toggle — Mods vs Sounds as icon buttons */}
+            {sections.length > 1 && (
+              <div className="flex items-center rounded-lg border border-border bg-bg-secondary p-1" role="tablist" aria-label="Section">
+                {sections.map((entry) => {
+                  const Icon = entry.modelName === 'Sound' ? Music : Package;
+                  const active = section === entry.modelName;
+                  return (
+                    <button
+                      key={entry.modelName}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setSection(entry.modelName)}
+                      className={`flex items-center gap-1.5 px-3 py-2 rounded-md transition-colors cursor-pointer ${
+                        active
+                          ? 'bg-bg-tertiary text-text-primary'
+                          : 'text-text-secondary hover:text-text-primary'
+                      }`}
+                      title={entry.pluralTitle}
+                    >
+                      <Icon className="w-4 h-4" />
+                      <span className="text-sm">{entry.pluralTitle}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
             {/* Global Volume Slider - visible when Sound section is selected */}
             {section === 'Sound' && (
               <div className="flex items-center gap-2 px-3 py-2 bg-bg-secondary border border-border rounded-lg">
@@ -881,6 +927,7 @@ export default function Browse() {
                 <span className="text-xs text-text-secondary tabular-nums w-8">{Math.round(soundVolume * 100)}%</span>
               </div>
             )}
+
             <DynamicSelect
               value={sort}
               onChange={(val) => setSort(val as SortOption)}
@@ -893,25 +940,99 @@ export default function Browse() {
                 { value: 'name', label: 'Name (A–Z)' },
               ]}
             />
-            {heroOptions.length > 0 && (
-              <DynamicSelect
-                value={String(heroCategoryId)}
-                onChange={(val) => setHeroCategoryId(val === 'all' ? 'all' : Number(val))}
-                options={[
-                  { value: 'all', label: 'All Heroes' },
-                  ...heroOptions.map((hero) => ({ value: String(hero.id), label: hero.label })),
-                ]}
-              />
-            )}
-            <DynamicSelect
-              value={String(categoryId)}
-              onChange={(val) => setCategoryId(val === 'all' ? 'all' : Number(val))}
-              options={[
-                { value: 'all', label: 'All Categories' },
-                ...categoryOptions.map((cat) => ({ value: String(cat.id), label: cat.label })),
-              ]}
-              disabled={heroCategoryId !== 'all'}
-            />
+
+            {/* Filters popover — houses hero + category selectors. Collapses two
+                always-visible dropdowns into one control with an active-count badge. */}
+            {(heroOptions.length > 0 || categoryOptions.length > 0) && (() => {
+              const filterCount =
+                (heroCategoryId !== 'all' ? 1 : 0) +
+                (categoryId !== 'all' ? 1 : 0);
+              return (
+                <div className="relative" ref={filtersRef}>
+                  <button
+                    type="button"
+                    onClick={() => setFiltersOpen((v) => !v)}
+                    aria-haspopup="dialog"
+                    aria-expanded={filtersOpen}
+                    className={`flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      filterCount > 0
+                        ? 'bg-accent/10 border-accent/40 text-accent hover:bg-accent/20'
+                        : 'bg-bg-secondary border-border text-text-primary hover:bg-bg-tertiary'
+                    }`}
+                  >
+                    <SlidersHorizontal className="w-4 h-4" />
+                    <span>Filters</span>
+                    {filterCount > 0 && (
+                      <span className="min-w-[18px] h-[18px] px-1 rounded-full bg-accent text-black text-[11px] font-semibold flex items-center justify-center">
+                        {filterCount}
+                      </span>
+                    )}
+                  </button>
+
+                  {filtersOpen && (
+                    <div
+                      className="absolute right-0 top-full mt-2 z-20 w-72 bg-bg-secondary border border-border rounded-lg shadow-xl p-4 animate-fade-in"
+                      role="dialog"
+                      aria-label="Filters"
+                    >
+                      <div className="flex items-center justify-between mb-3">
+                        <h4 className="text-sm font-semibold text-text-primary">Filters</h4>
+                        {filterCount > 0 && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setHeroCategoryId('all');
+                              setCategoryId('all');
+                            }}
+                            className="text-xs text-text-secondary hover:text-accent cursor-pointer"
+                          >
+                            Clear all
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="space-y-3">
+                        {heroOptions.length > 0 && (
+                          <label className="block">
+                            <span className="block text-xs font-medium text-text-secondary mb-1.5">Hero</span>
+                            <select
+                              value={String(heroCategoryId)}
+                              onChange={(e) => setHeroCategoryId(e.target.value === 'all' ? 'all' : Number(e.target.value))}
+                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                            >
+                              <option value="all">All Heroes</option>
+                              {heroOptions.map((hero) => (
+                                <option key={hero.id} value={String(hero.id)}>{hero.label}</option>
+                              ))}
+                            </select>
+                          </label>
+                        )}
+
+                        {categoryOptions.length > 0 && (
+                          <label className="block">
+                            <span className="block text-xs font-medium text-text-secondary mb-1.5">Category</span>
+                            <select
+                              value={String(categoryId)}
+                              onChange={(e) => setCategoryId(e.target.value === 'all' ? 'all' : Number(e.target.value))}
+                              disabled={heroCategoryId !== 'all'}
+                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <option value="all">All Categories</option>
+                              {categoryOptions.map((cat) => (
+                                <option key={cat.id} value={String(cat.id)}>{cat.label}</option>
+                              ))}
+                            </select>
+                            {heroCategoryId !== 'all' && (
+                              <span className="block text-[11px] text-text-tertiary mt-1">Hero filter overrides categories.</span>
+                            )}
+                          </label>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
           </div>
         </form>
       </div>

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -147,7 +147,7 @@ export default function Browse() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
-  const [totalCount, setTotalCount] = useState(0);
+  const [_totalCount, setTotalCount] = useState(0);
   const perPage = DEFAULT_PER_PAGE; // Fixed value for infinite scroll
   const [sort, setSort] = useState<SortOption>('default');
   const [sections, setSections] = useState<GameBananaSection[]>([]);

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1267,7 +1267,7 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
             ) : (
               <button
                 onClick={(e) => { e.stopPropagation(); onQuickDownload(); }}
-                className="flex-shrink-0 flex items-center justify-center w-7 h-7 bg-accent hover:bg-accent-secondary text-white rounded-full shadow-lg transition-colors cursor-pointer"
+                className="flex-shrink-0 flex items-center justify-center w-7 h-7 bg-accent hover:bg-accent-hover text-black rounded-full shadow-lg transition-colors cursor-pointer"
                 title="Install"
               >
                 <Download className="w-3.5 h-3.5" />
@@ -1493,18 +1493,18 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
       <div className="absolute top-2 right-2">
         {installed ? (
           <span
-            className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-white/25 shadow-md text-state-success ${isCompact ? 'w-7 h-7 text-sm' : 'w-8 h-8 text-base'}`}
+            className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-black/60 shadow-md text-state-success ${isCompact ? 'w-7 h-7 text-sm' : 'w-8 h-8 text-base'}`}
             title="Installed"
           >
             ✓
           </span>
         ) : downloading ? (
-          <div className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-white/25 shadow-md ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`} title="Downloading...">
+          <div className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-black/60 shadow-md ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`} title="Downloading...">
             <Loader2 className={`animate-spin text-accent ${isCompact ? 'w-4 h-4' : 'w-5 h-5'}`} />
           </div>
         ) : queuePosition ? (
           <div
-            className={`flex items-center justify-center bg-accent text-white rounded-full font-bold ring-1 ring-white/30 shadow-md ${isCompact ? 'w-7 h-7 text-[11px]' : 'w-8 h-8 text-xs'}`}
+            className={`flex items-center justify-center bg-accent text-black rounded-full font-bold ring-1 ring-black/50 shadow-md ${isCompact ? 'w-7 h-7 text-[11px]' : 'w-8 h-8 text-xs'}`}
             title={`Queued #${queuePosition}`}
           >
             {queuePosition}
@@ -1512,7 +1512,7 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
         ) : (
           <button
             onClick={(e) => { e.stopPropagation(); onQuickDownload(); }}
-            className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-white/25 shadow-md text-accent hover:bg-accent hover:text-white hover:ring-white/40 transition-all cursor-pointer ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`}
+            className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-black/60 shadow-md text-accent hover:bg-accent hover:text-black hover:ring-black/70 transition-all cursor-pointer ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`}
             title="Install"
           >
             <Download className={isCompact ? 'w-4 h-4' : 'w-5 h-5'} />

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -5,7 +5,7 @@ import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import { Button } from '../components/common/ui';
-import { PageHeader, EmptyState } from '../components/common/PageComponents';
+import { PageHeader, EmptyState, ConfirmModal } from '../components/common/PageComponents';
 interface ModWithThumbnail {
   id: string;
   name: string;
@@ -50,6 +50,8 @@ export default function Conflicts() {
   const [modsMap, setModsMap] = useState<Map<string, ModWithThumbnail>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
+  const [disabling, setDisabling] = useState(false);
   const { loadMods } = useAppStore();
 
   const loadConflicts = async () => {
@@ -83,13 +85,18 @@ export default function Conflicts() {
     loadConflicts();
   }, []);
 
-  const handleDisableMod = async (modId: string) => {
+  const confirmDisable = async () => {
+    if (!disableTarget) return;
+    setDisabling(true);
     try {
-      await disableMod(modId);
+      await disableMod(disableTarget.id);
       await loadMods();
       await loadConflicts();
+      setDisableTarget(null);
     } catch (err) {
       setError(String(err));
+    } finally {
+      setDisabling(false);
     }
   };
 
@@ -173,7 +180,7 @@ export default function Conflicts() {
                       </div>
                     )}
                     <button
-                      onClick={() => handleDisableMod(modA.id)}
+                      onClick={() => setDisableTarget(modA)}
                       aria-label={`Disable ${modA.name}`}
                       className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                     >
@@ -212,7 +219,7 @@ export default function Conflicts() {
                       </div>
                     )}
                     <button
-                      onClick={() => handleDisableMod(modB.id)}
+                      onClick={() => setDisableTarget(modB)}
                       aria-label={`Disable ${modB.name}`}
                       className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                     >
@@ -235,6 +242,27 @@ export default function Conflicts() {
           );
         })}
       </div>
+
+      <ConfirmModal
+        isOpen={disableTarget !== null}
+        onCancel={() => !disabling && setDisableTarget(null)}
+        onConfirm={confirmDisable}
+        title="Disable this mod?"
+        message={
+          disableTarget ? (
+            <>
+              <p className="mb-2">
+                <span className="text-text-primary font-medium">{disableTarget.name}</span> will be disabled and moved out of the addons folder. You can re-enable it from the Installed page.
+              </p>
+              {disableTarget.fileName && (
+                <p className="text-xs font-mono text-text-tertiary truncate" title={disableTarget.fileName}>{disableTarget.fileName}</p>
+              )}
+            </>
+          ) : ''
+        }
+        confirmLabel={disabling ? 'Disabling…' : 'Disable'}
+        variant="danger"
+      />
     </div>
   );
 }

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -175,7 +175,7 @@ export default function Conflicts() {
                     <button
                       onClick={() => handleDisableMod(modA.id)}
                       aria-label={`Disable ${modA.name}`}
-                      className="absolute inset-x-0 bottom-0 bg-red-500/80 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
+                      className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                     >
                       <span className="text-white text-sm font-medium flex items-center gap-1">
                         <X className="w-4 h-4" /> Disable
@@ -214,7 +214,7 @@ export default function Conflicts() {
                     <button
                       onClick={() => handleDisableMod(modB.id)}
                       aria-label={`Disable ${modB.name}`}
-                      className="absolute inset-x-0 bottom-0 bg-red-500/80 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
+                      className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                     >
                       <span className="text-white text-sm font-medium flex items-center gap-1">
                         <X className="w-4 h-4" /> Disable

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -110,28 +110,32 @@ export default function Conflicts() {
 
   if (error) {
     return (
-      <EmptyState
-        icon={AlertTriangle}
-        title="Error Loading Conflicts"
-        description={error ?? undefined}
-        variant="error"
-        action={
-          <Button onClick={loadConflicts}>Retry</Button>
-        }
-      />
+      <div className="h-full flex items-center justify-center p-6">
+        <EmptyState
+          icon={AlertTriangle}
+          title="Error Loading Conflicts"
+          description={error ?? undefined}
+          variant="error"
+          action={
+            <Button onClick={loadConflicts}>Retry</Button>
+          }
+        />
+      </div>
     );
   }
 
   if (conflicts.length === 0) {
     return (
-      <EmptyState
-        icon={CheckCircle}
-        title="No Conflicts Detected"
-        description="Your installed mods don't have any conflicts. Great!"
-        action={
-          <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
-        }
-      />
+      <div className="h-full flex items-center justify-center p-6">
+        <EmptyState
+          icon={CheckCircle}
+          title="No Conflicts Detected"
+          description="Your installed mods don't have any conflicts. Great!"
+          action={
+            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
+          }
+        />
+      </div>
     );
   }
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -14,6 +14,7 @@ import {
   Volume2,
   Info,
   Download,
+  UploadCloud,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -319,20 +320,6 @@ export default function Installed() {
     <div className="p-6">
       <PageHeader
         title="Installed Mods"
-        description={
-          <span className="flex items-center gap-2 flex-wrap">
-            <span>{enabledMods.length} enabled / {mods.length} total</span>
-            {mods.length > 0 && enabledMods.length === 0 && (
-              <span
-                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-yellow-500/15 text-yellow-400 border border-yellow-500/30 text-xs font-medium"
-                title="You have installed mods but none are enabled — nothing will apply when you launch."
-              >
-                <Info className="w-3 h-3" />
-                No mods enabled
-              </span>
-            )}
-          </span>
-        }
         action={
           <div className="flex items-center gap-3 flex-wrap">
             <div className="relative">
@@ -1008,6 +995,18 @@ interface ImportCustomModModalProps {
   onImport: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
 }
 
+const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
+
+function deriveModNameFromPath(p: string): string {
+  const base = p.split(/[\\/]/).pop() ?? '';
+  return base
+    .replace(/_dir\.vpk$/i, '')
+    .replace(/\.vpk$/i, '')
+    .replace(/^pak\d{2}_/, '')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+}
+
 function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) {
   const [vpkPath, setVpkPath] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -1016,32 +1015,16 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
   const [nsfw, setNsfw] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [vpkDragActive, setVpkDragActive] = useState(false);
+  const [imgDragActive, setImgDragActive] = useState(false);
 
-  const pickVpk = async () => {
-    const picked = await showOpenDialog({
-      title: 'Select VPK file',
-      filters: [{ name: 'VPK files', extensions: ['vpk'] }],
-    });
-    if (picked) {
-      setVpkPath(picked);
-      if (!name) {
-        const base = picked.split(/[\\/]/).pop() ?? '';
-        const cleaned = base
-          .replace(/_dir\.vpk$/i, '')
-          .replace(/\.vpk$/i, '')
-          .replace(/^pak\d{2}_/, '')
-          .replace(/[_-]+/g, ' ');
-        setName(cleaned.trim());
-      }
-    }
+  const acceptVpkPath = (picked: string) => {
+    setVpkPath(picked);
+    setError(null);
+    if (!name) setName(deriveModNameFromPath(picked));
   };
 
-  const pickImage = async () => {
-    const picked = await showOpenDialog({
-      title: 'Select thumbnail image',
-      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
-    });
-    if (!picked) return;
+  const acceptImagePath = async (picked: string) => {
     setImagePath(picked);
     setError(null);
     try {
@@ -1050,6 +1033,66 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
     } catch (err) {
       setThumbnailDataUrl('');
       setError(`Couldn't read image: ${String(err)}`);
+    }
+  };
+
+  const pickVpk = async () => {
+    const picked = await showOpenDialog({
+      title: 'Select VPK file',
+      filters: [{ name: 'VPK files', extensions: ['vpk'] }],
+    });
+    if (picked) acceptVpkPath(picked);
+  };
+
+  const pickImage = async () => {
+    const picked = await showOpenDialog({
+      title: 'Select thumbnail image',
+      filters: [{ name: 'Images', extensions: IMAGE_EXTS }],
+    });
+    if (picked) await acceptImagePath(picked);
+  };
+
+  const handleVpkDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setVpkDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    if (!/\.vpk$/i.test(file.name)) {
+      setError(`Expected a .vpk file — got "${file.name}".`);
+      return;
+    }
+    const path = window.electronAPI.getDroppedFilePath(file);
+    if (!path) {
+      setError('Could not resolve the dropped file path.');
+      return;
+    }
+    acceptVpkPath(path);
+  };
+
+  const handleImageDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setImgDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!IMAGE_EXTS.includes(ext)) {
+      setError(`Expected an image (${IMAGE_EXTS.join(', ')}) — got "${file.name}".`);
+      return;
+    }
+    const path = window.electronAPI.getDroppedFilePath(file);
+    if (!path) {
+      setError('Could not resolve the dropped image path.');
+      return;
+    }
+    await acceptImagePath(path);
+  };
+
+  const onZoneKeyDown = (e: React.KeyboardEvent, action: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      action();
     }
   };
 
@@ -1095,20 +1138,42 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
             <label className="block text-sm font-medium text-text-primary mb-1.5">
               VPK file <span className="text-red-400">*</span>
             </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={vpkPath}
-                readOnly
-                placeholder="No file selected"
-                className="flex-1 min-w-0 px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none truncate"
-              />
-              <button
-                onClick={pickVpk}
-                className="px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm hover:bg-bg-secondary transition-colors cursor-pointer"
-              >
-                Choose…
-              </button>
+            <div
+              role="button"
+              tabIndex={0}
+              aria-label={vpkPath ? `VPK selected: ${vpkPath}. Press Enter to change.` : 'Drop a VPK file here or press Enter to browse'}
+              onClick={pickVpk}
+              onKeyDown={(e) => onZoneKeyDown(e, pickVpk)}
+              onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setVpkDragActive(true); }}
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setVpkDragActive(true); }}
+              onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setVpkDragActive(false); }}
+              onDrop={handleVpkDrop}
+              className={`relative flex flex-col items-center justify-center gap-1.5 px-4 py-5 rounded-lg border border-dashed text-center cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${
+                vpkDragActive
+                  ? 'border-accent bg-accent/10'
+                  : vpkPath
+                    ? 'border-accent/40 bg-bg-tertiary/60 hover:bg-bg-tertiary'
+                    : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
+              }`}
+            >
+              {vpkPath ? (
+                <>
+                  <FilePlus className="w-5 h-5 text-accent" aria-hidden />
+                  <span className="text-sm text-text-primary font-medium truncate max-w-full">
+                    {vpkPath.split(/[\\/]/).pop()}
+                  </span>
+                  <span className="text-xs text-text-secondary font-mono truncate max-w-full">{vpkPath}</span>
+                  <span className="text-xs text-accent">Click or drop another to replace</span>
+                </>
+              ) : (
+                <>
+                  <UploadCloud className="w-6 h-6 text-text-secondary" aria-hidden />
+                  <span className="text-sm text-text-primary font-medium">
+                    Drop a <code className="font-mono text-accent">.vpk</code> here
+                  </span>
+                  <span className="text-xs text-text-secondary">or click to browse</span>
+                </>
+              )}
             </div>
             <p className="mt-1 text-xs text-text-secondary">
               The file will be copied into your addons folder and renamed with the next available pak## priority.
@@ -1132,23 +1197,43 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
             <label className="block text-sm font-medium text-text-primary mb-1.5">
               Thumbnail image <span className="text-text-secondary font-normal">(optional)</span>
             </label>
-            <div className="flex items-start gap-3">
+            <div
+              role="button"
+              tabIndex={0}
+              aria-label={imagePath ? `Thumbnail selected: ${imagePath}. Press Enter to change.` : 'Drop an image here or press Enter to browse'}
+              onClick={pickImage}
+              onKeyDown={(e) => onZoneKeyDown(e, pickImage)}
+              onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setImgDragActive(true); }}
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setImgDragActive(true); }}
+              onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setImgDragActive(false); }}
+              onDrop={handleImageDrop}
+              className={`flex items-center gap-3 p-3 rounded-lg border border-dashed cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${
+                imgDragActive
+                  ? 'border-accent bg-accent/10'
+                  : thumbnailDataUrl
+                    ? 'border-accent/40 bg-bg-tertiary/60 hover:bg-bg-tertiary'
+                    : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
+              }`}
+            >
               <div className="w-24 aspect-video bg-bg-tertiary rounded-md overflow-hidden flex items-center justify-center text-text-secondary flex-shrink-0">
                 {thumbnailDataUrl ? (
                   <img src={thumbnailDataUrl} alt="Thumbnail preview" className="w-full h-full object-cover" />
                 ) : (
-                  <ImagePlus className="w-5 h-5" />
+                  <ImagePlus className="w-5 h-5" aria-hidden />
                 )}
               </div>
-              <div className="flex-1 min-w-0 flex flex-col gap-2">
-                <button
-                  onClick={pickImage}
-                  className="px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm hover:bg-bg-secondary transition-colors cursor-pointer w-fit"
-                >
-                  {imagePath ? 'Change image…' : 'Choose image…'}
-                </button>
-                {imagePath && (
-                  <span className="text-xs text-text-secondary font-mono truncate">{imagePath}</span>
+              <div className="flex-1 min-w-0">
+                {imagePath ? (
+                  <>
+                    <div className="text-sm text-text-primary font-medium truncate">{imagePath.split(/[\\/]/).pop()}</div>
+                    <div className="text-xs text-text-secondary font-mono truncate">{imagePath}</div>
+                    <div className="text-xs text-accent mt-0.5">Click or drop another to replace</div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-sm text-text-primary font-medium">Drop an image here</div>
+                    <div className="text-xs text-text-secondary">or click to browse — {IMAGE_EXTS.join(', ')}</div>
+                  </>
                 )}
               </div>
             </div>
@@ -1182,7 +1267,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
           <button
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className="px-4 py-2 bg-accent hover:bg-accent-hover text-white rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            className="px-4 py-2 bg-accent hover:bg-accent-hover text-black rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
             Import

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -769,7 +769,7 @@ function HeroGalleryCard({
   const [isVisible, setIsVisible] = useState(false);
   const [renderLoaded, setRenderLoaded] = useState(false);
   const [nameLoaded, setNameLoaded] = useState(false);
-  const cardRef = useRef<HTMLButtonElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (isActive && !isVisible) {

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -494,7 +494,7 @@ function HeroOverlay({
   hero,
   visible,
   onClose,
-  cardRect,
+  cardRect: _cardRect,
   mods,
   onSelectSkin,
   isFavorite,

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -12,7 +12,7 @@ import type { Profile, ProfileCrosshairSettings } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import { Card, Badge, Button } from '../components/common/ui';
-import { ConfirmModal, EmptyState } from '../components/common/PageComponents';
+import { ConfirmModal, EmptyState, PageHeader } from '../components/common/PageComponents';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 
 export default function Profiles() {
@@ -142,20 +142,13 @@ export default function Profiles() {
 
   return (
     <div className="p-6 h-full flex flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-8 shrink-0">
-        <div className="flex items-center gap-3">
-          <div className="p-3 bg-accent/10 rounded-xl">
-            <Layers className="w-8 h-8 text-accent" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold font-reaver tracking-wide">Profiles</h1>
-            <p className="text-text-secondary">Save and restore your mod configurations</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Profiles"
+        description="Save and restore your mod configurations"
+        className="mb-6 shrink-0"
+      />
 
-      <div className="flex flex-col gap-6 flex-1 overflow-auto px-1 custom-scrollbar">
+      <div className="flex flex-col gap-6 flex-1 overflow-auto px-1">
         <div className="space-y-6 pr-1">
           {error && (
             <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-2 text-red-400">
@@ -188,17 +181,17 @@ export default function Profiles() {
           </Card>
 
           {/* Profile List */}
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5 pb-6">
-            {profiles.length === 0 ? (
-              <div className="col-span-full border border-dashed border-white/10 rounded-xl bg-bg-secondary/30 py-12">
-                <EmptyState
-                  icon={User}
-                  title="No Profiles Yet"
-                  description="Create your first profile above to save your current mod configuration."
-                />
-              </div>
-            ) : (
-              profiles.map((profile) => {
+          {profiles.length === 0 ? (
+            <div className="py-16">
+              <EmptyState
+                icon={User}
+                title="No Profiles Yet"
+                description="Create your first profile above to save your current mod configuration."
+              />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5 pb-6">
+              {profiles.map((profile) => {
                 const isApplying = applyingId === profile.id;
                 const isUpdating = updatingId === profile.id;
                 const isActive = activeProfileId === profile.id;
@@ -288,7 +281,7 @@ export default function Profiles() {
                             <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
                               Mods ({profile.mods.length})
                             </div>
-                            <div className="max-h-32 overflow-y-auto pr-2 custom-scrollbar space-y-1">
+                            <div className="max-h-32 overflow-y-auto pr-2 space-y-1">
                               {profile.mods.map((mod, idx) => {
                                 const displayName = modNameMap.get(mod.fileName) || mod.fileName;
                                 return (
@@ -330,7 +323,7 @@ export default function Profiles() {
                               <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
                                 Autoexec ({profile.autoexecCommands.length} commands)
                               </div>
-                              <div className="space-y-1 max-h-24 overflow-y-auto custom-scrollbar">
+                              <div className="space-y-1 max-h-24 overflow-y-auto">
                                 {profile.autoexecCommands.map((cmd, idx) => (
                                   <div key={idx} className="text-xs font-mono bg-white/5 rounded px-2 py-1 truncate" title={cmd}>
                                     {cmd}
@@ -344,9 +337,9 @@ export default function Profiles() {
                     </div>
                   </Card>
                 );
-              })
-            )}
-          </div>
+              })}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { Settings as SettingsIcon, FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle } from 'lucide-react';
+import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
 import {
   cleanupAddons,
@@ -11,6 +12,7 @@ import {
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
+import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
 
 export default function Settings() {
   const { settings, settingsLoading, loadSettings, saveSettings, detectDeadlock } = useAppStore();
@@ -28,6 +30,9 @@ export default function Settings() {
   const [syncProgress, setSyncProgress] = useState<{ section: string; modsProcessed: number; totalMods: number } | null>(null);
   const [isWipingCache, setIsWipingCache] = useState(false);
   const [wipeResult, setWipeResult] = useState<string | null>(null);
+  const [wipeConfirmOpen, setWipeConfirmOpen] = useState(false);
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const [resetResult, setResetResult] = useState<string | null>(null);
 
   // Updater state
   const [appVersion, setAppVersion] = useState<string>('');
@@ -288,9 +293,7 @@ export default function Settings() {
   };
 
   const handleWipeCache = async () => {
-    if (!confirm('Wipe the local mod cache? This will remove all cached mods and sync state.')) {
-      return;
-    }
+    setWipeConfirmOpen(false);
     setIsWipingCache(true);
     setWipeResult(null);
     try {
@@ -302,6 +305,18 @@ export default function Settings() {
       setWipeResult(String(err));
     } finally {
       setIsWipingCache(false);
+    }
+  };
+
+  const handleResetWizard = async () => {
+    setResetConfirmOpen(false);
+    if (!settings) return;
+    try {
+      await saveSettings({ ...settings, hasCompletedSetup: false });
+      setResetResult('The setup wizard will appear on the next app launch.');
+      setTimeout(() => setResetResult(null), 5000);
+    } catch (err) {
+      setResetResult(`Error: ${String(err)}`);
     }
   };
 
@@ -323,15 +338,10 @@ export default function Settings() {
 
   return (
     <div className="p-8 max-w-5xl mx-auto space-y-8">
-      <div className="flex items-center gap-3">
-        <div className="p-3 bg-accent/10 rounded-xl">
-          <SettingsIcon className="w-8 h-8 text-accent" />
-        </div>
-        <div>
-          <h1 className="text-3xl font-bold font-reaver tracking-wide">Settings</h1>
-          <p className="text-text-secondary">Configure game paths, preferences, and maintenance tasks</p>
-        </div>
-      </div>
+      <PageHeader
+        title="Settings"
+        description="Configure game paths, preferences, and maintenance tasks"
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Game Configuration Section - Full Width */}
@@ -598,14 +608,12 @@ export default function Settings() {
                 <p className="text-xs text-text-secondary mt-1">
                   Show the first-run setup wizard again on next app launch.
                 </p>
+                {resetResult && (
+                  <p className="text-xs text-accent mt-2 animate-fade-in">{resetResult}</p>
+                )}
               </div>
               <Button
-                onClick={async () => {
-                  if (settings) {
-                    await saveSettings({ ...settings, hasCompletedSetup: false });
-                    alert('Setup wizard will appear on next app restart.');
-                  }
-                }}
+                onClick={() => setResetConfirmOpen(true)}
                 variant="secondary"
                 size="sm"
                 icon={RefreshCw}
@@ -644,11 +652,9 @@ export default function Settings() {
                   </div>
                   <div className="w-full bg-bg-tertiary rounded-full h-1.5 overflow-hidden">
                     <div
-                      className="bg-accent h-full rounded-full transition-all duration-300 ease-out relative overflow-hidden"
+                      className="bg-accent h-full rounded-full transition-all duration-300 ease-out"
                       style={{ width: `${Math.min(100, (syncProgress.modsProcessed / syncProgress.totalMods) * 100)}%` }}
-                    >
-                      <div className="absolute inset-0 bg-white/20 animate-[shimmer_1s_infinite]" />
-                    </div>
+                    />
                   </div>
                 </div>
               )}
@@ -660,7 +666,7 @@ export default function Settings() {
 
             <div className="flex gap-3 shrink-0">
               <Button
-                onClick={handleWipeCache}
+                onClick={() => setWipeConfirmOpen(true)}
                 disabled={isWipingCache || isSyncing}
                 isLoading={isWipingCache}
                 variant="danger"
@@ -684,7 +690,7 @@ export default function Settings() {
       {/* Changelog Modal */}
       {showChangelog && updateStatus?.updateInfo && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in">
-          <div className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-2xl max-h-[80vh] overflow-hidden shadow-2xl animate-scale-in">
+          <div className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-2xl max-h-[80vh] overflow-hidden shadow-2xl animate-fade-in">
             <div className="flex items-center justify-between p-6 border-b border-white/10">
               <div>
                 <h2 className="text-xl font-bold">What's New in v{updateStatus.updateInfo.version}</h2>
@@ -705,7 +711,7 @@ export default function Settings() {
               {typeof updateStatus.updateInfo.releaseNotes === 'string' ? (
                 <div
                   className="prose prose-invert prose-sm max-w-none"
-                  dangerouslySetInnerHTML={{ __html: updateStatus.updateInfo.releaseNotes }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(updateStatus.updateInfo.releaseNotes) }}
                 />
               ) : Array.isArray(updateStatus.updateInfo.releaseNotes) ? (
                 <div className="space-y-4">
@@ -715,7 +721,7 @@ export default function Settings() {
                       {note.note && (
                         <div
                           className="prose prose-invert prose-sm max-w-none mt-1"
-                          dangerouslySetInnerHTML={{ __html: note.note }}
+                          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(note.note) }}
                         />
                       )}
                     </div>
@@ -745,6 +751,26 @@ export default function Settings() {
           </div>
         </div>
       )}
+
+      <ConfirmModal
+        isOpen={wipeConfirmOpen}
+        onCancel={() => setWipeConfirmOpen(false)}
+        onConfirm={handleWipeCache}
+        title="Wipe mod cache?"
+        message="This removes all cached mod metadata and sync state. The next Browse session will re-sync from GameBanana (a few minutes on first run). Your installed mods are not affected."
+        confirmLabel="Wipe Cache"
+        variant="danger"
+      />
+
+      <ConfirmModal
+        isOpen={resetConfirmOpen}
+        onCancel={() => setResetConfirmOpen(false)}
+        onConfirm={handleResetWizard}
+        title="Reset setup wizard?"
+        message="The first-run setup wizard will appear the next time you launch the app. Your settings and installed mods are not affected."
+        confirmLabel="Reset"
+        variant="primary"
+      />
     </div>
   );
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -47,7 +47,7 @@ export default function Stats() {
         playerHeroStats,
         playerMatchHistory,
         aggregatedStats,
-        localMMRHistory,
+        localMMRHistory: _localMMRHistory,
         localMatchHistory,
         playerDataLoading,
         playerDataError,
@@ -64,18 +64,18 @@ export default function Stats() {
         // Expanded analytics
         builds,
         buildsLoading,
-        patchNotes,
-        patchNotesLoading,
+        patchNotes: _patchNotes,
+        patchNotesLoading: _patchNotesLoading,
         heroCounters,
         heroSynergies,
         heroCounterSynergyLoading,
-        itemAnalytics,
-        itemAnalyticsLoading,
+        itemAnalytics: _itemAnalytics,
+        itemAnalyticsLoading: _itemAnalyticsLoading,
         badgeDistribution,
-        mmrDistribution,
+        mmrDistribution: _mmrDistribution,
         distributionLoading,
-        killDeathStats,
-        killDeathStatsLoading,
+        killDeathStats: _killDeathStats,
+        killDeathStatsLoading: _killDeathStatsLoading,
         heroCombStats,
         heroCombStatsLoading,
         // Actions
@@ -89,13 +89,13 @@ export default function Stats() {
         loadHeroAnalytics,
         loadSocialStats,
         loadBuilds,
-        loadPatchNotes,
+        loadPatchNotes: _loadPatchNotes,
         loadHeroCounters,
         loadHeroSynergies,
-        loadItemAnalytics,
+        loadItemAnalytics: _loadItemAnalytics,
         loadBadgeDistribution,
-        loadMMRDistribution,
-        loadKillDeathStats,
+        loadMMRDistribution: _loadMMRDistribution,
+        loadKillDeathStats: _loadKillDeathStats,
         loadHeroCombStats,
         refreshAll,
     } = useStatsStore()
@@ -154,7 +154,8 @@ export default function Stats() {
         }
     }
 
-    const selectedPlayer = trackedPlayers.find((p) => p.account_id === selectedAccountId)
+    const _selectedPlayer = trackedPlayers.find((p) => p.account_id === selectedAccountId)
+    void _selectedPlayer; // retained for upcoming player-detail panel
 
     const tabs: { id: Tab; label: string; icon: typeof Users }[] = [
         { id: 'overview', label: 'Overview', icon: BarChart3 },

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -260,6 +260,9 @@ export interface ElectronAPI {
     // Dialogs
     showOpenDialog: (options: OpenDialogOptions) => Promise<string | null>;
 
+    // Drag & drop
+    getDroppedFilePath: (file: File) => string;
+
     // Events
     onDownloadProgress: (callback: (data: DownloadProgressData) => void) => () => void;
     onDownloadExtracting: (callback: (data: DownloadEventData) => void) => () => void;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -246,6 +246,7 @@ export interface ElectronAPI {
     setMinaPreset: (args: SetMinaPresetArgs) => Promise<void>;
     listMinaVariants: (args: ListMinaVariantsArgs) => Promise<string[]>;
     applyMinaVariant: (args: ApplyMinaVariantArgs) => Promise<void>;
+    downloadMinaVariations: () => Promise<string>;
 
     // Maintenance
     cleanupAddons: () => Promise<CleanupResult>;


### PR DESCRIPTION
## Summary
Eleven focused commits cleaning up contrast/a11y, modernizing four legacy pages, adding drag-and-drop to the Custom Mod import, restructuring Browse's toolbar, and clearing the pre-existing TS errors on `main`.

## What changed

- **WCAG contrast + focus-visibility pass** (shared UI). Primary buttons were `text-white` on `bg-accent` (2.8:1, AA fail) → `text-black`. Secondary/ghost focus rings bumped from invisible (`/20` or none) to visible. Toggle gained a real focus indicator. Added `--color-text-tertiary` (Conflicts had been referencing the undefined token), bumped skeleton shimmer 0.04→0.09 so it's actually perceivable, added `prefers-reduced-motion` support, fixed AudioPreviewPlayer mute aria-label.
- **Installed: drag-and-drop file import.** Both VPK and thumbnail rows in the Import Custom Mod modal accept dropped files (extension-validated, kbd-activatable, accessible). Required preload work to expose `webUtils.getPathForFile` (Electron 32+ removed `File.path`) and a window-level `dragover/drop` swallow so stray drops don't navigate the window. Header simplified — dropped the `N enabled / N total` line so the title aligns with the toolbar controls.
- **Conflicts: confirm before disabling.** Disable buttons now route through ConfirmModal naming the mod and explaining where it goes. ConfirmModal itself was hardened: `role="dialog"`, `aria-modal`, `aria-labelledby`, backdrop click-to-cancel, fixed its own AA failures.
- **Autoexec / Profiles / Settings: PageHeader + ConfirmModal pass.** All three pages had ad-hoc icon+title headers — replaced with the shared `PageHeader`. Settings' Wipe Cache used `window.confirm()`, Reset Wizard used `window.alert()` — both now use ConfirmModal. Settings release notes now run through DOMPurify before `dangerouslySetInnerHTML`. Removed two broken animation references (`animate-scale-in`, `animate-[shimmer_…]`) that referenced undefined keyframes. Profiles' empty-state stopped rendering as a dashed grid cell.
- **Conflicts empty-state centering.** Required a Layout fix: the keyed `<Outlet>` wrapper had no height so percentage children collapsed. Adding `h-full` to the wrapper makes `h-full` reliably resolve in routed pages.
- **Browse toolbar restructure.** Mod / Sound section selector is now an icon-tab segmented control (Package / Music) instead of a dropdown. Hero + Category dropdowns collapsed into a single `Filters` popover with active-count badge, "Clear all", outside-click + Escape close. Darkened the four overlay-button rings on mod cards (`ring-white/25` was a glowing halo on bright thumbnails) and fixed two more `text-white on bg-accent` AA fails plus an undefined `bg-accent-secondary` hover token.
- **Sidebar UpdateModal.** Clicking the version footer when an update is pending now opens a focused UpdateModal in-place (sanitized release notes, download progress, context-aware Check / Download / Install button) instead of dumping the user in Settings to hunt for the Updates card. Falls back to `/settings` navigation when there's no update.
- **TypeScript cleanup.** Cleared all 14 pre-existing TS errors on `main`. Real fixes: `window.api` → `window.electronAPI` in HeroSkinsPanel (would've crashed at runtime when Mina download was clicked), missing `downloadMinaVariations` typing in `electron.d.ts`, `ModConflict.conflictType` was declared as `'priority' | 'samefile'` in two places but main emits `'priority' | 'file'` (aligned to source of truth), `cardRef` typed as `HTMLButtonElement` but attached to a `<div>`. Remaining unused-decl warnings (Stats experimental dashboard scaffolding) prefixed with `_` since the panels are still planned.

## Test plan
- [x] Browse: section icon-tabs switch Mod ↔ Sound; Filters popover opens on click and closes on outside-click / Esc; active-count badge appears when Hero or Category is set; Clear all resets both
- [x] Browse mod cards: install/installed/downloading/queued buttons read as dark pills against bright thumbnails (no white halo)
- [x] Installed → Add Custom Mod: drag a `.vpk` from Explorer into the top zone — populates path + auto-derives name; drop a non-VPK → inline error; drop on empty page background → window does NOT navigate
- [x] Conflicts: empty-state "No Conflicts Detected" centered both axes; clicking Disable on a mod opens ConfirmModal; Cancel leaves it alone, Confirm disables
- [x] Autoexec: Clear button prompts before wiping; header matches other pages
- [x] Profiles: with zero profiles, empty-state is plain centered (not a dashed grid cell)
- [x] Settings: Wipe Cache and Reset Wizard now use themed ConfirmModal (no native dialogs)
- [x] Sidebar: with an update pending, clicking the `vX.Y.Z` footer opens the UpdateModal (don't navigate to Settings); without pending update, falls back to Settings
- [x] Toggle keyboard focus shows an orange ring; Tab through Settings/Browse — secondary/ghost buttons all show visible focus rings
- [x] `pnpm tsc -p tsconfig.app.json --noEmit` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)