### PR TITLE
fix(installed): multi-select variant picker (1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented here. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [1.7.1] - 2026-05
+
+### Fixed
+- **Installed-page variant grouping** no longer forces mutual exclusion. Mods that ship multiple complementary VPKs in one archive (e.g. Dallas PAYDAY's model + voice lines, QoL Lock + optional addons) can now have any combination of variants enabled simultaneously. The picker switched from radio buttons to checkboxes and stays open between toggles so users can flip several without re-opening it; the card-level toggle flips the whole mod on or off as a unit
+- **Multi-VPK install picker** now defaults to *all* VPKs checked instead of just the first. Previously this silently dropped complementary content (e.g. installing only the model and forgetting the voice-lines VPK)
+
 ## [1.7.0] - 2026-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/MultiVpkPickerModal.tsx
+++ b/src/components/MultiVpkPickerModal.tsx
@@ -14,19 +14,17 @@ interface Props {
  * kept the alphabetically-first VPK and unlinked the rest — felt like data
  * loss to users. This modal makes the choice explicit.
  *
- * Default selection: only the first VPK is checked, matching the previous
- * implicit behavior. Users who want everything can flip the master toggle.
+ * Default selection: all VPKs are checked. Most multi-VPK archives ship
+ * complementary content (model + voice lines, mod + optional addons) where
+ * users want everything; unchecking unwanted variants is easier than
+ * remembering to check missing content.
  *
  * NOTE: the parent must mount this with a key tied to `data.requestId` so a
  * fresh request resets the selection — we deliberately avoid a syncing
  * useEffect here.
  */
 export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props) {
-    const [selected, setSelected] = useState<Set<string>>(() => {
-        const next = new Set<string>();
-        if (data.vpkFileNames[0]) next.add(data.vpkFileNames[0]);
-        return next;
-    });
+    const [selected, setSelected] = useState<Set<string>>(() => new Set(data.vpkFileNames));
 
     const allSelected = selected.size === data.vpkFileNames.length;
     const toggle = (vpk: string) => {

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -7,10 +7,11 @@ interface Props {
     /** Display name shared by the variants (use primary.name). */
     modName: string;
     variants: Mod[];
-    /** Called when the user picks a different variant. Caller is responsible
-     *  for enabling the target + disabling other variants (mutual exclusion). */
-    onSelect: (target: Mod) => Promise<void> | void;
-    /** Called when the user disables the currently-active variant. */
+    /** Toggle a single variant's enabled state. Variants are independent —
+     *  multiple can be active at once (e.g. a model VPK + its voice-lines
+     *  addon from the same mod page). */
+    onToggle: (target: Mod) => Promise<void> | void;
+    /** Called when the user disables every currently-enabled variant. */
     onDisableAll: () => Promise<void> | void;
     /** Called when the user requests deletion of a single variant. */
     onDeleteVariant: (variant: Mod) => Promise<void> | void;
@@ -33,9 +34,12 @@ function formatBytes(bytes: number): string {
 
 /**
  * Variant picker for grouped mods. Shown when the user clicks an Installed
- * card that represents multiple VPKs sharing a GameBanana mod id (e.g. five
- * presets of "Scientific Half Life as Rem"). One variant can be active at a
- * time; picking a new one disables the previous.
+ * card that represents multiple VPKs sharing a GameBanana mod id. Variants
+ * are independent — the user can enable any combination. Examples:
+ *   • Dallas PAYDAY ships a model VPK and a voice-lines VPK from one archive;
+ *     users want both on.
+ *   • A mod page with separate red/blue uploads: enable both if they don't
+ *     conflict, or just one if they do.
  *
  * Per-variant Delete lives here (rather than the card) so the card-level
  * Delete can keep its simple "remove this whole mod" meaning without
@@ -44,7 +48,7 @@ function formatBytes(bytes: number): string {
 export default function VariantPickerModal({
     modName,
     variants,
-    onSelect,
+    onToggle,
     onDisableAll,
     onDeleteVariant,
     onRenameVariant,
@@ -68,7 +72,7 @@ export default function VariantPickerModal({
         }
     }, [editingId]);
 
-    const active = variants.find((v) => v.enabled) ?? null;
+    const anyActive = variants.some((v) => v.enabled);
 
     const startRename = (v: Mod) => {
         setEditing({ id: v.id, draft: v.variantLabel ?? '' });
@@ -95,20 +99,18 @@ export default function VariantPickerModal({
 
     const pick = async (target: Mod) => {
         if (pending) return;
-        // Already active → treat as a no-op (don't toggle off; that's what
-        // the "Disable" button is for).
-        if (active?.id === target.id) return;
+        // Toggle this one variant's enabled state. Don't close the modal —
+        // users typically want to flip several before stepping back out.
         setPending(target.id);
         try {
-            await onSelect(target);
-            onClose();
+            await onToggle(target);
         } finally {
             setPending(null);
         }
     };
 
     const disableActive = async () => {
-        if (pending || !active) return;
+        if (pending || !anyActive) return;
         setPending('__disable__');
         try {
             await onDisableAll();
@@ -146,7 +148,7 @@ export default function VariantPickerModal({
                             {modName}
                         </h3>
                         <p className="text-xs text-text-secondary mt-0.5">
-                            {variants.length} variants — pick which one to enable
+                            {variants.length} variants — toggle any combination on or off
                         </p>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
@@ -172,7 +174,7 @@ export default function VariantPickerModal({
 
                 <div className="p-3 max-h-[60vh] overflow-y-auto space-y-1.5">
                     {variants.map((v) => {
-                        const isActive = active?.id === v.id;
+                        const isActive = v.enabled;
                         const isPending = pending === v.id;
                         const isDeletePending = pending === `delete:${v.id}`;
                         const isEditing = editing?.id === v.id;
@@ -207,11 +209,12 @@ export default function VariantPickerModal({
                                     onClick={() => pick(v)}
                                     disabled={!!pending || isEditing}
                                     className="flex-1 min-w-0 text-left cursor-pointer disabled:cursor-default disabled:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
-                                    title={isActive ? 'Currently active' : 'Switch to this variant'}
+                                    title={isActive ? 'Disable this variant' : 'Enable this variant'}
+                                    aria-pressed={isActive}
                                 >
                                     <div className="flex items-center gap-3">
                                         <span
-                                            className={`flex-shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+                                            className={`flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center ${
                                                 isActive ? 'border-accent bg-accent' : 'border-border bg-bg-secondary'
                                             }`}
                                             aria-hidden
@@ -327,7 +330,7 @@ export default function VariantPickerModal({
                                     </>
                                 )}
                                 {isPending && (
-                                    <span className="text-xs text-accent">Switching…</span>
+                                    <span className="text-xs text-accent">Toggling…</span>
                                 )}
                             </div>
                         );
@@ -335,7 +338,7 @@ export default function VariantPickerModal({
                 </div>
 
                 <div className="flex items-center justify-between gap-3 p-5 border-t border-border">
-                    {active ? (
+                    {anyActive ? (
                         <Button
                             variant="secondary"
                             size="sm"
@@ -344,12 +347,12 @@ export default function VariantPickerModal({
                             disabled={!!pending}
                             isLoading={pending === '__disable__'}
                         >
-                            Disable group
+                            Disable all
                         </Button>
                     ) : (
                         <span className="text-xs text-text-secondary inline-flex items-center gap-1.5">
                             <Power className="w-3 h-3" />
-                            No variant active — pick one to enable
+                            No variants active — toggle any to enable
                         </span>
                     )}
                     <Button variant="secondary" size="sm" onClick={onClose}>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -57,11 +57,15 @@ type ModEntry =
       kind: 'group';
       gameBananaId: number;
       variants: Mod[];
-      /** Currently-enabled variant in the group. Null when the whole group
-       *  is disabled. Mutual exclusion: only one variant is active at a time. */
+      /** First enabled variant in priority order, or null when every variant
+       *  is disabled. Used as a "group is on" flag and as the visual primary
+       *  when something's enabled. Variants are independent — multiple can be
+       *  enabled at once (e.g. a model VPK and its voice-lines VPK from one
+       *  archive). */
       active: Mod | null;
-      /** Mod we render visuals from (thumbnail, name, category). The active
-       *  variant when one's enabled, else the first variant by filename. */
+      /** Mod we render visuals from (thumbnail, name, category). The first
+       *  enabled variant when any is enabled, else the first variant by
+       *  filename. */
       primary: Mod;
       /** Sum of variant sizes — shown as the card's "size" field. */
       totalSize: number;
@@ -342,21 +346,14 @@ export default function Installed() {
   };
 
   /**
-   * Switch the active variant in a group. Disables every other variant in
-   * the group first (sequential, so the priority bookkeeping stays sane),
-   * then enables the target. If the target is already enabled this is a
-   * no-op. Mutual exclusion is enforced here rather than in the store so the
-   * existing toggleMod action stays single-mod.
+   * Flip a single variant's enabled state. Variants are independent — a
+   * mod's model VPK and its voice-lines VPK (same archive) or its red and
+   * blue uploads (different archives on the same mod page) can each be on
+   * or off without affecting the others. Sequential just because the store
+   * action is single-mod.
    */
-  const setActiveVariant = async (group: Extract<ModEntry, { kind: 'group' }>, target: Mod) => {
-    for (const v of group.variants) {
-      if (v.id !== target.id && v.enabled) {
-        await toggleMod(v.id);
-      }
-    }
-    if (!target.enabled) {
-      await toggleMod(target.id);
-    }
+  const toggleVariant = async (target: Mod) => {
+    await toggleMod(target.id);
   };
 
   const disableEntireGroup = async (group: Extract<ModEntry, { kind: 'group' }>) => {
@@ -367,14 +364,15 @@ export default function Installed() {
     }
   };
 
-  /** Top-level toggle on a grouped card. If anything's active, disable it;
-   *  otherwise enable the first variant by filename order (which becomes
-   *  the primary when nothing else is active). */
+  /** Top-level toggle on a grouped card. If any variant is active, disable
+   *  every active one ("turn the mod off"). Otherwise enable every variant
+   *  ("turn the mod on") — the user can open the picker to be selective. */
   const handleGroupToggle = async (group: Extract<ModEntry, { kind: 'group' }>) => {
-    if (group.active) {
-      await toggleMod(group.active.id);
-    } else if (group.variants.length > 0) {
-      await toggleMod(group.variants[0].id);
+    const anyActive = group.variants.some((v) => v.enabled);
+    for (const v of group.variants) {
+      if (anyActive ? v.enabled : !v.enabled) {
+        await toggleMod(v.id);
+      }
     }
   };
 
@@ -618,12 +616,12 @@ export default function Installed() {
    * Group cards:
    *   - Drag-reorder is disabled (the underlying VPKs span multiple priority
    *     slots; meaningful group-level reorder needs more design).
-   *   - Toggle hits the active variant (or enables the first variant when
-   *     the group is fully disabled).
+   *   - Toggle flips every variant on or off as a unit. The picker modal is
+   *     where the user enables/disables individual variants.
    *   - Delete asks the user to confirm removing every variant.
    *   - Card body click opens the variant picker modal.
-   *   - Conflicts shown are the union of conflicts on currently-enabled
-   *     variants (typically just one under mutual exclusion).
+   *   - Conflicts shown are the union of conflicts on every currently-enabled
+   *     variant.
    */
   const renderEntryCard = (entry: ModEntry, section: 'enabled' | 'disabled') => {
     if (entry.kind === 'single') {
@@ -739,18 +737,18 @@ export default function Installed() {
         onDragEnd={resetDragState}
         group={{
           variantCount: entry.variants.length,
-          // Display the active variant's user-given label when set, else
-          // the author's GameBanana file header, else the original GB
-          // filename stem (covers mods whose author left descriptions
-          // blank — e.g. "galaxy_rem_gold"), else the raw VPK filename.
-          // Lets the user see "Red preset" / "Gold w/ alt candle" on the
-          // card instead of "pak06_dir.vpk".
-          activeFileName: entry.active
-            ? (entry.active.variantLabel ??
-               entry.active.fileDescription ??
-               entry.active.sourceFileName ??
-               entry.active.fileName)
-            : null,
+          // Card badge label. Only meaningful when exactly one variant is
+          // active — then we show the variant's user-given label / GB file
+          // header / filename stem / raw VPK filename (precedence order).
+          // When 0 or 2+ are active, the variant-count pill + the card's
+          // on/off toggle convey enough at a glance; details live in the
+          // picker. Avoids redundancy with the meta-row "N variants" pill.
+          activeFileName: (() => {
+            const enabled = entry.variants.filter((v) => v.enabled);
+            if (enabled.length !== 1) return null;
+            const v = enabled[0];
+            return v.variantLabel ?? v.fileDescription ?? v.sourceFileName ?? v.fileName;
+          })(),
           onOpenPicker: () => setPickerGroupId(entry.gameBananaId),
         }}
       />
@@ -1008,7 +1006,7 @@ export default function Installed() {
           <VariantPickerModal
             modName={liveEntry.primary.name}
             variants={liveEntry.variants}
-            onSelect={(target) => setActiveVariant(liveEntry, target)}
+            onToggle={(target) => toggleVariant(target)}
             onDisableAll={() => disableEntireGroup(liveEntry)}
             onDeleteVariant={(variant) => deleteMod(variant.id)}
             onRenameVariant={(variant, label) => setVariantLabel(variant.id, label)}
@@ -1172,9 +1170,11 @@ interface ModCardProps {
    *  count and routes the card-body click to the picker modal. */
   group?: {
     variantCount: number;
-    /** Filename of the currently-active variant, or null if the group is
-     *  fully disabled. Shown in small text so the user can tell at a glance
-     *  which preset is live. */
+    /** Display label for the enabled variant when exactly one is on (and
+     *  null otherwise — for 0 active or 2+ active, the card's toggle state
+     *  plus the variant-count pill convey enough; details live in the
+     *  picker). Shown in small text so the user can tell at a glance which
+     *  preset is live in the common single-active case. */
     activeFileName: string | null;
     onOpenPicker: () => void;
   };
@@ -1328,7 +1328,7 @@ function ModCard({
                     tone="info"
                     variant="overlay"
                     icon={Layers}
-                    title={`Active variant: ${group.activeFileName} — click card to switch`}
+                    title={`${group.activeFileName} — click card to manage variants`}
                     className="max-w-full"
                   >
                     <span className="truncate">{group.activeFileName}</span>


### PR DESCRIPTION
## Summary
- **Variant picker is multi-select now.** 1.7's grouping treated sibling VPKs as mutually exclusive (radio picker, card toggle enables one). Two forum users reported that mods bundling complementary VPKs in one archive — Dallas PAYDAY (model + voice lines), QoL Lock (mod + optional addons) — became un-co-installable. Radio circles → checkboxes; rows toggle independently; modal stays open between toggles. Card-level toggle now flips every variant on or off as a unit.
- **Install-time multi-VPK picker** defaults to *all* VPKs checked instead of just the first. Most multi-VPK archives ship complementary content rather than alternatives, so unchecking unwanted ones is easier than remembering to check missing pieces.
- Stale "mutex" doc strings in `Installed.tsx` updated to describe the new semantics. No behavior change there — just keeping the source readable.

No backend changes. The download-time `autoDisableSiblingVariants` flow only fires for cross-archive variants (different `gameBananaFileId`s), so same-archive siblings were never affected by it — the regression lived entirely in the renderer's grouping/picker logic.

## Test plan
- [ ] Install a mod with multiple complementary VPKs (Dallas PAYDAY or similar) → both VPKs land enabled by default from the install picker
- [ ] Open the card's variant picker → both VPKs show with checkboxes, both checked
- [ ] Toggle one off via the picker → modal stays open, other variant stays on
- [ ] Card toggle off → both variants disable; card toggle on → both re-enable
- [ ] Install a mod with true mutex-style variants (red preset / blue preset uploaded separately) → both can still be enabled together via the picker if user wants; download-time auto-disable still disables the older one on re-download
- [ ] Active-variant badge on the thumbnail only shows when exactly one variant is enabled (not duplicated when 2+ are on)
- [ ] Single-VPK mods unaffected; conflict detection still aggregates across enabled variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)