### PR TITLE
Add accent color and overhaul ui

### DIFF
--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -24,6 +24,9 @@ export interface AppSettings {
      *  pair is hidden without persisting it to ignoredConflicts, so toggling
      *  back off restores the original conflict view. */
     ignoreConflictsByDefault: boolean;
+    /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
+     *  focus rings throughout the app. */
+    accentColor: string;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -41,6 +44,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     hasCompletedSetup: false,
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,
+    accentColor: '#f97316',
 };
 
 /**

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,8 @@ import { Button } from './common/ui';
 import { ConfirmModal } from './common/PageComponents';
 import { getSettings, setSettings, getGameinfoStatus, fixGameinfo } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
+import { applyAccentColor } from '../lib/accentColor';
+import { useAppStore } from '../stores/appStore';
 import type { OneClickSuspiciousFilesData, MultiVpkPickData } from '../types/electron';
 import MultiVpkPickerModal from './MultiVpkPickerModal';
 
@@ -37,6 +39,19 @@ export default function Layout() {
   const [oneClickBanner, setOneClickBanner] = useState<OneClickToast | null>(null);
   const [suspiciousPrompt, setSuspiciousPrompt] = useState<OneClickSuspiciousFilesData | null>(null);
   const [multiVpkPrompt, setMultiVpkPrompt] = useState<MultiVpkPickData | null>(null);
+
+  // Re-theme the app whenever the stored accent color changes. We pull
+  // settings into the global store on mount so the value is available before
+  // any page renders — otherwise the first paint flashes the default orange
+  // even when the user has picked a different accent.
+  const accentColor = useAppStore((s) => s.settings?.accentColor);
+  const loadStoreSettings = useAppStore((s) => s.loadSettings);
+  useEffect(() => {
+    loadStoreSettings();
+  }, [loadStoreSettings]);
+  useEffect(() => {
+    applyAccentColor(accentColor);
+  }, [accentColor]);
 
   useEffect(() => {
     const checkFirstRun = async () => {
@@ -293,7 +308,7 @@ export default function Layout() {
             );
             return (
               <div
-                className={`flex flex-col gap-1.5 overflow-hidden rounded-lg border text-sm shadow-lg backdrop-blur-sm min-w-[260px] max-w-[420px] ${
+                className={`flex flex-col gap-1.5 overflow-hidden rounded-sm border text-sm shadow-lg backdrop-blur-sm min-w-[260px] max-w-[420px] ${
                   isError
                     ? 'border-red-500/40 bg-red-500/15 text-red-200'
                     : isSuccess
@@ -333,7 +348,7 @@ export default function Layout() {
                 <span className="font-semibold text-text-primary">{suspiciousPrompt.modName}</span>{' '}
                 contains files that aren&apos;t typical for a Deadlock mod:
               </p>
-              <ul className="max-h-40 overflow-y-auto rounded-md border border-border bg-bg-tertiary px-3 py-2 text-xs font-mono text-yellow-200">
+              <ul className="max-h-40 overflow-y-auto rounded-sm border border-border bg-bg-tertiary px-3 py-2 text-xs font-mono text-yellow-200">
                 {suspiciousPrompt.files.slice(0, 30).map((f) => (
                   <li key={f}>{f}</li>
                 ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -289,7 +289,7 @@ export default function Sidebar() {
           onClick={() => setCollapsed((v) => !v)}
           title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          className={`flex items-center justify-center w-7 h-7 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 ${
+          className={`flex items-center justify-center w-7 h-7 rounded-sm text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 ${
             collapsed ? '' : 'absolute top-1/2 right-2 -translate-y-1/2'
           }`}
         >
@@ -305,7 +305,7 @@ export default function Sidebar() {
                 to={to}
                 title={collapsed ? `${label}: ${tooltip}` : tooltip}
                 className={({ isActive }) =>
-                  `group relative flex items-center leading-5 rounded-md text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 border ${
+                  `group relative flex items-center leading-5 rounded-sm text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 border ${
                     collapsed ? 'justify-center h-10' : 'gap-3 px-3 py-2.5'
                   } ${
                     isActive
@@ -329,12 +329,12 @@ export default function Sidebar() {
                         badgeTone === 'warning' ? (
                           <span
                             aria-hidden
-                            className="absolute top-1 right-1 w-2 h-2 rounded-full ring-2 ring-bg-secondary bg-state-warning"
+                            className="absolute top-1 right-1 w-2 h-2 rounded-sm ring-2 ring-bg-secondary bg-state-warning"
                           />
                         ) : null
                       ) : (
                         <span
-                          className={`px-1.5 py-0.5 text-[11px] font-semibold tabular-nums rounded-full min-w-[20px] text-center leading-4 ${
+                          className={`px-1.5 py-0.5 text-[11px] font-semibold tabular-nums rounded-sm min-w-[20px] text-center leading-4 ${
                             badgeTone === 'warning'
                               ? 'bg-state-warning/90 text-black'
                               : 'border border-text-primary/50 text-text-primary/80'
@@ -363,7 +363,7 @@ export default function Sidebar() {
               onClick={handleRestoreNow}
               disabled={restorePending}
               title={`Vanilla session active. ${stashStatus.modCount ?? 0} mod${stashStatus.modCount === 1 ? '' : 's'} stashed. Click to restore now.`}
-              className="w-full flex items-center justify-center h-10 rounded-md border border-yellow-500/40 bg-yellow-500/10 text-yellow-200 hover:bg-yellow-500/20 transition-colors disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+              className="w-full flex items-center justify-center h-10 rounded-sm border border-yellow-500/40 bg-yellow-500/10 text-yellow-200 hover:bg-yellow-500/20 transition-colors disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
             >
               {restorePending ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -372,7 +372,7 @@ export default function Sidebar() {
               )}
             </button>
           ) : (
-            <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-2 text-xs text-yellow-200 flex items-center gap-2">
+            <div className="rounded-sm border border-yellow-500/40 bg-yellow-500/10 px-2.5 py-2 text-xs text-yellow-200 flex items-center gap-2">
               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
               <span className="flex-1 leading-tight">
                 Vanilla: {stashStatus.modCount ?? 0} stashed
@@ -381,7 +381,7 @@ export default function Sidebar() {
                 onClick={handleRestoreNow}
                 disabled={restorePending}
                 title="Restore stashed mods now"
-                className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-yellow-500/20 hover:bg-yellow-500/30 disabled:opacity-60 transition-colors cursor-pointer disabled:cursor-not-allowed font-medium"
+                className="flex items-center gap-1 px-1.5 py-0.5 rounded-sm bg-yellow-500/20 hover:bg-yellow-500/30 disabled:opacity-60 transition-colors cursor-pointer disabled:cursor-not-allowed font-medium"
               >
                 {restorePending ? (
                   <Loader2 className="w-3 h-3 animate-spin" />
@@ -397,7 +397,7 @@ export default function Sidebar() {
         {/* Toasts need horizontal room to read, so suppress in collapsed mode. */}
         {toast && !collapsed && (
           <div
-            className={`rounded-md px-2.5 py-1.5 text-xs leading-snug ${
+            className={`rounded-sm px-2.5 py-1.5 text-xs leading-snug ${
               toast.kind === 'error'
                 ? 'border border-red-500/40 bg-red-500/10 text-red-300'
                 : 'border border-accent/40 bg-accent/10 text-accent'
@@ -440,7 +440,7 @@ export default function Sidebar() {
                   ? 'Restores stashed mods first, then launches Deadlock via Steam'
                   : 'Launch Deadlock with mods active'
             }
-            className={`flex w-full items-center rounded-md border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary text-sm font-semibold tracking-wide transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 disabled:opacity-50 disabled:cursor-not-allowed ${
+            className={`flex w-full items-center rounded-sm border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary text-sm font-semibold tracking-wide transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 disabled:opacity-50 disabled:cursor-not-allowed ${
               collapsed ? 'justify-center h-10' : 'gap-3 h-10 px-3'
             }`}
           >
@@ -462,7 +462,7 @@ export default function Sidebar() {
                   ? 'A vanilla session is already active. Restore mods first.'
                   : 'Temporarily stash mods, launch Deadlock via Steam, then auto-restore after the game starts'
             }
-            className={`flex w-full items-center rounded-md border border-transparent hover:border-accent/25 hover:bg-accent/5 text-text-secondary hover:text-text-primary text-sm font-medium tracking-wide transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 disabled:opacity-60 disabled:cursor-not-allowed ${
+            className={`flex w-full items-center rounded-sm border border-transparent hover:border-accent/25 hover:bg-accent/5 text-text-secondary hover:text-text-primary text-sm font-medium tracking-wide transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 disabled:opacity-60 disabled:cursor-not-allowed ${
               collapsed ? 'justify-center h-10' : 'gap-3 h-10 px-3'
             }`}
           >
@@ -480,7 +480,7 @@ export default function Sidebar() {
             <button
               onClick={() => setUpdateModalOpen(true)}
               title={`Update available. ${appVersion || 'Click to view'}.`}
-              className="flex items-center justify-center w-full h-7 text-accent cursor-pointer hover:bg-bg-tertiary rounded-md transition-colors"
+              className="flex items-center justify-center w-full h-7 text-accent cursor-pointer hover:bg-bg-tertiary rounded-sm transition-colors"
             >
               <Download className="w-3.5 h-3.5 animate-pulse" />
             </button>

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -41,7 +41,7 @@ interface ViewModeToggleProps {
 export function ViewModeToggle({ value, options, onChange, className = '' }: ViewModeToggleProps) {
     const anyIcon = options.some((o) => o.icon);
     return (
-        <div className={`flex items-center rounded-lg border border-border bg-bg-secondary p-0.5 text-sm ${className}`}>
+        <div className={`flex items-center rounded-sm border border-border bg-bg-secondary p-0.5 text-sm ${className}`}>
             {options.map((option) => {
                 const Icon = option.icon;
                 const active = value === option.value;
@@ -53,7 +53,7 @@ export function ViewModeToggle({ value, options, onChange, className = '' }: Vie
                         onClick={() => onChange(option.value)}
                         title={option.label}
                         aria-label={option.label}
-                        className={`${baseCls} rounded-md transition-colors cursor-pointer ${active
+                        className={`${baseCls} rounded-sm transition-colors cursor-pointer ${active
                             ? 'border border-accent/40 bg-accent/10 text-text-primary'
                             : 'border border-transparent text-text-secondary hover:text-text-primary hover:bg-bg-tertiary'
                             }`}
@@ -166,21 +166,22 @@ export function ConfirmModal({
             onClick={onCancel}
         >
             <div
-                className="bg-bg-secondary border border-border rounded-xl p-6 max-w-md w-full"
+                className="bg-bg-secondary border border-border rounded-sm p-6 max-w-md w-full relative overflow-hidden"
                 onClick={(e) => e.stopPropagation()}
             >
+                <span aria-hidden className={`absolute left-0 top-0 bottom-0 w-[2px] ${variant === 'danger' ? 'bg-red-500/60' : 'bg-accent/60'}`} />
                 <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
                 <div className="text-text-secondary mb-4">{message}</div>
                 <div className="flex justify-end gap-3">
                     <button
                         onClick={onCancel}
-                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-sm hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                     >
                         {cancelLabel}
                     </button>
                     <button
                         onClick={onConfirm}
-                        className={`px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
+                        className={`px-4 py-2 rounded-sm font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
                     >
                         {confirmLabel}
                     </button>

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -13,7 +13,10 @@ interface CardProps {
 
 export function Card({ children, className = '', contentClassName = '', title, icon: Icon, description, action }: CardProps) {
     return (
-        <div className={`bg-bg-secondary/50 backdrop-blur-sm border border-white/5 rounded-xl overflow-hidden ${className}`}>
+        <div className={`bg-bg-secondary/50 backdrop-blur-sm border border-white/5 rounded-sm overflow-hidden relative ${className}`}>
+            {/* Sharp accent edge — sits flush with the left side so cards read
+                as HUD callouts rather than soft web cards. */}
+            {(title || action) && <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />}
             {(title || action) && (
                 <div className="px-5 py-4 border-b border-white/5 flex flex-wrap items-center justify-between gap-4">
                     <div className="min-w-0">
@@ -51,7 +54,7 @@ export function Badge({ children, variant = 'neutral', className = '' }: BadgePr
     };
 
     return (
-        <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${variants[variant]} ${className}`}>
+        <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-xs font-medium border ${variants[variant]} ${className}`}>
             {children}
         </span>
     );
@@ -105,7 +108,7 @@ export function Tag({
     return (
         <span
             title={title}
-            className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-semibold leading-none ${surface} ${className}`}
+            className={`inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold leading-none ${surface} ${className}`}
         >
             {Icon && <Icon className="w-3 h-3" />}
             {children}
@@ -143,7 +146,7 @@ export function Slider({
             <div className="flex justify-between items-center">
                 {label && <label className="text-sm font-medium text-text-secondary">{label}</label>}
                 {showValue && (
-                    <span className="text-xs font-mono text-text-primary bg-bg-tertiary px-1.5 py-0.5 rounded">
+                    <span className="text-xs font-mono text-text-primary bg-bg-tertiary px-1.5 py-0.5 rounded-sm">
                         {formatValue ? formatValue(value) : value}
                     </span>
                 )}
@@ -220,7 +223,7 @@ export function Button({
     disabled,
     ...props
 }: ButtonProps) {
-    const baseStyles = 'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
+    const baseStyles = 'inline-flex items-center justify-center gap-2 rounded-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer';
 
     const variants = {
         primary: 'border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary focus:ring-accent',

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,7 @@ body {
 
 *::-webkit-scrollbar-thumb {
   background: var(--color-border);
-  border-radius: 999px;
+  border-radius: 2px;
   border: 2px solid var(--color-bg-secondary);
 }
 

--- a/src/lib/accentColor.ts
+++ b/src/lib/accentColor.ts
@@ -1,0 +1,51 @@
+// Accent color presets shown in Settings. Each preset is a pair of
+// (base, hover) hex values applied to --color-accent and --color-accent-hover
+// at runtime, so the whole UI re-themes without a reload.
+//
+// The default `Ember` is the original orange the app shipped with — picked as
+// the base so changing accents feels additive, not lossy.
+
+export interface AccentPreset {
+  id: string;
+  name: string;
+  color: string;
+  hover: string;
+}
+
+export const ACCENT_PRESETS: AccentPreset[] = [
+  { id: 'ember',   name: 'Ember',   color: '#f97316', hover: '#ea580c' },
+  { id: 'amber',   name: 'Amber',   color: '#f59e0b', hover: '#d97706' },
+  { id: 'crimson', name: 'Crimson', color: '#ef4444', hover: '#dc2626' },
+  { id: 'rose',    name: 'Rose',    color: '#ec4899', hover: '#db2777' },
+  { id: 'violet',  name: 'Violet',  color: '#8b5cf6', hover: '#7c3aed' },
+  { id: 'azure',   name: 'Azure',   color: '#3b82f6', hover: '#2563eb' },
+  { id: 'cyan',    name: 'Cyan',    color: '#06b6d4', hover: '#0891b2' },
+  { id: 'emerald', name: 'Emerald', color: '#10b981', hover: '#059669' },
+];
+
+export const DEFAULT_ACCENT_COLOR = ACCENT_PRESETS[0].color;
+
+function darken(hex: string, amount = 0.12): string {
+  const m = hex.replace('#', '').match(/.{2}/g);
+  if (!m) return hex;
+  const [r, g, b] = m.map((c) => parseInt(c, 16));
+  const adj = (v: number) => Math.max(0, Math.min(255, Math.round(v * (1 - amount))));
+  return `#${[adj(r), adj(g), adj(b)].map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/**
+ * Write the accent color to the document root as CSS variables. Tailwind's
+ * @theme tokens read these at use-site (e.g. `bg-accent`), so every component
+ * already wired to `--color-accent` updates without rerendering.
+ */
+export function applyAccentColor(color: string | null | undefined): void {
+  const base = color || DEFAULT_ACCENT_COLOR;
+  // Prefer the preset's curated hover (slightly darker, same saturation).
+  // For ad-hoc/custom hex values, fall back to a 12% darken so hover states
+  // still have visible feedback.
+  const preset = ACCENT_PRESETS.find((p) => p.color.toLowerCase() === base.toLowerCase());
+  const hover = preset ? preset.hover : darken(base);
+  const root = document.documentElement;
+  root.style.setProperty('--color-accent', base);
+  root.style.setProperty('--color-accent-hover', hover);
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
 import {
@@ -13,6 +13,7 @@ import {
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
+import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
 
 export default function Settings() {
   const { settings, settingsLoading, loadSettings, saveSettings, detectDeadlock } = useAppStore();
@@ -154,6 +155,17 @@ export default function Settings() {
     }
   };
 
+
+  const handleAccentChange = async (color: string) => {
+    // Apply optimistically so the UI re-themes the moment the swatch is
+    // clicked, even before the settings round-trip finishes. The store push
+    // in saveSettings re-triggers Layout's effect, but doing it here too
+    // avoids a perceptible flash on slower disks.
+    applyAccentColor(color);
+    if (settings) {
+      await saveSettings({ ...settings, accentColor: color });
+    }
+  };
 
   const handleHideNsfwChange = async (checked: boolean) => {
     if (settings) {
@@ -390,7 +402,7 @@ export default function Settings() {
                     onChange={(e) => handlePathChange(e.target.value)}
                     placeholder="/path/to/Deadlock"
                     disabled={isDevMode}
-                    className="w-full bg-bg-tertiary border border-white/5 rounded-lg px-4 py-2.5 text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-60 disabled:cursor-not-allowed font-mono text-sm"
+                    className="w-full bg-bg-tertiary border border-white/5 rounded-sm px-4 py-2.5 text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-60 disabled:cursor-not-allowed font-mono text-sm"
                   />
                 </div>
                 <Button
@@ -513,14 +525,57 @@ export default function Settings() {
                   <span>Downloading update...</span>
                   <span>{Math.round(updateStatus.progress)}%</span>
                 </div>
-                <div className="w-full bg-bg-tertiary rounded-full h-1.5 overflow-hidden">
+                <div className="w-full bg-bg-tertiary rounded-sm h-1.5 overflow-hidden">
                   <div
-                    className="bg-accent h-full rounded-full transition-all duration-300 ease-out"
+                    className="bg-accent h-full rounded-sm transition-all duration-300 ease-out"
                     style={{ width: `${updateStatus.progress}%` }}
                   />
                 </div>
               </div>
             )}
+          </div>
+        </Card>
+
+        {/* Appearance */}
+        <Card title="Appearance" icon={Palette} className="lg:col-span-2">
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h4 className="font-medium text-sm">Accent Color</h4>
+                <p className="text-xs text-text-secondary mt-1">
+                  Sets the highlight color used for buttons, links, and active states across the app.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {ACCENT_PRESETS.map((preset) => {
+                const current = (settings?.accentColor ?? DEFAULT_ACCENT_COLOR).toLowerCase();
+                const isActive = current === preset.color.toLowerCase();
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => handleAccentChange(preset.color)}
+                    title={preset.name}
+                    aria-label={`Accent: ${preset.name}`}
+                    aria-pressed={isActive}
+                    className={`group relative flex items-center gap-2 px-3 py-2 rounded-sm border text-xs font-medium tracking-wide transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${
+                      isActive
+                        ? 'border-white/30 bg-white/5 text-text-primary'
+                        : 'border-white/5 bg-bg-tertiary text-text-secondary hover:text-text-primary hover:border-white/20'
+                    }`}
+                    style={isActive ? { boxShadow: `inset 3px 0 0 ${preset.color}` } : undefined}
+                  >
+                    <span
+                      className="block w-4 h-4 rounded-sm border border-black/30"
+                      style={{ backgroundColor: preset.color }}
+                    />
+                    <span>{preset.name}</span>
+                    {isActive && <Check className="w-3.5 h-3.5 ml-0.5" style={{ color: preset.color }} />}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </Card>
 
@@ -572,7 +627,7 @@ export default function Settings() {
                 description="Use a dummy Deadlock directory for local testing without game files."
               />
               {isDevMode && settings?.devDeadlockPath && (
-                <div className="mt-2 text-xs font-mono bg-black/30 p-2 rounded text-text-secondary break-all">
+                <div className="mt-2 text-xs font-mono bg-black/30 p-2 rounded-sm text-text-secondary break-all">
                   {settings.devDeadlockPath}
                 </div>
               )}
@@ -680,9 +735,9 @@ export default function Settings() {
                     <span>Syncing {syncProgress.section}...</span>
                     <span>{Math.round((syncProgress.modsProcessed / syncProgress.totalMods) * 100)}%</span>
                   </div>
-                  <div className="w-full bg-bg-tertiary rounded-full h-1.5 overflow-hidden">
+                  <div className="w-full bg-bg-tertiary rounded-sm h-1.5 overflow-hidden">
                     <div
-                      className="bg-accent h-full rounded-full transition-all duration-300 ease-out"
+                      className="bg-accent h-full rounded-sm transition-all duration-300 ease-out"
                       style={{ width: `${Math.min(100, (syncProgress.modsProcessed / syncProgress.totalMods) * 100)}%` }}
                     />
                   </div>
@@ -720,7 +775,8 @@ export default function Settings() {
       {/* Changelog Modal */}
       {showChangelog && updateStatus?.updateInfo && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in">
-          <div className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-2xl max-h-[80vh] overflow-hidden shadow-2xl animate-fade-in">
+          <div className="bg-bg-secondary border border-white/10 rounded-sm w-full max-w-2xl max-h-[80vh] overflow-hidden shadow-2xl animate-fade-in relative">
+            <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
             <div className="flex items-center justify-between p-6 border-b border-white/10">
               <div>
                 <h2 className="text-xl font-bold">What's New in v{updateStatus.updateInfo.version}</h2>
@@ -732,7 +788,7 @@ export default function Settings() {
               </div>
               <button
                 onClick={() => setShowChangelog(false)}
-                className="p-2 rounded-lg hover:bg-white/5 transition-colors"
+                className="p-2 rounded-sm hover:bg-white/5 transition-colors"
               >
                 <X className="w-5 h-5" />
               </button>

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -54,4 +54,6 @@ export interface AppSettings {
   hasCompletedSetup: boolean;
   ignoredConflicts: string[];
   ignoreConflictsByDefault: boolean;
+  /** UI accent color (hex, e.g. "#f97316"). Falls back to default orange when unset. */
+  accentColor: string;
 }


### PR DESCRIPTION
- Persist accent color in app settings
- Add appearance swatches and apply theme live
- Tweak component styling for sharper UI surfaces


 
<img width="1262" height="790" alt="image" src="https://github.com/user-attachments/assets/3a066592-3213-4f64-8322-23d1c04d2972" />

<img width="1265" height="789" alt="image" src="https://github.com/user-attachments/assets/bee14f26-003c-4f0c-95c9-aa8297898a24" />
