### PR TITLE
Apt repository and managed-install awareness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,3 +237,143 @@ jobs:
           fi
           git commit -m "Update to ${{ steps.meta.outputs.version }}"
           git push origin master
+
+  apt-publish:
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && inputs.draft != true
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
+          path: artifacts
+
+      - name: Install reprepro
+        run: sudo apt-get update && sudo apt-get install -y reprepro
+
+      - name: Import GPG signing key
+        env:
+          APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+        run: |
+          if [ -z "$APT_GPG_PRIVATE_KEY" ]; then
+            echo "ERROR: APT_GPG_PRIVATE_KEY secret is not set"
+            exit 1
+          fi
+          # Loopback so reprepro -> gpg works without a tty.
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          gpgconf --kill gpg-agent || true
+          printf '%s\n' "$APT_GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          if [ -z "$KEY_ID" ]; then
+            echo "ERROR: no secret key found after import"
+            exit 1
+          fi
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+          echo "Imported signing key: $KEY_ID"
+
+      - name: Check out gh-pages branch (if it exists)
+        id: ghpages
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Initialize gh-pages working tree if missing
+        if: steps.ghpages.outcome != 'success'
+        run: |
+          rm -rf gh-pages
+          mkdir gh-pages
+          cd gh-pages
+          git init -b gh-pages
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Configure reprepro distribution
+        run: |
+          cd gh-pages
+          mkdir -p conf
+          cat > conf/distributions <<EOF
+          Origin: Grimoire
+          Label: Grimoire
+          Codename: stable
+          Architectures: amd64
+          Components: main
+          Description: Grimoire apt repository
+          SignWith: $GPG_KEY_ID
+          EOF
+
+      - name: Compute .deb path
+        id: deb
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DEB="artifacts/grimoire_${VERSION}_amd64.deb"
+          if [ ! -f "$DEB" ]; then
+            echo "ERROR: $DEB not found"
+            ls -la artifacts/
+            exit 1
+          fi
+          echo "path=$DEB" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Add .deb to apt repo (reprepro)
+        run: |
+          cd gh-pages
+          # reprepro refuses to re-include a package of the same version unless
+          # we remove it first — safe to ignore the not-present error.
+          reprepro --basedir . remove stable grimoire || true
+          reprepro --basedir . includedeb stable "../${{ steps.deb.outputs.path }}"
+
+      - name: Export public key
+        run: |
+          cd gh-pages
+          gpg --armor --export "$GPG_KEY_ID" > pubkey.asc
+
+      - name: Write index page
+        run: |
+          cd gh-pages
+          cat > index.html <<'EOF'
+          <!doctype html>
+          <html lang="en"><head><meta charset="utf-8">
+          <title>Grimoire apt repository</title>
+          <style>
+            body { font: 14px/1.5 system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #ddd; background: #111; }
+            pre { background: #1a1a1a; border: 1px solid #333; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+            a { color: #8af; }
+            h1 { margin-top: 0; }
+          </style>
+          </head><body>
+          <h1>Grimoire apt repository</h1>
+          <p>Install Grimoire on Debian/Ubuntu and derivatives:</p>
+          <pre>sudo install -d -m 0755 /etc/apt/keyrings
+          curl -fsSL https://slush97.github.io/grimoire/pubkey.asc \
+            | sudo tee /etc/apt/keyrings/grimoire.asc > /dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/grimoire.asc] https://slush97.github.io/grimoire stable main" \
+            | sudo tee /etc/apt/sources.list.d/grimoire.list
+          sudo apt update
+          sudo apt install grimoire</pre>
+          <p>After install, future versions arrive through your normal <code>apt upgrade</code>.</p>
+          <p>Source: <a href="https://github.com/Slush97/grimoire">github.com/Slush97/grimoire</a></p>
+          </body></html>
+          EOF
+
+      - name: Commit and push gh-pages
+        run: |
+          cd gh-pages
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "Publish ${GITHUB_REF_NAME}"
+          git push origin HEAD:gh-pages

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@
 - Linux: `.AppImage` or `.deb`
 - Arch Linux: `yay -S grimoire-bin` ([AUR](https://aur.archlinux.org/packages/grimoire-bin))
 
+Debian/Ubuntu (apt) for automatic updates:
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://slush97.github.io/grimoire/pubkey.asc \
+  | sudo tee /etc/apt/keyrings/grimoire.asc > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/grimoire.asc] https://slush97.github.io/grimoire stable main" \
+  | sudo tee /etc/apt/sources.list.d/grimoire.list
+sudo apt update && sudo apt install grimoire
+```
+
+After install, `sudo apt upgrade` and `yay -Syu` pick up new releases automatically.
+
 Requires Deadlock installed via Steam.
 
 ## Features

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -31,7 +31,7 @@ import './ipc/stats';
 import './ipc/updater';
 import './ipc/launch';
 
-import { initUpdater, checkForUpdates } from './services/updater';
+import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';
 
 let mainWindow: BrowserWindow | null = null;
@@ -218,15 +218,17 @@ if (!gotTheLock) {
         // or grimoire crashed while the user was playing vanilla). Runs in background.
         void runStartupRecovery();
 
-        // Initialize auto-updater (production only)
+        // Initialize auto-updater (production only). Skip the background check
+        // for apt/AUR/snap installs since the package manager owns updates.
         if (!is.dev && mainWindow) {
             initUpdater(mainWindow);
-            // Auto-check for updates after a short delay
-            setTimeout(() => {
-                checkForUpdates().catch((err) => {
-                    console.log('[Updater] Auto-check failed:', err.message);
-                });
-            }, 5000);
+            if (getInstallSource() !== 'managed') {
+                setTimeout(() => {
+                    checkForUpdates().catch((err) => {
+                        console.log('[Updater] Auto-check failed:', err.message);
+                    });
+                }, 5000);
+            }
         }
 
         app.on('activate', () => {

--- a/electron/main/ipc/updater.ts
+++ b/electron/main/ipc/updater.ts
@@ -5,11 +5,18 @@ import {
     downloadUpdate,
     quitAndInstall,
     getUpdateStatus,
+    getInstallSource,
 } from '../services/updater';
 
 // Get current app version
 ipcMain.handle('updater:getVersion', () => {
     return getAppVersion();
+});
+
+// Tell the renderer whether in-app updates are available, so apt/AUR users
+// see a "use your package manager" message instead of broken update buttons.
+ipcMain.handle('updater:getInstallSource', () => {
+    return getInstallSource();
 });
 
 // Get current update status

--- a/electron/main/services/updater.ts
+++ b/electron/main/services/updater.ts
@@ -4,6 +4,31 @@ import type { UpdateInfo } from 'electron-updater';
 import { app, BrowserWindow } from 'electron';
 import log from 'electron-log';
 
+export type InstallSource = 'managed' | 'appimage' | 'standard';
+
+// Detect installs owned by a system package manager (apt/AUR/snap/flatpak).
+// In-app updates would fail on these because /opt and /usr are root-owned, so
+// we route those users to their package manager instead.
+export function getInstallSource(): InstallSource {
+    if (process.platform === 'linux') {
+        if (process.env.APPIMAGE) return 'appimage';
+        const exec = process.execPath;
+        if (
+            exec.startsWith('/opt/') ||
+            exec.startsWith('/usr/') ||
+            exec.startsWith('/snap/') ||
+            exec.startsWith('/var/lib/flatpak/') ||
+            exec.startsWith('/app/')
+        ) {
+            return 'managed';
+        }
+    }
+    return 'standard';
+}
+
+const installSource = getInstallSource();
+const updaterDisabled = installSource === 'managed';
+
 // Configure logging
 autoUpdater.logger = log;
 log.transports.file.level = 'info';
@@ -49,6 +74,10 @@ function sendStatusToRenderer() {
 
 export function initUpdater(window: BrowserWindow) {
     mainWindow = window;
+    if (updaterDisabled) {
+        log.info('[Updater] System package install detected; in-app updater disabled.');
+        return;
+    }
 
     autoUpdater.on('checking-for-update', () => {
         currentStatus = { ...currentStatus, checking: true, error: null };
@@ -111,6 +140,7 @@ export function getAppVersion(): string {
 }
 
 export async function checkForUpdates(): Promise<UpdateInfo | null> {
+    if (updaterDisabled) return null;
     try {
         const result = await autoUpdater.checkForUpdates();
         return result?.updateInfo ?? null;
@@ -121,6 +151,7 @@ export async function checkForUpdates(): Promise<UpdateInfo | null> {
 }
 
 export async function downloadUpdate(): Promise<void> {
+    if (updaterDisabled) return;
     try {
         await autoUpdater.downloadUpdate();
     } catch (error) {
@@ -130,6 +161,7 @@ export async function downloadUpdate(): Promise<void> {
 }
 
 export function quitAndInstall(): void {
+    if (updaterDisabled) return;
     autoUpdater.quitAndInstall(false, true);
 }
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -137,6 +137,7 @@ export interface ElectronAPI {
     updater: {
         getVersion: () => Promise<string>;
         getStatus: () => Promise<UpdateStatus>;
+        getInstallSource: () => Promise<'managed' | 'appimage' | 'standard'>;
         checkForUpdates: () => Promise<UpdateInfo | null>;
         downloadUpdate: () => Promise<void>;
         installUpdate: () => void;
@@ -867,6 +868,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updater: {
         getVersion: () => ipcRenderer.invoke('updater:getVersion'),
         getStatus: () => ipcRenderer.invoke('updater:getStatus'),
+        getInstallSource: () => ipcRenderer.invoke('updater:getInstallSource'),
         checkForUpdates: () => ipcRenderer.invoke('updater:check'),
         downloadUpdate: () => ipcRenderer.invoke('updater:download'),
         installUpdate: () => ipcRenderer.invoke('updater:install'),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
-import { X, Download, ArrowDownCircle, RefreshCw, Sparkles, AlertTriangle } from 'lucide-react';
+import { X, Download, ArrowDownCircle, RefreshCw, Sparkles, AlertTriangle, Package } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { Button } from './common/ui';
+
+type InstallSource = 'managed' | 'appimage' | 'standard';
 
 interface UpdateInfo {
     version: string;
@@ -27,10 +29,12 @@ export default function UpdateModal({ onClose }: Props) {
     const [appVersion, setAppVersion] = useState('');
     const [status, setStatus] = useState<UpdateStatus | null>(null);
     const [checkedOnce, setCheckedOnce] = useState(false);
+    const [installSource, setInstallSource] = useState<InstallSource>('standard');
 
     useEffect(() => {
         window.electronAPI.updater.getVersion().then(setAppVersion);
         window.electronAPI.updater.getStatus().then(setStatus);
+        window.electronAPI.updater.getInstallSource().then(setInstallSource);
         const unsub = window.electronAPI.updater.onStatus((s) => {
             setStatus(s);
             if (!s.checking) setCheckedOnce(true);
@@ -108,6 +112,21 @@ export default function UpdateModal({ onClose }: Props) {
                 </div>
 
                 <div className="p-6 overflow-y-auto flex-1 min-h-0">
+                    {installSource === 'managed' && (
+                        <div className="flex items-start gap-3 p-4 rounded-lg bg-bg-tertiary border border-white/10 mb-4">
+                            <Package className="w-5 h-5 flex-shrink-0 mt-0.5 text-accent" />
+                            <div className="text-sm text-text-secondary space-y-2">
+                                <p className="text-text-primary font-medium">Managed by your package manager.</p>
+                                <p>This install was provided through apt or AUR. Update with your usual system upgrade:</p>
+                                <pre className="bg-bg-primary border border-white/10 rounded-sm p-2 text-xs font-mono overflow-x-auto">{`# apt
+sudo apt update && sudo apt upgrade grimoire
+
+# AUR
+yay -Syu grimoire-bin`}</pre>
+                            </div>
+                        </div>
+                    )}
+
                     {status?.error && (
                         <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm mb-4">
                             <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -177,7 +196,7 @@ export default function UpdateModal({ onClose }: Props) {
                                 </div>
                             )}
                         </>
-                    ) : !status?.available && !status?.checking && (
+                    ) : installSource !== 'managed' && !status?.available && !status?.checking && (
                         <p className="text-sm text-text-secondary">
                             Updates are delivered automatically through GitHub Releases. Click Check for Updates to look now.
                         </p>
@@ -188,7 +207,7 @@ export default function UpdateModal({ onClose }: Props) {
                     <Button onClick={onClose} variant="secondary">
                         Close
                     </Button>
-                    {status?.downloaded ? (
+                    {installSource === 'managed' ? null : status?.downloaded ? (
                         <Button onClick={handleInstall} icon={ArrowDownCircle}>
                             Install &amp; Restart
                         </Button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -54,6 +54,7 @@ export default function Settings() {
   } | null>(null);
   const [showChangelog, setShowChangelog] = useState(false);
   const [upToDate, setUpToDate] = useState(false);
+  const [installSource, setInstallSource] = useState<'managed' | 'appimage' | 'standard'>('standard');
 
   const isDevMode = settings?.devMode ?? false;
   const activeDeadlockPath = getActiveDeadlockPath(settings);
@@ -293,6 +294,7 @@ export default function Settings() {
   useEffect(() => {
     window.electronAPI.updater.getVersion().then(setAppVersion);
     window.electronAPI.updater.getStatus().then(setUpdateStatus);
+    window.electronAPI.updater.getInstallSource().then(setInstallSource);
     const unsub = window.electronAPI.updater.onStatus(setUpdateStatus);
     return unsub;
   }, []);
@@ -517,7 +519,7 @@ export default function Settings() {
                 )}
               </div>
               <div className="flex flex-wrap gap-2">
-                {updateStatus?.downloaded ? (
+                {installSource === 'managed' ? null : updateStatus?.downloaded ? (
                   <Button
                     onClick={handleInstallUpdate}
                     icon={ArrowDownCircle}
@@ -554,6 +556,18 @@ export default function Settings() {
                 )}
               </div>
             </div>
+
+            {installSource === 'managed' && (
+              <div className="rounded-lg bg-bg-tertiary border border-white/10 p-3 text-sm text-text-secondary space-y-2">
+                <p className="text-text-primary font-medium">Updates are managed by your package manager.</p>
+                <p>Grimoire was installed via apt or AUR. Update with your usual system upgrade:</p>
+                <pre className="bg-bg-primary border border-white/10 rounded-sm p-2 text-xs font-mono overflow-x-auto">{`# apt
+sudo apt update && sudo apt upgrade grimoire
+
+# AUR
+yay -Syu grimoire-bin`}</pre>
+              </div>
+            )}
 
             {updateStatus?.downloading && (
               <div className="animate-fade-in">

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -394,6 +394,7 @@ export interface ElectronAPI {
     updater: {
         getVersion: () => Promise<string>;
         getStatus: () => Promise<UpdateStatus>;
+        getInstallSource: () => Promise<'managed' | 'appimage' | 'standard'>;
         checkForUpdates: () => Promise<UpdateInfo | null>;
         downloadUpdate: () => Promise<void>;
         installUpdate: () => void;


### PR DESCRIPTION
## Summary
- Publish a signed Debian apt repository to `gh-pages` on every tagged release so Debian/Ubuntu users get apt-style updates alongside AUR.
- Detect installs running from `/opt`, `/usr`, `/snap`, or flatpak paths and replace the in-app updater UI with a "managed by your package manager" panel showing the right `apt upgrade` / `yay -Syu` command.
- Skip the 5s startup update check on managed installs so apt/AUR users no longer get prompts the package manager will overwrite.

## Test plan
- [ ] Tag `v1.9.1` and confirm `apt-publish` job creates the `gh-pages` branch with `dists/stable/main/binary-amd64/Packages`, `Release`, `InRelease`, `pool/main/g/grimoire/grimoire_1.9.1_amd64.deb`, `pubkey.asc`, and `index.html`.
- [ ] Switch GitHub Pages source to `gh-pages / (root)` and confirm `https://slush97.github.io/grimoire/pubkey.asc` resolves.
- [ ] Run the README install snippet on a fresh Debian/Ubuntu container; `apt install grimoire` succeeds without `[trusted=yes]`.
- [ ] Install the `.deb` on a Linux box, launch Grimoire, open Settings -> Updates: see the managed-install panel and no Check/Download buttons.
- [ ] AppImage build still surfaces the normal updater UI.
- [ ] Bump the published `.deb` (e.g. dry-run a v1.9.2) and confirm `sudo apt update && sudo apt upgrade grimoire` pulls the new version.