### PR TITLE
Release 1.7.0 — forum-feedback fixes, launch options, mod-details redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented here. Format is loosely based
 - **"Enable now" affordance** when a freshly-downloaded mod lands disabled — appears on the sidebar download-complete toast *and* as a yellow Enable pill in the Browse mod-details file row, so users don't have to bounce to Installed to flip it on
 - **Ignore conflicts.** Conflicts page gains a per-card Ignore action and an "Ignored (N)" panel at the bottom with Unignore. Pairs persist in app settings and are stripped by the backend detector
 - **Sibling-variant auto-disable toast** with a *View* action — previously silent on re-download, easy to mistake for data loss. Gated behind a new `autoDisableSiblingVariants` setting (default on)
+- **"Update all" button** on the Installed page header — visible when one or more mods carry the Update badge. Re-downloads each flagged mod serially through the existing download queue and restores each one's pre-update enabled state (downloads always land disabled by default). Per-item failures are caught so one bad mod doesn't halt the rest
 
 ### Changed
 - **Mod Details modal redesign.** Single-row header (status + category + title + date/download metadata + close), responsive two-column body at lg+ with independently scrollable image and content columns, vertical preview stack so users scroll naturally through every screenshot, click-to-zoom lightbox using GameBanana's full-resolution asset, and visually separated Files / Comments sections. Modal grows to `max-w-6xl` on wide screens so it stops leaving dark gutters on 1080p+ displays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project are documented here. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [1.7.0] - 2026-05
+
+### Added
+- **Steam Launch Options** field on the Autoexec page. Writes `-high -nojoy` (or whatever you set) into Steam's `localconfig.vdf` for Deadlock right before the launch URL fires. Surgical byte-level edits with a `.grimoire.bak` backup and atomic temp+rename; fails closed if the file structure doesn't match what we expect. Read-only status row shows the on-disk value and warns when Steam is currently running
+- **Multi-VPK picker.** Archives containing multiple `.vpk` files (Warden Remodel, etc.) now surface a checkbox modal listing every extracted file instead of silently keeping the first and unlinking the rest. Applies to both regular installs and the 1-Click flow
+- **Human-readable VPK labels** in the multi-VPK picker. Hero asset paths, materials/skybox folders, panorama theme folders, and map folders are detected and labeled (e.g. *"Abrams"*, *"Galaxy skybox"*); raw filename is shown muted underneath when nothing distinctive matches
+- **Multi-version picker.** Quick-download on a mod card with more than one downloadable file now opens the mod-details modal so the user picks the file explicitly. Single-file mods still quick-install in one click
+- **Variant grouping on the Installed page.** Multi-variant downloads of the same GameBanana mod collapse into a single card. Click the card to open a picker that lets the user switch the active variant (mutual exclusion), rename variants inline, delete individual variants, or disable the whole group. Drag-reorder moves a group as a block
+- **"Active variant" tag** on grouped Installed cards — Layers-iconed pill anchored to the bottom-left of the thumbnail shows which preset is live
+- **"Enable now" affordance** when a freshly-downloaded mod lands disabled — appears on the sidebar download-complete toast *and* as a yellow Enable pill in the Browse mod-details file row, so users don't have to bounce to Installed to flip it on
+- **Ignore conflicts.** Conflicts page gains a per-card Ignore action and an "Ignored (N)" panel at the bottom with Unignore. Pairs persist in app settings and are stripped by the backend detector
+- **Sibling-variant auto-disable toast** with a *View* action — previously silent on re-download, easy to mistake for data loss. Gated behind a new `autoDisableSiblingVariants` setting (default on)
+
+### Changed
+- **Mod Details modal redesign.** Single-row header (status + category + title + date/download metadata + close), responsive two-column body at lg+ with independently scrollable image and content columns, vertical preview stack so users scroll naturally through every screenshot, click-to-zoom lightbox using GameBanana's full-resolution asset, and visually separated Files / Comments sections. Modal grows to `max-w-6xl` on wide screens so it stops leaving dark gutters on 1080p+ displays
+- Mod Details now shows **all installed siblings** of the same GameBanana mod with an explicit *Active* badge on the enabled row, matching the Browse view
+- **GameBanana per-file headers** (`_sDescription`) now feed variant labels by default: rows read *"Gold w/ alt candle"* instead of `pak04_dir.vpk`. User renames still win. New installs only — no backfill
+- Letterboxed preview thumbs in the mod-details modal use a **blurred backdrop** instead of harsh black bars
+- **Autoexec page** reorganized: Launch Options card moves into the right column above "Your Commands" so the launch stack reads top-to-bottom: launch args → autoexec commands → file status
+- Installed page default view is **Cards (grid)** instead of List for new users; existing localStorage preference still wins
+- Sidebar download-complete toast removed in favor of the card-level Enable pill (less redundant — the user's eye is already on the card they clicked)
+
+### Fixed
+- **Browse-tab state survives navigation.** Search query, filters, view mode, sort, loaded mods, page state, and scroll position all persist when switching tabs and returning. Scroll restore had a latent bug — cleanup ran after React detached the ref, so saved `scrollTop` was always 0
+- **Search input debounced** (250ms). Stops blanking results into a skeleton grid on every keystroke; inline spinner shows in the input while debouncing or refetching
+- **FTS5 fallback to substring LIKE** when prefix search returns zero rows, so creative mod names and typos still surface something
+- Quick-download no longer silently picks a variant on multi-file mods
+
+## [1.6.2] - 2026-05
+
+### Changed
+- Installed-tab UX polish: faster variant swap, drag/view improvements
+
+### Fixed
+- Update modal release-notes styling
+- Crosshair preview now clears when the active preset is deselected
+
 ## [1.6.1] - 2026-04
 
 ### Added
@@ -122,6 +159,10 @@ All notable changes to this project are documented here. Format is loosely based
 
 Initial public release. Repo rebranded from `modmanager` to `grimoire`.
 
+[1.7.0]: https://github.com/Slush97/grimoire/releases/tag/v1.7.0
+[1.6.2]: https://github.com/Slush97/grimoire/releases/tag/v1.6.2
+[1.6.1]: https://github.com/Slush97/grimoire/releases/tag/v1.6.1
+[1.6.0]: https://github.com/Slush97/grimoire/releases/tag/v1.6.0
 [1.5.5]: https://github.com/Slush97/grimoire/releases/tag/v1.5.5
 [1.5.0]: https://github.com/Slush97/grimoire/releases/tag/v1.5.0
 [1.4.0]: https://github.com/Slush97/grimoire/releases/tag/v1.4.0

--- a/electron/main/ipc/conflicts.ts
+++ b/electron/main/ipc/conflicts.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
-import { detectConflicts, ModConflict } from '../services/conflicts';
+import { loadSettings, saveSettings } from '../services/settings';
+import { detectConflicts, conflictPairKey, ModConflict } from '../services/conflicts';
 
 /**
  * Get the active deadlock path from settings
@@ -20,4 +20,37 @@ ipcMain.handle('get-conflicts', async (): Promise<ModConflict[]> => {
         return [];
     }
     return await detectConflicts(deadlockPath);
+});
+
+// get-ignored-conflicts — returns the raw list of ignored pair keys. The
+// Conflicts page uses this to render an "Ignored" panel with Unignore actions.
+ipcMain.handle('get-ignored-conflicts', (): string[] => {
+    return loadSettings().ignoredConflicts ?? [];
+});
+
+// ignore-conflict — adds a pair to the ignored list. Idempotent — adding
+// the same pair twice is a no-op.
+ipcMain.handle('ignore-conflict', (_, modA: string, modB: string): string[] => {
+    const settings = loadSettings();
+    const key = conflictPairKey(modA, modB);
+    const current = settings.ignoredConflicts ?? [];
+    if (current.includes(key)) {
+        return current;
+    }
+    const next = [...current, key];
+    saveSettings({ ...settings, ignoredConflicts: next });
+    return next;
+});
+
+// unignore-conflict — removes a pair from the ignored list. No-op if the
+// pair wasn't ignored.
+ipcMain.handle('unignore-conflict', (_, modA: string, modB: string): string[] => {
+    const settings = loadSettings();
+    const key = conflictPairKey(modA, modB);
+    const current = settings.ignoredConflicts ?? [];
+    const next = current.filter((k) => k !== key);
+    if (next.length !== current.length) {
+        saveSettings({ ...settings, ignoredConflicts: next });
+    }
+    return next;
 });

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -11,7 +11,7 @@ import {
     GameBananaModsResponse,
     GameBananaModDetails,
 } from '../services/gamebanana';
-import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, resolveSuspiciousFileDecision, DownloadModArgs } from '../services/download';
+import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, resolveSuspiciousFileDecision, resolveMultiVpkPick, DownloadModArgs } from '../services/download';
 import { getMainWindow } from '../index';
 import { updateModNsfw } from '../services/modDatabase';
 
@@ -108,6 +108,14 @@ ipcMain.handle(
     'one-click-suspicious-response',
     (_, args: { requestId: string; accepted: boolean }): void => {
         resolveSuspiciousFileDecision(args.requestId, args.accepted);
+    }
+);
+
+// multi-vpk-pick-response (renderer hands back the user's VPK selection)
+ipcMain.handle(
+    'multi-vpk-pick-response',
+    (_, args: { requestId: string; selected: string[] | null }): void => {
+        resolveMultiVpkPick(args.requestId, args.selected === null ? null : { selected: args.selected });
     }
 );
 

--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -8,6 +8,7 @@ import {
     recoverFromStashOnStartup,
     type RestoreResult,
 } from '../services/launch';
+import { readLaunchOptions, isSteamRunning } from '../services/launchOptions';
 import { getMainWindow } from '../index';
 
 function getActiveDeadlockPath(): string | null {
@@ -50,6 +51,27 @@ ipcMain.handle('get-vanilla-stash-status', async (): Promise<{
         active: true,
         startedAt: stash.startedAt,
         modCount: stash.mods.length,
+    };
+});
+
+ipcMain.handle('get-steam-launch-options-status', async (): Promise<{
+    available: boolean;
+    configPath: string | null;
+    currentValue: string | null;
+    steamRunning: boolean;
+}> => {
+    const [lookup, running] = await Promise.all([
+        readLaunchOptions(),
+        isSteamRunning(),
+    ]);
+    if (!lookup) {
+        return { available: false, configPath: null, currentValue: null, steamRunning: running };
+    }
+    return {
+        available: true,
+        configPath: lookup.configPath,
+        currentValue: lookup.currentValue,
+        steamRunning: running,
     };
 });
 

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -45,6 +45,7 @@ function enrichMod(mod: Mod): Mod {
             categoryName: metadata.categoryName,
             sourceSection: metadata.sourceSection,
             nsfw: metadata.nsfw,
+            variantLabel: metadata.variantLabel,
         };
     }
     return mod;
@@ -88,6 +89,30 @@ ipcMain.handle('delete-mod', async (_, modId: string): Promise<void> => {
     }
     await deleteMod(deadlockPath, modId);
 });
+
+// set-variant-label — user-facing rename of a single VPK (the "variant"
+// inside a grouped mod). Stored alongside the mod's other metadata so it
+// survives priority renames via migrateModMetadata. An empty string clears
+// the label and falls back to the filename-derived display.
+ipcMain.handle(
+    'set-variant-label',
+    async (_, modId: string, label: string): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const all = await scanMods(deadlockPath);
+        const target = all.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+        const trimmed = label.trim();
+        setModMetadata(target.fileName, {
+            variantLabel: trimmed.length > 0 ? trimmed : undefined,
+        });
+        return enrichMod(target);
+    }
+);
 
 // set-mod-priority
 ipcMain.handle(

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -46,6 +46,7 @@ function enrichMod(mod: Mod): Mod {
             sourceSection: metadata.sourceSection,
             nsfw: metadata.nsfw,
             variantLabel: metadata.variantLabel,
+            fileDescription: metadata.fileDescription,
         };
     }
     return mod;

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -47,6 +47,7 @@ function enrichMod(mod: Mod): Mod {
             nsfw: metadata.nsfw,
             variantLabel: metadata.variantLabel,
             fileDescription: metadata.fileDescription,
+            sourceFileName: metadata.sourceFileName,
         };
     }
     return mod;

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -1,5 +1,14 @@
 import { scanMods, Mod } from './mods';
 import { parseVpkDirectory } from './vpk';
+import { loadSettings } from './settings';
+
+/**
+ * Build a stable order-independent key for a pair of mod ids. Sorts the two
+ * ids so detection order doesn't matter when checking the ignored list.
+ */
+export function conflictPairKey(a: string, b: string): string {
+    return a < b ? `${a}::${b}` : `${b}::${a}`;
+}
 
 // Files to ignore when checking for conflicts (non-game metadata files)
 const IGNORED_CONFLICT_FILES = new Set([
@@ -133,6 +142,14 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         }
     }
 
-    console.log(`[detectConflicts] Found ${conflicts.length} conflicts`);
-    return conflicts;
+    // Strip out any pairs the user has explicitly dismissed. We do this at
+    // the end rather than inside the loops so the ignored list stays a clean
+    // post-filter — easy to reason about and easy to disable later.
+    const ignored = new Set(loadSettings().ignoredConflicts ?? []);
+    const filtered = ignored.size === 0
+        ? conflicts
+        : conflicts.filter((c) => !ignored.has(conflictPairKey(c.modA, c.modB)));
+
+    console.log(`[detectConflicts] Found ${conflicts.length} conflicts (${conflicts.length - filtered.length} ignored)`);
+    return filtered;
 }

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -545,16 +545,51 @@ async function executeDownload(
                 }
             }
         } else if (!isMidnightMina) {
-            // Standard behavior: keep only the first VPK
+            // Multi-VPK archive (Warden Remodel et al). Previously kept only
+            // the alphabetically-first VPK and silently unlinked the rest —
+            // user feedback flagged that as data-loss-feeling. Now we prompt
+            // when there's more than one and let the user pick which to keep.
             installedVpks.sort((a, b) => a.localeCompare(b));
-            const [primaryVpk, ...extraVpks] = installedVpks;
-            installedVpks = primaryVpk ? [primaryVpk] : [];
-            for (const extraVpk of extraVpks) {
-                const extraPath = join(targetPath, extraVpk);
-                if (existsSync(extraPath)) {
-                    await fs.unlink(extraPath);
+            if (installedVpks.length > 1) {
+                const pickRequestId = randomUUID();
+                const pick = await awaitMultiVpkPick(
+                    pickRequestId,
+                    details.name ?? fileName,
+                    installedVpks,
+                    mainWindow
+                );
+                if (!pick || pick.selected.length === 0) {
+                    // Cancelled — wipe everything we extracted plus the archive.
+                    for (const vpk of installedVpks) {
+                        const extraPath = join(targetPath, vpk);
+                        if (existsSync(extraPath)) {
+                            await fs.unlink(extraPath).catch(() => { });
+                        }
+                    }
+                    if (existsSync(downloadPath)) {
+                        await fs.unlink(downloadPath).catch(() => { });
+                    }
+                    installedVpks = [];
+                    mainWindow?.webContents.send('download-error', {
+                        modId,
+                        fileId,
+                        errorCode: 'CANCELLED_BY_USER',
+                        message: 'Install cancelled.',
+                    });
+                    throw new Error('User cancelled multi-VPK pick');
                 }
+                const selectedSet = new Set(pick.selected);
+                for (const vpk of installedVpks) {
+                    if (!selectedSet.has(vpk)) {
+                        const extraPath = join(targetPath, vpk);
+                        if (existsSync(extraPath)) {
+                            await fs.unlink(extraPath);
+                        }
+                    }
+                }
+                installedVpks = installedVpks.filter((vpk) => selectedSet.has(vpk));
             }
+            // Single-VPK case: nothing to do — keep as-is.
         }
 
         // Clean up archive
@@ -626,6 +661,47 @@ export function resolveSuspiciousFileDecision(requestId: string, accepted: boole
         resolver(accepted);
         pendingSuspiciousDecisions.delete(requestId);
     }
+}
+
+// Multi-VPK picker decisions. The user picks which of N extracted VPKs to
+// keep when an archive (e.g. Warden Remodel) contains more than one. Null
+// means "cancel — discard everything".
+const pendingVpkPicks = new Map<
+    string,
+    (decision: { selected: string[] } | null) => void
+>();
+
+/** Renderer-facing IPC entry point for multi-VPK picker responses. */
+export function resolveMultiVpkPick(
+    requestId: string,
+    decision: { selected: string[] } | null
+): void {
+    const resolver = pendingVpkPicks.get(requestId);
+    if (resolver) {
+        resolver(decision);
+        pendingVpkPicks.delete(requestId);
+    }
+}
+
+/**
+ * Ask the renderer which VPKs from a multi-VPK archive to keep. Returns the
+ * subset the user wants to install, or null if they cancelled. Modal is
+ * driven by a `multi-vpk-pick` event keyed on requestId.
+ */
+function awaitMultiVpkPick(
+    requestId: string,
+    modName: string,
+    vpkFileNames: string[],
+    mainWindow: BrowserWindow | null
+): Promise<{ selected: string[] } | null> {
+    return new Promise((resolve) => {
+        pendingVpkPicks.set(requestId, resolve);
+        mainWindow?.webContents.send('multi-vpk-pick', {
+            requestId,
+            modName,
+            vpkFileNames,
+        });
+    });
 }
 
 function awaitSuspiciousDecision(
@@ -835,16 +911,47 @@ async function executeOneClickDownload(
 
         installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks);
 
-        // Standard 1-Click behavior: keep only the first VPK to avoid
-        // accidentally enabling many slots from a single archive.
+        // Multi-VPK 1-Click archive: prompt the user instead of silently
+        // dropping all but the first entry. Same shape as the regular
+        // download path so behavior is consistent across install entry points.
         installedVpks.sort((a, b) => a.localeCompare(b));
-        const [primaryVpk, ...extraVpks] = installedVpks;
-        installedVpks = primaryVpk ? [primaryVpk] : [];
-        for (const extraVpk of extraVpks) {
-            const extraPath = join(targetPath, extraVpk);
-            if (existsSync(extraPath)) {
-                await fs.unlink(extraPath);
+        if (installedVpks.length > 1) {
+            const pickRequestId = randomUUID();
+            const pick = await awaitMultiVpkPick(
+                pickRequestId,
+                enriched?.name ?? fileName,
+                installedVpks,
+                mainWindow
+            );
+            if (!pick || pick.selected.length === 0) {
+                for (const vpk of installedVpks) {
+                    const extraPath = join(targetPath, vpk);
+                    if (existsSync(extraPath)) {
+                        await fs.unlink(extraPath).catch(() => { });
+                    }
+                }
+                if (existsSync(downloadPath)) {
+                    await fs.unlink(downloadPath).catch(() => { });
+                }
+                installedVpks = [];
+                mainWindow?.webContents.send('download-error', {
+                    modId,
+                    fileId,
+                    errorCode: 'CANCELLED_BY_USER',
+                    message: 'Install cancelled.',
+                });
+                throw new Error('User cancelled multi-VPK pick');
             }
+            const selectedSet = new Set(pick.selected);
+            for (const vpk of installedVpks) {
+                if (!selectedSet.has(vpk)) {
+                    const extraPath = join(targetPath, vpk);
+                    if (existsSync(extraPath)) {
+                        await fs.unlink(extraPath);
+                    }
+                }
+            }
+            installedVpks = installedVpks.filter((vpk) => selectedSet.has(vpk));
         }
 
         if (existsSync(downloadPath)) {

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -10,6 +10,7 @@ import { fetchModDetails, GameBananaModDetails } from './gamebanana';
 import { getUsedPriorities, scanMods, disableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
 import { loadSettings } from './settings';
+import { getVpkLabels } from './vpk';
 import https from 'https';
 import http from 'http';
 
@@ -576,10 +577,14 @@ async function executeDownload(
             installedVpks.sort((a, b) => a.localeCompare(b));
             if (installedVpks.length > 1) {
                 const pickRequestId = randomUUID();
+                const vpkLabels = getVpkLabels(
+                    installedVpks.map((vpk) => ({ fileName: vpk, absPath: join(targetPath, vpk) }))
+                );
                 const pick = await awaitMultiVpkPick(
                     pickRequestId,
                     details.name ?? fileName,
                     installedVpks,
+                    vpkLabels,
                     mainWindow
                 );
                 if (!pick || pick.selected.length === 0) {
@@ -716,6 +721,7 @@ function awaitMultiVpkPick(
     requestId: string,
     modName: string,
     vpkFileNames: string[],
+    vpkLabels: Record<string, string>,
     mainWindow: BrowserWindow | null
 ): Promise<{ selected: string[] } | null> {
     return new Promise((resolve) => {
@@ -724,6 +730,7 @@ function awaitMultiVpkPick(
             requestId,
             modName,
             vpkFileNames,
+            vpkLabels,
         });
     });
 }
@@ -953,10 +960,14 @@ async function executeOneClickDownload(
         installedVpks.sort((a, b) => a.localeCompare(b));
         if (installedVpks.length > 1) {
             const pickRequestId = randomUUID();
+            const vpkLabels = getVpkLabels(
+                installedVpks.map((vpk) => ({ fileName: vpk, absPath: join(targetPath, vpk) }))
+            );
             const pick = await awaitMultiVpkPick(
                 pickRequestId,
                 enriched?.name ?? fileName,
                 installedVpks,
+                vpkLabels,
                 mainWindow
             );
             if (!pick || pick.selected.length === 0) {

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -29,6 +29,15 @@ export interface OneClickInstallArgs {
     enrichedDetails?: GameBananaModDetails;
 }
 
+/**
+ * Strip the trailing archive extension from a GameBanana filename so we keep
+ * a clean stem to use as a label fallback. Case-insensitive; leaves the rest
+ * of the name untouched (underscores etc. survive — the picker can prettify).
+ */
+function stripArchiveExtension(name: string): string {
+    return name.replace(/\.(zip|7z|rar|vpk)$/i, '').trim();
+}
+
 // Download queue to prevent race conditions with VPK priority assignment
 interface QueuedDownload {
     deadlockPath: string;
@@ -455,6 +464,11 @@ async function executeDownload(
     const fileDescription = details.files
         ?.find((f) => f.id === fileId)
         ?.description?.trim();
+    // Many mod authors leave file descriptions blank, so also capture the
+    // GB filename stem (e.g. "galaxy_rem_gold.zip" → "galaxy_rem_gold").
+    // This becomes the picker's second-line fallback so variants get a
+    // meaningful label even when the description is empty.
+    const sourceFileNameStem = stripArchiveExtension(fileName);
 
     const metadata = {
         modName: details.name,  // Store the actual mod name from GameBanana
@@ -467,6 +481,7 @@ async function executeDownload(
         sourceSection: section,
         nsfw: details.nsfw,  // Use actual NSFW flag from GameBanana
         fileDescription: fileDescription && fileDescription.length > 0 ? fileDescription : undefined,
+        sourceFileName: sourceFileNameStem.length > 0 ? sourceFileNameStem : undefined,
     };
 
     let installedVpks: string[] = [];
@@ -879,6 +894,7 @@ async function executeOneClickDownload(
     const oneClickFileDescription = enriched?.files
         ?.find((f) => f.id === fileId)
         ?.description?.trim();
+    const oneClickSourceFileName = stripArchiveExtension(fileName);
     const metadata = {
         modName: enriched?.name ?? fileName.replace(/\.(zip|7z|rar|vpk)$/i, ''),
         gameBananaId: realModId,
@@ -892,6 +908,7 @@ async function executeOneClickDownload(
             oneClickFileDescription && oneClickFileDescription.length > 0
                 ? oneClickFileDescription
                 : undefined,
+        sourceFileName: oneClickSourceFileName.length > 0 ? oneClickSourceFileName : undefined,
     };
 
     let installedVpks: string[] = [];

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -448,6 +448,14 @@ async function executeDownload(
         ? `${thumbnail.baseUrl}/${thumbnail.file530 || thumbnail.file}`
         : undefined;
 
+    // GameBanana lets mod authors label each file (e.g. "Gold w/ alt candle").
+    // Persist that header so the variant picker can show meaningful names by
+    // default — much friendlier than raw VPK filenames. Trim because the
+    // upstream field occasionally has surrounding whitespace.
+    const fileDescription = details.files
+        ?.find((f) => f.id === fileId)
+        ?.description?.trim();
+
     const metadata = {
         modName: details.name,  // Store the actual mod name from GameBanana
         gameBananaId: modId,
@@ -458,6 +466,7 @@ async function executeDownload(
         audioUrl: details.previewMedia?.metadata?.audioUrl,  // Persist for Sound mod preview
         sourceSection: section,
         nsfw: details.nsfw,  // Use actual NSFW flag from GameBanana
+        fileDescription: fileDescription && fileDescription.length > 0 ? fileDescription : undefined,
     };
 
     let installedVpks: string[] = [];
@@ -864,6 +873,12 @@ async function executeOneClickDownload(
         : undefined;
 
     const realModId = args.modId !== undefined && args.modId > 0 ? args.modId : undefined;
+    // Same trick as the regular download path: capture the author's per-file
+    // header so the variant picker has a sane default label. Only available
+    // when GB enrichment succeeded and the file id is recognised in the list.
+    const oneClickFileDescription = enriched?.files
+        ?.find((f) => f.id === fileId)
+        ?.description?.trim();
     const metadata = {
         modName: enriched?.name ?? fileName.replace(/\.(zip|7z|rar|vpk)$/i, ''),
         gameBananaId: realModId,
@@ -873,6 +888,10 @@ async function executeOneClickDownload(
         audioUrl: enriched?.previewMedia?.metadata?.audioUrl,
         sourceSection: section,
         nsfw: enriched?.nsfw,
+        fileDescription:
+            oneClickFileDescription && oneClickFileDescription.length > 0
+                ? oneClickFileDescription
+                : undefined,
     };
 
     let installedVpks: string[] = [];

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -9,6 +9,7 @@ import { setModMetadata } from './metadata';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
 import { getUsedPriorities, scanMods, disableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
+import { loadSettings } from './settings';
 import https from 'https';
 import http from 'http';
 
@@ -576,22 +577,37 @@ async function executeDownload(
     // the newest pick is the active one. Avoids file-conflict warnings between
     // sibling variants and matches the "Browse vs Installed" expectation that
     // re-downloading swaps which variant is active without losing the others.
-    try {
-        const installedSet = new Set(installedVpks);
-        const allMods = await scanMods(deadlockPath);
-        const stalePeers = allMods.filter(
-            (m) =>
-                m.enabled &&
-                m.gameBananaId === modId &&
-                m.gameBananaFileId !== fileId &&
-                !installedSet.has(m.fileName)
-        );
-        for (const peer of stalePeers) {
-            console.log(`[downloadMod] Auto-disabling sibling variant: ${peer.fileName}`);
-            await disableMod(deadlockPath, peer.id);
+    // Opt-out: settings.autoDisableSiblingVariants = false keeps every variant
+    // enabled (user may rely on intentional overlap between mods).
+    const settings = loadSettings();
+    if (settings.autoDisableSiblingVariants !== false) {
+        try {
+            const installedSet = new Set(installedVpks);
+            const allMods = await scanMods(deadlockPath);
+            const stalePeers = allMods.filter(
+                (m) =>
+                    m.enabled &&
+                    m.gameBananaId === modId &&
+                    m.gameBananaFileId !== fileId &&
+                    !installedSet.has(m.fileName)
+            );
+            const disabledPeers: Array<{ id: string; name: string; fileName: string }> = [];
+            for (const peer of stalePeers) {
+                console.log(`[downloadMod] Auto-disabling sibling variant: ${peer.fileName}`);
+                await disableMod(deadlockPath, peer.id);
+                disabledPeers.push({ id: peer.id, name: peer.name, fileName: peer.fileName });
+            }
+            if (disabledPeers.length > 0) {
+                mainWindow?.webContents.send('mods-auto-disabled', {
+                    reason: 'sibling-variant',
+                    modId,
+                    fileId,
+                    disabled: disabledPeers,
+                });
+            }
+        } catch (err) {
+            console.warn(`[downloadMod] Failed to auto-disable sibling variants:`, err);
         }
-    } catch (err) {
-        console.warn(`[downloadMod] Failed to auto-disable sibling variants:`, err);
     }
 
     // Notify completion

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -4,6 +4,8 @@ import { spawn } from 'child_process';
 import { shell } from 'electron';
 import { getUserDataPath } from '../utils/paths';
 import { getAddonsPath, getDisabledPath } from './deadlock';
+import { loadSettings } from './settings';
+import { writeLaunchOptions, readLaunchOptions, isSteamRunning } from './launchOptions';
 
 // Deadlock's Steam AppID — used for the steam://rungameid/... URI scheme.
 const DEADLOCK_STEAM_APP_ID = 1422450;
@@ -262,6 +264,42 @@ function scheduleMidLaunchRestore(
 }
 
 /**
+ * Sync the user's configured launch-options string into Steam's
+ * localconfig.vdf for Deadlock. Best-effort: failures are logged and
+ * swallowed so a broken Steam config can't block the user from launching.
+ *
+ * We only write when Steam isn't running — Steam clobbers localconfig.vdf on
+ * shutdown, so a write while Steam is up gets undone moments later. The
+ * caller (launchModded / launchVanilla) runs this BEFORE invoking the
+ * Steam URL, which is the safe window: Steam will pick up our edit when it
+ * starts.
+ */
+async function syncLaunchOptionsToSteam(): Promise<void> {
+    const settings = loadSettings();
+    const desired = settings.steamLaunchOptions ?? '';
+    try {
+        if (await isSteamRunning()) {
+            console.warn('[launch] Steam already running — skipping launch-options sync to avoid clobber.');
+            return;
+        }
+        // Only write if the value actually differs from what's on disk —
+        // avoids a needless backup + rewrite of a multi-megabyte file on
+        // every launch.
+        const current = await readLaunchOptions();
+        if (current && current.currentValue === desired) {
+            return;
+        }
+        if (!current && !desired) {
+            // Nothing set and nothing to set; skip even creating the entry.
+            return;
+        }
+        await writeLaunchOptions(desired);
+    } catch (err) {
+        console.warn('[launch] Failed to sync launch options to Steam:', err);
+    }
+}
+
+/**
  * Trigger Steam to launch Deadlock. Doesn't wait for the game to actually start.
  */
 async function triggerSteamLaunch(): Promise<void> {
@@ -297,6 +335,7 @@ export async function launchModded({
                 );
             }
         }
+        await syncLaunchOptionsToSteam();
         await triggerSteamLaunch();
     } finally {
         launchInFlight = false;
@@ -343,6 +382,7 @@ export async function launchVanilla({
     }
 
     try {
+        await syncLaunchOptionsToSteam();
         await triggerSteamLaunch();
     } catch (err) {
         // Steam URL failed — immediately restore so the user isn't left with

--- a/electron/main/services/launchOptions.ts
+++ b/electron/main/services/launchOptions.ts
@@ -430,31 +430,6 @@ function sniffIndent(text: string): string {
 }
 
 /**
- * Build the byte sequence we'll splice in for a brand-new app block. Mirrors
- * Steam's own formatting: each key on its own line, tab-indented.
- */
-function buildAppBlock(appId: string, options: string, indent: string, depth: number): string {
-    const outer = indent.repeat(depth);
-    const inner = indent.repeat(depth + 1);
-    return (
-        `\n${outer}${quoteVdfString(appId)}\n` +
-        `${outer}{\n` +
-        `${inner}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}\n` +
-        `${outer}}`
-    );
-}
-
-/**
- * Build the byte sequence for a new LaunchOptions key inside an existing app
- * block. Inserted right after the opening `{` so we don't have to deal with
- * matching the file's existing trailing whitespace.
- */
-function buildLaunchOptionsLine(options: string, indent: string, depth: number): string {
-    const inner = indent.repeat(depth);
-    return `\n${inner}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}`;
-}
-
-/**
  * Atomically write `content` to `path`. Writes to `<path>.tmp` first, then
  * renames. Creates a `<path>.bak` backup beforehand on first call (or if no
  * backup exists yet) so the user can recover from a bad write.
@@ -540,9 +515,6 @@ export async function writeLaunchOptions(
             insertion +
             `\n${appsLeading}` +
             text.slice(loc.appsBlock.braceClose);
-        // Reference the unused helper so future callers stay aware of it.
-        void buildAppBlock;
-        void buildLaunchOptionsLine;
     }
 
     await safeAtomicWrite(found.path, updated);

--- a/electron/main/services/launchOptions.ts
+++ b/electron/main/services/launchOptions.ts
@@ -1,0 +1,550 @@
+// Steam Launch Options writer.
+//
+// Steam stores per-app launch options inside each user's
+// `<SteamRoot>/userdata/<accountId>/config/localconfig.vdf`, at the path
+//   UserLocalConfigStore -> Software -> Valve -> Steam -> apps -> <appId> -> LaunchOptions
+//
+// Constraints we MUST respect:
+//   1. Steam must NOT be running when we write — Steam reloads on launch and
+//      overwrites the file on clean shutdown, clobbering our edit otherwise.
+//   2. localconfig.vdf is critical user data (per-game settings, friends, UI
+//      prefs). Anything we don't fully understand we must NOT touch — corrupt
+//      writes here can nuke the user's Steam config.
+//
+// Strategy: surgical byte-level edits.
+//   - Parse the file with a depth-tracking tokenizer just enough to find the
+//     exact byte range of the LaunchOptions value, the parent app block, or
+//     the apps block (whichever exists deepest).
+//   - Replace / insert at that range, leaving every other byte alone.
+//   - Backup the original to `.bak` before any write. Use atomic temp+rename.
+//   - Fail closed: if our scan can't find an expected structure, throw and
+//     surface the error to the renderer rather than guessing.
+
+import { promises as fs, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { spawn } from 'child_process';
+
+export const DEADLOCK_STEAM_APP_ID = '1422450';
+
+export interface LaunchOptionsLookup {
+    /** Absolute path to the localconfig.vdf we'll be editing. */
+    configPath: string;
+    /** Steam account ID (32-bit) the file belongs to. */
+    accountId: string;
+    /** Currently stored launch options, or null if the key isn't set yet. */
+    currentValue: string | null;
+}
+
+/** Per-platform candidate locations for Steam's `userdata` root. */
+function getSteamUserdataRoots(): string[] {
+    const paths: string[] = [];
+    const home = homedir();
+    if (process.platform === 'linux') {
+        paths.push(join(home, '.steam/steam/userdata'));
+        paths.push(join(home, '.local/share/Steam/userdata'));
+        paths.push(join(home, '.var/app/com.valvesoftware.Steam/.steam/steam/userdata'));
+    } else if (process.platform === 'win32') {
+        paths.push('C:\\Program Files (x86)\\Steam\\userdata');
+        paths.push('C:\\Program Files\\Steam\\userdata');
+    } else if (process.platform === 'darwin') {
+        paths.push(join(home, 'Library/Application Support/Steam/userdata'));
+    }
+    return paths;
+}
+
+/**
+ * Locate the right localconfig.vdf for the current Steam user.
+ *
+ * Heuristic: pick the userdata subfolder whose `config/localconfig.vdf` has
+ * the most recent mtime — this is the account Steam actually uses most. If
+ * the caller passes an explicit accountId, prefer that one if it exists.
+ */
+async function findLocalConfigPath(preferredAccountId?: string): Promise<{ path: string; accountId: string } | null> {
+    for (const root of getSteamUserdataRoots()) {
+        if (!existsSync(root)) continue;
+        let entries: string[];
+        try {
+            entries = await fs.readdir(root);
+        } catch {
+            continue;
+        }
+        const candidates: Array<{ accountId: string; configPath: string; mtime: number }> = [];
+        for (const entry of entries) {
+            // userdata subfolders are always numeric account IDs
+            if (!/^\d+$/.test(entry)) continue;
+            const configPath = join(root, entry, 'config', 'localconfig.vdf');
+            if (!existsSync(configPath)) continue;
+            try {
+                const stat = await fs.stat(configPath);
+                candidates.push({ accountId: entry, configPath, mtime: stat.mtimeMs });
+            } catch {
+                // ignore unreadable entries
+            }
+        }
+        if (candidates.length === 0) continue;
+        if (preferredAccountId) {
+            const match = candidates.find((c) => c.accountId === preferredAccountId);
+            if (match) return { path: match.configPath, accountId: match.accountId };
+        }
+        candidates.sort((a, b) => b.mtime - a.mtime);
+        return { path: candidates[0].configPath, accountId: candidates[0].accountId };
+    }
+    return null;
+}
+
+/** Whether Steam.exe / steam is currently running. Best-effort, platform-aware. */
+export async function isSteamRunning(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        if (process.platform === 'win32') {
+            const proc = spawn('tasklist.exe', ['/FI', 'IMAGENAME eq steam.exe', '/NH'], {
+                windowsHide: true,
+            });
+            let stdout = '';
+            proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+            proc.on('close', () => resolve(/steam\.exe/i.test(stdout)));
+            proc.on('error', () => resolve(false));
+        } else if (process.platform === 'linux' || process.platform === 'darwin') {
+            // pgrep returns 0 if any process matches. We look for the Steam
+            // client binary, not just any "steam" string in argv.
+            const proc = spawn('pgrep', ['-x', 'steam'], { stdio: ['ignore', 'pipe', 'ignore'] });
+            proc.on('close', (code) => resolve(code === 0));
+            proc.on('error', () => resolve(false));
+        } else {
+            resolve(false);
+        }
+    });
+}
+
+/**
+ * Skip whitespace and `// comments` from `i` onward. Returns the new index.
+ * Comments-to-EOL is a Valve VDF convention; Steam itself emits no comments
+ * but third-party tools sometimes add them, so we tolerate them on read.
+ */
+function skipWhitespace(text: string, i: number): number {
+    while (i < text.length) {
+        const c = text[i];
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+            i++;
+        } else if (c === '/' && text[i + 1] === '/') {
+            // Skip to end of line
+            const eol = text.indexOf('\n', i);
+            if (eol === -1) return text.length;
+            i = eol + 1;
+        } else {
+            break;
+        }
+    }
+    return i;
+}
+
+interface QuotedToken {
+    /** Inclusive byte offset of the opening `"`. */
+    start: number;
+    /** Inclusive byte offset of the closing `"`. */
+    end: number;
+    /** Decoded value (escape sequences resolved). */
+    value: string;
+}
+
+/**
+ * Read a quoted VDF string starting at `i` (which must point to `"`). Handles
+ * `\"` and `\\` escape sequences — Steam writes these when LaunchOptions
+ * contains a literal quote or backslash.
+ */
+function readQuoted(text: string, i: number): QuotedToken | null {
+    if (text[i] !== '"') return null;
+    const start = i;
+    let j = i + 1;
+    let value = '';
+    while (j < text.length) {
+        const c = text[j];
+        if (c === '\\' && j + 1 < text.length) {
+            const next = text[j + 1];
+            if (next === '"' || next === '\\') {
+                value += next;
+                j += 2;
+                continue;
+            }
+            // Unknown escape — pass through verbatim so we don't lose info.
+            value += c;
+            j++;
+            continue;
+        }
+        if (c === '"') {
+            return { start, end: j, value };
+        }
+        value += c;
+        j++;
+    }
+    return null;
+}
+
+/** Encode a string for VDF: escape `\` and `"`. */
+function quoteVdfString(s: string): string {
+    return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+interface BlockHandle {
+    /** Offset of the opening `{`. */
+    braceOpen: number;
+    /** Offset of the matching closing `}`. */
+    braceClose: number;
+}
+
+/**
+ * From just after a parent's opening `{`, scan its direct children and find
+ * the named block. Returns the brace offsets if found, or null if not.
+ *
+ * Direct children only — we don't recurse into grandchildren, callers chain
+ * calls explicitly so the traversal mirrors the VDF path they're walking.
+ */
+function findChildBlock(text: string, parentBodyStart: number, parentBodyEnd: number, targetKey: string): BlockHandle | null {
+    let i = parentBodyStart;
+    const targetLower = targetKey.toLowerCase();
+    while (i < parentBodyEnd) {
+        i = skipWhitespace(text, i);
+        if (i >= parentBodyEnd) break;
+        if (text[i] === '}') break;
+        const keyTok = readQuoted(text, i);
+        if (!keyTok) {
+            // Unrecognized syntax at this position — abort rather than guess.
+            return null;
+        }
+        i = keyTok.end + 1;
+        i = skipWhitespace(text, i);
+        if (text[i] === '"') {
+            // Leaf value — not a block, skip
+            const valTok = readQuoted(text, i);
+            if (!valTok) return null;
+            i = valTok.end + 1;
+            continue;
+        }
+        if (text[i] !== '{') {
+            // Bare key with no value — Valve allows this but it's nonsense
+            // here. Abort.
+            return null;
+        }
+        const braceOpen = i;
+        // Scan to matching close, respecting nested braces and strings
+        let depth = 1;
+        let j = i + 1;
+        while (j < parentBodyEnd && depth > 0) {
+            const c = text[j];
+            if (c === '"') {
+                const strTok = readQuoted(text, j);
+                if (!strTok) return null;
+                j = strTok.end + 1;
+            } else if (c === '/' && text[j + 1] === '/') {
+                const eol = text.indexOf('\n', j);
+                j = eol === -1 ? text.length : eol + 1;
+            } else if (c === '{') {
+                depth++;
+                j++;
+            } else if (c === '}') {
+                depth--;
+                if (depth === 0) break;
+                j++;
+            } else {
+                j++;
+            }
+        }
+        if (depth !== 0) return null; // Unmatched braces in file
+        const braceClose = j;
+        if (keyTok.value.toLowerCase() === targetLower) {
+            return { braceOpen, braceClose };
+        }
+        i = braceClose + 1;
+    }
+    return null;
+}
+
+/**
+ * Within the body of a block, find a leaf "key" "value" entry. Returns the
+ * byte range of the value token (inclusive of quotes) so callers can splice
+ * a replacement in place.
+ */
+function findChildLeaf(text: string, bodyStart: number, bodyEnd: number, targetKey: string): QuotedToken | null {
+    let i = bodyStart;
+    const targetLower = targetKey.toLowerCase();
+    while (i < bodyEnd) {
+        i = skipWhitespace(text, i);
+        if (i >= bodyEnd) break;
+        if (text[i] === '}') break;
+        const keyTok = readQuoted(text, i);
+        if (!keyTok) return null;
+        i = keyTok.end + 1;
+        i = skipWhitespace(text, i);
+        if (text[i] === '{') {
+            // It's a block, skip past it
+            let depth = 1;
+            let j = i + 1;
+            while (j < bodyEnd && depth > 0) {
+                const c = text[j];
+                if (c === '"') {
+                    const strTok = readQuoted(text, j);
+                    if (!strTok) return null;
+                    j = strTok.end + 1;
+                } else if (c === '{') {
+                    depth++; j++;
+                } else if (c === '}') {
+                    depth--;
+                    if (depth === 0) break;
+                    j++;
+                } else {
+                    j++;
+                }
+            }
+            if (depth !== 0) return null;
+            i = j + 1;
+            continue;
+        }
+        if (text[i] !== '"') return null;
+        const valTok = readQuoted(text, i);
+        if (!valTok) return null;
+        if (keyTok.value.toLowerCase() === targetLower) {
+            return valTok;
+        }
+        i = valTok.end + 1;
+    }
+    return null;
+}
+
+interface AppBlockLocation {
+    text: string;
+    /** Root config path the text came from. */
+    sourcePath: string;
+    /** Brace bounds of the appId block. Null if it doesn't exist yet. */
+    appBlock: BlockHandle | null;
+    /** Brace bounds of the apps parent block. Always non-null on success
+     *  because we require apps to exist before doing anything else. */
+    appsBlock: BlockHandle;
+}
+
+/**
+ * Walk down to `UserLocalConfigStore -> Software -> Valve -> Steam -> apps`,
+ * then look for our app inside it. Returns whatever boundary info we have so
+ * the caller can either splice an existing LaunchOptions value, insert one,
+ * or insert the whole appId block.
+ */
+function locateAppBlock(text: string, sourcePath: string, appId: string): AppBlockLocation {
+    // Locate the root object's body. The file starts with
+    //   "UserLocalConfigStore"\n{\n ... \n}
+    // so the body of the root is everything between the first { and its
+    // matching }.
+    const rootKey = readQuoted(text, skipWhitespace(text, 0));
+    if (!rootKey || rootKey.value !== 'UserLocalConfigStore') {
+        throw new Error('localconfig.vdf does not start with UserLocalConfigStore — refusing to edit.');
+    }
+    const rootBraceIdx = text.indexOf('{', rootKey.end + 1);
+    if (rootBraceIdx === -1) {
+        throw new Error('Malformed localconfig.vdf — no opening brace after root key.');
+    }
+    // Find matching close for root.
+    let depth = 1;
+    let j = rootBraceIdx + 1;
+    while (j < text.length && depth > 0) {
+        const c = text[j];
+        if (c === '"') {
+            const strTok = readQuoted(text, j);
+            if (!strTok) throw new Error('Malformed localconfig.vdf — unterminated string.');
+            j = strTok.end + 1;
+        } else if (c === '{') {
+            depth++; j++;
+        } else if (c === '}') {
+            depth--;
+            if (depth === 0) break;
+            j++;
+        } else {
+            j++;
+        }
+    }
+    if (depth !== 0) throw new Error('Malformed localconfig.vdf — unmatched root braces.');
+    const rootBlock: BlockHandle = { braceOpen: rootBraceIdx, braceClose: j };
+
+    const software = findChildBlock(text, rootBlock.braceOpen + 1, rootBlock.braceClose, 'Software');
+    if (!software) throw new Error('localconfig.vdf missing Software block — refusing to edit.');
+    const valve = findChildBlock(text, software.braceOpen + 1, software.braceClose, 'Valve');
+    if (!valve) throw new Error('localconfig.vdf missing Software/Valve block — refusing to edit.');
+    const steam = findChildBlock(text, valve.braceOpen + 1, valve.braceClose, 'Steam');
+    if (!steam) throw new Error('localconfig.vdf missing Software/Valve/Steam block — refusing to edit.');
+    const apps = findChildBlock(text, steam.braceOpen + 1, steam.braceClose, 'apps');
+    if (!apps) throw new Error('localconfig.vdf missing apps block — user may have never launched a Steam game.');
+
+    const appBlock = findChildBlock(text, apps.braceOpen + 1, apps.braceClose, appId);
+    return { text, sourcePath, appBlock, appsBlock: apps };
+}
+
+/**
+ * Public: read the currently-stored launch options for Deadlock. Returns
+ * null when the file or path doesn't exist (e.g. fresh Steam install). Does
+ * NOT throw on missing structure — those are normal "no options set" states.
+ */
+export async function readLaunchOptions(appId: string = DEADLOCK_STEAM_APP_ID): Promise<LaunchOptionsLookup | null> {
+    const found = await findLocalConfigPath();
+    if (!found) return null;
+    let text: string;
+    try {
+        text = await fs.readFile(found.path, 'utf-8');
+    } catch {
+        return null;
+    }
+    try {
+        const loc = locateAppBlock(text, found.path, appId);
+        if (!loc.appBlock) {
+            return { configPath: found.path, accountId: found.accountId, currentValue: null };
+        }
+        const leaf = findChildLeaf(text, loc.appBlock.braceOpen + 1, loc.appBlock.braceClose, 'LaunchOptions');
+        return {
+            configPath: found.path,
+            accountId: found.accountId,
+            currentValue: leaf ? leaf.value : null,
+        };
+    } catch {
+        // Structural problem — surface as "no current value" so the UI can
+        // still let the user save (the write path will surface a clearer
+        // error if the structure remains broken at write time).
+        return { configPath: found.path, accountId: found.accountId, currentValue: null };
+    }
+}
+
+/**
+ * Indent inferred from how the existing file formats its blocks. Steam's
+ * own writes use `\t`, but a Steam Beta build briefly used 2-space indents,
+ * and some user tools rewrite the file. We sniff one line of the file to
+ * match its style instead of forcing tabs.
+ */
+function sniffIndent(text: string): string {
+    // Look at the first indented line — the line after the root `{`.
+    const rootBrace = text.indexOf('{');
+    if (rootBrace === -1) return '\t';
+    const nextLineStart = text.indexOf('\n', rootBrace);
+    if (nextLineStart === -1) return '\t';
+    let i = nextLineStart + 1;
+    let indent = '';
+    while (i < text.length && (text[i] === '\t' || text[i] === ' ')) {
+        indent += text[i];
+        i++;
+    }
+    return indent || '\t';
+}
+
+/**
+ * Build the byte sequence we'll splice in for a brand-new app block. Mirrors
+ * Steam's own formatting: each key on its own line, tab-indented.
+ */
+function buildAppBlock(appId: string, options: string, indent: string, depth: number): string {
+    const outer = indent.repeat(depth);
+    const inner = indent.repeat(depth + 1);
+    return (
+        `\n${outer}${quoteVdfString(appId)}\n` +
+        `${outer}{\n` +
+        `${inner}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}\n` +
+        `${outer}}`
+    );
+}
+
+/**
+ * Build the byte sequence for a new LaunchOptions key inside an existing app
+ * block. Inserted right after the opening `{` so we don't have to deal with
+ * matching the file's existing trailing whitespace.
+ */
+function buildLaunchOptionsLine(options: string, indent: string, depth: number): string {
+    const inner = indent.repeat(depth);
+    return `\n${inner}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}`;
+}
+
+/**
+ * Atomically write `content` to `path`. Writes to `<path>.tmp` first, then
+ * renames. Creates a `<path>.bak` backup beforehand on first call (or if no
+ * backup exists yet) so the user can recover from a bad write.
+ */
+async function safeAtomicWrite(path: string, content: string): Promise<void> {
+    const backupPath = `${path}.grimoire.bak`;
+    if (!existsSync(backupPath)) {
+        try {
+            await fs.copyFile(path, backupPath);
+        } catch (err) {
+            console.warn('[launchOptions] Backup copy failed (continuing):', err);
+        }
+    }
+    const tmpPath = `${path}.grimoire.tmp`;
+    await fs.writeFile(tmpPath, content, 'utf-8');
+    await fs.rename(tmpPath, path);
+}
+
+/**
+ * Write the launch options string into localconfig.vdf. Must NOT be called
+ * while Steam is running — the caller is responsible for enforcing that
+ * (we expose isSteamRunning so they can prompt the user / wait).
+ *
+ * Returns the path that was written so the caller can log / surface it.
+ */
+export async function writeLaunchOptions(
+    options: string,
+    appId: string = DEADLOCK_STEAM_APP_ID
+): Promise<{ configPath: string; accountId: string }> {
+    const found = await findLocalConfigPath();
+    if (!found) {
+        throw new Error('Could not locate a Steam userdata folder — is Steam installed and have you logged in at least once?');
+    }
+    const text = await fs.readFile(found.path, 'utf-8');
+    const loc = locateAppBlock(text, found.path, appId);
+
+    const indent = sniffIndent(text);
+    let updated: string;
+
+    if (loc.appBlock) {
+        // The app block exists. Either replace an existing LaunchOptions
+        // value or add the key inside the block body.
+        const existing = findChildLeaf(text, loc.appBlock.braceOpen + 1, loc.appBlock.braceClose, 'LaunchOptions');
+        if (existing) {
+            // Replace just the value token (between its outer quotes).
+            updated =
+                text.slice(0, existing.start) +
+                quoteVdfString(options) +
+                text.slice(existing.end + 1);
+        } else {
+            // Insert LaunchOptions right after the opening `{`. depth needs
+            // to match: appBlock body is 5 levels deep from root indent
+            // (Software/Valve/Steam/apps/<appId>) → depth 6 from file's
+            // root indent unit.
+            //
+            // Rather than counting depth manually, look at the leading
+            // whitespace of the line containing the `{` and add one more
+            // indent.
+            const lineStart = text.lastIndexOf('\n', loc.appBlock.braceOpen) + 1;
+            const leading = text.slice(lineStart, loc.appBlock.braceOpen).match(/^[\t ]*/)?.[0] ?? '';
+            const innerIndent = leading + indent;
+            const insertion = `\n${innerIndent}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}`;
+            updated =
+                text.slice(0, loc.appBlock.braceOpen + 1) +
+                insertion +
+                text.slice(loc.appBlock.braceOpen + 1);
+        }
+    } else {
+        // The app block doesn't exist. Insert a new "<appId>" { ... } block
+        // just before the closing `}` of the apps block, matching the
+        // indent of the apps block's other children.
+        const lineStart = text.lastIndexOf('\n', loc.appsBlock.braceOpen) + 1;
+        const appsLeading = text.slice(lineStart, loc.appsBlock.braceOpen).match(/^[\t ]*/)?.[0] ?? '';
+        const childIndent = appsLeading + indent;
+        const grandIndent = childIndent + indent;
+        const insertion =
+            `\n${childIndent}${quoteVdfString(appId)}\n` +
+            `${childIndent}{\n` +
+            `${grandIndent}${quoteVdfString('LaunchOptions')}${indent}${quoteVdfString(options)}\n` +
+            `${childIndent}}`;
+        updated =
+            text.slice(0, loc.appsBlock.braceClose) +
+            insertion +
+            `\n${appsLeading}` +
+            text.slice(loc.appsBlock.braceClose);
+        // Reference the unused helper so future callers stay aware of it.
+        void buildAppBlock;
+        void buildLaunchOptionsLine;
+    }
+
+    await safeAtomicWrite(found.path, updated);
+    return { configPath: found.path, accountId: found.accountId };
+}

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -12,6 +12,7 @@ export interface ModMetadata {
     sourceSection?: string;
     nsfw?: boolean;
     isMinaPreset?: boolean; // Flag for Mina presets we extracted from the 7z
+    variantLabel?: string;  // User-provided label to disambiguate variants of the same mod
 }
 
 export type ModMetadataMap = Record<string, ModMetadata>;

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -14,6 +14,7 @@ export interface ModMetadata {
     isMinaPreset?: boolean; // Flag for Mina presets we extracted from the 7z
     variantLabel?: string;  // User-provided label to disambiguate variants of the same mod
     fileDescription?: string;  // GameBanana file "header" (_sDescription) — author's per-file label, used as fallback when the user hasn't named the variant
+    sourceFileName?: string;   // Original GameBanana filename stem (e.g. "galaxy_rem_gold") — used as a label fallback when the author didn't set a file header
 }
 
 export type ModMetadataMap = Record<string, ModMetadata>;

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -13,6 +13,7 @@ export interface ModMetadata {
     nsfw?: boolean;
     isMinaPreset?: boolean; // Flag for Mina presets we extracted from the 7z
     variantLabel?: string;  // User-provided label to disambiguate variants of the same mod
+    fileDescription?: string;  // GameBanana file "header" (_sDescription) — author's per-file label, used as fallback when the user hasn't named the variant
 }
 
 export type ModMetadataMap = Record<string, ModMetadata>;

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -30,6 +30,9 @@ export interface Mod {
     categoryName?: string;
     sourceSection?: string;
     nsfw?: boolean;
+    /** User-given name for this VPK, used to disambiguate variants of the
+     *  same GameBanana mod (e.g. "Red preset" vs "Blue preset"). Optional. */
+    variantLabel?: string;
 }
 
 /**

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -33,6 +33,10 @@ export interface Mod {
     /** User-given name for this VPK, used to disambiguate variants of the
      *  same GameBanana mod (e.g. "Red preset" vs "Blue preset"). Optional. */
     variantLabel?: string;
+    /** Author-provided file header from GameBanana (_sDescription). Used as
+     *  the variant-picker fallback when the user hasn't set a label of their
+     *  own, so rows show "Gold w/ alt candle" instead of the raw filename. */
+    fileDescription?: string;
 }
 
 /**

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -37,6 +37,11 @@ export interface Mod {
      *  the variant-picker fallback when the user hasn't set a label of their
      *  own, so rows show "Gold w/ alt candle" instead of the raw filename. */
     fileDescription?: string;
+    /** Original GameBanana filename stem (e.g. "galaxy_rem_gold"). Captured
+     *  so variants from mods whose author left descriptions empty still get
+     *  a meaningful label — falls between fileDescription and the local
+     *  pakNN_dir.vpk filename in the picker's display chain. */
+    sourceFileName?: string;
 }
 
 /**

--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -31,6 +31,103 @@ export interface SearchResult {
 }
 
 /**
+ * Order-by clause for a sort option. `hasQuery` differentiates relevance:
+ * with a query, sort by FTS5 rank; without one, fall back to recency.
+ */
+function buildOrderBy(sortBy: SearchOptions['sortBy'], hasQuery: boolean): string {
+    switch (sortBy) {
+        case 'relevance':
+            return hasQuery ? 'rank ASC' : 'date_modified DESC';
+        case 'likes':
+            return 'like_count DESC';
+        case 'date':
+            return 'date_modified DESC';
+        case 'date_added':
+            return 'date_added DESC';
+        case 'views':
+            return 'view_count DESC';
+        case 'name':
+            return 'name COLLATE NOCASE ASC';
+        default:
+            return 'date_modified DESC';
+    }
+}
+
+/**
+ * Fallback search used when the FTS5 path returns zero results. FTS5 is
+ * tokenized and prefix-only, so creative names ("MìnaMod-v2", typos, partial
+ * substrings inside a word) miss even when they should match. This runs a
+ * substring LIKE against the mod name as a safety net — slower (no FTS
+ * index), but only fires when FTS5 would have shown an empty page.
+ */
+function runFallbackSubstringSearch(
+    database: ReturnType<typeof initDatabase>,
+    rawQuery: string,
+    section: string | undefined,
+    categoryId: number | undefined,
+    heroName: string | undefined,
+    skinsCategoryId: number | undefined,
+    sortBy: SearchOptions['sortBy'],
+    limit: number,
+    offset: number
+): SearchResult {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    // Split on whitespace so multi-term searches still all have to match.
+    // Cap at 10 terms; longer queries get truncated rather than bloating the SQL.
+    const terms = rawQuery
+        .trim()
+        .split(/\s+/)
+        .filter((t) => t.length > 0)
+        .slice(0, 10);
+
+    terms.forEach((term, i) => {
+        const key = `fallback_term_${i}`;
+        params[key] = `%${term.toLowerCase()}%`;
+        conditions.push(`LOWER(mods.name) LIKE @${key}`);
+    });
+
+    if (section) {
+        conditions.push('mods.section = @section');
+        params.section = section;
+    }
+
+    if (categoryId !== undefined) {
+        if (heroName && skinsCategoryId !== undefined) {
+            params.heroNamePattern = `%${heroName.toLowerCase()}%`;
+            conditions.push('LOWER(mods.name) LIKE @heroNamePattern');
+        } else {
+            conditions.push('mods.category_id = @categoryId');
+            params.categoryId = categoryId;
+        }
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const orderBy = buildOrderBy(sortBy, false); // no FTS rank in fallback
+
+    const countRow = database
+        .prepare(`SELECT COUNT(*) as count FROM mods ${whereClause}`)
+        .get(params) as { count: number };
+    const totalCount = countRow.count;
+
+    params.limit = limit;
+    params.offset = offset;
+    const rows = database
+        .prepare(
+            `SELECT mods.*, 0 as rank FROM mods ${whereClause} ORDER BY ${orderBy} LIMIT @limit OFFSET @offset`
+        )
+        .all(params) as Record<string, unknown>[];
+
+    return {
+        mods: rows.map(mapRowToMod),
+        totalCount,
+        offset,
+        limit,
+    };
+}
+
+/**
  * Search mods using FTS5 full-text search
  */
 export function searchMods(options: SearchOptions): SearchResult {
@@ -54,6 +151,7 @@ export function searchMods(options: SearchOptions): SearchResult {
     // FTS5 search if query provided
     let fromClause = 'FROM mods';
     let rankSelect = '0 as rank';
+    let appliedFtsQuery = false;
     if (query && query.trim()) {
         // P2 fix #15: Limit query length to prevent ReDoS/expensive queries
         const truncatedQuery = query.slice(0, 500);
@@ -71,6 +169,7 @@ export function searchMods(options: SearchOptions): SearchResult {
                 fromClause = 'FROM mods JOIN mods_fts ON mods.id = mods_fts.rowid';
                 rankSelect = 'bm25(mods_fts) as rank';
                 conditions.push('mods_fts MATCH @query');
+                appliedFtsQuery = true;
             }
         }
     }
@@ -105,30 +204,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         console.log(`[searchMods] Params:`, JSON.stringify(params));
     }
 
-    // Determine ORDER BY
-    let orderBy: string;
-    switch (sortBy) {
-        case 'relevance':
-            orderBy = query?.trim() ? 'rank ASC' : 'date_modified DESC';
-            break;
-        case 'likes':
-            orderBy = 'like_count DESC';
-            break;
-        case 'date':
-            orderBy = 'date_modified DESC';
-            break;
-        case 'date_added':
-            orderBy = 'date_added DESC';
-            break;
-        case 'views':
-            orderBy = 'view_count DESC';
-            break;
-        case 'name':
-            orderBy = 'name COLLATE NOCASE ASC';
-            break;
-        default:
-            orderBy = 'date_modified DESC';
-    }
+    const orderBy = buildOrderBy(sortBy, !!query?.trim());
 
     // Count query
     const countQuery = `SELECT COUNT(*) as count ${fromClause} ${whereClause}`;
@@ -138,6 +214,24 @@ export function searchMods(options: SearchOptions): SearchResult {
 
     if (heroName && skinsCategoryId !== undefined) {
         console.log(`[searchMods] Result count: ${totalCount}`);
+    }
+
+    // FTS5 missed — fall back to substring matching so creative names / typos
+    // still surface something instead of an empty page. Only triggers when a
+    // real query was applied (avoids running an unnecessary second query when
+    // the user hasn't typed anything yet).
+    if (totalCount === 0 && appliedFtsQuery && query) {
+        return runFallbackSubstringSearch(
+            database,
+            query.slice(0, 500),
+            section,
+            categoryId,
+            heroName,
+            skinsCategoryId,
+            sortBy,
+            limit,
+            offset
+        );
     }
 
     // Main query with pagination

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -15,6 +15,11 @@ export interface AppSettings {
     experimentalStats: boolean;
     experimentalCrosshair: boolean;
     hasCompletedSetup: boolean;      // First-run setup completed
+    /** Mod pairs the user has dismissed in the Conflicts page. Each entry is
+     *  the two mod ids joined sorted with `::` (e.g. "abc123::def456") so the
+     *  order of detection doesn't affect matching. Detector strips these out
+     *  before returning so the warning stops appearing for that pair. */
+    ignoredConflicts: string[];
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -30,6 +35,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     experimentalStats: false,
     experimentalCrosshair: false,
     hasCompletedSetup: false,
+    ignoredConflicts: [],
 };
 
 /**

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -8,6 +8,8 @@ export interface AppSettings {
     devDeadlockPath: string | null;
     hideNsfwPreviews: boolean;
     hideOutdatedMods: boolean;       // Hide GameBanana mods flagged as outdated in Browse
+    autoDisableSiblingVariants: boolean; // When re-downloading a GB mod, auto-disable older variants
+    steamLaunchOptions: string;      // Args written to Steam's localconfig.vdf for Deadlock just before launch
     activeProfileId: string | null;  // Currently active profile
     autoSaveProfile: boolean;        // Auto-save when mods change
     experimentalStats: boolean;
@@ -21,6 +23,8 @@ const DEFAULT_SETTINGS: AppSettings = {
     devDeadlockPath: null,
     hideNsfwPreviews: false,
     hideOutdatedMods: false,
+    autoDisableSiblingVariants: true,
+    steamLaunchOptions: '',
     activeProfileId: null,
     autoSaveProfile: false,
     experimentalStats: false,

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -201,6 +201,65 @@ export function extractHeroFromPath(filePath: string): string | null {
 }
 
 /**
+ * Best-effort label derived from a VPK's file tree (VPKs have no authored
+ * title). Returns null when nothing distinctive matches — caller should
+ * fall back to the filename rather than guess.
+ */
+export function getVpkLabel(vpkPath: string): string | null {
+    const paths = parseVpkDirectory(vpkPath);
+    if (!paths || paths.length === 0) return null;
+
+    const titleCase = (s: string) =>
+        s.replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()).trim();
+
+    const heroes = new Set<string>();
+    for (const p of paths) {
+        const hero = extractHeroFromPath(p);
+        if (hero) heroes.add(hero);
+    }
+    if (heroes.size > 0 && heroes.size <= 3) {
+        return [...heroes].map(titleCase).join(', ');
+    }
+
+    const extractUnique = (pattern: RegExp): string[] => {
+        const set = new Set<string>();
+        for (const p of paths) {
+            const m = p.match(pattern);
+            if (m?.[1]) set.add(m[1].toLowerCase());
+        }
+        return [...set];
+    };
+
+    const skyboxes = extractUnique(/materials\/skybox\/([^/]+)\//i);
+    if (skyboxes.length === 1) return `${titleCase(skyboxes[0])} skybox`;
+    if (skyboxes.length > 1 && skyboxes.length <= 3) {
+        return `${skyboxes.map(titleCase).join(', ')} skyboxes`;
+    }
+
+    const maps = extractUnique(/^maps\/([^/]+?)(?:\.|\/)/i);
+    if (maps.length === 1) return `${titleCase(maps[0])} map`;
+
+    const uiThemes = extractUnique(/panorama\/(?:images|layout|styles)\/(?:hud|themes?)\/([^/]+)\//i);
+    if (uiThemes.length === 1) return `${titleCase(uiThemes[0])} UI`;
+
+    return null;
+}
+
+/** Batch wrapper around getVpkLabel; omits entries with no label. */
+export function getVpkLabels(vpkPaths: Array<{ fileName: string; absPath: string }>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const { fileName, absPath } of vpkPaths) {
+        try {
+            const label = getVpkLabel(absPath);
+            if (label) out[fileName] = label;
+        } catch {
+            // best-effort; missing label is fine
+        }
+    }
+    return out;
+}
+
+/**
  * Get a summary of what a VPK modifies
  */
 export function getVpkContentSummary(vpkPath: string): {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -463,6 +463,7 @@ interface MultiVpkPickData {
     requestId: string;
     modName: string;
     vpkFileNames: string[];
+    vpkLabels?: Record<string, string>;
 }
 
 interface GameBananaModsResponse {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -14,6 +14,7 @@ export interface ElectronAPI {
     enableMod: (modId: string) => Promise<Mod>;
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
+    setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
@@ -666,6 +667,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     enableMod: (modId: string) => ipcRenderer.invoke('enable-mod', modId),
     disableMod: (modId: string) => ipcRenderer.invoke('disable-mod', modId),
     deleteMod: (modId: string) => ipcRenderer.invoke('delete-mod', modId),
+    setVariantLabel: (modId: string, label: string) =>
+        ipcRenderer.invoke('set-variant-label', modId, label),
     setModPriority: (modId: string, priority: number) =>
         ipcRenderer.invoke('set-mod-priority', modId, priority),
     reorderMods: (orderedFileNames: string[]) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -81,6 +81,11 @@ export interface ElectronAPI {
         requestId: string,
         accepted: boolean
     ) => Promise<void>;
+    onMultiVpkPick: (callback: (data: MultiVpkPickData) => void) => () => void;
+    respondToMultiVpkPick: (
+        requestId: string,
+        selected: string[] | null
+    ) => Promise<void>;
 
     // Conflicts
     getConflicts: () => Promise<ModConflict[]>;
@@ -450,6 +455,12 @@ interface OneClickSuspiciousFilesData {
     files: string[];
 }
 
+interface MultiVpkPickData {
+    requestId: string;
+    modName: string;
+    vpkFileNames: string[];
+}
+
 interface GameBananaModsResponse {
     records: unknown[];
     totalCount: number;
@@ -762,6 +773,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     respondToOneClickSuspiciousFiles: (requestId: string, accepted: boolean) =>
         ipcRenderer.invoke('one-click-suspicious-response', { requestId, accepted }),
+
+    onMultiVpkPick: (callback: (data: MultiVpkPickData) => void) => {
+        const handler = (_event: Electron.IpcRendererEvent, data: MultiVpkPickData) => callback(data);
+        ipcRenderer.on('multi-vpk-pick', handler);
+        return () => ipcRenderer.removeListener('multi-vpk-pick', handler);
+    },
+
+    respondToMultiVpkPick: (requestId: string, selected: string[] | null) =>
+        ipcRenderer.invoke('multi-vpk-pick-response', { requestId, selected }),
 
     // Conflicts
     getConflicts: () => ipcRenderer.invoke('get-conflicts'),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -90,6 +90,9 @@ export interface ElectronAPI {
 
     // Conflicts
     getConflicts: () => Promise<ModConflict[]>;
+    getIgnoredConflicts: () => Promise<string[]>;
+    ignoreConflict: (modA: string, modB: string) => Promise<string[]>;
+    unignoreConflict: (modA: string, modB: string) => Promise<string[]>;
 
     // Profiles
     getProfiles: () => Promise<Profile[]>;
@@ -788,6 +791,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     // Conflicts
     getConflicts: () => ipcRenderer.invoke('get-conflicts'),
+    getIgnoredConflicts: () => ipcRenderer.invoke('get-ignored-conflicts'),
+    ignoreConflict: (modA: string, modB: string) =>
+        ipcRenderer.invoke('ignore-conflict', modA, modB),
+    unignoreConflict: (modA: string, modB: string) =>
+        ipcRenderer.invoke('unignore-conflict', modA, modB),
 
     // Profiles
     getProfiles: () => ipcRenderer.invoke('get-profiles'),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -26,6 +26,7 @@ export interface ElectronAPI {
     getVanillaStashStatus: () => Promise<VanillaStashStatus>;
     restoreVanillaStash: () => Promise<VanillaRestoreResult>;
     onVanillaRestoreComplete: (callback: (result: VanillaRestoreResult) => void) => () => void;
+    getSteamLaunchOptionsStatus: () => Promise<SteamLaunchOptionsStatus>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
@@ -63,6 +64,7 @@ export interface ElectronAPI {
     onDownloadExtracting: (callback: (data: DownloadEventData) => void) => () => void;
     onDownloadComplete: (callback: (data: DownloadEventData) => void) => () => void;
     onDownloadError: (callback: (data: DownloadErrorData) => void) => () => void;
+    onModsAutoDisabled: (callback: (data: ModsAutoDisabledData) => void) => () => void;
 
     // Download Queue
     getDownloadQueue: () => Promise<DownloadQueueItem[]>;
@@ -261,11 +263,20 @@ interface AppSettings {
     devDeadlockPath: string | null;
     hideNsfwPreviews: boolean;
     hideOutdatedMods: boolean;
+    autoDisableSiblingVariants: boolean;
+    steamLaunchOptions: string;
     activeProfileId: string | null;
     autoSaveProfile: boolean;
     experimentalStats: boolean;
     experimentalCrosshair: boolean;
     hasCompletedSetup: boolean;
+}
+
+interface SteamLaunchOptionsStatus {
+    available: boolean;
+    configPath: string | null;
+    currentValue: string | null;
+    steamRunning: boolean;
 }
 
 interface Mod {
@@ -404,6 +415,13 @@ interface DownloadErrorData {
     errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
     message: string;
     helpUrl?: string;
+}
+
+interface ModsAutoDisabledData {
+    reason: 'sibling-variant';
+    modId: number;
+    fileId: number;
+    disabled: Array<{ id: string; name: string; fileName: string }>;
 }
 
 interface DownloadQueueItem {
@@ -659,6 +677,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.on('vanilla-restore-complete', handler);
         return () => ipcRenderer.removeListener('vanilla-restore-complete', handler);
     },
+    getSteamLaunchOptionsStatus: () => ipcRenderer.invoke('get-steam-launch-options-status'),
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => ipcRenderer.invoke('browse-mods', args),
@@ -712,6 +731,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         const handler = (_event: Electron.IpcRendererEvent, data: DownloadErrorData) => callback(data);
         ipcRenderer.on('download-error', handler);
         return () => ipcRenderer.removeListener('download-error', handler);
+    },
+    onModsAutoDisabled: (callback: (data: ModsAutoDisabledData) => void) => {
+        const handler = (_event: Electron.IpcRendererEvent, data: ModsAutoDisabledData) => callback(data);
+        ipcRenderer.on('mods-auto-disabled', handler);
+        return () => ipcRenderer.removeListener('mods-auto-disabled', handler);
     },
 
     // Download Queue

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,7 +9,8 @@ import { Button } from './common/ui';
 import { ConfirmModal } from './common/PageComponents';
 import { getSettings, setSettings, getGameinfoStatus, fixGameinfo } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import type { OneClickSuspiciousFilesData } from '../types/electron';
+import type { OneClickSuspiciousFilesData, MultiVpkPickData } from '../types/electron';
+import MultiVpkPickerModal from './MultiVpkPickerModal';
 
 export default function Layout() {
   const navigate = useNavigate();
@@ -20,6 +21,7 @@ export default function Layout() {
   const [isFixingGameinfo, setIsFixingGameinfo] = useState(false);
   const [oneClickBanner, setOneClickBanner] = useState<{ message: string; isError: boolean } | null>(null);
   const [suspiciousPrompt, setSuspiciousPrompt] = useState<OneClickSuspiciousFilesData | null>(null);
+  const [multiVpkPrompt, setMultiVpkPrompt] = useState<MultiVpkPickData | null>(null);
 
   useEffect(() => {
     const checkFirstRun = async () => {
@@ -100,6 +102,13 @@ export default function Layout() {
     return unsubscribe;
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onMultiVpkPick((data) => {
+      setMultiVpkPrompt(data);
+    });
+    return unsubscribe;
+  }, []);
+
   const respondToSuspicious = async (accepted: boolean) => {
     if (!suspiciousPrompt) return;
     await window.electronAPI.respondToOneClickSuspiciousFiles(
@@ -107,6 +116,12 @@ export default function Layout() {
       accepted
     );
     setSuspiciousPrompt(null);
+  };
+
+  const respondToMultiVpk = async (selected: string[] | null) => {
+    if (!multiVpkPrompt) return;
+    await window.electronAPI.respondToMultiVpkPick(multiVpkPrompt.requestId, selected);
+    setMultiVpkPrompt(null);
   };
 
   const handleFixGameinfo = async () => {
@@ -228,6 +243,14 @@ export default function Layout() {
           ) : null
         }
       />
+      {multiVpkPrompt && (
+        <MultiVpkPickerModal
+          key={multiVpkPrompt.requestId}
+          data={multiVpkPrompt}
+          onConfirm={(selected) => respondToMultiVpk(selected)}
+          onCancel={() => respondToMultiVpk(null)}
+        />
+      )}
       {showWelcome && <WelcomeModal onComplete={handleSetupComplete} />}
     </div>
   );

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -26,6 +26,11 @@ interface ModDetailsModalProps {
   section: string;
   installed: boolean;
   installedFileIds: Set<number>;
+  /** GameBanana file id of the currently-enabled variant, when any. The file
+   *  row with this id gets an "Active" badge so the user can see which of
+   *  several installed variants is the one actually loaded. Browse uses null
+   *  (it has no notion of which variant is active across the whole library). */
+  activeFileId?: number | null;
   downloadingFileId: number | null;
   extracting: boolean;
   progress: { downloaded: number; total: number } | null;
@@ -42,6 +47,7 @@ export default function ModDetailsModal({
   section,
   installed,
   installedFileIds,
+  activeFileId = null,
   downloadingFileId,
   extracting,
   progress,
@@ -344,6 +350,7 @@ export default function ModDetailsModal({
                   {mod.files.map((file) => {
                     const isInstalled = installedFileIds.has(file.id);
                     const isUpdate = updateAvailable && isInstalled;
+                    const isActive = activeFileId !== null && activeFileId === file.id;
                     const isDownloadingThis = downloadingFileId === file.id;
                     const pct = progress && progress.total > 0
                       ? Math.round((progress.downloaded / progress.total) * 100)
@@ -354,22 +361,38 @@ export default function ModDetailsModal({
                         className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
                           isUpdate
                             ? 'border-accent/40 bg-accent/5'
-                            : isInstalled
-                              ? 'border-green-500/30 bg-green-500/5'
-                              : 'border-border bg-bg-tertiary'
+                            : isActive
+                              ? 'border-accent/50 bg-accent/10'
+                              : isInstalled
+                                ? 'border-green-500/30 bg-green-500/5'
+                                : 'border-border bg-bg-tertiary'
                         }`}
                       >
                         <div className={`flex-shrink-0 w-10 h-10 rounded-md flex items-center justify-center ${
                           isUpdate
                             ? 'bg-accent/15 text-accent'
-                            : isInstalled
-                              ? 'bg-green-500/15 text-green-400'
-                              : 'bg-bg-secondary text-text-secondary'
+                            : isActive
+                              ? 'bg-accent/20 text-accent'
+                              : isInstalled
+                                ? 'bg-green-500/15 text-green-400'
+                                : 'bg-bg-secondary text-text-secondary'
                         }`}>
                           <FileArchive className="w-5 h-5" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
+                            {isActive && (
+                              <span className="flex-shrink-0 text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5">
+                                Active
+                              </span>
+                            )}
+                          </div>
+                          {file.description && (
+                            <p className="text-xs text-text-secondary/90 mt-0.5 truncate" title={file.description}>
+                              {file.description}
+                            </p>
+                          )}
                           <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
                             <span>{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
                             <span className="opacity-50">•</span>

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -257,18 +257,29 @@ export default function ModDetailsModal({
                         type="button"
                         onClick={() => openLightboxAt(index)}
                         aria-label={`View image ${index + 1} of ${images.length} full size`}
-                        className="relative block w-full aspect-video bg-black rounded-lg overflow-hidden border border-border cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 group"
+                        className="relative block w-full aspect-video bg-bg-tertiary rounded-lg overflow-hidden border border-border cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 group"
                       >
-                        {/* NSFW handling lives on ModThumbnail, but its
-                            forced object-cover crops screenshots in
-                            unhelpful ways here. Use a raw <img> with
-                            object-contain + a manual NSFW blur to preserve
-                            full preview frames. */}
+                        {/* Letterbox fill — same image scaled to cover the
+                            slot and heavily blurred so non-16:9 previews get
+                            an art-matched backdrop instead of harsh black
+                            bars. Hidden from a11y; the contained image
+                            below carries the real meaning. NSFW path skips
+                            this so the blur+overlay still works as a
+                            single layer. */}
+                        {!(mod.nsfw && hideNsfwPreviews) && (
+                          <img
+                            src={previewSrc}
+                            alt=""
+                            aria-hidden
+                            loading="lazy"
+                            className="absolute inset-0 w-full h-full object-cover scale-110 blur-2xl opacity-60 pointer-events-none"
+                          />
+                        )}
                         <img
                           src={previewSrc}
                           alt={`${mod.name} - Image ${index + 1}`}
                           loading="lazy"
-                          className={`w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.01] ${
+                          className={`relative w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.01] ${
                             mod.nsfw && hideNsfwPreviews ? 'blur-xl scale-110' : ''
                           }`}
                         />

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -12,12 +12,13 @@ import {
   ChevronRight,
   FileArchive,
   CheckCircle2,
+  Power,
+  Maximize2,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type { GameBananaModDetails, GameBananaComment } from '../types/gamebanana';
 import { isModOutdated, formatDate } from '../types/gamebanana';
 import { getModComments } from '../lib/api';
-import ModThumbnail from './ModThumbnail';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
 import { Skeleton } from './common/Skeleton';
 
@@ -31,6 +32,14 @@ interface ModDetailsModalProps {
    *  several installed variants is the one actually loaded. Browse uses null
    *  (it has no notion of which variant is active across the whole library). */
   activeFileId?: number | null;
+  /** Per-file local install state, keyed by GameBanana file id. When provided
+   *  (Browse only — Installed leaves this undefined), an installed-but-disabled
+   *  file row shows an inline "Enable" pill so the user can flip it on without
+   *  leaving the Browse tab after downloading. */
+  installedFileStates?: Map<number, { modId: string; enabled: boolean }>;
+  /** Handler invoked when the user clicks the inline "Enable" pill. Receives
+   *  the local mod id of the disabled install. */
+  onEnableFile?: (modId: string) => void;
   downloadingFileId: number | null;
   extracting: boolean;
   progress: { downloaded: number; total: number } | null;
@@ -48,6 +57,8 @@ export default function ModDetailsModal({
   installed,
   installedFileIds,
   activeFileId = null,
+  installedFileStates,
+  onEnableFile,
   downloadingFileId,
   extracting,
   progress,
@@ -60,17 +71,18 @@ export default function ModDetailsModal({
 }: ModDetailsModalProps) {
   const images = mod.previewMedia?.images ?? [];
   const audioPreviewUrl = mod.previewMedia?.metadata?.audioUrl;
+  // Cursor into the images array — only the lightbox cares about this now
+  // that previews are stacked vertically rather than swapped via carousel.
+  // It tracks which image is currently zoomed and which one keyboard arrows
+  // step through while the lightbox is open.
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  const [imageLoading, setImageLoading] = useState(true);
   const [comments, setComments] = useState<GameBananaComment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
   const [commentsTotalCount, setCommentsTotalCount] = useState(0);
-
-  // Flip to loading whenever the active image slot changes. The spinner
-  // overlay clears when the hidden probe img fires onLoad/onError below.
-  useEffect(() => {
-    setImageLoading(true);
-  }, [currentImageIndex, mod.id]);
+  // Lightbox state — when true, the selected image renders full-screen at
+  // its native GB resolution so the user can inspect detail the inline
+  // preview hides.
+  const [lightboxOpen, setLightboxOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -95,8 +107,19 @@ export default function ModDetailsModal({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-      if (images.length > 1) {
+      if (e.key === 'Escape') {
+        // Lightbox eats ESC before the modal does, so users can dismiss the
+        // zoomed view without losing their place on the detail card.
+        if (lightboxOpen) {
+          setLightboxOpen(false);
+        } else {
+          onClose();
+        }
+      }
+      // Arrow keys only navigate while the lightbox is open — otherwise
+      // they'd silently mutate hidden state while the user scrolls the
+      // description with the cursor.
+      if (lightboxOpen && images.length > 1) {
         if (e.key === 'ArrowLeft') goToPrevious();
         if (e.key === 'ArrowRight') goToNext();
       }
@@ -104,12 +127,20 @@ export default function ModDetailsModal({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, images.length]);
+  }, [onClose, images.length, lightboxOpen]);
 
   const currentImage = images[currentImageIndex];
-  const currentImageUrl = currentImage
-    ? `${currentImage.baseUrl}/${currentImage.file530 || currentImage.file}`
+  // The lightbox loads the original GB asset for detail inspection.
+  // The inline stack uses file530 per image directly via raw <img> tags so
+  // each thumb can render and load independently as the user scrolls.
+  const currentImageFullUrl = currentImage
+    ? `${currentImage.baseUrl}/${currentImage.file}`
     : undefined;
+
+  const openLightboxAt = (index: number) => {
+    setCurrentImageIndex(index);
+    setLightboxOpen(true);
+  };
 
   const goToPrevious = () => {
     setCurrentImageIndex((prev) => (prev > 0 ? prev - 1 : images.length - 1));
@@ -137,370 +168,415 @@ export default function ModDetailsModal({
       aria-label={mod.name}
     >
       <div
-        className="relative bg-bg-secondary rounded-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col border border-border shadow-2xl"
+        className="relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl max-h-[90vh] overflow-hidden flex flex-col border border-border shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Close button — floats over the hero so it's always reachable */}
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          className="absolute top-3 right-3 z-20 p-2 rounded-full bg-black/60 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/10 transition-colors cursor-pointer"
-        >
-          <X className="w-4 h-4" />
-        </button>
-
-        {/* Hero area: image carousel with title overlay */}
-        {images.length > 0 ? (
-          <div className="relative w-full aspect-[16/9] max-h-[45vh] bg-black flex-shrink-0 overflow-hidden">
-            <ModThumbnail
-              src={currentImageUrl}
-              alt={`${mod.name} - Image ${currentImageIndex + 1}`}
-              nsfw={mod.nsfw}
-              hideNsfw={hideNsfwPreviews}
-              className={`w-full h-full object-contain transition-opacity duration-200 ${imageLoading ? 'opacity-0' : 'opacity-100'}`}
-            />
-            {/* Hidden probe img drives load/error signal */}
-            {currentImageUrl && (
-              <img
-                key={currentImageUrl}
-                ref={(el) => {
-                  if (el && el.complete && el.naturalWidth > 0) {
-                    setImageLoading(false);
-                  }
-                }}
-                src={currentImageUrl}
-                alt=""
-                aria-hidden
-                className="hidden"
-                onLoad={() => setImageLoading(false)}
-                onError={() => setImageLoading(false)}
-              />
-            )}
-            {imageLoading && (
-              <Skeleton className="absolute inset-0" rounded="none" />
-            )}
-
-            {/* Bottom gradient for title readability */}
-            <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-black/95 via-black/60 to-transparent pointer-events-none" />
-
-            {/* Carousel controls */}
-            {images.length > 1 && (
-              <>
-                <button
-                  onClick={goToPrevious}
-                  aria-label="Previous image"
-                  className="absolute left-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer backdrop-blur-sm border border-white/10"
-                >
-                  <ChevronLeft className="w-5 h-5" />
-                </button>
-                <button
-                  onClick={goToNext}
-                  aria-label="Next image"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/50 text-white/80 hover:bg-black/70 hover:text-white transition-colors cursor-pointer backdrop-blur-sm border border-white/10"
-                >
-                  <ChevronRight className="w-5 h-5" />
-                </button>
-                <div className="absolute top-3 left-3 px-2 py-1 rounded-md bg-black/60 backdrop-blur-sm text-white/90 text-xs border border-white/10">
-                  {currentImageIndex + 1} / {images.length}
-                </div>
-                <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 z-10">
-                  {images.map((_, index) => (
-                    <button
-                      key={index}
-                      onClick={() => setCurrentImageIndex(index)}
-                      className={`h-1.5 rounded-full transition-all cursor-pointer ${
-                        index === currentImageIndex
-                          ? 'w-6 bg-white'
-                          : 'w-1.5 bg-white/40 hover:bg-white/60'
-                      }`}
-                      aria-label={`Go to image ${index + 1}`}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-
-            {/* Title + badges overlay */}
-            <div className="absolute inset-x-0 bottom-0 p-5 flex items-end justify-between gap-4 z-[5]">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2 flex-wrap mb-1.5">
-                  {updateAvailable && (
-                    <span className="rounded-full bg-accent/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent border border-accent/40">
-                      Update Available
-                    </span>
-                  )}
-                  {installed && !updateAvailable && (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-green-500/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-300 border border-green-500/40">
-                      <CheckCircle2 className="w-2.5 h-2.5" />
-                      Installed
-                    </span>
-                  )}
-                  {outdated && (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/25 backdrop-blur-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-300 border border-yellow-500/40">
-                      <AlertTriangle className="w-2.5 h-2.5" />
-                      Outdated
-                    </span>
-                  )}
-                </div>
-                <h2 className="text-2xl font-bold text-white leading-tight drop-shadow-lg truncate">
-                  {mod.name}
-                </h2>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="p-6 border-b border-border flex-shrink-0">
-            <div className="flex items-center gap-2 flex-wrap mb-2">
-              {updateAvailable && (
-                <span className="rounded-full bg-accent/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
-                  Update Available
-                </span>
-              )}
-              {installed && !updateAvailable && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
-                  <CheckCircle2 className="w-2.5 h-2.5" />
-                  Installed
-                </span>
-              )}
-            </div>
-            <h2 className="text-2xl font-bold">{mod.name}</h2>
-          </div>
-        )}
-
-        {/* Metadata strip */}
-        {(dateAdded || dateModified || totalDownloads > 0) && (
-          <div className="flex items-center gap-4 px-5 py-3 border-b border-border bg-bg-primary/30 text-xs text-text-secondary flex-shrink-0 flex-wrap">
-            {dateAdded && dateAdded > 0 && (
-              <span className="flex items-center gap-1.5">
-                <Clock className="w-3 h-3" />
-                Added <span className="text-text-primary">{formatDate(dateAdded)}</span>
+        {/* Header — single row. Status badges, category, title, and dense
+            metadata cluster all fit on one line so the modal's vertical
+            budget goes to content, not chrome. Title shrinks/truncates
+            first when space gets tight; metadata hides on narrow screens. */}
+        <div className="flex items-center gap-3 px-5 py-3 border-b border-border flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {updateAvailable && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent border border-accent/40">
+                <Download className="w-2.5 h-2.5" />
+                Update
               </span>
             )}
-            {dateModified && dateModified > 0 && (
-              <span className={`flex items-center gap-1.5 ${outdated ? 'text-yellow-400' : ''}`}>
-                <Clock className="w-3 h-3" />
-                Updated <span className={outdated ? 'text-yellow-300' : 'text-text-primary'}>{formatDate(dateModified)}</span>
+            {installed && !updateAvailable && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400 border border-green-500/40">
+                <CheckCircle2 className="w-2.5 h-2.5" />
+                Installed
               </span>
             )}
-            {totalDownloads > 0 && (
-              <span className="flex items-center gap-1.5">
-                <Download className="w-3 h-3" />
-                <span className="text-text-primary">{totalDownloads.toLocaleString()}</span> downloads
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* Scrollable body */}
-        <div className="flex-1 overflow-y-auto">
-          <div className="p-5 space-y-5">
             {outdated && (
-              <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2.5 text-yellow-200 text-sm">
-                <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" />
-                <span>This mod was last updated on {formatDate(dateModified!)} and may not be compatible with the current version of Deadlock.</span>
-              </div>
+              <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-400 border border-yellow-500/40">
+                <AlertTriangle className="w-2.5 h-2.5" />
+                Outdated
+              </span>
             )}
-
-            {audioPreviewUrl && (
-              <div className="relative rounded-lg overflow-hidden border border-border bg-gradient-to-br from-bg-tertiary via-bg-secondary to-bg-tertiary p-4">
-                <div className="flex items-center gap-3 mb-3">
-                  <Volume2 className="w-5 h-5 text-accent" />
-                  <h3 className="font-medium text-text-primary">Audio Preview</h3>
-                </div>
-                <div className="flex items-end justify-center gap-0.5 mb-3 h-12">
-                  {[3, 5, 8, 12, 16, 20, 16, 12, 18, 14, 10, 6, 9, 14, 18, 14, 11, 7, 4, 6, 10, 14, 18, 14, 8, 5, 3].map((h, i) => (
-                    <div
-                      key={i}
-                      className="w-1.5 bg-accent/50 rounded-full transition-all"
-                      style={{ height: `${h * 2}px` }}
-                    />
-                  ))}
-                </div>
-                <div className="backdrop-blur-md bg-bg-primary/50 rounded-lg border border-white/10 p-1">
-                  <AudioPreviewPlayer
-                    src={audioPreviewUrl}
-                    className="w-full"
-                  />
-                </div>
-              </div>
+            {mod.category?.name && (
+              <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-secondary border border-border">
+                {mod.category.name}
+              </span>
             )}
+          </div>
+          <h2 className="text-lg lg:text-xl font-bold leading-tight truncate min-w-0 flex-1" title={mod.name}>
+            {mod.name}
+          </h2>
+          {(dateAdded || dateModified || totalDownloads > 0) && (
+            <div className="hidden md:flex items-center gap-3 text-xs text-text-secondary flex-shrink-0">
+              {dateAdded && dateAdded > 0 && (
+                <span className="flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  <span className="text-text-primary">{formatDate(dateAdded)}</span>
+                </span>
+              )}
+              {dateModified && dateModified > 0 && (
+                <span className={`flex items-center gap-1 ${outdated ? 'text-yellow-400' : ''}`}>
+                  <Clock className="w-3 h-3" />
+                  <span className={outdated ? 'text-yellow-300' : 'text-text-primary'}>{formatDate(dateModified)}</span>
+                </span>
+              )}
+              {totalDownloads > 0 && (
+                <span className="flex items-center gap-1">
+                  <Download className="w-3 h-3" />
+                  <span className="text-text-primary">{totalDownloads.toLocaleString()}</span>
+                </span>
+              )}
+            </div>
+          )}
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex-shrink-0 p-1.5 rounded-full text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
 
-            {section === 'Sound' && !audioPreviewUrl && images.length === 0 && (
-              <div className="flex items-center justify-center p-8 rounded-lg border border-border bg-bg-tertiary">
-                <div className="flex flex-col items-center gap-2 text-text-secondary">
-                  <Volume2 className="w-12 h-12 text-accent/60" />
-                  <span className="text-sm">Sound Mod</span>
-                  <span className="text-xs opacity-60">No audio preview available</span>
-                </div>
-              </div>
-            )}
-
-            {mod.description && (
-              <div className="text-sm text-text-secondary [&_p]:mb-2 [&_a]:text-accent [&_a]:hover:underline [&_img]:rounded-md [&_img]:my-2">
-                <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(mod.description) }} />
-              </div>
-            )}
-
-            {mod.files && mod.files.length > 0 && (
-              <div className="space-y-2">
-                <h3 className="font-semibold text-sm uppercase tracking-wide text-text-secondary">
-                  Files {mod.files.length > 1 && <span className="text-text-secondary/70 normal-case tracking-normal">({mod.files.length})</span>}
-                </h3>
-                <div className="space-y-2">
-                  {mod.files.map((file) => {
-                    const isInstalled = installedFileIds.has(file.id);
-                    const isUpdate = updateAvailable && isInstalled;
-                    const isActive = activeFileId !== null && activeFileId === file.id;
-                    const isDownloadingThis = downloadingFileId === file.id;
-                    const pct = progress && progress.total > 0
-                      ? Math.round((progress.downloaded / progress.total) * 100)
-                      : null;
+        {/* Body — single scroll on narrow (everything flows top to bottom),
+            two independently-scrollable columns on lg+. Independent scroll
+            on wide is critical now that previews stack vertically: scrolling
+            comments shouldn't drag the image column away, and vice versa. */}
+        <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
+            {/* Image / preview column */}
+            <div className="lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pr-3 space-y-3">
+              {images.length > 0 ? (
+                /* Vertical preview stack — every image renders inline so
+                   users scroll naturally to see all of them. Click any one
+                   to open the lightbox at that image's index. We use the
+                   530px preview here (fast load + sharp on the inline slot)
+                   and the original asset in the lightbox. */
+                <div className="space-y-3" aria-label="Image previews">
+                  {images.map((img, index) => {
+                    const previewSrc = `${img.baseUrl}/${img.file530 || img.file}`;
                     return (
-                      <div
-                        key={file.id}
-                        className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
-                          isUpdate
-                            ? 'border-accent/40 bg-accent/5'
-                            : isActive
-                              ? 'border-accent/50 bg-accent/10'
-                              : isInstalled
-                                ? 'border-green-500/30 bg-green-500/5'
-                                : 'border-border bg-bg-tertiary'
-                        }`}
+                      <button
+                        key={`${img.baseUrl}/${img.file}`}
+                        type="button"
+                        onClick={() => openLightboxAt(index)}
+                        aria-label={`View image ${index + 1} of ${images.length} full size`}
+                        className="relative block w-full aspect-video bg-black rounded-lg overflow-hidden border border-border cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 group"
                       >
-                        <div className={`flex-shrink-0 w-10 h-10 rounded-md flex items-center justify-center ${
-                          isUpdate
-                            ? 'bg-accent/15 text-accent'
-                            : isActive
-                              ? 'bg-accent/20 text-accent'
-                              : isInstalled
-                                ? 'bg-green-500/15 text-green-400'
-                                : 'bg-bg-secondary text-text-secondary'
-                        }`}>
-                          <FileArchive className="w-5 h-5" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
-                            {isActive && (
-                              <span className="flex-shrink-0 text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5">
-                                Active
-                              </span>
-                            )}
-                          </div>
-                          {file.description && (
-                            <p className="text-xs text-text-secondary/90 mt-0.5 truncate" title={file.description}>
-                              {file.description}
-                            </p>
-                          )}
-                          <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
-                            <span>{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
-                            <span className="opacity-50">•</span>
-                            <span>{file.downloadCount.toLocaleString()} downloads</span>
-                          </div>
-                          {isDownloadingThis && pct !== null && (
-                            <div className="mt-2 h-1 w-full rounded-full bg-bg-secondary overflow-hidden">
-                              <div
-                                className="h-full bg-accent transition-all duration-200"
-                                style={{ width: `${pct}%` }}
-                              />
-                            </div>
-                          )}
-                        </div>
-                        <button
-                          onClick={() => onDownload(file.id, file.fileName)}
-                          disabled={downloadingFileId !== null}
-                          className={`flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2 min-w-[110px] text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
-                            isUpdate
-                              ? 'bg-accent hover:bg-accent-hover text-white'
-                              : isInstalled
-                                ? 'bg-bg-secondary hover:bg-bg-primary text-text-primary border border-border'
-                                : 'bg-accent hover:bg-accent-hover text-white'
+                        {/* NSFW handling lives on ModThumbnail, but its
+                            forced object-cover crops screenshots in
+                            unhelpful ways here. Use a raw <img> with
+                            object-contain + a manual NSFW blur to preserve
+                            full preview frames. */}
+                        <img
+                          src={previewSrc}
+                          alt={`${mod.name} - Image ${index + 1}`}
+                          loading="lazy"
+                          className={`w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.01] ${
+                            mod.nsfw && hideNsfwPreviews ? 'blur-xl scale-110' : ''
                           }`}
-                        >
-                          {isDownloadingThis ? (
-                            <>
-                              <Loader2 className="w-4 h-4 animate-spin" />
-                              {extracting ? 'Extracting…' : pct !== null ? `${pct}%` : 'Starting'}
-                            </>
-                          ) : (
-                            <>
-                              <Download className="w-4 h-4" />
-                              {actionLabel(file.id)}
-                            </>
-                          )}
-                        </button>
-                      </div>
+                        />
+                        {mod.nsfw && hideNsfwPreviews && (
+                          <div className="absolute inset-0 flex items-center justify-center text-[11px] uppercase tracking-wide text-white/80 bg-black/40">
+                            NSFW preview hidden
+                          </div>
+                        )}
+                        {/* Per-image index pill + zoom affordance. The
+                            zoom button shows on hover so it doesn't
+                            compete with the image visually at rest. */}
+                        {images.length > 1 && (
+                          <div className="absolute top-2 left-2 px-2 py-0.5 rounded-md bg-black/55 backdrop-blur-sm text-white/85 text-[11px] border border-white/10">
+                            {index + 1} / {images.length}
+                          </div>
+                        )}
+                        <span className="absolute top-2 right-2 p-1.5 rounded-md bg-black/55 backdrop-blur-sm text-white/80 border border-white/10 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <Maximize2 className="w-3.5 h-3.5" />
+                        </span>
+                      </button>
                     );
                   })}
                 </div>
-              </div>
-            )}
-
-            <div className="space-y-3">
-              <h3 className="font-semibold text-sm uppercase tracking-wide text-text-secondary flex items-center gap-2">
-                <MessageSquare className="w-4 h-4" />
-                Comments {commentsTotalCount > 0 && <span className="normal-case tracking-normal text-text-secondary/70">({commentsTotalCount})</span>}
-              </h3>
-              {commentsLoading ? (
-                <div className="space-y-3">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div key={i} className="flex gap-3 p-3 bg-bg-tertiary rounded-lg">
-                      <Skeleton className="w-8 h-8 flex-shrink-0" rounded="full" />
-                      <div className="flex-1 space-y-2">
-                        <div className="flex items-center gap-2">
-                          <Skeleton className="h-3 w-24" />
-                          <Skeleton className="h-2.5 w-16" />
-                        </div>
-                        <Skeleton className="h-2.5 w-full" />
-                        <Skeleton className="h-2.5 w-2/3" />
-                      </div>
-                    </div>
-                  ))}
+              ) : section === 'Sound' && !audioPreviewUrl ? (
+                <div className="flex items-center justify-center p-8 rounded-lg border border-border bg-bg-tertiary">
+                  <div className="flex flex-col items-center gap-2 text-text-secondary">
+                    <Volume2 className="w-12 h-12 text-accent/60" />
+                    <span className="text-sm">Sound Mod</span>
+                    <span className="text-xs opacity-60">No audio preview available</span>
+                  </div>
                 </div>
-              ) : comments.length === 0 ? (
-                <p className="text-sm text-text-secondary py-2">No comments yet</p>
-              ) : (
-                <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
-                  {comments.map((comment) => (
-                    <div key={comment.id} className="flex gap-3 p-3 bg-bg-tertiary rounded-lg">
-                      {comment.poster.avatarUrl ? (
-                        <img
-                          src={comment.poster.avatarUrl}
-                          alt={comment.poster.name}
-                          className="w-8 h-8 rounded-full flex-shrink-0"
-                        />
-                      ) : (
-                        <div className="w-8 h-8 rounded-full flex-shrink-0 bg-bg-secondary" />
-                      )}
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="text-sm font-medium">{comment.poster.name}</span>
-                          <span className="text-[11px] text-text-secondary">{formatDate(comment.dateAdded)}</span>
-                        </div>
-                        <div
-                          className="text-sm text-text-secondary [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
-                          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
-                        />
-                      </div>
-                    </div>
-                  ))}
+              ) : null}
+
+              {audioPreviewUrl && (
+                <div className="relative rounded-lg overflow-hidden border border-border bg-gradient-to-br from-bg-tertiary via-bg-secondary to-bg-tertiary p-3">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Volume2 className="w-4 h-4 text-accent" />
+                    <h3 className="font-medium text-sm text-text-primary">Audio Preview</h3>
+                  </div>
+                  <div className="backdrop-blur-md bg-bg-primary/50 rounded-lg border border-white/10 p-1">
+                    <AudioPreviewPlayer
+                      src={audioPreviewUrl}
+                      className="w-full"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {outdated && (
+                <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2.5 text-yellow-200 text-xs">
+                  <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" />
+                  <span>This mod was last updated on {formatDate(dateModified!)} and may not be compatible with the current Deadlock version.</span>
                 </div>
               )}
             </div>
 
-            <a
-              href={`https://gamebanana.com/mods/${mod.id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
-            >
-              <ExternalLink className="w-4 h-4" />
-              View on GameBanana
-            </a>
-          </div>
+            {/* Content column — description / files / comments / GB link.
+                Takes the remaining horizontal space on wide layouts.
+                Independently scrollable on lg+ so reading comments or
+                installing a file doesn't move the image stack on the left. */}
+            <div className="flex-1 min-w-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pl-3 space-y-5">
+              {mod.description && (
+                <section>
+                  <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
+                    About
+                  </h3>
+                  <div className="text-sm text-text-secondary [&_p]:mb-2 [&_a]:text-accent [&_a]:hover:underline [&_img]:rounded-md [&_img]:my-2 [&_img]:max-w-full">
+                    <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(mod.description) }} />
+                  </div>
+                </section>
+              )}
+
+              {mod.files && mod.files.length > 0 && (
+                <section>
+                  <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
+                    Files {mod.files.length > 1 && <span className="text-text-secondary/70 normal-case tracking-normal">({mod.files.length})</span>}
+                  </h3>
+                  <div className="space-y-2">
+                    {mod.files.map((file) => {
+                      const isInstalled = installedFileIds.has(file.id);
+                      const isUpdate = updateAvailable && isInstalled;
+                      const isActive = activeFileId !== null && activeFileId === file.id;
+                      const isDownloadingThis = downloadingFileId === file.id;
+                      const installedFileState = installedFileStates?.get(file.id);
+                      const showEnablePill =
+                        !!installedFileState &&
+                        !installedFileState.enabled &&
+                        !!onEnableFile &&
+                        !isDownloadingThis;
+                      const pct = progress && progress.total > 0
+                        ? Math.round((progress.downloaded / progress.total) * 100)
+                        : null;
+                      return (
+                        <div
+                          key={file.id}
+                          className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                            isUpdate
+                              ? 'border-accent/40 bg-accent/5'
+                              : isActive
+                                ? 'border-accent/50 bg-accent/10'
+                                : isInstalled
+                                  ? 'border-green-500/30 bg-green-500/5'
+                                  : 'border-border bg-bg-tertiary'
+                          }`}
+                        >
+                          <div className={`flex-shrink-0 w-10 h-10 rounded-md flex items-center justify-center ${
+                            isUpdate
+                              ? 'bg-accent/15 text-accent'
+                              : isActive
+                                ? 'bg-accent/20 text-accent'
+                                : isInstalled
+                                  ? 'bg-green-500/15 text-green-400'
+                                  : 'bg-bg-secondary text-text-secondary'
+                          }`}>
+                            <FileArchive className="w-5 h-5" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
+                              {isActive && (
+                                <span className="flex-shrink-0 text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5">
+                                  Active
+                                </span>
+                              )}
+                            </div>
+                            {file.description && (
+                              <p className="text-xs text-text-secondary/90 mt-0.5 truncate" title={file.description}>
+                                {file.description}
+                              </p>
+                            )}
+                            <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
+                              <span>{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
+                              <span className="opacity-50">•</span>
+                              <span>{file.downloadCount.toLocaleString()} downloads</span>
+                            </div>
+                            {isDownloadingThis && pct !== null && (
+                              <div className="mt-2 h-1 w-full rounded-full bg-bg-secondary overflow-hidden">
+                                <div
+                                  className="h-full bg-accent transition-all duration-200"
+                                  style={{ width: `${pct}%` }}
+                                />
+                              </div>
+                            )}
+                          </div>
+                          {showEnablePill && installedFileState && (
+                            <button
+                              onClick={() => onEnableFile!(installedFileState.modId)}
+                              disabled={downloadingFileId !== null}
+                              title="Enable this mod"
+                              className="flex-shrink-0 flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium rounded-md transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-300 border border-yellow-500/40"
+                            >
+                              <Power className="w-3.5 h-3.5" />
+                              Enable
+                            </button>
+                          )}
+                          <button
+                            onClick={() => onDownload(file.id, file.fileName)}
+                            disabled={downloadingFileId !== null}
+                            className={`flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2 min-w-[110px] text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
+                              isUpdate
+                                ? 'bg-accent hover:bg-accent-hover text-white'
+                                : isInstalled
+                                  ? 'bg-bg-secondary hover:bg-bg-primary text-text-primary border border-border'
+                                  : 'bg-accent hover:bg-accent-hover text-white'
+                            }`}
+                          >
+                            {isDownloadingThis ? (
+                              <>
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                                {extracting ? 'Extracting…' : pct !== null ? `${pct}%` : 'Starting'}
+                              </>
+                            ) : (
+                              <>
+                                <Download className="w-4 h-4" />
+                                {actionLabel(file.id)}
+                              </>
+                            )}
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              )}
+
+              <section>
+                <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2 flex items-center gap-2">
+                  <MessageSquare className="w-3.5 h-3.5" />
+                  Comments {commentsTotalCount > 0 && <span className="normal-case tracking-normal text-text-secondary/70">({commentsTotalCount})</span>}
+                </h3>
+                {commentsLoading ? (
+                  <ul className="divide-y divide-border/60">
+                    {Array.from({ length: 2 }).map((_, i) => (
+                      <li key={i} className="flex gap-3 py-3 first:pt-0">
+                        <Skeleton className="w-7 h-7 flex-shrink-0" rounded="full" />
+                        <div className="flex-1 space-y-1.5">
+                          <div className="flex items-center gap-2">
+                            <Skeleton className="h-3 w-24" />
+                            <Skeleton className="h-2.5 w-16" />
+                          </div>
+                          <Skeleton className="h-2.5 w-full" />
+                          <Skeleton className="h-2.5 w-2/3" />
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : comments.length === 0 ? (
+                  <p className="text-sm text-text-secondary py-1">No comments yet</p>
+                ) : (
+                  /* Flat threaded layout — no per-comment card. Files stay
+                     as bordered action cards (each is something you DO);
+                     comments are conversational content (something you
+                     READ), so we strip the boxes and let the avatar + name
+                     + divider carry the visual hierarchy instead. */
+                  <ul className="divide-y divide-border/60">
+                    {comments.map((comment) => (
+                      <li key={comment.id} className="flex gap-3 py-3 first:pt-0">
+                        {comment.poster.avatarUrl ? (
+                          <img
+                            src={comment.poster.avatarUrl}
+                            alt={comment.poster.name}
+                            className="w-7 h-7 rounded-full flex-shrink-0"
+                          />
+                        ) : (
+                          <div className="w-7 h-7 rounded-full flex-shrink-0 bg-bg-tertiary" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-baseline gap-2 mb-0.5">
+                            <span className="text-sm font-medium text-text-primary">{comment.poster.name}</span>
+                            <span className="text-[11px] text-text-tertiary">{formatDate(comment.dateAdded)}</span>
+                          </div>
+                          <div
+                            className="text-sm text-text-secondary [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
+                          />
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <a
+                href={`https://gamebanana.com/mods/${mod.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
+              >
+                <ExternalLink className="w-4 h-4" />
+                View on GameBanana
+              </a>
+            </div>
         </div>
       </div>
+
+      {/* Lightbox overlay — sits above the modal so ESC closes it first.
+          Click outside the image dismisses; carousel arrows still work via
+          the global keydown listener so users can flip pictures while zoomed. */}
+      {lightboxOpen && currentImageFullUrl && (
+        <div
+          className="fixed inset-0 z-[60] bg-black/95 flex items-center justify-center p-4 animate-fade-in"
+          onClick={(e) => {
+            e.stopPropagation();
+            setLightboxOpen(false);
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${mod.name} — full size image`}
+        >
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setLightboxOpen(false); }}
+            aria-label="Close full size view"
+            className="absolute top-4 right-4 p-2 rounded-full bg-black/60 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/15 transition-colors cursor-pointer z-10"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          {images.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); goToPrevious(); }}
+                aria-label="Previous image"
+                className="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/60 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/15 transition-colors cursor-pointer z-10"
+              >
+                <ChevronLeft className="w-6 h-6" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); goToNext(); }}
+                aria-label="Next image"
+                className="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-black/60 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/15 transition-colors cursor-pointer z-10"
+              >
+                <ChevronRight className="w-6 h-6" />
+              </button>
+              <div className="absolute top-4 left-4 px-2.5 py-1 rounded-md bg-black/60 backdrop-blur-sm text-white/90 text-xs border border-white/15">
+                {currentImageIndex + 1} / {images.length}
+              </div>
+            </>
+          )}
+          <img
+            src={currentImageFullUrl}
+            alt={`${mod.name} - Image ${currentImageIndex + 1} (full size)`}
+            className="max-w-full max-h-full object-contain"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/MultiVpkPickerModal.tsx
+++ b/src/components/MultiVpkPickerModal.tsx
@@ -95,6 +95,7 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
                     <div className="max-h-64 overflow-y-auto space-y-1.5 pr-1">
                         {data.vpkFileNames.map((vpk) => {
                             const isChecked = selected.has(vpk);
+                            const label = data.vpkLabels?.[vpk];
                             return (
                                 <label
                                     key={vpk}
@@ -111,7 +112,16 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
                                         className="w-4 h-4 accent-accent cursor-pointer flex-shrink-0"
                                     />
                                     <FileArchive className="w-4 h-4 flex-shrink-0 opacity-70" />
-                                    <span className="font-mono text-xs truncate flex-1" title={vpk}>{vpk}</span>
+                                    <div className="min-w-0 flex-1">
+                                        {label ? (
+                                            <>
+                                                <div className="text-sm font-medium truncate" title={label}>{label}</div>
+                                                <div className="font-mono text-[11px] text-text-secondary/80 truncate" title={vpk}>{vpk}</div>
+                                            </>
+                                        ) : (
+                                            <span className="font-mono text-xs truncate block" title={vpk}>{vpk}</span>
+                                        )}
+                                    </div>
                                 </label>
                             );
                         })}

--- a/src/components/MultiVpkPickerModal.tsx
+++ b/src/components/MultiVpkPickerModal.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { FileArchive, Check, X } from 'lucide-react';
+import type { MultiVpkPickData } from '../types/electron';
+
+interface Props {
+    data: MultiVpkPickData;
+    onConfirm: (selected: string[]) => void;
+    onCancel: () => void;
+}
+
+/**
+ * Multi-VPK picker. Shown when an archive (Warden Remodel, etc.) yields more
+ * than one .vpk after extraction. Previously the install pipeline silently
+ * kept the alphabetically-first VPK and unlinked the rest — felt like data
+ * loss to users. This modal makes the choice explicit.
+ *
+ * Default selection: only the first VPK is checked, matching the previous
+ * implicit behavior. Users who want everything can flip the master toggle.
+ *
+ * NOTE: the parent must mount this with a key tied to `data.requestId` so a
+ * fresh request resets the selection — we deliberately avoid a syncing
+ * useEffect here.
+ */
+export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props) {
+    const [selected, setSelected] = useState<Set<string>>(() => {
+        const next = new Set<string>();
+        if (data.vpkFileNames[0]) next.add(data.vpkFileNames[0]);
+        return next;
+    });
+
+    const allSelected = selected.size === data.vpkFileNames.length;
+    const toggle = (vpk: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(vpk)) next.delete(vpk);
+            else next.add(vpk);
+            return next;
+        });
+    };
+
+    const toggleAll = () => {
+        if (allSelected) {
+            setSelected(new Set());
+        } else {
+            setSelected(new Set(data.vpkFileNames));
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="multi-vpk-pick-title"
+            onClick={onCancel}
+        >
+            <div
+                className="bg-bg-secondary border border-border rounded-xl w-full max-w-lg"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between p-5 border-b border-border">
+                    <h3 id="multi-vpk-pick-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
+                        <FileArchive className="w-5 h-5" />
+                        Multiple VPKs in archive
+                    </h3>
+                    <button
+                        onClick={onCancel}
+                        className="p-1 text-text-secondary hover:text-text-primary rounded cursor-pointer"
+                        aria-label="Close"
+                    >
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                <div className="p-5 space-y-4">
+                    <p className="text-sm text-text-secondary">
+                        <span className="font-medium text-text-primary">{data.modName}</span> contains{' '}
+                        {data.vpkFileNames.length} <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">.vpk</code> files.
+                        Pick which ones to install — leave any unwanted ones unchecked and they&apos;ll be skipped.
+                    </p>
+
+                    <div className="flex items-center justify-between pb-2 border-b border-border/60">
+                        <span className="text-xs uppercase tracking-wide text-text-secondary">
+                            {selected.size} of {data.vpkFileNames.length} selected
+                        </span>
+                        <button
+                            type="button"
+                            onClick={toggleAll}
+                            className="text-xs text-accent hover:text-accent-hover transition-colors cursor-pointer"
+                        >
+                            {allSelected ? 'Deselect all' : 'Select all'}
+                        </button>
+                    </div>
+
+                    <div className="max-h-64 overflow-y-auto space-y-1.5 pr-1">
+                        {data.vpkFileNames.map((vpk) => {
+                            const isChecked = selected.has(vpk);
+                            return (
+                                <label
+                                    key={vpk}
+                                    className={`flex items-center gap-3 p-2.5 rounded-lg border transition-colors cursor-pointer ${
+                                        isChecked
+                                            ? 'border-accent/40 bg-accent/5 text-text-primary'
+                                            : 'border-border bg-bg-tertiary text-text-secondary hover:bg-white/5'
+                                    }`}
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={isChecked}
+                                        onChange={() => toggle(vpk)}
+                                        className="w-4 h-4 accent-accent cursor-pointer flex-shrink-0"
+                                    />
+                                    <FileArchive className="w-4 h-4 flex-shrink-0 opacity-70" />
+                                    <span className="font-mono text-xs truncate flex-1" title={vpk}>{vpk}</span>
+                                </label>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <div className="flex justify-end gap-3 p-5 border-t border-border">
+                    <button
+                        onClick={onCancel}
+                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-white/10 transition-colors cursor-pointer"
+                    >
+                        Cancel install
+                    </button>
+                    <button
+                        onClick={() => onConfirm(Array.from(selected))}
+                        disabled={selected.size === 0}
+                        className="px-4 py-2 bg-accent hover:bg-accent-hover text-black rounded-lg font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                    >
+                        <Check className="w-4 h-4" />
+                        Install {selected.size > 0 ? `${selected.size}` : ''}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -43,8 +43,16 @@ export default function Sidebar() {
   const [stashStatus, setStashStatus] = useState<VanillaStashStatus>({ active: false });
   const [launchPending, setLaunchPending] = useState<'modded' | 'vanilla' | null>(null);
   const [restorePending, setRestorePending] = useState(false);
-  const [toast, setToast] = useState<{ kind: 'info' | 'error'; text: string } | null>(null);
+  // Toasts can carry an optional action button — used for "Enable" after a
+  // fresh download and "Re-enable" after a sibling auto-disable. The action
+  // closes the toast when invoked.
+  const [toast, setToast] = useState<{
+    kind: 'info' | 'error';
+    text: string;
+    action?: { label: string; onClick: () => void | Promise<void> };
+  } | null>(null);
   const [updateModalOpen, setUpdateModalOpen] = useState(false);
+  const toggleMod = useAppStore((state) => state.toggleMod);
 
   const refreshStashStatus = useCallback(async () => {
     try {
@@ -115,7 +123,10 @@ export default function Sidebar() {
 
   useEffect(() => {
     if (!toast) return;
-    const t = setTimeout(() => setToast(null), 6000);
+    // Stickier when there's an action — give the user time to actually
+    // notice and tap it.
+    const lifetime = toast.action ? 10000 : 6000;
+    const t = setTimeout(() => setToast(null), lifetime);
     return () => clearTimeout(t);
   }, [toast]);
 
@@ -130,12 +141,50 @@ export default function Sidebar() {
       const tail = names.length > 2 ? ` and ${names.length - 2} more` : '';
       setToast({
         kind: 'info',
-        text: `Disabled older variant${names.length === 1 ? '' : 's'}: ${head}${tail}. Re-enable in Installed if you want to keep both.`,
+        text: `Disabled older variant${names.length === 1 ? '' : 's'}: ${head}${tail}.`,
+        action: {
+          label: 'View',
+          onClick: () => navigate('/'),
+        },
       });
       loadMods();
     });
     return unsub;
-  }, [loadMods]);
+  }, [loadMods, navigate]);
+
+  // Post-download "Enable now" toast. Users complained that finished downloads
+  // dropped them on Browse with the new mod silently sitting in disabled/ —
+  // they had to navigate to Installed and toggle it themselves. This surfaces
+  // an Enable button right where they are so the round-trip isn't needed.
+  useEffect(() => {
+    const unsub = window.electronAPI.onDownloadComplete(async (data) => {
+      // Wait one tick so the loadMods() chained off download-complete in
+      // Browse/Installed has time to refresh the store. Otherwise the mod
+      // we just downloaded won't be in `mods` yet.
+      await new Promise((r) => setTimeout(r, 250));
+      const fresh = useAppStore.getState().mods;
+      const justInstalled = fresh.find(
+        (m) =>
+          m.gameBananaId === data.modId &&
+          m.gameBananaFileId === data.fileId
+      );
+      if (!justInstalled) return;
+      // If it landed enabled (rare — only happens on rapid re-download of an
+      // already-enabled mod), nothing to do.
+      if (justInstalled.enabled) return;
+      setToast({
+        kind: 'info',
+        text: `Installed “${justInstalled.name}” (disabled).`,
+        action: {
+          label: 'Enable now',
+          onClick: async () => {
+            await toggleMod(justInstalled.id);
+          },
+        },
+      });
+    });
+    return unsub;
+  }, [toggleMod]);
 
   const navItems = useMemo(() => {
     type BadgeTone = 'muted' | 'warning';
@@ -307,7 +356,29 @@ export default function Sidebar() {
                 : 'border border-accent/40 bg-accent/10 text-accent'
             }`}
           >
-            {toast.text}
+            <div>{toast.text}</div>
+            {toast.action && (
+              <button
+                type="button"
+                onClick={async () => {
+                  const action = toast.action;
+                  if (!action) return;
+                  // Dismiss immediately so a slow handler doesn't leave a
+                  // stale toast on screen.
+                  setToast(null);
+                  try {
+                    await action.onClick();
+                  } catch (err) {
+                    console.warn('[Sidebar] toast action failed:', err);
+                  }
+                }}
+                className={`mt-1.5 text-xs font-medium underline-offset-2 hover:underline cursor-pointer ${
+                  toast.kind === 'error' ? 'text-red-200' : 'text-accent-hover'
+                }`}
+              >
+                {toast.action.label}
+              </button>
+            )}
           </div>
         )}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -119,6 +119,24 @@ export default function Sidebar() {
     return () => clearTimeout(t);
   }, [toast]);
 
+  // Surface auto-disabled sibling variants. The download backend silently
+  // moves older variants of the same GB mod into disabled/ on re-download; this
+  // toast tells the user what happened so it doesn't look like data loss.
+  useEffect(() => {
+    const unsub = window.electronAPI.onModsAutoDisabled((data) => {
+      if (!data.disabled.length) return;
+      const names = data.disabled.map((m) => m.name);
+      const head = names.slice(0, 2).join(', ');
+      const tail = names.length > 2 ? ` and ${names.length - 2} more` : '';
+      setToast({
+        kind: 'info',
+        text: `Disabled older variant${names.length === 1 ? '' : 's'}: ${head}${tail}. Re-enable in Installed if you want to keep both.`,
+      });
+      loadMods();
+    });
+    return unsub;
+  }, [loadMods]);
+
   const navItems = useMemo(() => {
     type BadgeTone = 'muted' | 'warning';
     type NavItem = {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,7 +52,6 @@ export default function Sidebar() {
     action?: { label: string; onClick: () => void | Promise<void> };
   } | null>(null);
   const [updateModalOpen, setUpdateModalOpen] = useState(false);
-  const toggleMod = useAppStore((state) => state.toggleMod);
 
   const refreshStashStatus = useCallback(async () => {
     try {
@@ -151,40 +150,6 @@ export default function Sidebar() {
     });
     return unsub;
   }, [loadMods, navigate]);
-
-  // Post-download "Enable now" toast. Users complained that finished downloads
-  // dropped them on Browse with the new mod silently sitting in disabled/ —
-  // they had to navigate to Installed and toggle it themselves. This surfaces
-  // an Enable button right where they are so the round-trip isn't needed.
-  useEffect(() => {
-    const unsub = window.electronAPI.onDownloadComplete(async (data) => {
-      // Wait one tick so the loadMods() chained off download-complete in
-      // Browse/Installed has time to refresh the store. Otherwise the mod
-      // we just downloaded won't be in `mods` yet.
-      await new Promise((r) => setTimeout(r, 250));
-      const fresh = useAppStore.getState().mods;
-      const justInstalled = fresh.find(
-        (m) =>
-          m.gameBananaId === data.modId &&
-          m.gameBananaFileId === data.fileId
-      );
-      if (!justInstalled) return;
-      // If it landed enabled (rare — only happens on rapid re-download of an
-      // already-enabled mod), nothing to do.
-      if (justInstalled.enabled) return;
-      setToast({
-        kind: 'info',
-        text: `Installed “${justInstalled.name}” (disabled).`,
-        action: {
-          label: 'Enable now',
-          onClick: async () => {
-            await toggleMod(justInstalled.id);
-          },
-        },
-      });
-    });
-    return unsub;
-  }, [toggleMod]);
 
   const navItems = useMemo(() => {
     type BadgeTone = 'muted' | 'warning';

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, Check, Trash2, Power, PowerOff, Info, Pencil } from 'lucide-react';
+import type { Mod } from '../types/mod';
+import { Button } from './common/ui';
+
+interface Props {
+    /** Display name shared by the variants (use primary.name). */
+    modName: string;
+    variants: Mod[];
+    /** Called when the user picks a different variant. Caller is responsible
+     *  for enabling the target + disabling other variants (mutual exclusion). */
+    onSelect: (target: Mod) => Promise<void> | void;
+    /** Called when the user disables the currently-active variant. */
+    onDisableAll: () => Promise<void> | void;
+    /** Called when the user requests deletion of a single variant. */
+    onDeleteVariant: (variant: Mod) => Promise<void> | void;
+    /** Persist a user-given label for a variant. Empty string clears it. */
+    onRenameVariant: (variant: Mod, label: string) => Promise<void> | void;
+    /** Optional — open the GameBanana details modal for this mod. When set,
+     *  a small "Mod page" link appears in the header. Not provided when the
+     *  group has no GB id (shouldn't happen since groups require one). */
+    onOpenModDetails?: () => void;
+    onClose: () => void;
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+/**
+ * Variant picker for grouped mods. Shown when the user clicks an Installed
+ * card that represents multiple VPKs sharing a GameBanana mod id (e.g. five
+ * presets of "Scientific Half Life as Rem"). One variant can be active at a
+ * time; picking a new one disables the previous.
+ *
+ * Per-variant Delete lives here (rather than the card) so the card-level
+ * Delete can keep its simple "remove this whole mod" meaning without
+ * ambiguity about which file would be removed.
+ */
+export default function VariantPickerModal({
+    modName,
+    variants,
+    onSelect,
+    onDisableAll,
+    onDeleteVariant,
+    onRenameVariant,
+    onOpenModDetails,
+    onClose,
+}: Props) {
+    const [pending, setPending] = useState<string | null>(null);
+    // Per-row rename state. Holds the variant id being edited plus the
+    // working draft text; null when no row is in edit mode.
+    const [editing, setEditing] = useState<{ id: string; draft: string } | null>(null);
+    const editInputRef = useRef<HTMLInputElement | null>(null);
+
+    // Focus + select when the editing target changes (entering edit mode
+    // for a new row). Driven by the id alone so we don't re-focus on every
+    // keystroke as the draft updates.
+    const editingId = editing?.id ?? null;
+    useEffect(() => {
+        if (editingId && editInputRef.current) {
+            editInputRef.current.focus();
+            editInputRef.current.select();
+        }
+    }, [editingId]);
+
+    const active = variants.find((v) => v.enabled) ?? null;
+
+    const startRename = (v: Mod) => {
+        setEditing({ id: v.id, draft: v.variantLabel ?? '' });
+    };
+
+    const cancelRename = () => setEditing(null);
+
+    const commitRename = async (v: Mod) => {
+        if (!editing || editing.id !== v.id || pending) return;
+        const next = editing.draft.trim();
+        // No-op when the value hasn't changed (avoids a needless write).
+        if (next === (v.variantLabel ?? '')) {
+            setEditing(null);
+            return;
+        }
+        setPending(`rename:${v.id}`);
+        try {
+            await onRenameVariant(v, next);
+            setEditing(null);
+        } finally {
+            setPending(null);
+        }
+    };
+
+    const pick = async (target: Mod) => {
+        if (pending) return;
+        // Already active → treat as a no-op (don't toggle off; that's what
+        // the "Disable" button is for).
+        if (active?.id === target.id) return;
+        setPending(target.id);
+        try {
+            await onSelect(target);
+            onClose();
+        } finally {
+            setPending(null);
+        }
+    };
+
+    const disableActive = async () => {
+        if (pending || !active) return;
+        setPending('__disable__');
+        try {
+            await onDisableAll();
+            onClose();
+        } finally {
+            setPending(null);
+        }
+    };
+
+    const handleDelete = async (variant: Mod) => {
+        if (pending) return;
+        setPending(`delete:${variant.id}`);
+        try {
+            await onDeleteVariant(variant);
+        } finally {
+            setPending(null);
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="variant-picker-title"
+            onClick={onClose}
+        >
+            <div
+                className="bg-bg-secondary border border-border rounded-xl w-full max-w-xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between p-5 border-b border-border gap-3">
+                    <div className="min-w-0">
+                        <h3 id="variant-picker-title" className="text-lg font-semibold text-text-primary truncate">
+                            {modName}
+                        </h3>
+                        <p className="text-xs text-text-secondary mt-0.5">
+                            {variants.length} variants — pick which one to enable
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                        {onOpenModDetails && (
+                            <button
+                                onClick={onOpenModDetails}
+                                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary border border-border hover:border-accent/40 rounded cursor-pointer transition-colors"
+                                title="Open the GameBanana mod page"
+                            >
+                                <Info className="w-3.5 h-3.5" />
+                                Mod page
+                            </button>
+                        )}
+                        <button
+                            onClick={onClose}
+                            className="p-1 text-text-secondary hover:text-text-primary rounded cursor-pointer"
+                            aria-label="Close"
+                        >
+                            <X className="w-5 h-5" />
+                        </button>
+                    </div>
+                </div>
+
+                <div className="p-3 max-h-[60vh] overflow-y-auto space-y-1.5">
+                    {variants.map((v) => {
+                        const isActive = active?.id === v.id;
+                        const isPending = pending === v.id;
+                        const isDeletePending = pending === `delete:${v.id}`;
+                        const isEditing = editing?.id === v.id;
+                        const isRenamePending = pending === `rename:${v.id}`;
+                        // Title text shown on the row: label takes priority, fall
+                        // back to filename so the row is never blank.
+                        const primaryTitle = v.variantLabel ?? v.fileName;
+                        const showSecondaryFileName = !!v.variantLabel;
+                        return (
+                            <div
+                                key={v.id}
+                                className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                                    isActive
+                                        ? 'border-accent/40 bg-accent/5'
+                                        : 'border-border bg-bg-tertiary hover:bg-white/5'
+                                }`}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => pick(v)}
+                                    disabled={!!pending || isEditing}
+                                    className="flex-1 min-w-0 text-left cursor-pointer disabled:cursor-default disabled:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
+                                    title={isActive ? 'Currently active' : 'Switch to this variant'}
+                                >
+                                    <div className="flex items-center gap-3">
+                                        <span
+                                            className={`flex-shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+                                                isActive ? 'border-accent bg-accent' : 'border-border bg-bg-secondary'
+                                            }`}
+                                            aria-hidden
+                                        >
+                                            {isActive && <Check className="w-2.5 h-2.5 text-black" strokeWidth={3} />}
+                                        </span>
+                                        <div className="min-w-0 flex-1">
+                                            {isEditing ? (
+                                                <input
+                                                    ref={editInputRef}
+                                                    type="text"
+                                                    value={editing.draft}
+                                                    onChange={(e) => setEditing({ id: v.id, draft: e.target.value })}
+                                                    onClick={(e) => e.stopPropagation()}
+                                                    onKeyDown={(e) => {
+                                                        e.stopPropagation();
+                                                        if (e.key === 'Enter') {
+                                                            e.preventDefault();
+                                                            void commitRename(v);
+                                                        } else if (e.key === 'Escape') {
+                                                            e.preventDefault();
+                                                            cancelRename();
+                                                        }
+                                                    }}
+                                                    placeholder="e.g. Red preset"
+                                                    maxLength={80}
+                                                    className="w-full bg-bg-secondary border border-accent/50 rounded px-2 py-1 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
+                                                />
+                                            ) : (
+                                                <div className="flex items-center gap-2 min-w-0">
+                                                    <span
+                                                        className={`truncate ${v.variantLabel ? 'text-sm text-text-primary font-medium' : 'font-mono text-sm text-text-primary'}`}
+                                                        title={primaryTitle}
+                                                    >
+                                                        {primaryTitle}
+                                                    </span>
+                                                    {isActive && (
+                                                        <span className="text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5 flex-shrink-0">
+                                                            Active
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            )}
+                                            <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5 min-w-0">
+                                                <span className="flex-shrink-0">{formatBytes(v.size)}</span>
+                                                <span className="opacity-50 flex-shrink-0">•</span>
+                                                <span className="flex-shrink-0">Slot #{v.priority}</span>
+                                                {showSecondaryFileName && !isEditing && (
+                                                    <>
+                                                        <span className="opacity-50 flex-shrink-0">•</span>
+                                                        <span className="font-mono truncate opacity-70" title={v.fileName}>
+                                                            {v.fileName}
+                                                        </span>
+                                                    </>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </button>
+                                {isEditing ? (
+                                    <div className="flex items-center gap-1 flex-shrink-0">
+                                        <button
+                                            type="button"
+                                            onClick={() => commitRename(v)}
+                                            disabled={!!pending}
+                                            className="p-1.5 text-accent hover:bg-accent/10 rounded transition-colors cursor-pointer disabled:opacity-50"
+                                            title="Save"
+                                            aria-label="Save variant name"
+                                        >
+                                            {isRenamePending ? (
+                                                <span className="inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                            ) : (
+                                                <Check className="w-4 h-4" />
+                                            )}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={cancelRename}
+                                            disabled={!!pending}
+                                            className="p-1.5 text-text-secondary hover:text-text-primary hover:bg-white/5 rounded transition-colors cursor-pointer disabled:opacity-50"
+                                            title="Cancel"
+                                            aria-label="Cancel rename"
+                                        >
+                                            <X className="w-4 h-4" />
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <>
+                                        <button
+                                            type="button"
+                                            onClick={() => startRename(v)}
+                                            disabled={!!pending}
+                                            className="flex-shrink-0 p-1.5 text-text-secondary hover:text-accent hover:bg-accent/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-50"
+                                            title={v.variantLabel ? 'Rename variant' : 'Give this variant a name'}
+                                            aria-label="Rename variant"
+                                        >
+                                            <Pencil className="w-4 h-4" />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleDelete(v)}
+                                            disabled={!!pending}
+                                            className="flex-shrink-0 p-1.5 text-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-50"
+                                            title={`Delete ${primaryTitle}`}
+                                            aria-label={`Delete ${primaryTitle}`}
+                                        >
+                                            {isDeletePending ? (
+                                                <span className="inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                            ) : (
+                                                <Trash2 className="w-4 h-4" />
+                                            )}
+                                        </button>
+                                    </>
+                                )}
+                                {isPending && (
+                                    <span className="text-xs text-accent">Switching…</span>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="flex items-center justify-between gap-3 p-5 border-t border-border">
+                    {active ? (
+                        <Button
+                            variant="secondary"
+                            size="sm"
+                            icon={PowerOff}
+                            onClick={disableActive}
+                            disabled={!!pending}
+                            isLoading={pending === '__disable__'}
+                        >
+                            Disable group
+                        </Button>
+                    ) : (
+                        <span className="text-xs text-text-secondary inline-flex items-center gap-1.5">
+                            <Power className="w-3 h-3" />
+                            No variant active — pick one to enable
+                        </span>
+                    )}
+                    <Button variant="secondary" size="sm" onClick={onClose}>
+                        Done
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -179,14 +179,20 @@ export default function VariantPickerModal({
                         const isRenamePending = pending === `rename:${v.id}`;
                         // Title precedence: user rename wins, else the
                         // GameBanana file header the author set (e.g. "Gold
-                        // w/ alt candle"), else the raw VPK filename. Show
-                        // the filename as a secondary line whenever we used
-                        // a friendlier label up top so the underlying file
-                        // is still discoverable.
+                        // w/ alt candle"), else the original GB filename
+                        // stem (covers mods whose author left descriptions
+                        // empty — far more useful than pak04_dir.vpk), else
+                        // the local VPK filename. Show the local filename as
+                        // a secondary line whenever we used a friendlier
+                        // label up top so the underlying file is still
+                        // discoverable.
                         const primaryTitle =
-                            v.variantLabel ?? v.fileDescription ?? v.fileName;
+                            v.variantLabel ??
+                            v.fileDescription ??
+                            v.sourceFileName ??
+                            v.fileName;
                         const showSecondaryFileName =
-                            !!v.variantLabel || !!v.fileDescription;
+                            !!v.variantLabel || !!v.fileDescription || !!v.sourceFileName;
                         return (
                             <div
                                 key={v.id}

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -177,10 +177,16 @@ export default function VariantPickerModal({
                         const isDeletePending = pending === `delete:${v.id}`;
                         const isEditing = editing?.id === v.id;
                         const isRenamePending = pending === `rename:${v.id}`;
-                        // Title text shown on the row: label takes priority, fall
-                        // back to filename so the row is never blank.
-                        const primaryTitle = v.variantLabel ?? v.fileName;
-                        const showSecondaryFileName = !!v.variantLabel;
+                        // Title precedence: user rename wins, else the
+                        // GameBanana file header the author set (e.g. "Gold
+                        // w/ alt candle"), else the raw VPK filename. Show
+                        // the filename as a secondary line whenever we used
+                        // a friendlier label up top so the underlying file
+                        // is still discoverable.
+                        const primaryTitle =
+                            v.variantLabel ?? v.fileDescription ?? v.fileName;
+                        const showSecondaryFileName =
+                            !!v.variantLabel || !!v.fileDescription;
                         return (
                             <div
                                 key={v.id}
@@ -231,7 +237,7 @@ export default function VariantPickerModal({
                                             ) : (
                                                 <div className="flex items-center gap-2 min-w-0">
                                                     <span
-                                                        className={`truncate ${v.variantLabel ? 'text-sm text-text-primary font-medium' : 'font-mono text-sm text-text-primary'}`}
+                                                        className={`truncate ${showSecondaryFileName ? 'text-sm text-text-primary font-medium' : 'font-mono text-sm text-text-primary'}`}
                                                         title={primaryTitle}
                                                     >
                                                         {primaryTitle}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,6 +55,10 @@ export async function deleteMod(modId: string): Promise<void> {
   return window.electronAPI.deleteMod(modId);
 }
 
+export async function setVariantLabel(modId: string, label: string): Promise<Mod> {
+  return window.electronAPI.setVariantLabel(modId, label);
+}
+
 export async function setModPriority(modId: string, priority: number): Promise<Mod> {
   return window.electronAPI.setModPriority(modId, priority);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -233,6 +233,24 @@ export async function getConflicts(): Promise<ModConflict[]> {
   return window.electronAPI.getConflicts();
 }
 
+export async function getIgnoredConflicts(): Promise<string[]> {
+  return window.electronAPI.getIgnoredConflicts();
+}
+
+export async function ignoreConflict(modA: string, modB: string): Promise<string[]> {
+  return window.electronAPI.ignoreConflict(modA, modB);
+}
+
+export async function unignoreConflict(modA: string, modB: string): Promise<string[]> {
+  return window.electronAPI.unignoreConflict(modA, modB);
+}
+
+/** Build the ignored-list key for a pair of mod ids. Mirrors the backend
+ *  helper so the renderer can match locally without an extra IPC roundtrip. */
+export function conflictPairKey(a: string, b: string): string {
+  return a < b ? `${a}::${b}` : `${b}::${a}`;
+}
+
 // =====================
 // Profiles API
 // =====================

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -219,88 +219,6 @@ export default function Autoexec() {
                 className="shrink-0"
             />
 
-            {/* Steam Launch Options. Stored in app settings, written into
-                Steam's localconfig.vdf right before grimoire triggers Deadlock
-                via the steam:// URL. Steam must be closed when we write — we
-                handle that by writing during the launch flow, when Steam is
-                guaranteed not to be running yet. */}
-            <Card title="Steam Launch Options" icon={Rocket} className="shrink-0">
-                <div className="space-y-3">
-                    <p className="text-xs text-text-secondary">
-                        Args passed to Deadlock when launched via Steam (e.g.{' '}
-                        <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">-condebug</code>
-                        {' '}for Deadlock Rich Presence). Grimoire writes these into Steam&apos;s
-                        config right before launching the game.
-                    </p>
-
-                    <div className="flex gap-2">
-                        <input
-                            type="text"
-                            value={launchOptionsDraft}
-                            onChange={(e) => setLaunchOptionsDraft(e.target.value)}
-                            placeholder="-condebug -high"
-                            className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
-                        />
-                        <Button
-                            onClick={handleSaveLaunchOptions}
-                            disabled={launchSaving || !launchOptionsDirty || !appSettings}
-                            isLoading={launchSaving}
-                            icon={Save}
-                        >
-                            Save
-                        </Button>
-                    </div>
-
-                    {launchMessage && (
-                        <div
-                            role="status"
-                            aria-live="polite"
-                            className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${
-                                launchMessage.startsWith('Error')
-                                    ? 'bg-red-500/10 border-red-500/20 text-red-400'
-                                    : 'bg-green-500/10 border-green-500/20 text-green-400'
-                            }`}
-                        >
-                            {launchMessage.startsWith('Error') ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
-                            {launchMessage}
-                        </div>
-                    )}
-
-                    {launchStatus && (
-                        <div className="text-xs text-text-secondary space-y-1">
-                            {launchStatus.available ? (
-                                <>
-                                    <div>
-                                        Currently in Steam config:{' '}
-                                        {launchStatus.currentValue
-                                            ? <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">{launchStatus.currentValue}</code>
-                                            : <span className="italic">none</span>}
-                                    </div>
-                                    {launchStatus.steamRunning && (
-                                        <div className="flex items-start gap-1.5 text-yellow-400">
-                                            <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
-                                            <span>
-                                                Steam is running. We can&apos;t safely update its config
-                                                while Steam is open — close Steam before launching
-                                                Deadlock via grimoire so the options take effect.
-                                            </span>
-                                        </div>
-                                    )}
-                                </>
-                            ) : (
-                                <div className="flex items-start gap-1.5 text-yellow-400">
-                                    <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
-                                    <span>
-                                        Couldn&apos;t find a Steam userdata folder. Launch Deadlock
-                                        via Steam once so it creates the config, then come back.
-                                    </span>
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
-            </Card>
-
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
                 {/* Left Panel - Command Presets */}
                 <div className="w-full lg:w-1/2 flex flex-col gap-4 overflow-hidden order-2 lg:order-1">
@@ -369,6 +287,97 @@ export default function Autoexec() {
 
                 {/* Right Panel - Active Commands */}
                 <div className="w-full lg:w-1/2 flex flex-col gap-4 overflow-hidden order-1 lg:order-2">
+                    {/* Launch options card — lives in the right column so the
+                        "what runs when I launch" stack stays together (launch
+                        args → autoexec commands → file status). Compact by
+                        design so it doesn't dwarf Your Commands. */}
+                    <Card title="Launch Options" icon={Rocket} className="shrink-0">
+                        <div className="space-y-2.5">
+                            <p className="text-xs text-text-secondary">
+                                Args passed to Deadlock when launched via Steam. Written into
+                                Steam&apos;s config right before grimoire launches the game.
+                            </p>
+
+                            <div className="flex gap-2">
+                                <input
+                                    type="text"
+                                    value={launchOptionsDraft}
+                                    onChange={(e) => setLaunchOptionsDraft(e.target.value)}
+                                    placeholder="-high -nojoy"
+                                    className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+                                />
+                                <Button
+                                    onClick={handleSaveLaunchOptions}
+                                    disabled={launchSaving || !launchOptionsDirty || !appSettings}
+                                    isLoading={launchSaving}
+                                    icon={Save}
+                                >
+                                    Save
+                                </Button>
+                            </div>
+
+                            {launchMessage && (
+                                <div
+                                    role="status"
+                                    aria-live="polite"
+                                    className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${
+                                        launchMessage.startsWith('Error')
+                                            ? 'bg-red-500/10 border-red-500/20 text-red-400'
+                                            : 'bg-green-500/10 border-green-500/20 text-green-400'
+                                    }`}
+                                >
+                                    {launchMessage.startsWith('Error') ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
+                                    {launchMessage}
+                                </div>
+                            )}
+
+                            {launchStatus && (() => {
+                                if (!launchStatus.available) {
+                                    return (
+                                        <div className="flex items-start gap-1.5 text-xs text-yellow-400">
+                                            <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
+                                            <span>
+                                                Steam config not found. Launch Deadlock via Steam once,
+                                                then come back.
+                                            </span>
+                                        </div>
+                                    );
+                                }
+                                // Only surface the on-disk value when it diverges from what
+                                // the user has saved in grimoire — otherwise it's just noise.
+                                const savedValue = appSettings?.steamLaunchOptions ?? '';
+                                const onDisk = launchStatus.currentValue ?? '';
+                                const inSync = savedValue === onDisk;
+                                return (
+                                    <div className="space-y-2 pt-1 border-t border-border/40">
+                                        {!inSync && (
+                                            <div className="flex items-baseline justify-between gap-2 text-xs">
+                                                <span className="text-text-secondary uppercase tracking-wide">In Steam now</span>
+                                                <code className="font-mono text-text-primary/80 bg-black/30 px-1.5 py-0.5 rounded truncate min-w-0">
+                                                    {onDisk || '(empty)'}
+                                                </code>
+                                            </div>
+                                        )}
+                                        {!inSync && !launchSaving && (
+                                            <div className="text-[11px] text-text-secondary/70">
+                                                Your saved value will overwrite this on next grimoire launch.
+                                            </div>
+                                        )}
+                                        {launchStatus.steamRunning && (
+                                            <div className="flex items-start gap-1.5 text-xs text-yellow-400">
+                                                <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
+                                                <span>
+                                                    Steam is running. Close it before launching Deadlock
+                                                    via grimoire so the write isn&apos;t clobbered.
+                                                </span>
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })()}
+                        </div>
+                    </Card>
+
                     <Card
                         className="flex flex-col"
                         title={`Your Commands (${commands.length})`}

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle } from 'lucide-react';
-import { getSettings } from '../lib/api';
+import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket } from 'lucide-react';
+import { getSettings, setSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
 import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
+import type { AppSettings } from '../types/mod';
+import type { SteamLaunchOptionsStatus } from '../types/electron';
 
 // Popular Deadlock autoexec command presets
 const COMMAND_PRESETS = [
@@ -82,11 +84,22 @@ export default function Autoexec() {
     const [hasUnsaved, setHasUnsaved] = useState(false);
     const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
+    // Steam launch options — owned by appSettings; written into Steam's
+    // localconfig.vdf right before the game launches. Local UI state holds
+    // the unsaved edit; `settings.steamLaunchOptions` is the source of truth.
+    const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+    const [launchOptionsDraft, setLaunchOptionsDraft] = useState('');
+    const [launchStatus, setLaunchStatus] = useState<SteamLaunchOptionsStatus | null>(null);
+    const [launchSaving, setLaunchSaving] = useState(false);
+    const [launchMessage, setLaunchMessage] = useState<string | null>(null);
+
     // Load game path, autoexec status, and existing commands
     useEffect(() => {
         const load = async () => {
             const settings = await getSettings();
             setGamePath(settings.deadlockPath);
+            setAppSettings(settings);
+            setLaunchOptionsDraft(settings.steamLaunchOptions ?? '');
             if (settings.deadlockPath) {
                 const s = await window.electronAPI.getAutoexecStatus(settings.deadlockPath);
                 setStatus(s);
@@ -96,9 +109,42 @@ export default function Autoexec() {
                     setCommands(result.commands);
                 }
             }
+            try {
+                const status = await window.electronAPI.getSteamLaunchOptionsStatus();
+                setLaunchStatus(status);
+            } catch (err) {
+                console.warn('Failed to read Steam launch options status:', err);
+            }
         };
         load();
     }, []);
+
+    const launchOptionsDirty = (appSettings?.steamLaunchOptions ?? '') !== launchOptionsDraft;
+
+    const handleSaveLaunchOptions = async () => {
+        if (!appSettings) return;
+        setLaunchSaving(true);
+        setLaunchMessage(null);
+        try {
+            const next: AppSettings = { ...appSettings, steamLaunchOptions: launchOptionsDraft };
+            await setSettings(next);
+            setAppSettings(next);
+            setLaunchMessage('Saved. Applied next time you launch Deadlock via grimoire.');
+            // Re-read current VDF value so the user sees the actual on-disk
+            // state (it only changes when we write before a launch).
+            try {
+                const status = await window.electronAPI.getSteamLaunchOptionsStatus();
+                setLaunchStatus(status);
+            } catch {
+                // best-effort
+            }
+            setTimeout(() => setLaunchMessage(null), 4000);
+        } catch (err) {
+            setLaunchMessage(`Error: ${err}`);
+        } finally {
+            setLaunchSaving(false);
+        }
+    };
 
     const filteredPresets = useMemo(() => {
         if (!searchTerm) return COMMAND_PRESETS;
@@ -172,6 +218,88 @@ export default function Autoexec() {
                 description="Manage startup commands and game configuration"
                 className="shrink-0"
             />
+
+            {/* Steam Launch Options. Stored in app settings, written into
+                Steam's localconfig.vdf right before grimoire triggers Deadlock
+                via the steam:// URL. Steam must be closed when we write — we
+                handle that by writing during the launch flow, when Steam is
+                guaranteed not to be running yet. */}
+            <Card title="Steam Launch Options" icon={Rocket} className="shrink-0">
+                <div className="space-y-3">
+                    <p className="text-xs text-text-secondary">
+                        Args passed to Deadlock when launched via Steam (e.g.{' '}
+                        <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">-condebug</code>
+                        {' '}for Deadlock Rich Presence). Grimoire writes these into Steam&apos;s
+                        config right before launching the game.
+                    </p>
+
+                    <div className="flex gap-2">
+                        <input
+                            type="text"
+                            value={launchOptionsDraft}
+                            onChange={(e) => setLaunchOptionsDraft(e.target.value)}
+                            placeholder="-condebug -high"
+                            className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+                        />
+                        <Button
+                            onClick={handleSaveLaunchOptions}
+                            disabled={launchSaving || !launchOptionsDirty || !appSettings}
+                            isLoading={launchSaving}
+                            icon={Save}
+                        >
+                            Save
+                        </Button>
+                    </div>
+
+                    {launchMessage && (
+                        <div
+                            role="status"
+                            aria-live="polite"
+                            className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${
+                                launchMessage.startsWith('Error')
+                                    ? 'bg-red-500/10 border-red-500/20 text-red-400'
+                                    : 'bg-green-500/10 border-green-500/20 text-green-400'
+                            }`}
+                        >
+                            {launchMessage.startsWith('Error') ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
+                            {launchMessage}
+                        </div>
+                    )}
+
+                    {launchStatus && (
+                        <div className="text-xs text-text-secondary space-y-1">
+                            {launchStatus.available ? (
+                                <>
+                                    <div>
+                                        Currently in Steam config:{' '}
+                                        {launchStatus.currentValue
+                                            ? <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">{launchStatus.currentValue}</code>
+                                            : <span className="italic">none</span>}
+                                    </div>
+                                    {launchStatus.steamRunning && (
+                                        <div className="flex items-start gap-1.5 text-yellow-400">
+                                            <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
+                                            <span>
+                                                Steam is running. We can&apos;t safely update its config
+                                                while Steam is open — close Steam before launching
+                                                Deadlock via grimoire so the options take effect.
+                                            </span>
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                <div className="flex items-start gap-1.5 text-yellow-400">
+                                    <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
+                                    <span>
+                                        Couldn&apos;t find a Steam userdata folder. Launch Deadlock
+                                        via Steam once so it creates the config, then come back.
+                                    </span>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </Card>
 
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
                 {/* Left Panel - Command Presets */}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -780,6 +780,16 @@ export default function Browse() {
         return;
       }
 
+      // When a mod has more than one downloadable file (different versions,
+      // variant builds, etc.) we used to silently pick whichever had the
+      // highest download count. Forum feedback flagged that — surface the
+      // details modal so the user can choose which file to install.
+      if (details.files.length > 1) {
+        setSelectedMod(details);
+        setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
+        return;
+      }
+
       const file = getPrimaryFile(details.files);
 
       // If nothing is currently downloading, set this as the active download

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import {
   Search,
   Loader2,
@@ -16,6 +16,7 @@ import {
   Package,
   Music,
   SlidersHorizontal,
+  Power,
 } from 'lucide-react';
 import {
   browseMods,
@@ -145,6 +146,8 @@ function findCategoryByName(
 
 export default function Browse() {
   const { settings, loadSettings, loadMods, mods: installedMods, soundVolume, setSoundVolume, browseUi, setBrowseUi } = useAppStore();
+  const browseSession = useAppStore((s) => s.browseSession);
+  const setBrowseSession = useAppStore((s) => s.setBrowseSession);
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
@@ -155,11 +158,23 @@ export default function Browse() {
   const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
   const setHeroCategoryId = useCallback((v: number | 'all') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
   const setCategoryId = useCallback((v: number | 'all') => setBrowseUi({ categoryId: v }), [setBrowseUi]);
-  const [mods, setMods] = useState<GameBananaMod[]>([]);
+
+  // Hydrate from session cache on mount so navigating away + back doesn't
+  // wipe loaded results or scroll position. The cache stamp encodes current
+  // filters; if filters changed in between (impossible today since they only
+  // change on Browse, but defensive) we ignore the stale cache.
+  const initialFilterStamp = `${browseUi.section}|${browseUi.search}|${browseUi.sort}|${browseUi.categoryId}|${browseUi.heroCategoryId}`;
+  const initialCache = browseSession && browseSession.stamp === initialFilterStamp
+    ? browseSession
+    : null;
+
+  const [mods, setMods] = useState<GameBananaMod[]>(
+    () => (initialCache?.mods as GameBananaMod[] | undefined) ?? []
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(1);
-  const [_totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(() => initialCache?.page ?? 1);
+  const [_totalCount, setTotalCount] = useState(() => initialCache?.totalCount ?? 0);
   const perPage = DEFAULT_PER_PAGE; // Fixed value for infinite scroll
   const [sections, setSections] = useState<GameBananaSection[]>([]);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>([]);
@@ -173,7 +188,28 @@ export default function Browse() {
   const [downloadProgress, setDownloadProgress] = useState<{ downloaded: number; total: number } | null>(null);
   const [extracting, setExtracting] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
+  const [hasMore, setHasMore] = useState(() => initialCache?.hasMore ?? true);
+
+  // Last fetch's identity stamp. Value-comparison gate: if the next call to
+  // fetchMods/searchLocal would target the same (page + filters), skip it.
+  // Initialized from the session cache so hydrated state isn't re-fetched.
+  // Value-based (not "skip first run" ref) so it survives React StrictMode's
+  // double effect run in dev — the second setup compares stamps and short-
+  // circuits, instead of consuming a one-shot skip flag.
+  const lastFetchedStampRef = useRef<string | null>(
+    initialCache ? `${initialCache.page}|${browseUi.search}|${browseUi.sort}|${browseUi.section}|${browseUi.categoryId}|${browseUi.heroCategoryId}` : null
+  );
+  // Cached scroll position waiting to be applied once the grid is mounted
+  // and laid out. Cleared after restoration.
+  const pendingScrollTopRef = useRef<number | null>(initialCache?.scrollTop ?? null);
+  // The outer scroll container — same element with `h-full overflow-y-auto`.
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  // Live mirror of the scroll container's scrollTop. Updated from a scroll
+  // listener so the unmount cleanup has a valid value to persist — by the
+  // time a useEffect cleanup runs, React has already detached
+  // `scrollContainerRef.current`, so reading scrollTop from the DOM ref
+  // there always returned 0 and the saved position was useless.
+  const latestScrollTopRef = useRef<number>(initialCache?.scrollTop ?? 0);
   // When local search fails (e.g. SQLite error), this flips so the main fetch
   // effect falls back to the API path. Resets whenever filter inputs change.
   const [localSearchFailed, setLocalSearchFailed] = useState(false);
@@ -262,11 +298,78 @@ export default function Browse() {
 
   // Keep a fresh `mods` reference outside the fetch closures so they can check
   // "did the user already have results visible?" without making `mods` a
-  // useCallback dep (that would self-trigger).
+  // useCallback dep (that would self-trigger). Also doubles as the source
+  // for the unmount-time cache save.
   const modsRef = useRef<GameBananaMod[]>(mods);
+  const pageRef = useRef<number>(page);
+  const hasMoreRef = useRef<boolean>(hasMore);
+  const totalCountRef = useRef<number>(_totalCount);
   useEffect(() => {
     modsRef.current = mods;
   }, [mods]);
+  useEffect(() => {
+    pageRef.current = page;
+  }, [page]);
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+  useEffect(() => {
+    totalCountRef.current = _totalCount;
+  }, [_totalCount]);
+
+  // Restore cached scroll position once the first paint with hydrated mods
+  // is on screen. useLayoutEffect (not useEffect) so we scroll before the
+  // browser paints, avoiding a visible jump from 0 to the saved offset.
+  useLayoutEffect(() => {
+    const target = pendingScrollTopRef.current;
+    if (target === null) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTop = target;
+    pendingScrollTopRef.current = null;
+  }, []);
+
+  // Mirror scrollTop into a ref on every scroll. The unmount cleanup below
+  // runs as a passive effect — by then React has already nulled
+  // `scrollContainerRef.current`, so we can't read scrollTop off the DOM
+  // there. The ref gives us the last-known value to persist instead.
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const onScroll = () => {
+      latestScrollTopRef.current = container.scrollTop;
+    };
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => container.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Persist session cache on unmount so navigating back resumes exactly
+  // where the user left off. Refs feed the cleanup with current values
+  // since the closure captures at first render.
+  useEffect(() => {
+    return () => {
+      const ui = useAppStore.getState().browseUi;
+      const stamp = `${ui.section}|${ui.search}|${ui.sort}|${ui.categoryId}|${ui.heroCategoryId}`;
+      const cachedMods = modsRef.current;
+      // Don't cache an empty state — would just bypass the next fetch
+      // unhelpfully. Clear instead so the next mount starts fresh.
+      if (cachedMods.length === 0) {
+        setBrowseSession(null);
+        return;
+      }
+      // Read scrollTop from the live mirror — `scrollContainerRef.current` is
+      // already null here (React detaches DOM refs before passive cleanups).
+      const scrollTop = latestScrollTopRef.current;
+      setBrowseSession({
+        mods: cachedMods,
+        page: pageRef.current,
+        hasMore: hasMoreRef.current,
+        totalCount: totalCountRef.current,
+        scrollTop,
+        stamp,
+      });
+    };
+  }, [setBrowseSession]);
 
   // Derived (not state) so the right code path runs in the same render the
   // user picks a hero/types a query. Storing it in useState lagged a render,
@@ -287,6 +390,13 @@ export default function Browse() {
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
     if (useLocalSearch) return;
+    // Value-compare gate: skip when we'd be re-fetching the exact same state
+    // we already loaded. Covers cache hydration on mount AND React
+    // StrictMode's double-effect setup. Set BEFORE the network call so
+    // a second setup hitting this line sees the stamp and returns.
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}`;
+    if (lastFetchedStampRef.current === stamp) return;
+    lastFetchedStampRef.current = stamp;
 
     // On a fresh load (no results yet) show the skeleton; on a refetch keep
     // the stale list visible and just surface a soft progress indicator so
@@ -352,11 +462,17 @@ export default function Browse() {
     section,
     perPage,
     effectiveCategoryId,
+    heroCategoryId,
     useLocalSearch,
   ]);
 
   // Local search function using SQLite cache
   const searchLocal = useCallback(async () => {
+    // Same value-compare gate as fetchMods so the shared stamp prevents
+    // re-fetching cached state and survives StrictMode double-mount.
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}`;
+    if (lastFetchedStampRef.current === stamp) return;
+    lastFetchedStampRef.current = stamp;
     // Same anti-flash logic as fetchMods: skeleton only on truly empty first
     // load. Subsequent refetches keep the previous result set visible until
     // the new one arrives.
@@ -450,7 +566,18 @@ export default function Browse() {
     }
   }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, modCategories]);
 
+  // Value-compare gate for the filter-reset: remember what filters last
+  // triggered a reset; only reset when the new combination is actually
+  // different. This survives both initial cache hydration and React
+  // StrictMode's double-effect run (the second setup sees the same stamp
+  // and short-circuits, instead of consuming a one-shot skip flag).
+  const lastResetFiltersRef = useRef<string | null>(
+    `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${perPage}`
+  );
   useEffect(() => {
+    const current = `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${perPage}`;
+    if (lastResetFiltersRef.current === current) return;
+    lastResetFiltersRef.current = current;
     // Reset pagination when filters change but keep previous results visible
     // until the new query lands. Blanking mods here is what produced the
     // skeleton flash on every keystroke pre-debounce.
@@ -506,6 +633,11 @@ export default function Browse() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Track whether `section` actually changed (vs. the effect just firing on
+  // mount because deps populated for the first time). Without this guard the
+  // hero/category filters were reset to 'all' on every remount, which then
+  // triggered a refetch and threw away the cached scroll position.
+  const lastLoadedSectionRef = useRef<string | null>(null);
   useEffect(() => {
     let active = true;
     const selected = sections.find((entry) => entry.modelName === section);
@@ -516,13 +648,20 @@ export default function Browse() {
       };
     }
 
+    const sectionChanged = lastLoadedSectionRef.current !== null && lastLoadedSectionRef.current !== section;
+    lastLoadedSectionRef.current = section;
+
     const loadCategories = async () => {
       try {
         const data = await getGamebananaCategories(selected.categoryModelName);
         if (!active) return;
         setCategories(data);
-        setHeroCategoryId('all');
-        setCategoryId('all');
+        // Only reset the hero/category filter when the user actually
+        // switched sections — not on every remount.
+        if (sectionChanged) {
+          setHeroCategoryId('all');
+          setCategoryId('all');
+        }
       } catch (err) {
         if (active) {
           setError(String(err));
@@ -847,6 +986,26 @@ export default function Browse() {
     return ids;
   }, [installedMods]);
 
+  // Per-card lookup so each ModCard knows the local mod's id + enabled state.
+  // Drives the inline "Enable" affordance: once a download finishes, the
+  // top-right of the card flips from a downloading spinner into either a
+  // green ✓ (already enabled) or a yellow Enable pill (still disabled).
+  const installedByGbId = useMemo(() => {
+    const map = new Map<number, { id: string; enabled: boolean }>();
+    for (const mod of installedMods) {
+      if (typeof mod.gameBananaId !== 'number') continue;
+      // If a user has multiple variants of the same GB mod installed, prefer
+      // the enabled one — that's the relevant state to show.
+      const existing = map.get(mod.gameBananaId);
+      if (!existing || (mod.enabled && !existing.enabled)) {
+        map.set(mod.gameBananaId, { id: mod.id, enabled: mod.enabled });
+      }
+    }
+    return map;
+  }, [installedMods]);
+
+  const toggleMod = useAppStore((state) => state.toggleMod);
+
   // Track installed file IDs for per-file "Reinstall" button state
   const installedFileIds = useMemo(() => {
     const ids = new Set<number>();
@@ -877,7 +1036,7 @@ export default function Browse() {
   }
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="h-full overflow-y-auto" ref={scrollContainerRef}>
       {/* Header with Search */}
       <div className="sticky top-0 z-10 p-4 border-b border-border bg-bg-primary">
         <form onSubmit={handleSearch}>
@@ -1191,11 +1350,13 @@ export default function Browse() {
               {displayMods.map((mod) => {
                 const queueIndex = downloadQueue.findIndex(q => q.modId === mod.id);
                 const isQueued = queueIndex >= 0;
+                const installedLocal = installedByGbId.get(mod.id);
                 return (
                   <ModCard
                     key={mod.id}
                     mod={mod}
                     installed={installedIds.has(mod.id)}
+                    installedDisabled={!!installedLocal && !installedLocal.enabled}
                     downloading={downloading?.modId === mod.id}
                     queuePosition={isQueued ? queueIndex + 1 : undefined}
                     viewMode={viewMode}
@@ -1212,6 +1373,9 @@ export default function Browse() {
                     }}
                     onClick={() => handleModClick(mod)}
                     onQuickDownload={() => handleQuickDownload(mod)}
+                    onEnable={installedLocal && !installedLocal.enabled
+                      ? () => toggleMod(installedLocal.id)
+                      : undefined}
                   />
                 );
               })}
@@ -1256,6 +1420,9 @@ export default function Browse() {
 interface ModCardProps {
   mod: GameBananaMod;
   installed: boolean;
+  /** True when the local install for this GB mod is currently disabled.
+   *  Drives the inline Enable affordance shown after a fresh download. */
+  installedDisabled?: boolean;
   downloading: boolean;
   queuePosition?: number;
   viewMode: ViewMode;
@@ -1267,6 +1434,9 @@ interface ModCardProps {
   onPlayingChange: (playing: boolean) => void;
   onClick: () => void;
   onQuickDownload: () => void;
+  /** Toggle the local mod's enabled state. Provided only when there's an
+   *  installed-but-disabled mod to enable. */
+  onEnable?: () => void;
 }
 
 function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
@@ -1293,7 +1463,7 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
   );
 }
 
-function ModCard({ mod, installed, downloading, queuePosition, viewMode, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, onPlayingChange, onClick, onQuickDownload }: ModCardProps) {
+function ModCard({ mod, installed, installedDisabled, downloading, queuePosition, viewMode, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, onPlayingChange, onClick, onQuickDownload, onEnable }: ModCardProps) {
   const thumbnail = getModThumbnail(mod);
   const audioPreview = section === 'Sound' ? getSoundPreviewUrl(mod) : undefined;
   const isCompact = viewMode === 'compact';
@@ -1347,7 +1517,16 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <h3 className="font-medium truncate flex-1">{mod.name}</h3>
-            {installed ? (
+            {installed && installedDisabled && onEnable ? (
+              <button
+                onClick={(e) => { e.stopPropagation(); onEnable(); }}
+                className="flex-shrink-0 flex items-center gap-1.5 px-2.5 h-7 bg-state-warning/15 hover:bg-state-warning/25 border border-state-warning/40 text-state-warning rounded-full text-xs font-semibold transition-colors cursor-pointer"
+                title="Enable this mod (currently in your disabled folder)"
+              >
+                <Power className="w-3 h-3" />
+                Enable
+              </button>
+            ) : installed ? (
               <Tag tone="success" variant="overlay" title="Installed" className="flex-shrink-0">
                 <span aria-hidden>✓</span>
                 Installed
@@ -1581,12 +1760,24 @@ function ModCard({ mod, installed, downloading, queuePosition, viewMode, section
         </div>
       )}
 
-      {/* Download button overlay — top right with backdrop */}
+      {/* Download / Enable button overlay — top right with backdrop */}
       <div className="absolute top-2 right-2">
-        {installed ? (
+        {installed && installedDisabled && onEnable ? (
+          // Mod just installed but still in the disabled folder. Surface an
+          // inline Enable affordance right where the user's eye is rather
+          // than forcing them to the Installed tab.
+          <button
+            onClick={(e) => { e.stopPropagation(); onEnable(); }}
+            className={`flex items-center gap-1.5 rounded-full bg-state-warning/90 hover:bg-state-warning text-black backdrop-blur-sm ring-1 ring-black/40 shadow-md font-semibold transition-colors cursor-pointer ${isCompact ? 'h-7 px-2 text-[11px]' : 'h-8 px-2.5 text-xs'}`}
+            title="Enable this mod (currently in your disabled folder)"
+          >
+            <Power className={isCompact ? 'w-3 h-3' : 'w-3.5 h-3.5'} />
+            Enable
+          </button>
+        ) : installed ? (
           <span
             className={`flex items-center justify-center rounded-full bg-black/70 backdrop-blur-sm ring-1 ring-black/60 shadow-md text-state-success ${isCompact ? 'w-7 h-7 text-sm' : 'w-8 h-8 text-base'}`}
-            title="Installed"
+            title="Installed and enabled"
           >
             ✓
           </span>

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1017,6 +1017,23 @@ export default function Browse() {
     return ids;
   }, [installedMods]);
 
+  // Per-file install map for the details modal. Lets a row that's installed
+  // but currently disabled surface an inline "Enable" pill — matches the
+  // affordance already on the tile card. If multiple local mods share a
+  // file id (rare, e.g. dupe installs), prefer the enabled one as the
+  // representative since that's the actionable state.
+  const installedFileStates = useMemo(() => {
+    const map = new Map<number, { modId: string; enabled: boolean }>();
+    for (const mod of installedMods) {
+      if (typeof mod.gameBananaFileId !== 'number') continue;
+      const existing = map.get(mod.gameBananaFileId);
+      if (!existing || (mod.enabled && !existing.enabled)) {
+        map.set(mod.gameBananaFileId, { modId: mod.id, enabled: mod.enabled });
+      }
+    }
+    return map;
+  }, [installedMods]);
+
   // Just use all loaded mods - infinite scroll handles pagination.
   // Hide outdated mods if the user has opted in.
   const displayMods = settings?.hideOutdatedMods
@@ -1403,6 +1420,8 @@ export default function Browse() {
           section={section}
           installed={installedIds.has(selectedMod.id)}
           installedFileIds={installedFileIds}
+          installedFileStates={installedFileStates}
+          onEnableFile={(modId) => toggleMod(modId)}
           downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
           extracting={extracting}
           progress={downloadProgress}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -45,6 +45,10 @@ const DEFAULT_PER_PAGE = 20;
 type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
 type ViewMode = 'grid' | 'compact' | 'list';
 const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
+// Persist filter UI inputs across page navigation. The store keeps these in
+// memory so visiting Installed and coming back doesn't blow away the user's
+// current search/filter context. Kept out of localStorage so a fresh launch
+// starts clean — sessions, not preferences.
 
 // Only show these categories in the dropdown (lowercase for matching)
 const ALLOWED_CATEGORIES = new Set(['hud', 'other/misc', 'maps']);
@@ -140,26 +144,29 @@ function findCategoryByName(
 }
 
 export default function Browse() {
-  const { settings, loadSettings, loadMods, mods: installedMods, soundVolume, setSoundVolume } = useAppStore();
+  const { settings, loadSettings, loadMods, mods: installedMods, soundVolume, setSoundVolume, browseUi, setBrowseUi } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
+  // Filter inputs are mirrored from the store so they survive page nav.
+  // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
+  const { search, viewMode, sort, section, heroCategoryId, categoryId } = browseUi;
+  const setSearch = useCallback((v: string) => setBrowseUi({ search: v }), [setBrowseUi]);
+  const setViewMode = useCallback((v: ViewMode) => setBrowseUi({ viewMode: v }), [setBrowseUi]);
+  const setSort = useCallback((v: SortOption) => setBrowseUi({ sort: v }), [setBrowseUi]);
+  const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
+  const setHeroCategoryId = useCallback((v: number | 'all') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
+  const setCategoryId = useCallback((v: number | 'all') => setBrowseUi({ categoryId: v }), [setBrowseUi]);
   const [mods, setMods] = useState<GameBananaMod[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [_totalCount, setTotalCount] = useState(0);
   const perPage = DEFAULT_PER_PAGE; // Fixed value for infinite scroll
-  const [sort, setSort] = useState<SortOption>('default');
   const [sections, setSections] = useState<GameBananaSection[]>([]);
-  const [section, setSection] = useState('Mod');
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>([]);
   // Hero list comes from the Mod section's category tree (Mod -> Skins -> heroes).
   // Cached separately so hero filtering still works on the Sound tab, where the
   // current section's category tree has no Skins parent.
   const [modCategories, setModCategories] = useState<GameBananaCategoryNode[]>([]);
-  const [heroCategoryId, setHeroCategoryId] = useState<number | 'all'>('all');
-  const [categoryId, setCategoryId] = useState<number | 'all'>('all');
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [selectedMod, setSelectedMod] = useState<GameBananaModDetails | null>(null);
   const [selectedModDates, setSelectedModDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   const [downloading, setDownloading] = useState<{ modId: number; fileId: number } | null>(null);
@@ -241,32 +248,56 @@ export default function Browse() {
       ? (categoryId === 'all' ? undefined : categoryId)
       : heroCategoryId;
 
-  const effectiveSearch = search;
+  // Debounce the search input: every keystroke previously fired a full FTS5
+  // query + count + render, which felt slow even when the DB was fast. 250ms
+  // is short enough that typing-to-results still feels responsive but long
+  // enough to absorb fast typing into a single request.
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const effectiveSearch = debouncedSearch;
+
+  // Keep a fresh `mods` reference outside the fetch closures so they can check
+  // "did the user already have results visible?" without making `mods` a
+  // useCallback dep (that would self-trigger).
+  const modsRef = useRef<GameBananaMod[]>(mods);
+  useEffect(() => {
+    modsRef.current = mods;
+  }, [mods]);
 
   // Derived (not state) so the right code path runs in the same render the
   // user picks a hero/types a query. Storing it in useState lagged a render,
   // which caused fetchMods (API, no hero filter) to race with searchLocal and
   // overwrite real results with an empty API response.
   const useLocalSearch = useMemo(() => {
-    const hasSearchQuery = search.trim().length > 0;
+    const hasSearchQuery = debouncedSearch.trim().length > 0;
     const hasHeroFilter = heroCategoryId !== 'all';
     return (hasSearchQuery || hasHeroFilter) && hasLocalCache && !localSearchFailed;
-  }, [search, heroCategoryId, hasLocalCache, localSearchFailed]);
+  }, [debouncedSearch, heroCategoryId, hasLocalCache, localSearchFailed]);
 
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
   useEffect(() => {
     setLocalSearchFailed(false);
-  }, [search, heroCategoryId, section]);
+  }, [debouncedSearch, heroCategoryId, section]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
     if (useLocalSearch) return;
 
-    // Show loading spinner on first page, loading indicator otherwise
+    // On a fresh load (no results yet) show the skeleton; on a refetch keep
+    // the stale list visible and just surface a soft progress indicator so
+    // each keystroke doesn't repaint the whole grid as gray boxes.
     if (page === 1) {
-      setLoading(true);
-      setMods([]);
+      const hadResults = modsRef.current.length > 0;
+      if (hadResults) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
       setHasMore(true);
     } else {
       setLoadingMore(true);
@@ -326,10 +357,16 @@ export default function Browse() {
 
   // Local search function using SQLite cache
   const searchLocal = useCallback(async () => {
-    // Show loading spinner on first page, loading indicator otherwise
+    // Same anti-flash logic as fetchMods: skeleton only on truly empty first
+    // load. Subsequent refetches keep the previous result set visible until
+    // the new one arrives.
     if (page === 1) {
-      setLoading(true);
-      setMods([]);
+      const hadResults = modsRef.current.length > 0;
+      if (hadResults) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
       setHasMore(true);
     } else {
       setLoadingMore(true);
@@ -414,10 +451,12 @@ export default function Browse() {
   }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, modCategories]);
 
   useEffect(() => {
+    // Reset pagination when filters change but keep previous results visible
+    // until the new query lands. Blanking mods here is what produced the
+    // skeleton flash on every keystroke pre-debounce.
     setPage(1);
     setHasMore(true);
-    setMods([]);
-  }, [search, sort, section, effectiveCategoryId, perPage]);
+  }, [debouncedSearch, sort, section, effectiveCategoryId, perPage]);
 
   useEffect(() => {
     let active = true;
@@ -461,6 +500,10 @@ export default function Browse() {
     return () => {
       active = false;
     };
+    // Run once on mount: section selection is read inside but we don't want
+    // refires on every tab switch (that would re-fetch the section list
+    // unnecessarily). setSection is stable from the store.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -492,7 +535,7 @@ export default function Browse() {
     return () => {
       active = false;
     };
-  }, [sections, section]);
+  }, [sections, section, setCategoryId, setHeroCategoryId]);
 
   useEffect(() => {
     if (useLocalSearch) {
@@ -839,6 +882,14 @@ export default function Browse() {
                 className="w-full bg-bg-secondary border border-border rounded-lg pl-3 pr-16 py-2 text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent"
               />
               <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                {/* Inline spinner while debouncing or refetching with stale results.
+                    Replaces the prior whole-grid skeleton flash on every keystroke. */}
+                {(search !== debouncedSearch || (loadingMore && page === 1)) && (
+                  <Loader2
+                    className="w-4 h-4 mx-1 animate-spin text-text-secondary"
+                    aria-label="Searching"
+                  />
+                )}
                 {search && (
                   <button
                     type="button"

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
-import { AlertTriangle, CheckCircle, RefreshCw, X } from 'lucide-react';
-import { getConflicts, disableMod, getMods } from '../lib/api';
+import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye } from 'lucide-react';
+import {
+  getConflicts,
+  disableMod,
+  getMods,
+  getIgnoredConflicts,
+  ignoreConflict,
+  unignoreConflict,
+  conflictPairKey,
+} from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
@@ -48,19 +56,27 @@ function ConflictsSkeleton() {
 export default function Conflicts() {
   const [conflicts, setConflicts] = useState<ModConflict[]>([]);
   const [modsMap, setModsMap] = useState<Map<string, ModWithThumbnail>>(new Map());
+  // Set of ignored pair keys ("idA::idB" sorted). Used both to filter
+  // detected conflicts (defense-in-depth — backend already filters) and to
+  // render the "Ignored" panel.
+  const [ignored, setIgnored] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
   const [disabling, setDisabling] = useState(false);
+  // Tracks which pair the user is currently toggling so we can disable just
+  // that row's buttons during the round-trip without freezing the whole page.
+  const [pendingPair, setPendingPair] = useState<string | null>(null);
   const { loadMods } = useAppStore();
 
   const loadConflicts = async () => {
     setLoading(true);
     setError(null);
     try {
-      const [conflictResult, modsResult] = await Promise.all([
+      const [conflictResult, modsResult, ignoredResult] = await Promise.all([
         getConflicts(),
         getMods(),
+        getIgnoredConflicts(),
       ]);
 
       const map = new Map<string, ModWithThumbnail>();
@@ -74,10 +90,46 @@ export default function Conflicts() {
       }
       setModsMap(map);
       setConflicts(conflictResult);
+      setIgnored(new Set(ignoredResult));
     } catch (err) {
       setError(String(err));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleIgnore = async (modA: string, modB: string) => {
+    const key = conflictPairKey(modA, modB);
+    setPendingPair(key);
+    try {
+      const next = await ignoreConflict(modA, modB);
+      setIgnored(new Set(next));
+      // Backend filters ignored pairs from get-conflicts, so dropping locally
+      // keeps the UI consistent without a second round-trip.
+      setConflicts((prev) =>
+        prev.filter((c) => conflictPairKey(c.modA, c.modB) !== key)
+      );
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  const handleUnignore = async (key: string) => {
+    const [modA, modB] = key.split('::');
+    if (!modA || !modB) return;
+    setPendingPair(key);
+    try {
+      const next = await unignoreConflict(modA, modB);
+      setIgnored(new Set(next));
+      // Re-detect so the unignored pair shows back up if still conflicting.
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
     }
   };
 
@@ -124,7 +176,7 @@ export default function Conflicts() {
     );
   }
 
-  if (conflicts.length === 0) {
+  if (conflicts.length === 0 && ignored.size === 0) {
     return (
       <div className="h-full flex items-center justify-center p-6">
         <EmptyState
@@ -143,12 +195,27 @@ export default function Conflicts() {
     <div className="p-6">
       <PageHeader
         title={`Conflicts (${conflicts.length})`}
-        description="Resolve conflicts between installed mods"
+        description={
+          conflicts.length === 0
+            ? 'No active conflicts — review or restore your ignored pairs below.'
+            : 'Resolve conflicts between installed mods'
+        }
         action={
           <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
         }
         className="mb-6"
       />
+
+      {/* Empty active-conflict slot when every conflict has been dismissed.
+          We don't redirect to the global empty state because the user still
+          has the ignored list to manage — making everything disappear would
+          hide the only path back. */}
+      {conflicts.length === 0 && (
+        <div className="mb-6 p-4 rounded-xl border border-border bg-bg-secondary text-sm text-text-secondary flex items-center gap-2">
+          <CheckCircle className="w-4 h-4 text-green-400" />
+          No active conflicts. {ignored.size > 0 && `${ignored.size} pair(s) currently ignored — see below.`}
+        </div>
+      )}
 
       {/* Grid of conflict cards */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -163,8 +230,20 @@ export default function Conflicts() {
             >
               {/* Header */}
               <div className="bg-yellow-500/10 px-4 py-2 flex items-center gap-2 border-b border-yellow-500/20">
-                <AlertTriangle className="w-4 h-4 text-yellow-500" />
-                <span className="text-sm text-yellow-400">{conflict.details}</span>
+                <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
+                <span className="text-sm text-yellow-400 min-w-0 flex-1 truncate" title={conflict.details}>
+                  {conflict.details}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleIgnore(conflict.modA, conflict.modB)}
+                  disabled={pendingPair === conflictPairKey(conflict.modA, conflict.modB)}
+                  title="Stop flagging this pair as a conflict"
+                  className="flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-tertiary rounded transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <EyeOff className="w-3.5 h-3.5" />
+                  Ignore
+                </button>
               </div>
 
               {/* Two mod cards */}
@@ -246,6 +325,51 @@ export default function Conflicts() {
           );
         })}
       </div>
+
+      {/* Ignored conflicts panel — sits at the bottom of the page so the
+          live conflict list stays the primary focus. Each row shows the two
+          mod names plus an Unignore action that re-runs detection so the
+          pair shows back up if it's still actually conflicting. */}
+      {ignored.size > 0 && (
+        <div className="mt-10">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-text-secondary mb-3 flex items-center gap-2">
+            <EyeOff className="w-4 h-4" />
+            Ignored ({ignored.size})
+          </h3>
+          <div className="rounded-xl border border-border bg-bg-secondary divide-y divide-border">
+            {Array.from(ignored).map((key) => {
+              const [idA, idB] = key.split('::');
+              const a = modsMap.get(idA);
+              const b = modsMap.get(idB);
+              // If either mod was uninstalled while ignored we still show the
+              // entry (using a placeholder) so the user can clean it up. The
+              // backend's filter is a no-op for missing ids — they just
+              // never re-appear as active conflicts.
+              const aName = a?.name ?? '(removed mod)';
+              const bName = b?.name ?? '(removed mod)';
+              return (
+                <div key={key} className="flex items-center gap-3 px-4 py-3">
+                  <div className="min-w-0 flex-1 flex items-center gap-2 text-sm">
+                    <span className="truncate text-text-primary" title={aName}>{aName}</span>
+                    <span className="text-text-tertiary text-xs flex-shrink-0">vs</span>
+                    <span className="truncate text-text-primary" title={bName}>{bName}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleUnignore(key)}
+                    disabled={pendingPair === key}
+                    className="flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-tertiary rounded transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Restore conflict detection for this pair"
+                  >
+                    <Eye className="w-3.5 h-3.5" />
+                    Unignore
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <ConfirmModal
         isOpen={disableTarget !== null}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -195,6 +195,13 @@ export default function Installed() {
   // Map of mod id → true if a newer version exists on GameBanana.
   const [updatesAvailable, setUpdatesAvailable] = useState<Set<string>>(new Set());
 
+  // "Update all" confirm + progress. Progress is null when idle, otherwise
+  // { done, total } so the button can render "Updating 2/5…" and stay disabled
+  // for the duration of the run.
+  const [updateAllConfirmOpen, setUpdateAllConfirmOpen] = useState(false);
+  const [updateAllProgress, setUpdateAllProgress] = useState<{ done: number; total: number } | null>(null);
+  const [updateAllError, setUpdateAllError] = useState<string | null>(null);
+
   const openModDetails = async (m: typeof mods[number]) => {
     if (!m.gameBananaId) return;
     const section = m.sourceSection ?? 'Mod';
@@ -262,6 +269,65 @@ export default function Installed() {
       loadMods();
     } catch (err) {
       setDetailsError(String(err));
+    }
+  };
+
+  /**
+   * Bulk-update every mod currently flagged in updatesAvailable. Snapshots
+   * pre-update enabled state per mod and re-applies it after the new install
+   * lands — downloads always go to the disabled folder by default, so without
+   * this restore step the user would have to manually re-enable each one.
+   * Failures are caught per-item so one bad mod doesn't halt the rest.
+   */
+  const handleUpdateAll = async () => {
+    setUpdateAllConfirmOpen(false);
+    setUpdateAllError(null);
+    const snapshots = mods
+      .filter((m) => updatesAvailable.has(m.id) && m.gameBananaId && typeof m.gameBananaFileId === 'number')
+      .map((m) => ({
+        oldId: m.id,
+        gameBananaId: m.gameBananaId!,
+        gameBananaFileId: m.gameBananaFileId!,
+        fileName: m.fileName,
+        section: m.sourceSection ?? 'Mod',
+        categoryId: m.categoryId ?? 0,
+        wasEnabled: m.enabled,
+      }));
+    if (snapshots.length === 0) return;
+    setUpdateAllProgress({ done: 0, total: snapshots.length });
+    const failures: string[] = [];
+    for (let i = 0; i < snapshots.length; i++) {
+      const s = snapshots[i];
+      try {
+        await deleteMod(s.oldId);
+        await downloadMod(s.gameBananaId, s.gameBananaFileId, s.fileName, s.section, s.categoryId);
+      } catch (err) {
+        failures.push(`${s.fileName}: ${String(err)}`);
+      }
+      setUpdateAllProgress({ done: i + 1, total: snapshots.length });
+    }
+    // Refresh once so the new installs are in the store with their new ids,
+    // then re-enable anything that was enabled before. Match-by GB ids; the
+    // local mod id changes on reinstall.
+    await loadMods();
+    const refreshed = useAppStore.getState().mods;
+    for (const s of snapshots) {
+      if (!s.wasEnabled) continue;
+      const newMod = refreshed.find(
+        (m) => m.gameBananaId === s.gameBananaId && m.gameBananaFileId === s.gameBananaFileId,
+      );
+      if (newMod && !newMod.enabled) {
+        try {
+          await toggleMod(newMod.id);
+        } catch (err) {
+          failures.push(`re-enable ${s.fileName}: ${String(err)}`);
+        }
+      }
+    }
+    setUpdateAllProgress(null);
+    if (failures.length > 0) {
+      setUpdateAllError(`${failures.length} mod${failures.length === 1 ? '' : 's'} failed to update. See console for details.`);
+      console.warn('[Update all] failures:', failures);
     }
   };
 
@@ -758,6 +824,19 @@ export default function Installed() {
                 {conflictMap.size / 2} conflicts
               </Button>
             )}
+            {(updatesAvailable.size > 0 || updateAllProgress) && (
+              <Button
+                variant="primary"
+                onClick={() => setUpdateAllConfirmOpen(true)}
+                icon={Download}
+                isLoading={!!updateAllProgress}
+                title="Re-download every mod with a newer version on GameBanana and restore each one's enabled state"
+              >
+                {updateAllProgress
+                  ? `Updating ${updateAllProgress.done}/${updateAllProgress.total}…`
+                  : `Update all (${updatesAvailable.size})`}
+              </Button>
+            )}
             <Button
               variant="secondary"
               onClick={() => setImportOpen(true)}
@@ -844,6 +923,37 @@ export default function Installed() {
           >
             {visibleDisabled.map((entry) => renderEntryCard(entry, 'disabled'))}
           </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={updateAllConfirmOpen}
+        title={`Update all (${updatesAvailable.size})?`}
+        message={
+          <>
+            Re-download every mod flagged with an available update. Each one's enabled state
+            will be restored after the install finishes. Downloads run one at a time and may
+            take a while.
+          </>
+        }
+        confirmLabel={`Update ${updatesAvailable.size}`}
+        variant="primary"
+        onConfirm={handleUpdateAll}
+        onCancel={() => setUpdateAllConfirmOpen(false)}
+      />
+
+      {updateAllError && (
+        <div className="fixed bottom-4 right-4 z-50 max-w-md bg-red-500/10 border border-red-500/30 text-red-300 rounded-lg px-4 py-3 shadow-lg flex items-start gap-3">
+          <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <div className="flex-1 text-sm">{updateAllError}</div>
+          <button
+            type="button"
+            onClick={() => setUpdateAllError(null)}
+            className="text-red-300 hover:text-red-100 p-1 -m-1 cursor-pointer"
+            aria-label="Dismiss"
+          >
+            <X className="w-4 h-4" />
+          </button>
         </div>
       )}
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -24,10 +24,12 @@ import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod } from '../lib/api';
 import type { ModConflict } from '../lib/api';
+import type { Mod } from '../types/mod';
 import type { GameBananaModDetails } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import ModDetailsModal from '../components/ModDetailsModal';
+import VariantPickerModal from '../components/VariantPickerModal';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition } from '../lib/lockerUtils';
 import { Button, Tag } from '../components/common/ui';
 import { PageHeader, ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
@@ -42,6 +44,92 @@ function formatBytes(bytes: number): string {
 
 type DropPosition = 'before' | 'after';
 
+/**
+ * Rows on the Installed page are either standalone mods or groups of variants
+ * sharing the same GameBanana mod (e.g. five preset VPKs from one skin pack).
+ * Grouped entries collapse to a single card with a "N variants" badge; the
+ * picker modal handles per-variant select/delete.
+ */
+type ModEntry =
+  | { kind: 'single'; mod: Mod; key: string }
+  | {
+      kind: 'group';
+      gameBananaId: number;
+      variants: Mod[];
+      /** Currently-enabled variant in the group. Null when the whole group
+       *  is disabled. Mutual exclusion: only one variant is active at a time. */
+      active: Mod | null;
+      /** Mod we render visuals from (thumbnail, name, category). The active
+       *  variant when one's enabled, else the first variant by filename. */
+      primary: Mod;
+      /** Sum of variant sizes — shown as the card's "size" field. */
+      totalSize: number;
+      key: string;
+    };
+
+function buildModEntries(mods: Mod[]): ModEntry[] {
+  const byGb = new Map<number, Mod[]>();
+  const singles: Mod[] = [];
+  for (const m of mods) {
+    if (typeof m.gameBananaId === 'number' && m.gameBananaId > 0) {
+      const arr = byGb.get(m.gameBananaId) ?? [];
+      arr.push(m);
+      byGb.set(m.gameBananaId, arr);
+    } else {
+      singles.push(m);
+    }
+  }
+  // Singletons (only one mod for a given GB id) collapse back to single
+  // entries — the group concept only matters when there are 2+ variants.
+  for (const [gb, variants] of Array.from(byGb.entries())) {
+    if (variants.length === 1) {
+      singles.push(variants[0]);
+      byGb.delete(gb);
+    }
+  }
+
+  const entries: ModEntry[] = [];
+  for (const m of singles) {
+    entries.push({ kind: 'single', mod: m, key: `single:${m.id}` });
+  }
+  for (const [gameBananaId, variants] of byGb) {
+    // Sort variants by current priority so drag-reorder lines up with the
+    // user's mental model ("which slot is this in?") and the picker shows
+    // them in the same order as the addons folder.
+    variants.sort((a, b) => a.priority - b.priority);
+    const active = variants.find((v) => v.enabled) ?? null;
+    const primary = active ?? variants[0];
+    const totalSize = variants.reduce((sum, v) => sum + v.size, 0);
+    entries.push({
+      kind: 'group',
+      gameBananaId,
+      variants,
+      active,
+      primary,
+      totalSize,
+      key: `group:${gameBananaId}`,
+    });
+  }
+  return entries;
+}
+
+/** A group is considered "enabled" when it has a currently-active variant. */
+function isEntryEnabled(entry: ModEntry): boolean {
+  return entry.kind === 'single' ? entry.mod.enabled : entry.active !== null;
+}
+
+/** Sort key for ordering enabled/disabled sections. Uses the primary's
+ *  priority for groups so reorder math stays consistent with the existing
+ *  per-mod priority system. */
+function entrySortPriority(entry: ModEntry): number {
+  return entry.kind === 'single' ? entry.mod.priority : entry.primary.priority;
+}
+
+/** Searchable display name for an entry (the visible card title). */
+function entryName(entry: ModEntry): string {
+  return entry.kind === 'single' ? entry.mod.name : entry.primary.name;
+}
+
 export default function Installed() {
   const navigate = useNavigate();
   const {
@@ -54,20 +142,27 @@ export default function Installed() {
     toggleMod,
     deleteMod,
     reorderMods,
+    setVariantLabel,
     importCustomMod,
     soundVolume,
   } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = localStorage.getItem('installedViewMode');
-    return stored === 'grid' || stored === 'compact' || stored === 'list' ? stored : 'list';
+    return stored === 'grid' || stored === 'compact' || stored === 'list' ? stored : 'grid';
   });
   useEffect(() => {
     localStorage.setItem('installedViewMode', viewMode);
   }, [viewMode]);
   const [search, setSearch] = useState('');
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
-  const [modToDelete, setModToDelete] = useState<{ id: string; name: string } | null>(null);
+  // Delete confirmation. `ids` is a list so the same prompt can drive both
+  // single-mod and "all variants in this group" deletions.
+  const [modToDelete, setModToDelete] = useState<{ ids: string[]; name: string; isGroup: boolean } | null>(null);
+  // GB id of the group whose picker is open, or null. The actual entry is
+  // derived from live `mods` each render so per-variant deletes inside the
+  // picker reflect immediately without juggling a separate snapshot.
+  const [pickerGroupId, setPickerGroupId] = useState<number | null>(null);
   const [importOpen, setImportOpen] = useState(false);
 
   // Drag-and-drop reorder state. `draggingSection` scopes drops so dragging
@@ -150,9 +245,49 @@ export default function Installed() {
   };
 
   const handleDeleteConfirm = async () => {
-    if (modToDelete) {
-      await deleteMod(modToDelete.id);
-      setModToDelete(null);
+    if (!modToDelete) return;
+    // Sequential to keep priority renames coherent — parallel deletes have
+    // raced renameVpks before.
+    for (const id of modToDelete.ids) {
+      await deleteMod(id);
+    }
+    setModToDelete(null);
+  };
+
+  /**
+   * Switch the active variant in a group. Disables every other variant in
+   * the group first (sequential, so the priority bookkeeping stays sane),
+   * then enables the target. If the target is already enabled this is a
+   * no-op. Mutual exclusion is enforced here rather than in the store so the
+   * existing toggleMod action stays single-mod.
+   */
+  const setActiveVariant = async (group: Extract<ModEntry, { kind: 'group' }>, target: Mod) => {
+    for (const v of group.variants) {
+      if (v.id !== target.id && v.enabled) {
+        await toggleMod(v.id);
+      }
+    }
+    if (!target.enabled) {
+      await toggleMod(target.id);
+    }
+  };
+
+  const disableEntireGroup = async (group: Extract<ModEntry, { kind: 'group' }>) => {
+    for (const v of group.variants) {
+      if (v.enabled) {
+        await toggleMod(v.id);
+      }
+    }
+  };
+
+  /** Top-level toggle on a grouped card. If anything's active, disable it;
+   *  otherwise enable the first variant by filename order (which becomes
+   *  the primary when nothing else is active). */
+  const handleGroupToggle = async (group: Extract<ModEntry, { kind: 'group' }>) => {
+    if (group.active) {
+      await toggleMod(group.active.id);
+    } else if (group.variants.length > 0) {
+      await toggleMod(group.variants[0].id);
     }
   };
 
@@ -310,14 +445,24 @@ export default function Installed() {
     disabledMods.some((m, i) => m.priority !== enabledMods.length + i + 1);
   const conflictCount = conflictMap.size > 0 ? new Set([...conflictMap.keys()]).size : 0;
 
+  // Group variants sharing a GB mod id under a single card. Singletons and
+  // custom imports (no GB id) keep their old card behavior.
+  const allEntries = buildModEntries(mods);
+  const enabledEntries = allEntries
+    .filter(isEntryEnabled)
+    .sort((a, b) => entrySortPriority(a) - entrySortPriority(b));
+  const disabledEntries = allEntries
+    .filter((e) => !isEntryEnabled(e))
+    .sort((a, b) => entrySortPriority(a) - entrySortPriority(b));
+
   // Filter by search query (case-insensitive substring on name). Drag-and-drop
   // reorder is still correct because it targets the full enabled list order,
   // not the filtered view.
   const searchNeedle = search.trim().toLowerCase();
-  const matchesSearch = (m: typeof mods[number]) =>
-    !searchNeedle || m.name.toLowerCase().includes(searchNeedle);
-  const visibleEnabled = enabledMods.filter(matchesSearch);
-  const visibleDisabled = disabledMods.filter(matchesSearch);
+  const matchesSearchEntry = (entry: ModEntry) =>
+    !searchNeedle || entryName(entry).toLowerCase().includes(searchNeedle);
+  const visibleEnabled = enabledEntries.filter(matchesSearchEntry);
+  const visibleDisabled = disabledEntries.filter(matchesSearchEntry);
   const totalMatches = visibleEnabled.length + visibleDisabled.length;
 
   const resetDragState = () => {
@@ -327,6 +472,19 @@ export default function Installed() {
     setDropPosition(null);
   };
 
+  /** Locate the entry that holds a given mod id within a section's entries. */
+  const findEntryForModId = (entries: ModEntry[], id: string): ModEntry | undefined => {
+    return entries.find((e) =>
+      e.kind === 'single' ? e.mod.id === id : e.variants.some((v) => v.id === id)
+    );
+  };
+
+  /**
+   * Entry-aware drag reorder. Singles move one mod; groups move all their
+   * variants as a block, keeping internal priority order. After the reshuffle
+   * we flatten back to a filename list and hand it to reorderMods, which
+   * renames pak##_ prefixes to lock in new priorities.
+   */
   const applyReorder = (
     sourceId: string,
     targetId: string,
@@ -334,21 +492,27 @@ export default function Installed() {
     section: 'enabled' | 'disabled'
   ) => {
     if (sourceId === targetId) return;
-    const list = section === 'enabled' ? enabledMods : disabledMods;
-    const sourceIdx = list.findIndex((m) => m.id === sourceId);
-    if (sourceIdx === -1) return;
+    const entries = section === 'enabled' ? enabledEntries : disabledEntries;
+    const sourceEntry = findEntryForModId(entries, sourceId);
+    const targetEntry = findEntryForModId(entries, targetId);
+    if (!sourceEntry || !targetEntry || sourceEntry.key === targetEntry.key) return;
 
-    const working = list.slice();
-    const [moved] = working.splice(sourceIdx, 1);
-    const adjustedTargetIdx = working.findIndex((m) => m.id === targetId);
-    if (adjustedTargetIdx === -1) return;
-    const insertAt = position === 'before' ? adjustedTargetIdx : adjustedTargetIdx + 1;
-    working.splice(insertAt, 0, moved);
+    const working = entries.slice();
+    const sourceIdx = working.indexOf(sourceEntry);
+    working.splice(sourceIdx, 1);
+    const targetIdx = working.indexOf(targetEntry);
+    if (targetIdx === -1) return;
+    const insertAt = position === 'before' ? targetIdx : targetIdx + 1;
+    working.splice(insertAt, 0, sourceEntry);
 
-    const unchanged = working.every((m, i) => m.id === list[i].id);
+    const flatten = (es: ModEntry[]) =>
+      es.flatMap((e) => (e.kind === 'single' ? [e.mod] : e.variants));
+    const next = flatten(working);
+    const prev = flatten(entries);
+    const unchanged = next.every((m, i) => m.id === prev[i]?.id);
     if (unchanged) return;
 
-    reorderMods(working.map((m) => m.fileName));
+    reorderMods(next.map((m) => m.fileName));
   };
 
   const compactPriorities = () => {
@@ -357,6 +521,147 @@ export default function Installed() {
     const ordered = [...enabledMods, ...disabledMods];
     if (ordered.length === 0) return;
     reorderMods(ordered.map((m) => m.fileName));
+  };
+
+  /**
+   * Render a single entry as a ModCard. Centralizes both the "single mod"
+   * and "grouped variants" paths so the enabled/disabled sections don't
+   * each carry a 40-line inline JSX block.
+   *
+   * Group cards:
+   *   - Drag-reorder is disabled (the underlying VPKs span multiple priority
+   *     slots; meaningful group-level reorder needs more design).
+   *   - Toggle hits the active variant (or enables the first variant when
+   *     the group is fully disabled).
+   *   - Delete asks the user to confirm removing every variant.
+   *   - Card body click opens the variant picker modal.
+   *   - Conflicts shown are the union of conflicts on currently-enabled
+   *     variants (typically just one under mutual exclusion).
+   */
+  const renderEntryCard = (entry: ModEntry, section: 'enabled' | 'disabled') => {
+    if (entry.kind === 'single') {
+      const mod = entry.mod;
+      return (
+        <ModCard
+          key={entry.key}
+          mod={mod}
+          viewMode={viewMode}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          conflicts={conflictMap.get(mod.id) || []}
+          soundVolume={soundVolume}
+          updateAvailable={updatesAvailable.has(mod.id)}
+          onOpenDetails={mod.gameBananaId ? () => openModDetails(mod) : undefined}
+          onToggle={() => toggleMod(mod.id)}
+          onDelete={() => setModToDelete({ ids: [mod.id], name: mod.name, isGroup: false })}
+          draggable={!searchNeedle}
+          isDragging={draggingId === mod.id}
+          isDropTarget={dropTargetId === mod.id}
+          dropPosition={dropTargetId === mod.id ? dropPosition : null}
+          onDragStart={() => {
+            setDraggingId(mod.id);
+            setDraggingSection(section);
+          }}
+          onDragOver={(pos) => {
+            if (!draggingId || draggingId === mod.id) return;
+            if (draggingSection !== section) return;
+            setDropTargetId(mod.id);
+            setDropPosition(pos);
+          }}
+          onDragLeaveCard={() => {
+            if (dropTargetId === mod.id) {
+              setDropTargetId(null);
+              setDropPosition(null);
+            }
+          }}
+          onDrop={() => {
+            if (draggingId && dropTargetId && dropPosition && draggingSection === section) {
+              applyReorder(draggingId, dropTargetId, dropPosition, section);
+            }
+            resetDragState();
+          }}
+          onDragEnd={resetDragState}
+        />
+      );
+    }
+    // Group entry. Stand-in `mod` is the primary so the card visuals look
+    // right; the `group` prop tells ModCard to swap filename for variant
+    // count and route clicks to the picker.
+    const aggregateConflicts: ModConflict[] = [];
+    for (const v of entry.variants) {
+      if (v.enabled) {
+        const c = conflictMap.get(v.id);
+        if (c) aggregateConflicts.push(...c);
+      }
+    }
+    const anyUpdateAvailable = entry.variants.some((v) => updatesAvailable.has(v.id));
+    // Drag uses the primary's mod id as the representative for the whole
+    // group. applyReorder maps this id back to the entry and moves the
+    // whole variant block.
+    const dragRepId = entry.primary.id;
+    return (
+      <ModCard
+        key={entry.key}
+        mod={{
+          ...entry.primary,
+          // Group's overall enable state is "active variant exists", not
+          // the primary's individual flag (matches sort + section choice).
+          enabled: entry.active !== null,
+          // Card meta shows total size across variants.
+          size: entry.totalSize,
+        }}
+        viewMode={viewMode}
+        hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+        conflicts={aggregateConflicts}
+        soundVolume={soundVolume}
+        updateAvailable={anyUpdateAvailable}
+        onOpenDetails={() => setPickerGroupId(entry.gameBananaId)}
+        onToggle={() => handleGroupToggle(entry)}
+        onDelete={() =>
+          setModToDelete({
+            ids: entry.variants.map((v) => v.id),
+            name: entry.primary.name,
+            isGroup: true,
+          })
+        }
+        draggable={!searchNeedle}
+        isDragging={draggingId === dragRepId}
+        isDropTarget={dropTargetId === dragRepId}
+        dropPosition={dropTargetId === dragRepId ? dropPosition : null}
+        onDragStart={() => {
+          setDraggingId(dragRepId);
+          setDraggingSection(section);
+        }}
+        onDragOver={(pos) => {
+          if (!draggingId || draggingId === dragRepId) return;
+          if (draggingSection !== section) return;
+          setDropTargetId(dragRepId);
+          setDropPosition(pos);
+        }}
+        onDragLeaveCard={() => {
+          if (dropTargetId === dragRepId) {
+            setDropTargetId(null);
+            setDropPosition(null);
+          }
+        }}
+        onDrop={() => {
+          if (draggingId && dropTargetId && dropPosition && draggingSection === section) {
+            applyReorder(draggingId, dropTargetId, dropPosition, section);
+          }
+          resetDragState();
+        }}
+        onDragEnd={resetDragState}
+        group={{
+          variantCount: entry.variants.length,
+          // Display the active variant's user-given label when set; falls
+          // back to the VPK filename. Lets the user see "Red preset" on
+          // the card instead of "pak06_dir.vpk".
+          activeFileName: entry.active
+            ? (entry.active.variantLabel ?? entry.active.fileName)
+            : null,
+          onOpenPicker: () => setPickerGroupId(entry.gameBananaId),
+        }}
+      />
+    );
   };
 
   // No mods at all
@@ -493,47 +798,7 @@ export default function Installed() {
                   : 'space-y-2'
             }
           >
-            {visibleEnabled.map((mod) => (
-              <ModCard
-                key={mod.id}
-                mod={mod}
-                viewMode={viewMode}
-                hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
-                conflicts={conflictMap.get(mod.id) || []}
-                soundVolume={soundVolume}
-                updateAvailable={updatesAvailable.has(mod.id)}
-                onOpenDetails={mod.gameBananaId ? () => openModDetails(mod) : undefined}
-                onToggle={() => toggleMod(mod.id)}
-                onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
-                draggable={!searchNeedle}
-                isDragging={draggingId === mod.id}
-                isDropTarget={dropTargetId === mod.id}
-                dropPosition={dropTargetId === mod.id ? dropPosition : null}
-                onDragStart={() => {
-                  setDraggingId(mod.id);
-                  setDraggingSection('enabled');
-                }}
-                onDragOver={(pos) => {
-                  if (!draggingId || draggingId === mod.id) return;
-                  if (draggingSection !== 'enabled') return;
-                  setDropTargetId(mod.id);
-                  setDropPosition(pos);
-                }}
-                onDragLeaveCard={() => {
-                  if (dropTargetId === mod.id) {
-                    setDropTargetId(null);
-                    setDropPosition(null);
-                  }
-                }}
-                onDrop={() => {
-                  if (draggingId && dropTargetId && dropPosition && draggingSection === 'enabled') {
-                    applyReorder(draggingId, dropTargetId, dropPosition, 'enabled');
-                  }
-                  resetDragState();
-                }}
-                onDragEnd={resetDragState}
-              />
-            ))}
+            {visibleEnabled.map((entry) => renderEntryCard(entry, 'enabled'))}
           </div>
         </div>
       )}
@@ -550,62 +815,31 @@ export default function Installed() {
                   : 'space-y-2'
             }
           >
-            {visibleDisabled.map((mod) => (
-              <ModCard
-                key={mod.id}
-                mod={mod}
-                viewMode={viewMode}
-                hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
-                conflicts={conflictMap.get(mod.id) || []}
-                soundVolume={soundVolume}
-                updateAvailable={updatesAvailable.has(mod.id)}
-                onOpenDetails={mod.gameBananaId ? () => openModDetails(mod) : undefined}
-                onToggle={() => toggleMod(mod.id)}
-                onDelete={() => setModToDelete({ id: mod.id, name: mod.name })}
-                draggable={!searchNeedle}
-                isDragging={draggingId === mod.id}
-                isDropTarget={dropTargetId === mod.id}
-                dropPosition={dropTargetId === mod.id ? dropPosition : null}
-                onDragStart={() => {
-                  setDraggingId(mod.id);
-                  setDraggingSection('disabled');
-                }}
-                onDragOver={(pos) => {
-                  if (!draggingId || draggingId === mod.id) return;
-                  if (draggingSection !== 'disabled') return;
-                  setDropTargetId(mod.id);
-                  setDropPosition(pos);
-                }}
-                onDragLeaveCard={() => {
-                  if (dropTargetId === mod.id) {
-                    setDropTargetId(null);
-                    setDropPosition(null);
-                  }
-                }}
-                onDrop={() => {
-                  if (draggingId && dropTargetId && dropPosition && draggingSection === 'disabled') {
-                    applyReorder(draggingId, dropTargetId, dropPosition, 'disabled');
-                  }
-                  resetDragState();
-                }}
-                onDragEnd={resetDragState}
-              />
-            ))}
+            {visibleDisabled.map((entry) => renderEntryCard(entry, 'disabled'))}
           </div>
         </div>
       )}
 
       <ConfirmModal
         isOpen={!!modToDelete}
-        title="Delete Mod?"
+        title={modToDelete?.isGroup ? `Delete ${modToDelete.ids.length} variants?` : 'Delete Mod?'}
         message={
-          <>
-            Are you sure you want to delete{' '}
-            <span className="font-medium text-text-primary">{modToDelete?.name}</span>? This action
-            cannot be undone.
-          </>
+          modToDelete?.isGroup ? (
+            <>
+              Delete all {modToDelete.ids.length} variants of{' '}
+              <span className="font-medium text-text-primary">{modToDelete.name}</span>? This
+              removes every VPK in the group. To keep some, cancel and use the variant picker
+              instead.
+            </>
+          ) : (
+            <>
+              Are you sure you want to delete{' '}
+              <span className="font-medium text-text-primary">{modToDelete?.name}</span>? This
+              action cannot be undone.
+            </>
+          )
         }
-        confirmLabel="Delete"
+        confirmLabel={modToDelete?.isGroup ? `Delete ${modToDelete.ids.length}` : 'Delete'}
         variant="danger"
         onConfirm={handleDeleteConfirm}
         onCancel={() => setModToDelete(null)}
@@ -619,6 +853,42 @@ export default function Installed() {
           }}
         />
       )}
+
+      {(() => {
+        if (pickerGroupId === null) return null;
+        // Derive the live entry from current mods so deletes inside the
+        // picker reflect immediately. If the group has disappeared (all
+        // variants deleted or moved), auto-close the picker.
+        const liveEntry = allEntries.find(
+          (e) => e.kind === 'group' && e.gameBananaId === pickerGroupId
+        ) as Extract<ModEntry, { kind: 'group' }> | undefined;
+        if (!liveEntry) {
+          // Defer close to avoid setState during render warnings.
+          queueMicrotask(() => setPickerGroupId(null));
+          return null;
+        }
+        return (
+          <VariantPickerModal
+            modName={liveEntry.primary.name}
+            variants={liveEntry.variants}
+            onSelect={(target) => setActiveVariant(liveEntry, target)}
+            onDisableAll={() => disableEntireGroup(liveEntry)}
+            onDeleteVariant={(variant) => deleteMod(variant.id)}
+            onRenameVariant={(variant, label) => setVariantLabel(variant.id, label)}
+            onOpenModDetails={
+              liveEntry.primary.gameBananaId
+                ? () => {
+                    // Stash the picker so the user can return to it after
+                    // closing the details modal.
+                    setPickerGroupId(null);
+                    openModDetails(liveEntry.primary);
+                  }
+                : undefined
+            }
+            onClose={() => setPickerGroupId(null)}
+          />
+        );
+      })()}
 
       {detailsLoading && (
         <div
@@ -759,6 +1029,17 @@ interface ModCardProps {
   onDragLeaveCard?: () => void;
   onDrop?: () => void;
   onDragEnd?: () => void;
+  /** Present when this card represents a grouped set of variants (same
+   *  GameBanana mod, multiple VPKs). Swaps the filename meta for a variants
+   *  count and routes the card-body click to the picker modal. */
+  group?: {
+    variantCount: number;
+    /** Filename of the currently-active variant, or null if the group is
+     *  fully disabled. Shown in small text so the user can tell at a glance
+     *  which preset is live. */
+    activeFileName: string | null;
+    onOpenPicker: () => void;
+  };
 }
 
 function ModCard({
@@ -780,9 +1061,11 @@ function ModCard({
   onDragLeaveCard,
   onDrop,
   onDragEnd,
+  group,
 }: ModCardProps) {
   const hasConflicts = conflicts.length > 0;
   const handleDownRef = useRef<boolean>(false);
+  const isGroupCard = !!group;
 
   const indicatorClasses = (() => {
     if (!isDropTarget || !dropPosition) return '';
@@ -916,8 +1199,8 @@ function ModCard({
                 }}
                 disabled={!onOpenDetails}
                 className="absolute inset-0 w-full h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default enabled:cursor-pointer"
-                title={onOpenDetails ? 'View mod details' : undefined}
-                aria-label={onOpenDetails ? `View details for ${mod.name}` : undefined}
+                title={onOpenDetails ? (isGroupCard ? 'Pick variant' : 'View mod details') : undefined}
+                aria-label={onOpenDetails ? (isGroupCard ? `Pick a variant for ${mod.name}` : `View details for ${mod.name}`) : undefined}
               >
                 {heroRenderUrl ? (
                   <>
@@ -969,8 +1252,8 @@ function ModCard({
             }}
             disabled={!onOpenDetails}
             className="group relative w-full aspect-video bg-bg-tertiary rounded-md overflow-hidden block focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default enabled:cursor-pointer"
-            title={onOpenDetails ? 'View mod details' : undefined}
-            aria-label={onOpenDetails ? `View details for ${mod.name}` : undefined}
+            title={onOpenDetails ? (isGroupCard ? 'Pick variant' : 'View mod details') : undefined}
+            aria-label={onOpenDetails ? (isGroupCard ? `Pick a variant for ${mod.name}` : `View details for ${mod.name}`) : undefined}
           >
             <ModThumbnail
               src={mod.thumbnailUrl}
@@ -1045,12 +1328,26 @@ function ModCard({
               <span className="flex-shrink-0 px-1.5 py-0.5 bg-bg-tertiary rounded text-xs">{mod.categoryName}</span>
             )}
             <span className="flex-shrink-0">{formatBytes(mod.size)}</span>
-            <span
-              className="font-mono truncate opacity-60 hover:opacity-100 cursor-help min-w-0"
-              title={mod.fileName}
-            >
-              {mod.fileName}
-            </span>
+            {group ? (
+              <span className="flex-shrink-0 px-1.5 py-0.5 bg-accent/15 text-accent rounded text-xs font-medium" title="Click the card to pick a variant">
+                {group.variantCount} variants
+              </span>
+            ) : (
+              <span
+                className="font-mono truncate opacity-60 hover:opacity-100 cursor-help min-w-0"
+                title={mod.fileName}
+              >
+                {mod.fileName}
+              </span>
+            )}
+            {group?.activeFileName && (
+              <span
+                className="font-mono truncate opacity-60 hover:opacity-100 cursor-help min-w-0"
+                title={`Active: ${group.activeFileName}`}
+              >
+                {group.activeFileName}
+              </span>
+            )}
           </div>
         </div>
 
@@ -1078,8 +1375,8 @@ function ModCard({
                 onOpenDetails();
               }}
               className="p-1 text-text-secondary hover:text-accent transition-colors cursor-pointer"
-              title="View mod details"
-              aria-label={`View details for ${mod.name}`}
+              title={isGroupCard ? 'Pick variant' : 'View mod details'}
+              aria-label={isGroupCard ? `Pick a variant for ${mod.name}` : `View details for ${mod.name}`}
             >
               <Info className="w-4 h-4" />
             </button>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -18,6 +18,7 @@ import {
   List,
   LayoutGrid,
   Grid3x3,
+  Layers,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -673,11 +674,16 @@ export default function Installed() {
         group={{
           variantCount: entry.variants.length,
           // Display the active variant's user-given label when set, else
-          // the author's GameBanana file header, else the raw VPK filename.
+          // the author's GameBanana file header, else the original GB
+          // filename stem (covers mods whose author left descriptions
+          // blank — e.g. "galaxy_rem_gold"), else the raw VPK filename.
           // Lets the user see "Red preset" / "Gold w/ alt candle" on the
           // card instead of "pak06_dir.vpk".
           activeFileName: entry.active
-            ? (entry.active.variantLabel ?? entry.active.fileDescription ?? entry.active.fileName)
+            ? (entry.active.variantLabel ??
+               entry.active.fileDescription ??
+               entry.active.sourceFileName ??
+               entry.active.fileName)
             : null,
           onOpenPicker: () => setPickerGroupId(entry.gameBananaId),
         }}
@@ -1200,6 +1206,26 @@ function ModCard({
                 </Tag>
               )}
             </div>
+            {/* Active-variant badge anchored at the bottom so it doesn't fight
+                the top-right Conflict/Update stack or visually clash with the
+                accent-colored Enable toggle in the card body. A short gradient
+                behind it keeps the label legible against busy thumbnail art. */}
+            {group?.activeFileName && (
+              <>
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black/75 via-black/40 to-transparent z-[5]" />
+                <div className="absolute bottom-2 left-2 right-2 z-10 flex">
+                  <Tag
+                    tone="info"
+                    variant="overlay"
+                    icon={Layers}
+                    title={`Active variant: ${group.activeFileName} — click card to switch`}
+                    className="max-w-full"
+                  >
+                    <span className="truncate">{group.activeFileName}</span>
+                  </Tag>
+                </div>
+              </>
+            )}
           </>
         );
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -181,6 +181,10 @@ export default function Installed() {
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const [detailsUpdateAvailable, setDetailsUpdateAvailable] = useState(false);
   const [detailsInstalledFileIds, setDetailsInstalledFileIds] = useState<Set<number>>(new Set());
+  // GameBanana fileId of the currently-enabled variant in the group (when any).
+  // Drives the "Active" badge in the details modal so users can see which file
+  // is the one actually loaded in-game, not just which ones are installed.
+  const [detailsActiveFileId, setDetailsActiveFileId] = useState<number | null>(null);
   const [detailsDates, setDetailsDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   // Local id of the installed mod that triggered the overlay. On download we
   // delete this entry first so Update/Reinstall replaces the old VPK instead
@@ -199,7 +203,22 @@ export default function Installed() {
     setDetailsSection(section);
     setDetailsCategoryId(categoryId);
     setDetailsSourceModId(m.id);
-    setDetailsInstalledFileIds(m.gameBananaFileId ? new Set([m.gameBananaFileId]) : new Set());
+    // Build the installed-file set from every sibling sharing this GB id,
+    // not just the clicked variant. Otherwise the modal flags only one row
+    // as "Reinstall" when multiple variants of the same mod are present —
+    // diverging from Browse, which already aggregates correctly.
+    const siblingFileIds = new Set<number>();
+    let activeFileId: number | null = null;
+    for (const candidate of mods) {
+      if (candidate.gameBananaId !== m.gameBananaId) continue;
+      if (typeof candidate.gameBananaFileId !== 'number') continue;
+      siblingFileIds.add(candidate.gameBananaFileId);
+      if (candidate.enabled && activeFileId === null) {
+        activeFileId = candidate.gameBananaFileId;
+      }
+    }
+    setDetailsInstalledFileIds(siblingFileIds);
+    setDetailsActiveFileId(activeFileId);
     setDetailsUpdateAvailable(updatesAvailable.has(m.id));
     setDetailsDates(null);
     try {
@@ -223,6 +242,7 @@ export default function Installed() {
     setDetailsError(null);
     setDetailsUpdateAvailable(false);
     setDetailsSourceModId(null);
+    setDetailsActiveFileId(null);
     setDetailsDates(null);
   };
 
@@ -652,11 +672,12 @@ export default function Installed() {
         onDragEnd={resetDragState}
         group={{
           variantCount: entry.variants.length,
-          // Display the active variant's user-given label when set; falls
-          // back to the VPK filename. Lets the user see "Red preset" on
-          // the card instead of "pak06_dir.vpk".
+          // Display the active variant's user-given label when set, else
+          // the author's GameBanana file header, else the raw VPK filename.
+          // Lets the user see "Red preset" / "Gold w/ alt candle" on the
+          // card instead of "pak06_dir.vpk".
           activeFileName: entry.active
-            ? (entry.active.variantLabel ?? entry.active.fileName)
+            ? (entry.active.variantLabel ?? entry.active.fileDescription ?? entry.active.fileName)
             : null,
           onOpenPicker: () => setPickerGroupId(entry.gameBananaId),
         }}
@@ -929,6 +950,7 @@ export default function Installed() {
           section={detailsSection}
           installed={true}
           installedFileIds={detailsInstalledFileIds}
+          activeFileId={detailsActiveFileId}
           downloadingFileId={null}
           extracting={false}
           progress={null}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -167,6 +167,12 @@ export default function Settings() {
     }
   };
 
+  const handleAutoDisableSiblingsChange = async (checked: boolean) => {
+    if (settings) {
+      await saveSettings({ ...settings, autoDisableSiblingVariants: checked });
+    }
+  };
+
   const handleDevModeChange = async (checked: boolean) => {
     if (!settings) return;
     if (checked) {
@@ -529,6 +535,15 @@ export default function Settings() {
               onChange={handleHideOutdatedChange}
               label="Hide Outdated Mods"
               description="Hide mods in Browse that haven't been updated since the current game version cutoff."
+            />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.autoDisableSiblingVariants ?? true}
+              onChange={handleAutoDisableSiblingsChange}
+              label="Auto-disable older variants on re-download"
+              description="When you re-download a GameBanana mod with a different file, automatically disable the previously installed variant. Disable this if you want to keep multiple variants enabled at once."
             />
 
             <div className="h-px bg-white/5" />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -69,6 +69,25 @@ const DEFAULT_BROWSE_UI: BrowseUiState = {
   categoryId: 'all',
 };
 
+// Cached page state: lets the Browse tab resume exactly where the user left
+// it (same loaded mods, same page count, same scroll position) when they
+// navigate away and back. In-memory only — we don't persist this across app
+// restarts because a stale list of mods could be misleading on next launch.
+//
+// Import shape from gamebanana types is awkward to wire here, so the cache
+// stores opaque `unknown` and Browse.tsx asserts the type at the boundary.
+export interface BrowseSessionCache {
+  mods: unknown[];
+  page: number;
+  hasMore: boolean;
+  totalCount: number;
+  scrollTop: number;
+  /** Stamp of the filter state these mods belong to. If any filter changes
+   *  while Browse is unmounted (impossible today, but defensive), we'll
+   *  refetch instead of restoring stale results. */
+  stamp: string;
+}
+
 interface AppState {
   // Settings
   settings: AppSettings | null;
@@ -88,6 +107,10 @@ interface AppState {
 
   // Browse-page UI state (preserved across page nav)
   browseUi: BrowseUiState;
+
+  // Cached fetched mods + scroll position so the Browse tab resumes where
+  // the user left it instead of refetching + scrolling to top.
+  browseSession: BrowseSessionCache | null;
 
   // Actions
   loadSettings: () => Promise<void>;
@@ -112,6 +135,9 @@ interface AppState {
   // Browse UI state
   setBrowseUi: (partial: Partial<BrowseUiState>) => void;
   resetBrowseUi: () => void;
+
+  // Browse session cache (loaded mods + scroll position)
+  setBrowseSession: (cache: BrowseSessionCache | null) => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -125,6 +151,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   downloadCountsCache: new Map(),
   soundVolume: 0.7,
   browseUi: { ...DEFAULT_BROWSE_UI },
+  browseSession: null,
 
   // Load settings from backend
   loadSettings: async () => {
@@ -294,6 +321,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   resetBrowseUi: () => {
     set({ browseUi: { ...DEFAULT_BROWSE_UI } });
+  },
+
+  setBrowseSession: (cache: BrowseSessionCache | null) => {
+    set({ browseSession: cache });
   },
 }));
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -122,6 +122,7 @@ interface AppState {
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
   reorderMods: (orderedFileNames: string[]) => Promise<void>;
+  setVariantLabel: (modId: string, label: string) => Promise<void>;
   importCustomMod: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
 
   // Download counts cache actions
@@ -260,6 +261,17 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (err) {
       set({ modsError: String(err) });
       get().loadMods();
+    }
+  },
+
+  setVariantLabel: async (modId: string, label: string) => {
+    try {
+      const updated = await api.setVariantLabel(modId, label);
+      set({
+        mods: get().mods.map((m) => (m.id === modId ? updated : m)),
+      });
+    } catch (err) {
+      set({ modsError: String(err) });
     }
   },
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -12,6 +12,63 @@ interface CacheEntry<T> {
 // TTL for download counts cache (1 hour in ms)
 const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 
+// Browse-page UI state. Kept in the store (not local component state) so it
+// survives navigation away from /browse and back — user complaint: search
+// query, view mode, and filters all reset when switching pages.
+export type BrowseSortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
+export type BrowseViewMode = 'grid' | 'compact' | 'list';
+export interface BrowseUiState {
+  search: string;
+  viewMode: BrowseViewMode;
+  sort: BrowseSortOption;
+  section: string;
+  heroCategoryId: number | 'all';
+  categoryId: number | 'all';
+}
+
+// viewMode + sort behave like preferences (the user mentioned wanting their
+// "list vs blocks" choice remembered). Cache them in localStorage so they
+// survive app restarts. The rest of BrowseUiState is session-only — search
+// queries and filters shouldn't follow the user across launches.
+const VIEW_MODE_KEY = 'browseViewMode';
+const SORT_KEY = 'browseSort';
+
+const VIEW_MODES: BrowseViewMode[] = ['grid', 'compact', 'list'];
+const SORT_OPTIONS: BrowseSortOption[] = ['default', 'popular', 'recent', 'updated', 'views', 'name'];
+
+function readPersistedViewMode(): BrowseViewMode {
+  try {
+    const stored = localStorage.getItem(VIEW_MODE_KEY);
+    if (stored && (VIEW_MODES as string[]).includes(stored)) {
+      return stored as BrowseViewMode;
+    }
+  } catch {
+    // localStorage may be unavailable (e.g. SSR, restricted contexts).
+  }
+  return 'grid';
+}
+
+function readPersistedSort(): BrowseSortOption {
+  try {
+    const stored = localStorage.getItem(SORT_KEY);
+    if (stored && (SORT_OPTIONS as string[]).includes(stored)) {
+      return stored as BrowseSortOption;
+    }
+  } catch {
+    // ignore
+  }
+  return 'default';
+}
+
+const DEFAULT_BROWSE_UI: BrowseUiState = {
+  search: '',
+  viewMode: readPersistedViewMode(),
+  sort: readPersistedSort(),
+  section: 'Mod',
+  heroCategoryId: 'all',
+  categoryId: 'all',
+};
+
 interface AppState {
   // Settings
   settings: AppSettings | null;
@@ -28,6 +85,9 @@ interface AppState {
 
   // Global sound preview volume (0-1)
   soundVolume: number;
+
+  // Browse-page UI state (preserved across page nav)
+  browseUi: BrowseUiState;
 
   // Actions
   loadSettings: () => Promise<void>;
@@ -48,6 +108,10 @@ interface AppState {
 
   // Sound volume
   setSoundVolume: (volume: number) => void;
+
+  // Browse UI state
+  setBrowseUi: (partial: Partial<BrowseUiState>) => void;
+  resetBrowseUi: () => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -60,6 +124,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   modsError: null,
   downloadCountsCache: new Map(),
   soundVolume: 0.7,
+  browseUi: { ...DEFAULT_BROWSE_UI },
 
   // Load settings from backend
   loadSettings: async () => {
@@ -207,6 +272,28 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Set global sound preview volume
   setSoundVolume: (volume: number) => {
     set({ soundVolume: Math.max(0, Math.min(1, volume)) });
+  },
+
+  // Patch Browse UI state. Use a partial so callers can update one field at
+  // a time without restating the rest. viewMode + sort also mirror to
+  // localStorage so they persist across app restarts.
+  setBrowseUi: (partial: Partial<BrowseUiState>) => {
+    set({ browseUi: { ...get().browseUi, ...partial } });
+    try {
+      if (partial.viewMode !== undefined) {
+        localStorage.setItem(VIEW_MODE_KEY, partial.viewMode);
+      }
+      if (partial.sort !== undefined) {
+        localStorage.setItem(SORT_KEY, partial.sort);
+      }
+    } catch {
+      // localStorage write may fail (quota, restricted context); state still
+      // updates in memory so the user's current session works.
+    }
+  },
+
+  resetBrowseUi: () => {
+    set({ browseUi: { ...DEFAULT_BROWSE_UI } });
   },
 }));
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -256,6 +256,7 @@ export interface ElectronAPI {
     enableMod: (modId: string) => Promise<Mod>;
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
+    setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -146,6 +146,12 @@ export interface OneClickSuspiciousFilesData {
     files: string[];
 }
 
+export interface MultiVpkPickData {
+    requestId: string;
+    modName: string;
+    vpkFileNames: string[];
+}
+
 export interface SyncProgressData {
     section: string;
     currentPage: number;
@@ -315,6 +321,11 @@ export interface ElectronAPI {
     respondToOneClickSuspiciousFiles: (
         requestId: string,
         accepted: boolean
+    ) => Promise<void>;
+    onMultiVpkPick: (callback: (data: MultiVpkPickData) => void) => () => void;
+    respondToMultiVpkPick: (
+        requestId: string,
+        selected: string[] | null
     ) => Promise<void>;
 
     // Conflicts

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -150,6 +150,9 @@ export interface MultiVpkPickData {
     requestId: string;
     modName: string;
     vpkFileNames: string[];
+    /** filename → human-readable label derived from VPK contents. Missing
+     *  entries fall back to the filename in the picker. */
+    vpkLabels?: Record<string, string>;
 }
 
 export interface SyncProgressData {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -331,6 +331,9 @@ export interface ElectronAPI {
 
     // Conflicts
     getConflicts: () => Promise<ModConflict[]>;
+    getIgnoredConflicts: () => Promise<string[]>;
+    ignoreConflict: (modA: string, modB: string) => Promise<string[]>;
+    unignoreConflict: (modA: string, modB: string) => Promise<string[]>;
 
     // Profiles
     getProfiles: () => Promise<Profile[]>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -80,6 +80,13 @@ export interface VanillaStashStatus {
     modCount?: number;
 }
 
+export interface SteamLaunchOptionsStatus {
+    available: boolean;
+    configPath: string | null;
+    currentValue: string | null;
+    steamRunning: boolean;
+}
+
 export interface VanillaRestoreResult {
     restored: number;
     skipped: number;
@@ -104,6 +111,13 @@ export interface DownloadErrorData {
     errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
     message: string;
     helpUrl?: string;
+}
+
+export interface ModsAutoDisabledData {
+    reason: 'sibling-variant';
+    modId: number;
+    fileId: number;
+    disabled: Array<{ id: string; name: string; fileName: string }>;
 }
 
 export interface DownloadQueueItem {
@@ -248,6 +262,7 @@ export interface ElectronAPI {
     getVanillaStashStatus: () => Promise<VanillaStashStatus>;
     restoreVanillaStash: () => Promise<VanillaRestoreResult>;
     onVanillaRestoreComplete: (callback: (result: VanillaRestoreResult) => void) => () => void;
+    getSteamLaunchOptionsStatus: () => Promise<SteamLaunchOptionsStatus>;
 
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
@@ -284,6 +299,7 @@ export interface ElectronAPI {
     onDownloadExtracting: (callback: (data: DownloadEventData) => void) => () => void;
     onDownloadComplete: (callback: (data: DownloadEventData) => void) => () => void;
     onDownloadError: (callback: (data: DownloadErrorData) => void) => () => void;
+    onModsAutoDisabled: (callback: (data: ModsAutoDisabledData) => void) => () => void;
 
     // Download Queue
     getDownloadQueue: () => Promise<DownloadQueueItem[]>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -16,6 +16,7 @@ export interface Mod {
   categoryName?: string;
   sourceSection?: string;
   nsfw?: boolean;
+  variantLabel?: string;
 }
 
 export interface Profile {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,6 +17,7 @@ export interface Mod {
   sourceSection?: string;
   nsfw?: boolean;
   variantLabel?: string;
+  fileDescription?: string;
 }
 
 export interface Profile {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -42,6 +42,8 @@ export interface AppSettings {
   devDeadlockPath: string | null;
   hideNsfwPreviews: boolean;
   hideOutdatedMods: boolean;
+  autoDisableSiblingVariants: boolean;
+  steamLaunchOptions: string;
   activeProfileId: string | null;
   autoSaveProfile: boolean;
   experimentalStats: boolean;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -18,6 +18,7 @@ export interface Mod {
   nsfw?: boolean;
   variantLabel?: string;
   fileDescription?: string;
+  sourceFileName?: string;
 }
 
 export interface Profile {
@@ -51,4 +52,5 @@ export interface AppSettings {
   experimentalStats: boolean;
   experimentalCrosshair: boolean;
   hasCompletedSetup: boolean;
+  ignoredConflicts: string[];
 }


### PR DESCRIPTION
## Summary

Substantial UX pass driven by forum feedback. Headline additions:

- **Steam Launch Options** field on the Autoexec page — surgical byte-level edits to `localconfig.vdf` with backup + atomic rename, fired in the safe window before the Steam launch URL
- **Multi-VPK picker** — replaces the silent "keep first, unlink rest" behavior for multi-file archives. Includes human-readable labels (hero/skybox/map detection) when GameBanana headers are blank
- **Multi-version picker** — quick-download on multi-file mods now opens the details modal instead of guessing the variant
- **Variant grouping on Installed** — multi-variant downloads of the same GB mod collapse into one card with a picker for switch / rename / per-variant delete / disable-group; drag-reorder moves the group as a block
- **Mod Details modal redesign** — single-row header, two-column responsive body, vertical preview stack, click-to-zoom lightbox, blurred backdrop on letterboxed thumbs
- **"Update all" button** on the Installed page header — re-downloads every mod flagged with an available update and restores each one's enabled state when the new install lands
- **Ignore conflicts** — per-card Ignore + "Ignored (N)" panel; pairs persist in app settings
- **"Enable now" affordance** — yellow Enable pill on freshly-downloaded disabled mods, both in the sidebar download toast and the Browse mod-details file row
- **Browse-tab state survives navigation** — search, filters, view, sort, loaded mods, page, and scroll position all restore on return. Fixes a latent bug where saved scrollTop was always 0
- **Search debouncing** (250ms) + FTS5 fallback to substring LIKE when prefix search returns nothing
- **Sibling-variant auto-disable toast** — previously silent on re-download; now toasted with View action and gated behind a setting

Full breakdown in [CHANGELOG.md](CHANGELOG.md).

## Test plan
- [ ] \`pnpm lint\` — clean (3 pre-existing warnings in untouched files only)
- [ ] \`pnpm build\` — main/preload/renderer all build
- [ ] Steam Launch Options: set value, verify \`localconfig.vdf\` gets the surgical insert + \`.grimoire.bak\`; verify warning shown when Steam is running
- [ ] Download a multi-VPK archive — picker appears, selecting a subset works, deselected \`.vpk\`s are not installed
- [ ] Download a multi-version mod via the card's quick action — details modal opens instead of silently picking
- [ ] Install 2+ variants of the same GB mod — Installed page shows one grouped card; click opens picker; switch variant, rename, delete-one, disable-group all work; drag the group
- [ ] Open mod details from Installed picker — sibling variants show Reinstall; active row shows the *Active* badge
- [ ] Browse: search, scroll, switch to Installed, return — state restored
- [ ] Browse: search query 2-char prefix vs partial term — FTS prefix path and LIKE fallback both return results
- [ ] Conflicts page: Ignore a pair, verify it disappears and shows in "Ignored (N)"; Unignore restores it
- [ ] Download a disabled mod — sidebar toast shows *Enable now*; clicking it enables and dismisses the toast
- [ ] With multiple mods carrying the Update badge: header shows *Update all (N)*; clicking opens confirm modal; after confirm, button shows progress and each previously-enabled mod is re-enabled when the run finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)