### PR TITLE
fix(browse): hero filter on Sound tab, audio play button on searched mods, larger window

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -31,10 +31,10 @@ let mainWindow: BrowserWindow | null = null;
 
 function createWindow(): void {
     mainWindow = new BrowserWindow({
-        width: 800,
-        height: 600,
-        minWidth: 600,
-        minHeight: 400,
+        width: 1280,
+        height: 800,
+        minWidth: 900,
+        minHeight: 600,
         title: 'Grimoire',
         show: false, // Don't show until ready to prevent white flash
         backgroundColor: '#1e1e2e', // Dark background matching app theme

--- a/electron/main/services/modDatabase.ts
+++ b/electron/main/services/modDatabase.ts
@@ -19,6 +19,7 @@ export interface CachedMod {
     hasFiles: boolean;
     isNsfw: boolean;
     thumbnailUrl: string | null;
+    audioUrl: string | null;
     profileUrl: string;
     cachedAt: number;
 }
@@ -80,6 +81,7 @@ export function initDatabase(): Database.Database {
                 has_files INTEGER DEFAULT 1,
                 is_nsfw INTEGER DEFAULT 0,
                 thumbnail_url TEXT,
+                audio_url TEXT,
                 profile_url TEXT,
                 cached_at INTEGER DEFAULT (strftime('%s', 'now'))
             );
@@ -207,12 +209,12 @@ export function upsertMod(mod: CachedMod): void {
             id, name, section, category_id, category_name,
             submitter_name, submitter_id, like_count, view_count,
             date_added, date_modified, has_files, is_nsfw,
-            thumbnail_url, profile_url, cached_at
+            thumbnail_url, audio_url, profile_url, cached_at
         ) VALUES (
             @id, @name, @section, @categoryId, @categoryName,
             @submitterName, @submitterId, @likeCount, @viewCount,
             @dateAdded, @dateModified, @hasFiles, @isNsfw,
-            @thumbnailUrl, @profileUrl, @cachedAt
+            @thumbnailUrl, @audioUrl, @profileUrl, @cachedAt
         )
         ON CONFLICT(id) DO UPDATE SET
             name = excluded.name,
@@ -228,6 +230,7 @@ export function upsertMod(mod: CachedMod): void {
             has_files = excluded.has_files,
             is_nsfw = excluded.is_nsfw,
             thumbnail_url = excluded.thumbnail_url,
+            audio_url = excluded.audio_url,
             profile_url = excluded.profile_url,
             cached_at = excluded.cached_at
     `);
@@ -248,12 +251,12 @@ export function upsertMods(mods: CachedMod[]): void {
             id, name, section, category_id, category_name,
             submitter_name, submitter_id, like_count, view_count,
             date_added, date_modified, has_files, is_nsfw,
-            thumbnail_url, profile_url, cached_at
+            thumbnail_url, audio_url, profile_url, cached_at
         ) VALUES (
             @id, @name, @section, @categoryId, @categoryName,
             @submitterName, @submitterId, @likeCount, @viewCount,
             @dateAdded, @dateModified, @hasFiles, @isNsfw,
-            @thumbnailUrl, @profileUrl, @cachedAt
+            @thumbnailUrl, @audioUrl, @profileUrl, @cachedAt
         )
         ON CONFLICT(id) DO UPDATE SET
             name = excluded.name,
@@ -269,6 +272,7 @@ export function upsertMods(mods: CachedMod[]): void {
             has_files = excluded.has_files,
             is_nsfw = excluded.is_nsfw,
             thumbnail_url = excluded.thumbnail_url,
+            audio_url = excluded.audio_url,
             profile_url = excluded.profile_url,
             cached_at = excluded.cached_at
     `);
@@ -364,6 +368,7 @@ export function mapRowToMod(row: Record<string, unknown>): CachedMod {
         hasFiles: row.has_files != null ? (row.has_files as number) === 1 : true,
         isNsfw: row.is_nsfw != null ? (row.is_nsfw as number) === 1 : false,
         thumbnailUrl: row.thumbnail_url as string | null,
+        audioUrl: row.audio_url as string | null,
         profileUrl: (row.profile_url as string) ?? '',
         cachedAt: (row.cached_at as number) ?? 0,
     };
@@ -438,5 +443,11 @@ function runMigrations(database: Database.Database): void {
     if (!hasDownloadCount) {
         console.log('[ModDatabase] Running migration: adding download_count column');
         database.exec('ALTER TABLE mods ADD COLUMN download_count INTEGER');
+    }
+
+    const hasAudioUrl = tableInfo.some(col => col.name === 'audio_url');
+    if (!hasAudioUrl) {
+        console.log('[ModDatabase] Running migration: adding audio_url column');
+        database.exec('ALTER TABLE mods ADD COLUMN audio_url TEXT');
     }
 }

--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -79,6 +79,7 @@ function mapToCache(mod: GameBananaMod, section: string): CachedMod {
         hasFiles: mod.hasFiles ?? true,
         isNsfw: mod.nsfw ?? false,
         thumbnailUrl,
+        audioUrl: mod.previewMedia?.metadata?.audioUrl ?? null,
         profileUrl: mod.profileUrl,
         cachedAt: Math.floor(Date.now() / 1000),
     };

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -153,6 +153,10 @@ export default function Browse() {
   const [sections, setSections] = useState<GameBananaSection[]>([]);
   const [section, setSection] = useState('Mod');
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>([]);
+  // Hero list comes from the Mod section's category tree (Mod -> Skins -> heroes).
+  // Cached separately so hero filtering still works on the Sound tab, where the
+  // current section's category tree has no Skins parent.
+  const [modCategories, setModCategories] = useState<GameBananaCategoryNode[]>([]);
   const [heroCategoryId, setHeroCategoryId] = useState<number | 'all'>('all');
   const [categoryId, setCategoryId] = useState<number | 'all'>('all');
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
@@ -163,7 +167,9 @@ export default function Browse() {
   const [extracting, setExtracting] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
-  const [useLocalSearch, setUseLocalSearch] = useState(false);
+  // When local search fails (e.g. SQLite error), this flips so the main fetch
+  // effect falls back to the API path. Resets whenever filter inputs change.
+  const [localSearchFailed, setLocalSearchFailed] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [downloadQueue, setDownloadQueue] = useState<Array<{ modId: number; fileId: number; fileName: string }>>([]);
@@ -237,14 +243,21 @@ export default function Browse() {
 
   const effectiveSearch = search;
 
-  // Use local search when:
-  // 1. There's an active search query AND we have cache, OR
-  // 2. A hero filter is selected (to enable enhanced OR search)
-  useEffect(() => {
+  // Derived (not state) so the right code path runs in the same render the
+  // user picks a hero/types a query. Storing it in useState lagged a render,
+  // which caused fetchMods (API, no hero filter) to race with searchLocal and
+  // overwrite real results with an empty API response.
+  const useLocalSearch = useMemo(() => {
     const hasSearchQuery = search.trim().length > 0;
     const hasHeroFilter = heroCategoryId !== 'all';
-    setUseLocalSearch((hasSearchQuery || hasHeroFilter) && hasLocalCache);
-  }, [search, hasLocalCache, heroCategoryId]);
+    return (hasSearchQuery || hasHeroFilter) && hasLocalCache && !localSearchFailed;
+  }, [search, heroCategoryId, hasLocalCache, localSearchFailed]);
+
+  // Reset the failure flag whenever the user changes filters so a one-off
+  // backend error doesn't permanently disable local search.
+  useEffect(() => {
+    setLocalSearchFailed(false);
+  }, [search, heroCategoryId, section]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
@@ -333,9 +346,10 @@ export default function Browse() {
         name: 'name',
       };
 
-      // Get hero name and skins category ID for enhanced hero search
-      // Look up hero name directly from Skins children to avoid circular dependency
-      const skinsCat = findCategoryByName(categories, 'Skins');
+      // Hero list lives under Mod -> Skins, but we want the filter to work on
+      // any section (Sound mods include the hero name in the title), so always
+      // resolve the hero from the Mod-category tree.
+      const skinsCat = findCategoryByName(modCategories, 'Skins');
       const selectedHeroName = heroCategoryId !== 'all' && skinsCat?.children
         ? skinsCat.children.find(c => c.id === heroCategoryId)?.name
         : undefined;
@@ -366,15 +380,20 @@ export default function Browse() {
         rootCategory: m.categoryId ? { id: m.categoryId, name: m.categoryName || '' } : undefined,
         submitter: m.submitterName ? { id: m.submitterId || 0, name: m.submitterName } : undefined,
         previewMedia: (() => {
-          if (!m.thumbnailUrl) return undefined;
-          const lastSlash = m.thumbnailUrl.lastIndexOf('/');
-          if (lastSlash === -1) return undefined;
-          const baseUrl = m.thumbnailUrl.substring(0, lastSlash);
-          const file = m.thumbnailUrl.substring(lastSlash + 1);
-          if (!baseUrl || !file) return undefined;
-          return {
-            images: [{ baseUrl, file, file530: file }]
-          };
+          let images: { baseUrl: string; file: string; file530: string }[] | undefined;
+          if (m.thumbnailUrl) {
+            const lastSlash = m.thumbnailUrl.lastIndexOf('/');
+            if (lastSlash !== -1) {
+              const baseUrl = m.thumbnailUrl.substring(0, lastSlash);
+              const file = m.thumbnailUrl.substring(lastSlash + 1);
+              if (baseUrl && file) {
+                images = [{ baseUrl, file, file530: file }];
+              }
+            }
+          }
+          const metadata = m.audioUrl ? { audioUrl: m.audioUrl } : undefined;
+          if (!images && !metadata) return undefined;
+          return { images, metadata };
         })(),
       }));
 
@@ -387,19 +406,32 @@ export default function Browse() {
       setHasMore(convertedMods.length === perPage && page * perPage < result.totalCount);
     } catch (err) {
       console.error('Local search failed, falling back to API:', err);
-      // Setting useLocalSearch to false will trigger the effect to call fetchMods
-      setUseLocalSearch(false);
+      setLocalSearchFailed(true);
     } finally {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, categories]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, modCategories]);
 
   useEffect(() => {
     setPage(1);
     setHasMore(true);
     setMods([]);
   }, [search, sort, section, effectiveCategoryId, perPage]);
+
+  useEffect(() => {
+    let active = true;
+    getGamebananaCategories('ModCategory')
+      .then((data) => {
+        if (active) setModCategories(data);
+      })
+      .catch(() => {
+        // Hero filter just won't be available; not fatal.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -727,8 +759,7 @@ export default function Browse() {
   };
 
   const heroOptions = useMemo(() => {
-    if (section !== 'Mod') return [];
-    const skins = findCategoryByName(categories, 'Skins');
+    const skins = findCategoryByName(modCategories, 'Skins');
     if (!skins?.children) return [];
     return skins.children
       .filter((child) => child.itemCount > 0)
@@ -736,7 +767,7 @@ export default function Browse() {
         id: child.id,
         label: child.name,
       }));
-  }, [categories, section]);
+  }, [modCategories]);
 
   const categoryOptions = useMemo(() => {
     const heroIds = new Set(heroOptions.map((hero) => hero.id));

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -162,6 +162,7 @@ export interface CachedMod {
     hasFiles: boolean;
     isNsfw: boolean;
     thumbnailUrl: string | null;
+    audioUrl: string | null;
     profileUrl: string;
     cachedAt: number;
 }


### PR DESCRIPTION
## Summary

Addresses three of the four items from the user-reported issue:

- **Hero filter now works on the Audio (Sound) tab.** The hero list is now sourced from a cached Mod-section category tree (`Mod -> Skins -> heroes`) so it stays available regardless of which tab is active. Backend (`searchService.ts`) already supports name-LIKE hero matching across sections.
- **Play button now appears on searched audio mods.** Local search converted `CachedMod -> GameBananaMod` without `previewMedia.metadata.audioUrl`, so `getSoundPreviewUrl` returned `undefined` for cached results and the player was suppressed. Adds `audio_url` to the `mods` table (with migration), persists it during sync, and rebuilds `previewMedia.metadata.audioUrl` in the renderer's converter. Existing cached rows fill in on the next Refresh.
- **Default window size enlarged.** `800x600 -> 1280x800`, min `600x400 -> 900x600`. Re: comment — the previous default was a 4:3 footprint that felt cramped/square on modern displays. `1280x800` is a 16:10 landscape default that better fits the sidebar + grid layout.

### Bonus race fix

While verifying the hero filter, a flash-then-empty bug surfaced: picking a hero would briefly show correct local-search results then collapse to "no mods match your filters". Root cause was that `useLocalSearch` was stored in `useState` and set inside a `useEffect`, so it lagged one render behind hero changes. The first dispatch fired `fetchMods` (API path, with a Mod-section category id applied to a Sound query — empty) and the second fired `searchLocal` (correct), but the slower API response settled last and overwrote real results. Fixed by deriving `useLocalSearch` via `useMemo` so the right path is taken in the same render. The SQLite-error fallback is preserved via a `localSearchFailed` flag that resets on filter change.

### Skipped: Profiles restoring deleted mods

Per discussion in the issue thread: profiles being snapshots of *enable/disable state* rather than the mod files themselves is consistent with standard CRUD semantics — `delete` removes from disk by design. Not changing this behavior.

## Test plan

- [x] On the Mods tab, pick a hero → results filter correctly, no flash-then-empty.
- [x] On the Sound tab, the Hero dropdown now appears in Filters → picking a hero filters audio mods whose title contains the hero name.
- [x] On the Sound tab, type a search query → the matching mods now show the play button (after a Refresh to populate `audio_url` for already-cached rows).
- [x] Fresh install: window opens at 1280x800; min size is 900x600 and resizing below that is blocked.
- [x] Existing install: DB migration runs without errors (`audio_url` column added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)