### PR TITLE
feat(installed/conflicts): variant reorder + bulk Ignore-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [1.7.2] - 2026-05
+
+### Added
+- **Variant reorder inside the picker.** Now that variants can be co-loaded (1.7.1 multi-select), the relative load order between siblings matters — later loads win overlapping files. Picker rows now expose both ▲/▼ chevron buttons and full drag-and-drop (GripVertical handle), wired through the same `reorderMods` pipeline the Installed page already uses. Cross-section moves are blocked in both UIs so reordering can't silently flip a variant's on/off status
+- **"Ignore all" bulk action** on the Conflicts page header. Visible whenever active conflicts exist; click → confirm dialog ("Ignore all 8 conflicts?") → moves every active pair to the *Ignored* section in one batch. Individual *Unignore* still restores pairs one at a time
+
+### Fixed
+- **Sidebar conflict-badge no longer goes stale** after Ignore / Unignore. The badge useEffect only re-ran when the mods list changed, which doesn't happen for ignore-conflict (it just persists settings). Page now dispatches a `grimoire:conflicts-changed` window event so the Sidebar re-fetches the count immediately instead of waiting for an app restart
+
+### Changed
+- Dropped the redundant *Active* text badge on variant picker rows — the accent-colored outline plus the filled checkbox already convey the same state
+- The group-card drag tooltip now matches the actual behavior; group cards have been draggable as a contiguous block since the 1.7 variant-grouping feature, but a stale comment had claimed otherwise
+
 ## [1.7.1] - 2026-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -78,21 +78,28 @@ export default function Sidebar() {
   // old 10s setInterval re-ran a full VPK-directory parse for every enabled
   // mod, and in dev that repeatedly-opening-and-closing of file handles was
   // triggering a Windows system sound every tick.
+  //
+  // Also listens for `grimoire:conflicts-changed` (dispatched by the Conflicts
+  // page after ignore/unignore). Those actions don't touch the mods list, so
+  // without this the badge stayed stuck at the pre-ignore count until restart.
+  const refreshConflictCount = useCallback(async () => {
+    try {
+      const conflicts = await getConflicts();
+      setConflictCount(conflicts.length);
+    } catch {
+      setConflictCount(0);
+    }
+  }, []);
+
   useEffect(() => {
-    let cancelled = false;
-    const loadConflicts = async () => {
-      try {
-        const conflicts = await getConflicts();
-        if (!cancelled) setConflictCount(conflicts.length);
-      } catch {
-        if (!cancelled) setConflictCount(0);
-      }
-    };
-    loadConflicts();
-    return () => {
-      cancelled = true;
-    };
-  }, [mods]);
+    void refreshConflictCount();
+  }, [mods, refreshConflictCount]);
+
+  useEffect(() => {
+    const handler = () => void refreshConflictCount();
+    window.addEventListener('grimoire:conflicts-changed', handler);
+    return () => window.removeEventListener('grimoire:conflicts-changed', handler);
+  }, [refreshConflictCount]);
 
   useEffect(() => {
     refreshStashStatus();

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Check, Trash2, Power, PowerOff, Info, Pencil, ChevronUp, ChevronDown } from 'lucide-react';
+import { X, Check, Trash2, Power, PowerOff, Info, Pencil, ChevronUp, ChevronDown, GripVertical } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import { Button } from './common/ui';
+
+type DropPosition = 'before' | 'after';
 
 interface Props {
     /** Display name shared by the variants (use primary.name). */
@@ -16,6 +18,11 @@ interface Props {
      *  for refusing cross-section swaps; this picker just disables the
      *  button when the neighbor isn't in the same enabled state. */
     onMoveVariant: (target: Mod, direction: 'up' | 'down') => Promise<void> | void;
+    /** Drag-drop reorder. Drops source before or after neighbor in load
+     *  order. Same cross-section constraint as onMoveVariant — the picker
+     *  refuses to set dropTargetId when source and target are in different
+     *  enabled states, so this handler can assume same-section. */
+    onReorderVariantTo: (source: Mod, neighbor: Mod, position: DropPosition) => Promise<void> | void;
     /** Called when the user disables every currently-enabled variant. */
     onDisableAll: () => Promise<void> | void;
     /** Called when the user requests deletion of a single variant. */
@@ -55,6 +62,7 @@ export default function VariantPickerModal({
     variants,
     onToggle,
     onMoveVariant,
+    onReorderVariantTo,
     onDisableAll,
     onDeleteVariant,
     onRenameVariant,
@@ -66,6 +74,21 @@ export default function VariantPickerModal({
     // working draft text; null when no row is in edit mode.
     const [editing, setEditing] = useState<{ id: string; draft: string } | null>(null);
     const editInputRef = useRef<HTMLInputElement | null>(null);
+    // Drag-and-drop state. dropPosition is computed from cursor Y vs row
+    // midpoint; the visual indicator (top/bottom border on the target row)
+    // matches the position the source will land in. handleDownRef gates the
+    // drag to the grip icon so clicks on toggle/rename/delete/chevrons don't
+    // accidentally start one.
+    const [draggingId, setDraggingId] = useState<string | null>(null);
+    const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+    const [dropPosition, setDropPosition] = useState<DropPosition | null>(null);
+    const handleDownRef = useRef(false);
+    const resetDrag = () => {
+        setDraggingId(null);
+        setDropTargetId(null);
+        setDropPosition(null);
+        handleDownRef.current = false;
+    };
 
     // Focus + select when the editing target changes (entering edit mode
     // for a new row). Driven by the id alone so we don't re-focus on every
@@ -208,6 +231,8 @@ export default function VariantPickerModal({
                         const showReorder = variants.length > 1;
                         const isMoveUpPending = pending === `move:${v.id}:up`;
                         const isMoveDownPending = pending === `move:${v.id}:down`;
+                        const isDragging = draggingId === v.id;
+                        const isDropTarget = dropTargetId === v.id;
                         // Title precedence: user rename wins, else the
                         // GameBanana file header the author set (e.g. "Gold
                         // w/ alt candle"), else the original GB filename
@@ -227,12 +252,85 @@ export default function VariantPickerModal({
                         return (
                             <div
                                 key={v.id}
-                                className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                                draggable={showReorder && !isEditing && !pending}
+                                onDragStart={(e) => {
+                                    if (!handleDownRef.current) {
+                                        e.preventDefault();
+                                        return;
+                                    }
+                                    handleDownRef.current = false;
+                                    e.dataTransfer.effectAllowed = 'move';
+                                    try {
+                                        e.dataTransfer.setData('text/plain', v.id);
+                                    } catch {
+                                        // Firefox is picky about setData; ignore failures.
+                                    }
+                                    setDraggingId(v.id);
+                                }}
+                                onDragOver={(e) => {
+                                    if (!draggingId || draggingId === v.id) return;
+                                    const source = variants.find((x) => x.id === draggingId);
+                                    if (!source || source.enabled !== v.enabled) return;
+                                    e.preventDefault();
+                                    e.dataTransfer.dropEffect = 'move';
+                                    const rect = e.currentTarget.getBoundingClientRect();
+                                    const midY = rect.top + rect.height / 2;
+                                    const pos: DropPosition = e.clientY < midY ? 'before' : 'after';
+                                    setDropTargetId(v.id);
+                                    setDropPosition(pos);
+                                }}
+                                onDragLeave={(e) => {
+                                    // Children fire dragleave on the row; only clear when the
+                                    // cursor actually exits the row's bounding box.
+                                    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+                                    if (dropTargetId === v.id) {
+                                        setDropTargetId(null);
+                                        setDropPosition(null);
+                                    }
+                                }}
+                                onDrop={async (e) => {
+                                    e.preventDefault();
+                                    const sourceId = draggingId;
+                                    const pos = dropPosition;
+                                    resetDrag();
+                                    if (!sourceId || sourceId === v.id || !pos) return;
+                                    const source = variants.find((x) => x.id === sourceId);
+                                    if (!source || source.enabled !== v.enabled) return;
+                                    setPending(`move:${sourceId}:drag`);
+                                    try {
+                                        await onReorderVariantTo(source, v, pos);
+                                    } finally {
+                                        setPending(null);
+                                    }
+                                }}
+                                onDragEnd={resetDrag}
+                                className={`relative flex items-center gap-3 p-3 rounded-lg border transition-colors ${
                                     isActive
                                         ? 'border-accent/40 bg-accent/5'
                                         : 'border-border bg-bg-tertiary hover:bg-white/5'
-                                }`}
+                                } ${isDragging ? 'opacity-50' : ''}`}
                             >
+                                {isDropTarget && dropPosition && (
+                                    <span
+                                        aria-hidden
+                                        className={`absolute left-2 right-2 ${dropPosition === 'before' ? '-top-[3px]' : '-bottom-[3px]'} h-[3px] bg-accent pointer-events-none rounded-full`}
+                                    />
+                                )}
+                                {showReorder && (
+                                    <div
+                                        onMouseDown={() => {
+                                            handleDownRef.current = true;
+                                        }}
+                                        onMouseUp={() => {
+                                            handleDownRef.current = false;
+                                        }}
+                                        className="flex-shrink-0 p-1 text-text-secondary hover:text-text-primary cursor-grab active:cursor-grabbing select-none"
+                                        title="Drag to reorder"
+                                        aria-label="Drag to reorder"
+                                    >
+                                        <GripVertical className="w-4 h-4" />
+                                    </div>
+                                )}
                                 <button
                                     type="button"
                                     onClick={() => pick(v)}

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -273,19 +273,12 @@ export default function VariantPickerModal({
                                                     className="w-full bg-bg-secondary border border-accent/50 rounded px-2 py-1 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
                                                 />
                                             ) : (
-                                                <div className="flex items-center gap-2 min-w-0">
-                                                    <span
-                                                        className={`truncate ${showSecondaryFileName ? 'text-sm text-text-primary font-medium' : 'font-mono text-sm text-text-primary'}`}
-                                                        title={primaryTitle}
-                                                    >
-                                                        {primaryTitle}
-                                                    </span>
-                                                    {isActive && (
-                                                        <span className="text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5 flex-shrink-0">
-                                                            Active
-                                                        </span>
-                                                    )}
-                                                </div>
+                                                <span
+                                                    className={`block truncate ${showSecondaryFileName ? 'text-sm text-text-primary font-medium' : 'font-mono text-sm text-text-primary'}`}
+                                                    title={primaryTitle}
+                                                >
+                                                    {primaryTitle}
+                                                </span>
                                             )}
                                             <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5 min-w-0">
                                                 <span className="flex-shrink-0">{formatBytes(v.size)}</span>

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Check, Trash2, Power, PowerOff, Info, Pencil } from 'lucide-react';
+import { X, Check, Trash2, Power, PowerOff, Info, Pencil, ChevronUp, ChevronDown } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import { Button } from './common/ui';
 
@@ -11,6 +11,11 @@ interface Props {
      *  multiple can be active at once (e.g. a model VPK + its voice-lines
      *  addon from the same mod page). */
     onToggle: (target: Mod) => Promise<void> | void;
+    /** Swap a variant with its picker-neighbor (up = earlier load slot,
+     *  down = later, wins overlapping file conflicts). Caller is responsible
+     *  for refusing cross-section swaps; this picker just disables the
+     *  button when the neighbor isn't in the same enabled state. */
+    onMoveVariant: (target: Mod, direction: 'up' | 'down') => Promise<void> | void;
     /** Called when the user disables every currently-enabled variant. */
     onDisableAll: () => Promise<void> | void;
     /** Called when the user requests deletion of a single variant. */
@@ -49,6 +54,7 @@ export default function VariantPickerModal({
     modName,
     variants,
     onToggle,
+    onMoveVariant,
     onDisableAll,
     onDeleteVariant,
     onRenameVariant,
@@ -130,6 +136,16 @@ export default function VariantPickerModal({
         }
     };
 
+    const move = async (variant: Mod, direction: 'up' | 'down') => {
+        if (pending) return;
+        setPending(`move:${variant.id}:${direction}`);
+        try {
+            await onMoveVariant(variant, direction);
+        } finally {
+            setPending(null);
+        }
+    };
+
     return (
         <div
             className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
@@ -173,12 +189,25 @@ export default function VariantPickerModal({
                 </div>
 
                 <div className="p-3 max-h-[60vh] overflow-y-auto space-y-1.5">
-                    {variants.map((v) => {
+                    {variants.map((v, idx) => {
                         const isActive = v.enabled;
                         const isPending = pending === v.id;
                         const isDeletePending = pending === `delete:${v.id}`;
                         const isEditing = editing?.id === v.id;
                         const isRenamePending = pending === `rename:${v.id}`;
+                        // Reorder buttons swap with the picker-neighbor in load
+                        // order. Allowed only when the neighbor shares the
+                        // variant's enabled state — cross-section swaps would
+                        // flip a variant's on/off status implicitly. Hide the
+                        // controls entirely when the group has just one
+                        // variant (nothing to swap with).
+                        const prev = idx > 0 ? variants[idx - 1] : null;
+                        const nextSibling = idx < variants.length - 1 ? variants[idx + 1] : null;
+                        const canMoveUp = !!prev && prev.enabled === v.enabled;
+                        const canMoveDown = !!nextSibling && nextSibling.enabled === v.enabled;
+                        const showReorder = variants.length > 1;
+                        const isMoveUpPending = pending === `move:${v.id}:up`;
+                        const isMoveDownPending = pending === `move:${v.id}:down`;
                         // Title precedence: user rename wins, else the
                         // GameBanana file header the author set (e.g. "Gold
                         // w/ alt candle"), else the original GB filename
@@ -303,6 +332,50 @@ export default function VariantPickerModal({
                                     </div>
                                 ) : (
                                     <>
+                                        {showReorder && (
+                                            <div className="flex flex-col gap-0.5 flex-shrink-0">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => move(v, 'up')}
+                                                    disabled={!!pending || !canMoveUp}
+                                                    className="p-0.5 text-text-secondary hover:text-accent hover:bg-accent/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+                                                    title={
+                                                        canMoveUp
+                                                            ? 'Move up (loads earlier — overlapping files lose to later loads)'
+                                                            : idx === 0
+                                                                ? 'Already first in load order'
+                                                                : 'Adjacent variant is in a different section'
+                                                    }
+                                                    aria-label="Move variant up in load order"
+                                                >
+                                                    {isMoveUpPending ? (
+                                                        <span className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                                    ) : (
+                                                        <ChevronUp className="w-3.5 h-3.5" />
+                                                    )}
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => move(v, 'down')}
+                                                    disabled={!!pending || !canMoveDown}
+                                                    className="p-0.5 text-text-secondary hover:text-accent hover:bg-accent/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+                                                    title={
+                                                        canMoveDown
+                                                            ? 'Move down (loads later — wins overlapping files)'
+                                                            : idx === variants.length - 1
+                                                                ? 'Already last in load order'
+                                                                : 'Adjacent variant is in a different section'
+                                                    }
+                                                    aria-label="Move variant down in load order"
+                                                >
+                                                    {isMoveDownPending ? (
+                                                        <span className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                                    ) : (
+                                                        <ChevronDown className="w-3.5 h-3.5" />
+                                                    )}
+                                                </button>
+                                            </div>
+                                        )}
                                         <button
                                             type="button"
                                             onClick={() => startRename(v)}

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -63,6 +63,11 @@ export default function Conflicts() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
+  // Bulk-ignore confirmation. `ignoringAll` blocks the modal action while
+  // the sequential ignoreConflict calls run so the user can't cancel
+  // mid-iteration and leave the page in a partial state.
+  const [ignoreAllConfirmOpen, setIgnoreAllConfirmOpen] = useState(false);
+  const [ignoringAll, setIgnoringAll] = useState(false);
   const [disabling, setDisabling] = useState(false);
   // Tracks which pair the user is currently toggling so we can disable just
   // that row's buttons during the round-trip without freezing the whole page.
@@ -117,6 +122,47 @@ export default function Conflicts() {
       setError(String(err));
     } finally {
       setPendingPair(null);
+    }
+  };
+
+  /**
+   * Bulk-ignore every currently active conflict pair. Sequential because the
+   * backend persists ignored pairs into app settings — parallel calls would
+   * race on the same settings object. Each call returns the full ignored
+   * list, so we take the last successful result and seed `ignored` once
+   * instead of N times. On any failure we re-fetch from the source of
+   * truth to avoid drifting; one toast captures the failure count rather
+   * than spamming the error banner per pair.
+   */
+  const handleIgnoreAll = async () => {
+    if (conflicts.length === 0) return;
+    setIgnoringAll(true);
+    const pairs = conflicts.slice();
+    let lastIgnored: string[] | null = null;
+    const failures: string[] = [];
+    try {
+      for (const c of pairs) {
+        try {
+          lastIgnored = await ignoreConflict(c.modA, c.modB);
+        } catch (err) {
+          failures.push(`${c.modA} ↔ ${c.modB}: ${String(err)}`);
+        }
+      }
+      if (lastIgnored) setIgnored(new Set(lastIgnored));
+      if (failures.length === 0) {
+        setConflicts([]);
+      } else {
+        // Partial failure — backend is the source of truth, refetch.
+        await loadConflicts();
+        setError(`Failed to ignore ${failures.length} pair${failures.length === 1 ? '' : 's'}. See console for details.`);
+        console.warn('[Conflicts] ignore-all failures:', failures);
+      }
+      // Single event after the whole batch — the Sidebar badge re-fetches
+      // once instead of N times during the loop.
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } finally {
+      setIgnoringAll(false);
+      setIgnoreAllConfirmOpen(false);
     }
   };
 
@@ -206,7 +252,19 @@ export default function Conflicts() {
             : 'Resolve conflicts between installed mods'
         }
         action={
-          <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
+          <div className="flex items-center gap-2">
+            {conflicts.length > 0 && (
+              <Button
+                variant="secondary"
+                onClick={() => setIgnoreAllConfirmOpen(true)}
+                icon={EyeOff}
+                title="Move every active conflict pair to the Ignored section. Reversible per-pair via Unignore."
+              >
+                Ignore all
+              </Button>
+            )}
+            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
+          </div>
         }
         className="mb-6"
       />
@@ -395,6 +453,24 @@ export default function Conflicts() {
         }
         confirmLabel={disabling ? 'Disabling…' : 'Disable'}
         variant="danger"
+      />
+
+      <ConfirmModal
+        isOpen={ignoreAllConfirmOpen}
+        onCancel={() => !ignoringAll && setIgnoreAllConfirmOpen(false)}
+        onConfirm={handleIgnoreAll}
+        title={`Ignore all ${conflicts.length} conflict${conflicts.length === 1 ? '' : 's'}?`}
+        message={
+          <>
+            <p className="mb-2">
+              Every currently active conflict pair will move to the <span className="text-text-primary font-medium">Ignored</span> section below.
+            </p>
+            <p className="text-xs text-text-tertiary">
+              Reversible — you can restore any pair individually with <em>Unignore</em>.
+            </p>
+          </>
+        }
+        confirmLabel={ignoringAll ? 'Ignoring…' : `Ignore ${conflicts.length}`}
       />
     </div>
   );

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -109,6 +109,10 @@ export default function Conflicts() {
       setConflicts((prev) =>
         prev.filter((c) => conflictPairKey(c.modA, c.modB) !== key)
       );
+      // Sidebar's badge count is derived from getConflicts() and only refreshes
+      // on mods-list changes. Ignore/unignore don't touch mods, so notify the
+      // Sidebar explicitly — otherwise the badge stays stale until restart.
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
     } catch (err) {
       setError(String(err));
     } finally {
@@ -126,6 +130,7 @@ export default function Conflicts() {
       // Re-detect so the unignored pair shows back up if still conflicting.
       const fresh = await getConflicts();
       setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
     } catch (err) {
       setError(String(err));
     } finally {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -377,19 +377,52 @@ export default function Installed() {
   };
 
   /**
-   * Swap a variant with its picker-neighbor in load order. The picker shows
-   * a group's variants sorted by priority, so "up" = lower priority slot =
-   * loads earlier, "down" = higher slot = loads later (and wins overlapping
-   * file conflicts). Only allowed when the neighbor shares the variant's
-   * enabled state: cross-section swaps would implicitly flip a variant's
-   * on/off status, which the user didn't ask for. The picker disables the
-   * button in those cases.
+   * Reorder a variant relative to one of its picker-siblings. Used by both
+   * the chevron up/down buttons and the picker's drag-and-drop. Returns
+   * early when the neighbor lives in a different section — cross-section
+   * moves would silently flip a variant's on/off status, which the picker
+   * UI explicitly blocks.
    *
-   * Implementation: find the variant and its neighbor inside the same
-   * section list (enabledMods or disabledMods), swap their indices, then
-   * pass the full reordered filename list to reorderMods. The backend
-   * renumbers densely 1..N within each section, so the swap manifests as a
-   * pak##_ filename rename on disk.
+   * The picker shows a group's variants sorted by priority, so the
+   * before/after semantics match what the user sees: drop "before" puts
+   * the source at the neighbor's slot (loads earlier); drop "after" puts
+   * it just past the neighbor (loads later, wins overlapping files).
+   *
+   * Implementation: splice the source out of its section list, re-find the
+   * neighbor's index (it may have shifted when source was removed), splice
+   * the source back in before/after the neighbor, then pass the full
+   * filename list to reorderMods. The backend renumbers densely 1..N
+   * inside each section, so the index changes manifest as pak##_ renames
+   * on disk.
+   */
+  const reorderVariantTo = async (
+    source: Mod,
+    neighbor: Mod,
+    position: DropPosition
+  ) => {
+    if (source.id === neighbor.id) return;
+    if (source.enabled !== neighbor.enabled) return;
+
+    const section = source.enabled ? enabledMods : disabledMods;
+    const next = section.slice();
+    const srcIdx = next.findIndex((m) => m.id === source.id);
+    if (srcIdx === -1) return;
+    next.splice(srcIdx, 1);
+    const neighborIdx = next.findIndex((m) => m.id === neighbor.id);
+    if (neighborIdx === -1) return;
+    const insertAt = position === 'before' ? neighborIdx : neighborIdx + 1;
+    next.splice(insertAt, 0, source);
+
+    const full = source.enabled
+      ? [...next, ...disabledMods]
+      : [...enabledMods, ...next];
+    await reorderMods(full.map((m) => m.fileName));
+  };
+
+  /**
+   * Convenience wrapper for the chevron buttons in the variant picker.
+   * "Up" / "down" map to swapping with the picker-neighbor in the obvious
+   * direction; reorderVariantTo handles the section-safety check.
    */
   const moveVariant = async (
     group: Extract<ModEntry, { kind: 'group' }>,
@@ -401,18 +434,7 @@ export default function Installed() {
     const neighborIdx = direction === 'up' ? idxInPicker - 1 : idxInPicker + 1;
     if (neighborIdx < 0 || neighborIdx >= group.variants.length) return;
     const neighbor = group.variants[neighborIdx];
-    if (neighbor.enabled !== target.enabled) return;
-
-    const section = target.enabled ? enabledMods : disabledMods;
-    const sectionNext = section.slice();
-    const a = sectionNext.findIndex((m) => m.id === target.id);
-    const b = sectionNext.findIndex((m) => m.id === neighbor.id);
-    if (a === -1 || b === -1) return;
-    [sectionNext[a], sectionNext[b]] = [sectionNext[b], sectionNext[a]];
-    const next = target.enabled
-      ? [...sectionNext, ...disabledMods]
-      : [...enabledMods, ...sectionNext];
-    await reorderMods(next.map((m) => m.fileName));
+    await reorderVariantTo(target, neighbor, direction === 'up' ? 'before' : 'after');
   };
 
   // Auto-scroll the main content container while drag-reordering. Native HTML
@@ -1050,6 +1072,9 @@ export default function Installed() {
             variants={liveEntry.variants}
             onToggle={(target) => toggleVariant(target)}
             onMoveVariant={(target, direction) => moveVariant(liveEntry, target, direction)}
+            onReorderVariantTo={(source, neighbor, position) =>
+              reorderVariantTo(source, neighbor, position)
+            }
             onDisableAll={() => disableEntireGroup(liveEntry)}
             onDeleteVariant={(variant) => deleteMod(variant.id)}
             onRenameVariant={(variant, label) => setVariantLabel(variant.id, label)}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -376,6 +376,45 @@ export default function Installed() {
     }
   };
 
+  /**
+   * Swap a variant with its picker-neighbor in load order. The picker shows
+   * a group's variants sorted by priority, so "up" = lower priority slot =
+   * loads earlier, "down" = higher slot = loads later (and wins overlapping
+   * file conflicts). Only allowed when the neighbor shares the variant's
+   * enabled state: cross-section swaps would implicitly flip a variant's
+   * on/off status, which the user didn't ask for. The picker disables the
+   * button in those cases.
+   *
+   * Implementation: find the variant and its neighbor inside the same
+   * section list (enabledMods or disabledMods), swap their indices, then
+   * pass the full reordered filename list to reorderMods. The backend
+   * renumbers densely 1..N within each section, so the swap manifests as a
+   * pak##_ filename rename on disk.
+   */
+  const moveVariant = async (
+    group: Extract<ModEntry, { kind: 'group' }>,
+    target: Mod,
+    direction: 'up' | 'down'
+  ) => {
+    const idxInPicker = group.variants.findIndex((v) => v.id === target.id);
+    if (idxInPicker === -1) return;
+    const neighborIdx = direction === 'up' ? idxInPicker - 1 : idxInPicker + 1;
+    if (neighborIdx < 0 || neighborIdx >= group.variants.length) return;
+    const neighbor = group.variants[neighborIdx];
+    if (neighbor.enabled !== target.enabled) return;
+
+    const section = target.enabled ? enabledMods : disabledMods;
+    const sectionNext = section.slice();
+    const a = sectionNext.findIndex((m) => m.id === target.id);
+    const b = sectionNext.findIndex((m) => m.id === neighbor.id);
+    if (a === -1 || b === -1) return;
+    [sectionNext[a], sectionNext[b]] = [sectionNext[b], sectionNext[a]];
+    const next = target.enabled
+      ? [...sectionNext, ...disabledMods]
+      : [...enabledMods, ...sectionNext];
+    await reorderMods(next.map((m) => m.fileName));
+  };
+
   // Auto-scroll the main content container while drag-reordering. Native HTML
   // drag-and-drop doesn't fire pointer events, so we hook `dragover` at the
   // window and start a rAF loop whenever the cursor is near the top/bottom
@@ -614,10 +653,13 @@ export default function Installed() {
    * each carry a 40-line inline JSX block.
    *
    * Group cards:
-   *   - Drag-reorder is disabled (the underlying VPKs span multiple priority
-   *     slots; meaningful group-level reorder needs more design).
+   *   - Drag-reorder moves every variant as a contiguous block, preserving
+   *     their internal order (applyReorder + buildModEntries handle the
+   *     block math). Disabled during search since the visible order doesn't
+   *     match the full priority order.
    *   - Toggle flips every variant on or off as a unit. The picker modal is
-   *     where the user enables/disables individual variants.
+   *     where the user enables/disables individual variants and reorders
+   *     them relative to each other.
    *   - Delete asks the user to confirm removing every variant.
    *   - Card body click opens the variant picker modal.
    *   - Conflicts shown are the union of conflicts on every currently-enabled
@@ -1007,6 +1049,7 @@ export default function Installed() {
             modName={liveEntry.primary.name}
             variants={liveEntry.variants}
             onToggle={(target) => toggleVariant(target)}
+            onMoveVariant={(target, direction) => moveVariant(liveEntry, target, direction)}
             onDisableAll={() => disableEntireGroup(liveEntry)}
             onDeleteVariant={(variant) => deleteMod(variant.id)}
             onRenameVariant={(variant, label) => setVariantLabel(variant.id, label)}


### PR DESCRIPTION
## Summary
Five small post-1.7.1 fixes / features, all driven by what surfaced when actually using the multi-select picker shipped in v1.7.1.

- **Sidebar conflict badge no longer goes stale** after Ignore/Unignore. The badge useEffect only re-ran on `mods` changes, and ignore-conflict updates app settings without touching `mods` — so the badge stayed pinned at its pre-ignore count until restart. Conflicts page now dispatches a `grimoire:conflicts-changed` window event after ignore/unignore; the Sidebar listens and re-fetches `getConflicts()`.
- **Within-group variant reorder** via picker chevrons (▲/▼). Now that variants can be co-loaded (1.7.1 multi-select), the order between siblings matters — later loads win overlapping files. Buttons disabled at picker boundaries and across the enabled/disabled section boundary so users can't silently flip a variant's on/off status by reordering across it.
- **Drag-and-drop reorder in the picker** using the same GripVertical handle pattern the Installed ModCard uses. Same cross-section guard. Drop indicator (accent bar above/below the target row) computed from cursor Y vs row midpoint.
- **Dropped the redundant "ACTIVE" text badge** on picker rows — the accent-bordered outline + accent-filled checkbox already triple-coded the same state.
- **Bulk "Ignore all" button** on the Conflicts page. Click → ConfirmModal ("Ignore all 8 conflicts?") → sequential `ignoreConflict` calls (parallel would race on the same app-settings object), single `grimoire:conflicts-changed` event after the batch. Partial failures refetch from backend and surface a single error.

Also fixed a stale group-card doc comment ("drag-reorder is disabled") — group cards have actually been draggable since the 1.7 variant-grouping feature shipped; `applyReorder` already handled them as contiguous blocks. Comment now matches the code.

No backend or IPC changes anywhere. Within-picker reorder reuses the existing `reorderMods` pipeline (chevron and drag both funnel through a single `reorderVariantTo(source, neighbor, position)` helper). Ignore-all reuses the existing `ignore-conflict` IPC.

## Test plan
- [x] Conflicts page: Ignore a pair → sidebar Conflicts badge drops immediately (no restart needed)
- [x] Conflicts page: Unignore a pair from the Ignored section → sidebar badge restores if pair is still conflicting
- [x] Conflicts page: "Ignore all" button only visible when conflicts.length > 0
- [x] Conflicts page: Confirm dialog shows correct count ("Ignore all 3 conflicts?") and singular/plural form
- [x] Conflicts page: Confirm → all pairs move to Ignored section, sidebar badge → 0
- [x] Variant picker: per row, ▲/▼ chevrons swap with the adjacent picker-neighbor; Slot # numbers update on screen
- [x] Variant picker: chevron is disabled (greyed) at top/bottom of picker (`Already first in load order` / `Already last in load order` tooltip)
- [x] Variant picker: chevron is disabled when adjacent variant is in a different enabled state (`Adjacent variant is in a different section` tooltip)
- [x] Variant picker: GripVertical handle is draggable; clicking toggle/chevron/rename/delete does NOT initiate a drag
- [x] Variant picker: drop indicator (accent bar) shows above target row when cursor is in the top half, below when bottom half
- [x] Variant picker: dragged row dims to 50% opacity while in flight
- [x] Variant picker: cannot drop onto a row in a different enabled state (no indicator appears)
- [x] Variant picker: no "ACTIVE" text badge anywhere; outline + checkbox-fill still convey active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)