### PR TITLE
1-click polish — metadata recovery, lifecycle toast, modal date dedup

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -116,6 +116,50 @@ ipcMain.handle(
     }
 );
 
+// backfill-gamebanana-file-id — heal legacy 1-click installs that were saved
+// before we recovered the file id from the archive URL. The renderer matches
+// a local variant to a GameBanana file row (by sourceFileName/fileName or by
+// sole-file fallback) and asks us to persist the resolved id plus the file's
+// canonical label fields, so both the per-file install state in
+// ModDetailsModal and the variant picker's title flip to the right values on
+// the next render. Label fields are only written when no existing value is
+// present so a user's variantLabel rename never gets clobbered (the picker
+// already prefers variantLabel over fileDescription, but we belt-and-brace
+// against fileDescription/sourceFileName too).
+interface BackfillPayload {
+    gameBananaFileId: number;
+    fileDescription?: string;
+    sourceFileName?: string;
+}
+ipcMain.handle(
+    'backfill-gamebanana-file-id',
+    async (_, modId: string, payload: BackfillPayload): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const all = await scanMods(deadlockPath);
+        const target = all.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+        const existing = getModMetadata(target.fileName) ?? {};
+        const patch: Record<string, unknown> = { gameBananaFileId: payload.gameBananaFileId };
+        if (payload.fileDescription && !existing.fileDescription) {
+            patch.fileDescription = payload.fileDescription;
+        }
+        // Overwrite sourceFileName only when missing or when it's the old
+        // placeholder (gamebanana-mod-{timestamp}) — a real GB stem from a
+        // working enrichment path is kept as-is.
+        const placeholderName = existing.sourceFileName?.match(/^gamebanana-mod-\d+$/);
+        if (payload.sourceFileName && (!existing.sourceFileName || placeholderName)) {
+            patch.sourceFileName = payload.sourceFileName;
+        }
+        setModMetadata(target.fileName, patch);
+        return enrichMod(target);
+    }
+);
+
 // set-mod-priority
 ipcMain.handle(
     'set-mod-priority',

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -39,6 +39,50 @@ function stripArchiveExtension(name: string): string {
     return name.replace(/\.(zip|7z|rar|vpk)$/i, '').trim();
 }
 
+/**
+ * GameBanana's per-file download URLs are `/dl/<fileId>` (or `/mmdl/<fileId>`).
+ * The trailing path segment IS the file id, so we can recover it deterministically
+ * from the archive URL handed to the 1-click protocol — no enrichment, no header
+ * parsing required. Returns undefined when the URL isn't shaped like a GB
+ * file-download endpoint.
+ */
+function extractGameBananaFileIdFromUrl(url: string): number | undefined {
+    try {
+        const parsed = new URL(url);
+        if (!parsed.hostname.endsWith('gamebanana.com')) return undefined;
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        const last = segments[segments.length - 1];
+        if (!last) return undefined;
+        const id = parseInt(last, 10);
+        return Number.isFinite(id) && id > 0 ? id : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Pull the filename out of an HTTP Content-Disposition header. Handles both
+ * RFC 5987 `filename*=UTF-8''...` (preferred when present, supports unicode)
+ * and the older `filename="..."` form. Returns undefined if neither is
+ * present or the value is empty after decoding. Used by 1-click installs to
+ * recover the canonical archive name when the URL itself doesn't include it.
+ */
+function parseContentDispositionFilename(header: string): string | undefined {
+    const rfc5987 = /filename\*\s*=\s*([^']*)'[^']*'([^;]+)/i.exec(header);
+    if (rfc5987) {
+        try {
+            const decoded = decodeURIComponent(rfc5987[2].trim()).replace(/^"|"$/g, '');
+            if (decoded.length > 0) return decoded;
+        } catch { /* fall through */ }
+    }
+    const legacy = /filename\s*=\s*"?([^";]+)"?/i.exec(header);
+    if (legacy) {
+        const value = legacy[1].trim();
+        if (value.length > 0) return value;
+    }
+    return undefined;
+}
+
 // Download queue to prevent race conditions with VPK priority assignment
 interface QueuedDownload {
     deadlockPath: string;
@@ -238,7 +282,8 @@ async function downloadFile(
     destPath: string,
     onProgress: (downloaded: number, total: number) => void,
     connectionTimeoutMs = 30000,
-    responseTimeoutMs = 600000 // 10 minutes for large files
+    responseTimeoutMs = 600000, // 10 minutes for large files
+    onResponseFilename?: (filename: string) => void
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         const protocol = url.startsWith('https') ? https : http;
@@ -264,7 +309,7 @@ async function downloadFile(
                             return;
                         }
                     }
-                    downloadFile(redirectUrl, destPath, onProgress, connectionTimeoutMs, responseTimeoutMs)
+                    downloadFile(redirectUrl, destPath, onProgress, connectionTimeoutMs, responseTimeoutMs, onResponseFilename)
                         .then(resolve)
                         .catch(reject);
                     return;
@@ -274,6 +319,16 @@ async function downloadFile(
             if (response.statusCode !== 200) {
                 reject(new Error(`Download failed with status ${response.statusCode}`));
                 return;
+            }
+
+            // GameBanana's /mmdl/<id> and /dl/<id> URLs don't carry the archive
+            // filename in the path, but the final response sets it via
+            // Content-Disposition. Surface it so 1-click installs can match the
+            // local archive against the GB file list by canonical name.
+            const disposition = response.headers['content-disposition'];
+            if (disposition && onResponseFilename) {
+                const parsed = parseContentDispositionFilename(disposition);
+                if (parsed) onResponseFilename(parsed);
             }
 
             const totalSize = parseInt(response.headers['content-length'] || '0', 10);
@@ -796,14 +851,30 @@ async function executeOneClickDownload(
     const targetPath = getDisabledPath(deadlockPath);
     let downloadPath = join(targetPath, fileName);
 
-    await downloadFile(archiveUrl, downloadPath, (downloaded, total) => {
-        mainWindow?.webContents.send('download-progress', {
-            modId,
-            fileId,
-            downloaded,
-            total,
-        });
-    });
+    // Capture the canonical archive name from Content-Disposition. GB's 1-click
+    // URL points at /mmdl/<id> which has no extension, so the URL-derived
+    // fileName above is a generic placeholder; the response header carries the
+    // real name (e.g. "bozzsilverv2.zip") which we use to match against the
+    // mod's file list.
+    let responseFilename: string | undefined;
+
+    await downloadFile(
+        archiveUrl,
+        downloadPath,
+        (downloaded, total) => {
+            mainWindow?.webContents.send('download-progress', {
+                modId,
+                fileId,
+                downloaded,
+                total,
+            });
+        },
+        undefined,
+        undefined,
+        (name) => {
+            responseFilename = name;
+        }
+    );
 
     try {
         const actualSize = statSync(downloadPath).size;
@@ -895,16 +966,47 @@ async function executeOneClickDownload(
         : undefined;
 
     const realModId = args.modId !== undefined && args.modId > 0 ? args.modId : undefined;
-    // Same trick as the regular download path: capture the author's per-file
-    // header so the variant picker has a sane default label. Only available
-    // when GB enrichment succeeded and the file id is recognised in the list.
-    const oneClickFileDescription = enriched?.files
-        ?.find((f) => f.id === fileId)
-        ?.description?.trim();
-    const oneClickSourceFileName = stripArchiveExtension(fileName);
+    // GameBanana's grimoire:// protocol only carries the archive URL + mod id,
+    // not the file id. Recover it by matching the URL (and falling back to the
+    // filename, then to a sole file row) against the enriched file list so the
+    // resulting variant carries the same gameBananaFileId a manual install
+    // would. Without this, the file row in ModDetailsModal can't recognise the
+    // 1-click variant as installed and a second click silently creates a
+    // duplicate. The URL match is fragile in practice: the protocol passes
+    // GB's user-facing download endpoint (mmdl/) while _sDownloadUrl is often
+    // the file-redirect URL (dl/), so single-file mods fall through to the
+    // positional match below.
+    const enrichedFiles = enriched?.files ?? [];
+    const urlFileId = extractGameBananaFileIdFromUrl(archiveUrl);
+    let matchedFile =
+        (urlFileId !== undefined
+            ? enrichedFiles.find((f) => f.id === urlFileId)
+            : undefined) ??
+        (responseFilename
+            ? enrichedFiles.find((f) => f.fileName === responseFilename)
+            : undefined) ??
+        enrichedFiles.find((f) => f.downloadUrl === archiveUrl) ??
+        enrichedFiles.find((f) => f.fileName === fileName);
+    if (!matchedFile && enrichedFiles.length === 1) {
+        matchedFile = enrichedFiles[0];
+    }
+    // If we got the file id from the URL but enrichment was missing/failed,
+    // still record it so per-file install state lights up — the label fields
+    // will just fall back to URL/header-derived names.
+    const resolvedFileId = matchedFile?.id ?? urlFileId;
+    if (!matchedFile && enrichedFiles.length > 0) {
+        console.warn(
+            `[oneClickInstall] Could not match archiveUrl=${archiveUrl} (urlFileId=${urlFileId ?? '<none>'}, response=${responseFilename ?? '<none>'}, fileName=${fileName}) to any of ${enrichedFiles.length} GB file rows; gameBananaFileId=${resolvedFileId ?? '<none>'}.`
+        );
+    }
+    const oneClickFileDescription = matchedFile?.description?.trim();
+    const oneClickSourceFileName = stripArchiveExtension(
+        matchedFile?.fileName ?? responseFilename ?? fileName
+    );
     const metadata = {
         modName: enriched?.name ?? fileName.replace(/\.(zip|7z|rar|vpk)$/i, ''),
         gameBananaId: realModId,
+        gameBananaFileId: resolvedFileId,
         categoryId: enriched?.category?.id,
         categoryName: enriched?.category?.name,
         thumbnailUrl,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -673,6 +673,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     deleteMod: (modId: string) => ipcRenderer.invoke('delete-mod', modId),
     setVariantLabel: (modId: string, label: string) =>
         ipcRenderer.invoke('set-variant-label', modId, label),
+    backfillGameBananaFileId: (
+        modId: string,
+        payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
+    ) => ipcRenderer.invoke('backfill-gamebanana-file-id', modId, payload),
     setModPriority: (modId: string, priority: number) =>
         ipcRenderer.invoke('set-mod-priority', modId, priority),
     reorderMods: (orderedFileNames: string[]) =>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { AlertTriangle, Download, Loader2 } from 'lucide-react';
+import { AlertTriangle, Check, Download, Loader2 } from 'lucide-react';
 import Sidebar from './Sidebar';
 import WelcomeModal from './WelcomeModal';
 import SyncIndicator from './SyncIndicator';
@@ -19,7 +19,22 @@ export default function Layout() {
   const [loading, setLoading] = useState(true);
   const [gameinfoAlert, setGameinfoAlert] = useState<string | null>(null);
   const [isFixingGameinfo, setIsFixingGameinfo] = useState(false);
-  const [oneClickBanner, setOneClickBanner] = useState<{ message: string; isError: boolean } | null>(null);
+  // Toast state for 1-click installs. Lives through the full install
+  // lifecycle: starting → downloading (with %) → extracting → success/error.
+  // modId is the GB mod id from the protocol URL — used to filter download
+  // events so we don't react to unrelated downloads from the Browse tab.
+  type OneClickToast =
+    | { phase: 'starting'; modId: number | undefined; label: string }
+    | {
+        phase: 'downloading';
+        modId: number | undefined;
+        label: string;
+        progress: { downloaded: number; total: number };
+      }
+    | { phase: 'extracting'; modId: number | undefined; label: string }
+    | { phase: 'success'; modId: number | undefined; label: string }
+    | { phase: 'error'; modId: number | undefined; label: string; message: string };
+  const [oneClickBanner, setOneClickBanner] = useState<OneClickToast | null>(null);
   const [suspiciousPrompt, setSuspiciousPrompt] = useState<OneClickSuspiciousFilesData | null>(null);
   const [multiVpkPrompt, setMultiVpkPrompt] = useState<MultiVpkPickData | null>(null);
 
@@ -61,7 +76,12 @@ export default function Layout() {
   useEffect(() => {
     const unsubscribe = window.electronAPI.onOneClickInstall((data) => {
       if (data.error) {
-        setOneClickBanner({ message: data.error, isError: true });
+        setOneClickBanner({
+          phase: 'error',
+          modId: data.modId,
+          label: data.modName ?? 'mod',
+          message: data.error,
+        });
         return;
       }
       const label = data.modName ?? (() => {
@@ -77,22 +97,67 @@ export default function Layout() {
           return 'mod';
         }
       })();
-      setOneClickBanner({
-        message: `Installing ${label} from GameBanana…`,
-        isError: false,
-      });
+      setOneClickBanner({ phase: 'starting', modId: data.modId, label });
       navigate('/');
     });
     return unsubscribe;
   }, [navigate]);
 
+  // Mirror the download lifecycle into the 1-click toast. We use the modId
+  // from the protocol URL as the join key so unrelated downloads from the
+  // Browse tab don't hijack the banner.
+  useEffect(() => {
+    const progressUnsub = window.electronAPI.onDownloadProgress((data) => {
+      setOneClickBanner((prev) => {
+        if (!prev || prev.modId === undefined || prev.modId !== data.modId) return prev;
+        if (prev.phase === 'success' || prev.phase === 'error') return prev;
+        return {
+          phase: 'downloading',
+          modId: prev.modId,
+          label: prev.label,
+          progress: { downloaded: data.downloaded, total: data.total },
+        };
+      });
+    });
+    const extractingUnsub = window.electronAPI.onDownloadExtracting((data) => {
+      setOneClickBanner((prev) => {
+        if (!prev || prev.modId === undefined || prev.modId !== data.modId) return prev;
+        return { phase: 'extracting', modId: prev.modId, label: prev.label };
+      });
+    });
+    const completeUnsub = window.electronAPI.onDownloadComplete((data) => {
+      setOneClickBanner((prev) => {
+        if (!prev || prev.modId === undefined || prev.modId !== data.modId) return prev;
+        return { phase: 'success', modId: prev.modId, label: prev.label };
+      });
+    });
+    const errorUnsub = window.electronAPI.onDownloadError((data) => {
+      setOneClickBanner((prev) => {
+        if (!prev || prev.modId === undefined || prev.modId !== data.modId) return prev;
+        return { phase: 'error', modId: prev.modId, label: prev.label, message: data.message };
+      });
+    });
+    return () => {
+      progressUnsub();
+      extractingUnsub();
+      completeUnsub();
+      errorUnsub();
+    };
+  }, []);
+
+  // Auto-dismiss only at terminal states. While in flight (starting,
+  // downloading, extracting) the toast stays put so the user can watch
+  // the percentage tick up.
   useEffect(() => {
     if (!oneClickBanner) return;
-    const timeout = setTimeout(
-      () => setOneClickBanner(null),
-      oneClickBanner.isError ? 8000 : 4000
-    );
-    return () => clearTimeout(timeout);
+    if (oneClickBanner.phase === 'success') {
+      const t = setTimeout(() => setOneClickBanner(null), 2500);
+      return () => clearTimeout(t);
+    }
+    if (oneClickBanner.phase === 'error') {
+      const t = setTimeout(() => setOneClickBanner(null), 8000);
+      return () => clearTimeout(t);
+    }
   }, [oneClickBanner]);
 
   useEffect(() => {
@@ -194,19 +259,63 @@ export default function Layout() {
       </div>
       {oneClickBanner && (
         <div className="fixed left-1/2 top-4 z-50 -translate-x-1/2">
-          <div
-            className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm shadow-lg backdrop-blur-sm ${oneClickBanner.isError
-              ? 'border-red-500/40 bg-red-500/15 text-red-200'
-              : 'border-accent/40 bg-accent/15 text-accent-foreground'
-              }`}
-          >
-            {oneClickBanner.isError ? (
-              <AlertTriangle className="h-4 w-4" />
+          {(() => {
+            const isError = oneClickBanner.phase === 'error';
+            const isSuccess = oneClickBanner.phase === 'success';
+            const pct =
+              oneClickBanner.phase === 'downloading' && oneClickBanner.progress.total > 0
+                ? Math.min(
+                    100,
+                    Math.round(
+                      (oneClickBanner.progress.downloaded / oneClickBanner.progress.total) * 100
+                    )
+                  )
+                : null;
+            const message =
+              oneClickBanner.phase === 'error'
+                ? oneClickBanner.message
+                : oneClickBanner.phase === 'success'
+                ? `Installed ${oneClickBanner.label}`
+                : oneClickBanner.phase === 'extracting'
+                ? `Extracting ${oneClickBanner.label}…`
+                : oneClickBanner.phase === 'downloading'
+                ? `Downloading ${oneClickBanner.label}${pct !== null ? ` — ${pct}%` : ''}`
+                : `Installing ${oneClickBanner.label} from GameBanana…`;
+            const icon = isError ? (
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            ) : isSuccess ? (
+              <Check className="h-4 w-4 flex-shrink-0" />
+            ) : oneClickBanner.phase === 'extracting' ||
+              oneClickBanner.phase === 'starting' ? (
+              <Loader2 className="h-4 w-4 flex-shrink-0 animate-spin" />
             ) : (
-              <Download className="h-4 w-4" />
-            )}
-            <span>{oneClickBanner.message}</span>
-          </div>
+              <Download className="h-4 w-4 flex-shrink-0" />
+            );
+            return (
+              <div
+                className={`flex flex-col gap-1.5 overflow-hidden rounded-lg border text-sm shadow-lg backdrop-blur-sm min-w-[260px] max-w-[420px] ${
+                  isError
+                    ? 'border-red-500/40 bg-red-500/15 text-red-200'
+                    : isSuccess
+                    ? 'border-green-500/40 bg-green-500/15 text-green-200'
+                    : 'border-accent/40 bg-accent/15 text-accent-foreground'
+                }`}
+              >
+                <div className="flex items-center gap-2 px-4 py-2">
+                  {icon}
+                  <span className="truncate">{message}</span>
+                </div>
+                {pct !== null && (
+                  <div className="h-1 w-full bg-bg-secondary/40">
+                    <div
+                      className="h-full bg-accent transition-all duration-200"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })()}
         </div>
       )}
       <ConfirmModal

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -204,28 +204,38 @@ export default function ModDetailsModal({
           <h2 className="text-lg lg:text-xl font-bold leading-tight truncate min-w-0 flex-1" title={mod.name}>
             {mod.name}
           </h2>
-          {(dateAdded || dateModified || totalDownloads > 0) && (
-            <div className="hidden md:flex items-center gap-3 text-xs text-text-secondary flex-shrink-0">
-              {dateAdded && dateAdded > 0 && (
-                <span className="flex items-center gap-1">
-                  <Clock className="w-3 h-3" />
-                  <span className="text-text-primary">{formatDate(dateAdded)}</span>
-                </span>
-              )}
-              {dateModified && dateModified > 0 && (
-                <span className={`flex items-center gap-1 ${outdated ? 'text-yellow-400' : ''}`}>
-                  <Clock className="w-3 h-3" />
-                  <span className={outdated ? 'text-yellow-300' : 'text-text-primary'}>{formatDate(dateModified)}</span>
-                </span>
-              )}
-              {totalDownloads > 0 && (
-                <span className="flex items-center gap-1">
-                  <Download className="w-3 h-3" />
-                  <span className="text-text-primary">{totalDownloads.toLocaleString()}</span>
-                </span>
-              )}
-            </div>
-          )}
+          {(() => {
+            // Hide the modified date when it formats to the same day as the
+            // added date — common for fresh uploads where both timestamps
+            // fall on the same calendar day, which makes the header read
+            // "5/12/2026 5/12/2026".
+            const addedStr = dateAdded && dateAdded > 0 ? formatDate(dateAdded) : null;
+            const modifiedStr = dateModified && dateModified > 0 ? formatDate(dateModified) : null;
+            const showModified = modifiedStr !== null && modifiedStr !== addedStr;
+            if (!addedStr && !showModified && totalDownloads === 0) return null;
+            return (
+              <div className="hidden md:flex items-center gap-3 text-xs text-text-secondary flex-shrink-0">
+                {addedStr && (
+                  <span className="flex items-center gap-1">
+                    <Clock className="w-3 h-3" />
+                    <span className="text-text-primary">{addedStr}</span>
+                  </span>
+                )}
+                {showModified && (
+                  <span className={`flex items-center gap-1 ${outdated ? 'text-yellow-400' : ''}`}>
+                    <Clock className="w-3 h-3" />
+                    <span className={outdated ? 'text-yellow-300' : 'text-text-primary'}>{modifiedStr}</span>
+                  </span>
+                )}
+                {totalDownloads > 0 && (
+                  <span className="flex items-center gap-1">
+                    <Download className="w-3 h-3" />
+                    <span className="text-text-primary">{totalDownloads.toLocaleString()}</span>
+                  </span>
+                )}
+              </div>
+            );
+          })()}
           <button
             onClick={onClose}
             aria-label="Close"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,6 +59,13 @@ export async function setVariantLabel(modId: string, label: string): Promise<Mod
   return window.electronAPI.setVariantLabel(modId, label);
 }
 
+export async function backfillGameBananaFileId(
+  modId: string,
+  payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
+): Promise<Mod> {
+  return window.electronAPI.backfillGameBananaFileId(modId, payload);
+}
+
 export async function setModPriority(modId: string, priority: number): Promise<Mod> {
   return window.electronAPI.setModPriority(modId, priority);
 }

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -24,6 +24,7 @@ import {
   downloadMod,
   getGamebananaSections,
   getGamebananaCategories,
+  backfillGameBananaFileId,
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import type {
@@ -1033,6 +1034,80 @@ export default function Browse() {
     }
     return map;
   }, [installedMods]);
+
+  // Heal legacy 1-click installs that pre-date the forward fix. Those variants
+  // have the right gameBananaId but no gameBananaFileId, so ModDetailsModal
+  // can't recognise the matching file row as installed and the user ends up
+  // clicking Install again, creating a duplicate. When the modal opens, try
+  // to recover the file id by matching the local sourceFileName against the
+  // GB file list; if only one variant lacks an id and only one file row
+  // exists on the page, match unambiguously by position. Healed variants
+  // become visible to installedFileIds on the next loadMods.
+  useEffect(() => {
+    if (!selectedMod) return;
+    const candidates = installedMods.filter(
+      (m) => m.gameBananaId === selectedMod.id && typeof m.gameBananaFileId !== 'number'
+    );
+    if (candidates.length === 0) return;
+    const files = selectedMod.files ?? [];
+    if (files.length === 0) return;
+
+    const usedFileIds = new Set<number>();
+    for (const m of installedMods) {
+      if (m.gameBananaId === selectedMod.id && typeof m.gameBananaFileId === 'number') {
+        usedFileIds.add(m.gameBananaFileId);
+      }
+    }
+    const availableFiles = files.filter((f) => !usedFileIds.has(f.id));
+
+    type Match = {
+      modId: string;
+      payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string };
+    };
+    const matches: Match[] = [];
+    for (const mod of candidates) {
+      const source = mod.sourceFileName?.toLowerCase();
+      // Skip the placeholder our old 1-click flow used so we don't try to
+      // match "gamebanana-mod-1778634670877" against real GB file rows.
+      const usableSource = source && !/^gamebanana-mod-\d+$/.test(source) ? source : undefined;
+      let matched = usableSource
+        ? availableFiles.find(
+            (f) => f.fileName.replace(/\.(zip|7z|rar|vpk)$/i, '').toLowerCase() === usableSource
+          )
+        : undefined;
+      if (!matched && candidates.length === 1 && availableFiles.length === 1) {
+        matched = availableFiles[0];
+      }
+      if (matched) {
+        const stem = matched.fileName.replace(/\.(zip|7z|rar|vpk)$/i, '').trim();
+        matches.push({
+          modId: mod.id,
+          payload: {
+            gameBananaFileId: matched.id,
+            fileDescription: matched.description?.trim() || undefined,
+            sourceFileName: stem.length > 0 ? stem : undefined,
+          },
+        });
+        usedFileIds.add(matched.id);
+      }
+    }
+    if (matches.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        for (const m of matches) {
+          await backfillGameBananaFileId(m.modId, m.payload);
+        }
+        if (!cancelled) await loadMods();
+      } catch (err) {
+        console.warn('[Browse] backfill gameBananaFileId failed:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedMod, installedMods, loadMods]);
 
   // Just use all loaded mods - infinite scroll handles pagination.
   // Hide outdated mods if the user has opted in.

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -260,6 +260,10 @@ export interface ElectronAPI {
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
+    backfillGameBananaFileId: (
+      modId: string,
+      payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
+    ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;


### PR DESCRIPTION
## Summary
- **1-click metadata recovery** — extract the GameBanana file id directly from the archive URL (`/dl/<id>` or `/mmdl/<id>`) and flow `fileDescription` + `sourceFileName` from the matched file row. New 1-click installs now show the GB header in the variant picker and light up "Installed" on the per-file row. Legacy placeholder variants are healed when the mod page opens in Browse, but only when matching is unambiguous (single variant + single file).
- **Lifecycle toast** — the top banner used to disappear after 4 seconds regardless of state. It now tracks the install through `starting → downloading (with %) → extracting → success/error`, joined by modId so manual downloads from Browse don't hijack it.
- **Modal date dedup** — fresh uploads with the same `dateAdded` and `dateModified` were rendering "5/12/2026 5/12/2026" in the modal header. Compare formatted strings and skip the duplicate; outdated styling still applies when the dates actually differ.

## Test plan
- [ ] 1-click a single-file mod (e.g. Paige) → variant picker shows the GB filename, ModDetailsModal file row shows "Reinstall"
- [ ] 1-click a multi-file mod (e.g. Twin Turbo over Vyper) twice on different files → each variant gets distinct labels from its GB file row
- [ ] Open a mod page where a legacy placeholder variant exists → backfill heals on open (single-variant single-file case)
- [ ] Watch the top toast on a 1-click of a large mod → percentage ticks, then "Extracting…", then green "Installed", then fades
- [ ] Open the modal for a mod uploaded today → only one date in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)