### PR TITLE
Release 1.9.2 plus collection import, profile rename, support card

### DIFF
--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -6,10 +6,14 @@ import {
     fetchSubmissions,
     fetchModDetails,
     fetchModComments,
+    fetchCollection,
+    fetchCollectionItems,
     GameBananaSection,
     GameBananaCategoryNode,
     GameBananaModsResponse,
     GameBananaModDetails,
+    GameBananaCollection,
+    GameBananaCollectionItemsResponse,
 } from '../services/gamebanana';
 import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, resolveSuspiciousFileDecision, resolveMultiVpkPick, DownloadModArgs } from '../services/download';
 import { getMainWindow } from '../index';
@@ -141,5 +145,24 @@ ipcMain.handle(
     'get-gamebanana-categories',
     async (_, args: GetCategoriesArgs): Promise<GameBananaCategoryNode[]> => {
         return fetchCategoryTree(args.categoryModelName);
+    }
+);
+
+// get-collection — metadata only
+ipcMain.handle(
+    'get-collection',
+    async (_, args: { collectionId: number }): Promise<GameBananaCollection> => {
+        return fetchCollection(args.collectionId);
+    }
+);
+
+// get-collection-items — one page (15 records, server-capped)
+ipcMain.handle(
+    'get-collection-items',
+    async (
+        _,
+        args: { collectionId: number; page?: number }
+    ): Promise<GameBananaCollectionItemsResponse> => {
+        return fetchCollectionItems(args.collectionId, args.page ?? 1);
     }
 );

--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -3,6 +3,7 @@ import { loadSettings, saveSettings } from '../services/settings';
 import {
     loadProfiles,
     createProfile,
+    createProfileFromGameBananaIds,
     updateProfile,
     applyProfile,
     deleteProfile,
@@ -42,6 +43,22 @@ ipcMain.handle('create-profile', async (_, name: string, crosshairSettings?: Pro
 
     return profile;
 });
+
+// create-profile-from-gamebanana-ids — used by the collection import flow
+// to make a profile containing only the mods that were just imported.
+ipcMain.handle(
+    'create-profile-from-gamebanana-ids',
+    async (
+        _,
+        args: { name: string; gameBananaIds: number[] }
+    ): Promise<Profile> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        return createProfileFromGameBananaIds(deadlockPath, args.name, args.gameBananaIds);
+    }
+);
 
 // update-profile
 ipcMain.handle('update-profile', async (_, profileId: string, crosshairSettings?: ProfileCrosshairSettings): Promise<Profile> => {

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -6,7 +6,7 @@ import { BrowserWindow } from 'electron';
 import { getDisabledPath } from './deadlock';
 import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles } from './extract';
 import { randomUUID } from 'crypto';
-import { setModMetadata } from './metadata';
+import { setModMetadata, getModMetadata } from './metadata';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
 import { getUsedPriorities, scanMods, disableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
@@ -742,13 +742,19 @@ async function executeDownload(
         try {
             const installedSet = new Set(installedVpks);
             const allMods = await scanMods(deadlockPath);
-            const stalePeers = allMods.filter(
-                (m) =>
-                    m.enabled &&
-                    m.gameBananaId === modId &&
-                    m.gameBananaFileId !== fileId &&
-                    !installedSet.has(m.fileName)
-            );
+            // scanMods returns filesystem state only; gameBananaId and
+            // gameBananaFileId live in the metadata sidecar (enriched at
+            // the IPC boundary by enrichMod). Read them per-mod here or the
+            // filter never matches and no sibling variants ever get disabled.
+            const stalePeers = allMods.filter((m) => {
+                if (!m.enabled) return false;
+                if (installedSet.has(m.fileName)) return false;
+                const meta = getModMetadata(m.fileName);
+                return (
+                    meta?.gameBananaId === modId &&
+                    meta?.gameBananaFileId !== fileId
+                );
+            });
             const disabledPeers: Array<{ id: string; name: string; fileName: string }> = [];
             for (const peer of stalePeers) {
                 console.log(`[downloadMod] Auto-disabling sibling variant: ${peer.fileName}`);

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -105,6 +105,41 @@ export interface GameBananaModDetails {
     previewMedia?: GameBananaPreviewMedia;
 }
 
+export interface GameBananaCollection {
+    id: number;
+    name: string;
+    description?: string;
+    dateAdded: number;
+    dateModified: number;
+    submitter?: GameBananaSubmitter;
+    previewMedia?: GameBananaPreviewMedia;
+}
+
+export interface GameBananaCollectionItem {
+    id: number;
+    modelName: string;
+    name: string;
+    profileUrl: string;
+    dateAdded: number;
+    dateModified: number;
+    likeCount: number;
+    viewCount: number;
+    hasFiles: boolean;
+    nsfw: boolean;
+    gameId?: number;
+    gameName?: string;
+    submitter?: GameBananaSubmitter;
+    previewMedia?: GameBananaPreviewMedia;
+    rootCategory?: GameBananaCategory;
+}
+
+export interface GameBananaCollectionItemsResponse {
+    records: GameBananaCollectionItem[];
+    totalCount: number;
+    isComplete: boolean;
+    perPage: number;
+}
+
 // Raw API response types
 interface SectionRaw {
     _sPluralTitle: string;
@@ -208,6 +243,49 @@ interface ModDetailsRaw {
     _aFiles?: FileRaw[];
     _aPreviewMedia?: ModRaw['_aPreviewMedia'];
     _aCategory?: ModRaw['_aRootCategory'];
+}
+
+interface CollectionRaw {
+    _idRow: number;
+    _sName: string;
+    _sDescription?: string;
+    _tsDateAdded: number;
+    _tsDateModified: number;
+    _aSubmitter?: ModRaw['_aSubmitter'];
+    _aPreviewMedia?: ModRaw['_aPreviewMedia'];
+}
+
+interface CollectionItemRaw {
+    _idRow: number;
+    _sModelName: string;
+    _sName: string;
+    _sProfileUrl: string;
+    _tsDateAdded: number;
+    _tsDateModified?: number;
+    _tsDateUpdated?: number;
+    _bHasFiles?: boolean;
+    _bHasContentRatings?: boolean;
+    _bIsNsfw?: boolean;
+    _nLikeCount?: number;
+    _nViewCount?: number;
+    _aSubmitter?: ModRaw['_aSubmitter'];
+    _aPreviewMedia?: ModRaw['_aPreviewMedia'];
+    _aRootCategory?: ModRaw['_aRootCategory'];
+    _aGame?: {
+        _idRow?: number;
+        _sName?: string;
+        _sProfileUrl?: string;
+        _sIconUrl?: string;
+    };
+}
+
+interface CollectionItemsResponseRaw {
+    _aRecords: CollectionItemRaw[];
+    _aMetadata: {
+        _nRecordCount: number;
+        _nPerpage: number;
+        _bIsComplete: boolean;
+    };
 }
 
 /**
@@ -522,5 +600,124 @@ export async function fetchModDetails(
                     : undefined,
             }
             : undefined,
+    };
+}
+
+function mapSubmitter(raw: ModRaw['_aSubmitter']): GameBananaSubmitter | undefined {
+    if (!raw) return undefined;
+    return {
+        id: raw._idRow,
+        name: raw._sName,
+        avatarUrl: raw._sAvatarUrl,
+    };
+}
+
+function mapPreviewMedia(raw: ModRaw['_aPreviewMedia']): GameBananaPreviewMedia | undefined {
+    if (!raw?._aImages && !raw?._aMetadata) return undefined;
+    return {
+        images: raw._aImages
+            ?.filter((img) => img && img._sBaseUrl)
+            .map((img) => ({
+                baseUrl: img._sBaseUrl,
+                file: img._sFile,
+                file220: img._sFile220,
+                file530: img._sFile530,
+            })),
+        metadata: raw._aMetadata ? { audioUrl: raw._aMetadata._sAudioUrl } : undefined,
+    };
+}
+
+/**
+ * Parse a collection identifier from either a numeric id or a GameBanana URL.
+ * Accepts "164637", "https://gamebanana.com/collections/164637", or trailing
+ * fragments/queries. Returns null on garbage so the UI can show a friendly error.
+ */
+export function parseCollectionId(input: string): number | null {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+
+    if (/^\d+$/.test(trimmed)) {
+        const n = Number(trimmed);
+        return Number.isFinite(n) && n > 0 ? n : null;
+    }
+
+    try {
+        const url = new URL(trimmed);
+        if (!url.hostname.endsWith('gamebanana.com')) return null;
+        const match = url.pathname.match(/\/collections\/(\d+)/i);
+        if (!match) return null;
+        const n = Number(match[1]);
+        return Number.isFinite(n) && n > 0 ? n : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Fetch a collection's metadata (name, description, submitter, preview).
+ * Items live on a separate endpoint — see fetchCollectionItems.
+ */
+export async function fetchCollection(collectionId: number): Promise<GameBananaCollection> {
+    const url = `${GAMEBANANA_API_BASE}/Collection/${collectionId}?_csvProperties=_idRow,_sName,_sDescription,_aSubmitter,_aPreviewMedia,_tsDateAdded,_tsDateModified`;
+    console.log('[fetchCollection] URL:', url);
+    const raw = await fetchJson<CollectionRaw>(url);
+
+    return {
+        id: raw._idRow,
+        name: raw._sName,
+        description: raw._sDescription,
+        dateAdded: raw._tsDateAdded,
+        dateModified: raw._tsDateModified,
+        submitter: mapSubmitter(raw._aSubmitter),
+        previewMedia: mapPreviewMedia(raw._aPreviewMedia),
+    };
+}
+
+/**
+ * Fetch one page of collection items. The Items endpoint server-caps perPage
+ * at 15 regardless of the requested value, so callers paginate by incrementing
+ * `page` until `isComplete` is true.
+ */
+export async function fetchCollectionItems(
+    collectionId: number,
+    page = 1
+): Promise<GameBananaCollectionItemsResponse> {
+    const url = `${GAMEBANANA_API_BASE}/Collection/${collectionId}/Items?_nPage=${page}`;
+    console.log('[fetchCollectionItems] URL:', url);
+    const raw = await fetchJson<CollectionItemsResponseRaw>(url);
+
+    const records = (raw._aRecords ?? []).map<GameBananaCollectionItem>((item) => ({
+        id: item._idRow,
+        modelName: item._sModelName,
+        name: item._sName,
+        profileUrl: item._sProfileUrl,
+        dateAdded: item._tsDateAdded,
+        dateModified: item._tsDateModified ?? item._tsDateUpdated ?? item._tsDateAdded,
+        likeCount: item._nLikeCount ?? 0,
+        viewCount: item._nViewCount ?? 0,
+        hasFiles: item._bHasFiles ?? false,
+        // Items endpoint doesn't return _bIsNsfw; fall back to _bHasContentRatings
+        // (same heuristic used by mapMod for list endpoints).
+        nsfw: item._bIsNsfw ?? item._bHasContentRatings ?? false,
+        gameId: item._aGame?._idRow,
+        gameName: item._aGame?._sName,
+        submitter: mapSubmitter(item._aSubmitter),
+        previewMedia: mapPreviewMedia(item._aPreviewMedia),
+        rootCategory: item._aRootCategory
+            ? {
+                id: item._aRootCategory._idRow,
+                name: item._aRootCategory._sName,
+                modelName: item._aRootCategory._sModelName,
+                profileUrl: item._aRootCategory._sProfileUrl,
+                iconUrl: item._aRootCategory._sIconUrl,
+            }
+            : undefined,
+    }));
+
+    return {
+        records,
+        totalCount: raw._aMetadata._nRecordCount,
+        isComplete: raw._aMetadata._bIsComplete,
+        perPage: raw._aMetadata._nPerpage,
     };
 }

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkS
 import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
 import { scanMods, enableMod, disableMod, setModPriority } from './mods';
+import { getModMetadata } from './metadata';
 import { readAutoexec, writeAutoexec } from './autoexec';
 
 export interface ProfileMod {
@@ -129,9 +130,11 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
  * profile contains ONLY the mods that were just imported, not every other
  * enabled mod in the user's library.
  *
- * Mods whose gameBananaId matches but aren't currently enabled are still
- * included with their actual enabled state preserved — so a user who
- * disables one mid-import gets that reflected in the profile.
+ * Mods are recorded as enabled=true regardless of their current filesystem
+ * state. The download pipeline installs new mods to the disabled folder,
+ * so capturing live state would save the profile with everything disabled.
+ * The user's intent in saving a collection as a profile is "make these the
+ * active set when I apply this", so we encode that explicitly.
  */
 export async function createProfileFromGameBananaIds(
     deadlockPath: string,
@@ -140,9 +143,14 @@ export async function createProfileFromGameBananaIds(
 ): Promise<Profile> {
     const idSet = new Set(gameBananaIds);
     const mods = await scanMods(deadlockPath);
-    const matching = mods.filter((mod) =>
-        mod.gameBananaId !== undefined && idSet.has(mod.gameBananaId)
-    );
+    // scanMods returns filesystem-only state. gameBananaId lives in the
+    // metadata sidecar (read at the IPC layer via enrichMod), so we look
+    // it up per-mod here. Without this the filter never matches and the
+    // profile saves zero mods.
+    const matching = mods.filter((mod) => {
+        const metadata = getModMetadata(mod.fileName);
+        return metadata?.gameBananaId !== undefined && idSet.has(metadata.gameBananaId);
+    });
 
     const autoexecData = readAutoexec(deadlockPath);
     const now = new Date().toISOString();
@@ -152,7 +160,7 @@ export async function createProfileFromGameBananaIds(
         name,
         mods: matching.map((mod) => ({
             fileName: mod.fileName,
-            enabled: mod.enabled,
+            enabled: true,
             priority: mod.priority,
         })),
         autoexecCommands: autoexecData.commands,

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -124,6 +124,50 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
 }
 
 /**
+ * Create a profile from a specific subset of installed mods, identified by
+ * GameBanana mod ids. Used by the collection import flow: the resulting
+ * profile contains ONLY the mods that were just imported, not every other
+ * enabled mod in the user's library.
+ *
+ * Mods whose gameBananaId matches but aren't currently enabled are still
+ * included with their actual enabled state preserved — so a user who
+ * disables one mid-import gets that reflected in the profile.
+ */
+export async function createProfileFromGameBananaIds(
+    deadlockPath: string,
+    name: string,
+    gameBananaIds: number[]
+): Promise<Profile> {
+    const idSet = new Set(gameBananaIds);
+    const mods = await scanMods(deadlockPath);
+    const matching = mods.filter((mod) =>
+        mod.gameBananaId !== undefined && idSet.has(mod.gameBananaId)
+    );
+
+    const autoexecData = readAutoexec(deadlockPath);
+    const now = new Date().toISOString();
+
+    const profile: Profile = {
+        id: generateProfileId(),
+        name,
+        mods: matching.map((mod) => ({
+            fileName: mod.fileName,
+            enabled: mod.enabled,
+            priority: mod.priority,
+        })),
+        autoexecCommands: autoexecData.commands,
+        createdAt: now,
+        updatedAt: now,
+    };
+
+    const profiles = loadProfiles();
+    profiles.push(profile);
+    saveProfiles(profiles);
+
+    return profile;
+}
+
+/**
  * Update an existing profile with current mod state
  * Only saves enabled mods - disabled mods are not included
  */

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -38,6 +38,8 @@ export interface ElectronAPI {
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;
     getGameBananaCategories: (args: GetCategoriesArgs) => Promise<GameBananaCategoryNode[]>;
+    getCollection: (args: { collectionId: number }) => Promise<GameBananaCollection>;
+    getCollectionItems: (args: { collectionId: number; page?: number }) => Promise<GameBananaCollectionItemsResponse>;
 
     // Mina Variants
     setMinaPreset: (args: SetMinaPresetArgs) => Promise<void>;
@@ -99,6 +101,7 @@ export interface ElectronAPI {
     // Profiles
     getProfiles: () => Promise<Profile[]>;
     createProfile: (name: string, crosshairSettings?: ProfileCrosshairSettings) => Promise<Profile>;
+    createProfileFromGameBananaIds: (args: { name: string; gameBananaIds: number[] }) => Promise<Profile>;
     updateProfile: (profileId: string, crosshairSettings?: ProfileCrosshairSettings) => Promise<Profile>;
     applyProfile: (profileId: string) => Promise<Profile>;
     deleteProfile: (profileId: string) => Promise<void>;
@@ -513,6 +516,23 @@ interface GameBananaCategoryNode {
     children?: GameBananaCategoryNode[];
 }
 
+interface GameBananaCollection {
+    id: number;
+    name: string;
+    description?: string;
+    dateAdded: number;
+    dateModified: number;
+    submitter?: unknown;
+    previewMedia?: unknown;
+}
+
+interface GameBananaCollectionItemsResponse {
+    records: unknown[];
+    totalCount: number;
+    isComplete: boolean;
+    perPage: number;
+}
+
 interface ModConflict {
     modA: string;
     modAName: string;
@@ -728,6 +748,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getGameBananaSections: () => ipcRenderer.invoke('get-gamebanana-sections'),
     getGameBananaCategories: (args: GetCategoriesArgs) =>
         ipcRenderer.invoke('get-gamebanana-categories', args),
+    getCollection: (args: { collectionId: number }) =>
+        ipcRenderer.invoke('get-collection', args),
+    getCollectionItems: (args: { collectionId: number; page?: number }) =>
+        ipcRenderer.invoke('get-collection-items', args),
 
     // Mina Variants
     setMinaPreset: (args: SetMinaPresetArgs) => ipcRenderer.invoke('set-mina-preset', args),
@@ -824,6 +848,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Profiles
     getProfiles: () => ipcRenderer.invoke('get-profiles'),
     createProfile: (name: string, crosshairSettings?: ProfileCrosshairSettings) => ipcRenderer.invoke('create-profile', name, crosshairSettings),
+    createProfileFromGameBananaIds: (args: { name: string; gameBananaIds: number[] }) =>
+        ipcRenderer.invoke('create-profile-from-gamebanana-ids', args),
     updateProfile: (profileId: string, crosshairSettings?: ProfileCrosshairSettings) => ipcRenderer.invoke('update-profile', profileId, crosshairSettings),
     applyProfile: (profileId: string) => ipcRenderer.invoke('apply-profile', profileId),
     deleteProfile: (profileId: string) => ipcRenderer.invoke('delete-profile', profileId),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -943,7 +943,7 @@ export default function ImportCollectionModal({
                   selected.size === 0 ||
                   !activeDeadlockPath ||
                   rows.length === 0 ||
-                  !rowsRef.current.some(
+                  !rows.some(
                     (r) => selected.has(r.item.id) && r.status === 'idle'
                   )
                 }

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -1,0 +1,960 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  X,
+  Loader2,
+  Library,
+  Download,
+  CheckCircle2,
+  AlertTriangle,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+  Ban,
+} from 'lucide-react';
+import {
+  getCollection,
+  getCollectionItems,
+  getModDetails,
+  downloadMod,
+  createProfileFromGameBananaIds,
+} from '../lib/api';
+import { Button } from './common/ui';
+import ModThumbnail from './ModThumbnail';
+import type {
+  GameBananaCollection,
+  GameBananaCollectionItem,
+  GameBananaFile,
+  GameBananaModDetails,
+  GameBananaPreviewMedia,
+} from '../types/gamebanana';
+import {
+  getModThumbnail,
+  getPrimaryFile,
+  parseCollectionId,
+} from '../types/gamebanana';
+
+// GameBanana game id for Deadlock — items in other games can't be installed.
+const DEADLOCK_GAME_ID = 20948;
+
+// Item types Grimoire can install. Matches Browse.tsx SECTION_WHITELIST.
+const SUPPORTED_MODEL_NAMES = new Set(['Mod', 'Sound']);
+
+interface ImportCollectionModalProps {
+  hideNsfwPreviews: boolean;
+  installedIds: Set<number>;
+  queuedIds: Set<number>;
+  activeDeadlockPath: string | null;
+  onClose: () => void;
+}
+
+type SkipReason =
+  | { kind: 'wrong-game'; gameName?: string }
+  | { kind: 'unsupported-type'; modelName: string }
+  | { kind: 'no-files' }
+  | { kind: 'files-unavailable' };
+
+// Live status mirrors the main-process queue so users see what's actually
+// happening rather than a single ambiguous "queued" label.
+type RowStatus =
+  | 'idle'           // not submitted
+  | 'resolving'      // fetching mod details (variant lookup or pre-queue)
+  | 'queued'         // accepted by main-process queue, waiting
+  | 'downloading'    // currently the active download
+  | 'installed'      // download-complete event received
+  | 'cancelled'      // user removed from queue or stopped batch
+  | 'failed';        // download-error event received or details fetch threw
+
+interface ItemRow {
+  item: GameBananaCollectionItem;
+  selectable: boolean;
+  skip?: SkipReason;
+  status: RowStatus;
+  statusMessage?: string;
+  details?: GameBananaModDetails;
+  detailsLoading?: boolean;
+  detailsError?: string;
+  pickedFileId?: number;
+  variantsOpen?: boolean;
+}
+
+function classifySkip(item: GameBananaCollectionItem): SkipReason | undefined {
+  if (!SUPPORTED_MODEL_NAMES.has(item.modelName)) {
+    return { kind: 'unsupported-type', modelName: item.modelName };
+  }
+  if (item.gameId !== undefined && item.gameId !== DEADLOCK_GAME_ID) {
+    return { kind: 'wrong-game', gameName: item.gameName };
+  }
+  if (!item.hasFiles) {
+    return { kind: 'no-files' };
+  }
+  return undefined;
+}
+
+function initialStatus(
+  item: GameBananaCollectionItem,
+  installedIds: Set<number>,
+  queuedIds: Set<number>
+): RowStatus {
+  if (installedIds.has(item.id)) return 'installed';
+  if (queuedIds.has(item.id)) return 'queued';
+  return 'idle';
+}
+
+function buildRows(
+  items: GameBananaCollectionItem[],
+  installedIds: Set<number>,
+  queuedIds: Set<number>
+): ItemRow[] {
+  return items.map((item) => {
+    const skip = classifySkip(item);
+    return {
+      item,
+      selectable: !skip,
+      skip,
+      status: skip ? 'idle' : initialStatus(item, installedIds, queuedIds),
+    };
+  });
+}
+
+function skipReasonLabel(reason: SkipReason): string {
+  switch (reason.kind) {
+    case 'wrong-game':
+      return `Skipped: ${reason.gameName ?? 'different game'}`;
+    case 'unsupported-type':
+      return `Skipped: ${reason.modelName} not supported`;
+    case 'no-files':
+      return 'Skipped: no downloadable files';
+    case 'files-unavailable':
+      return 'Files unavailable';
+  }
+}
+
+// Render file preview thumbnail via the same getter as collection items so
+// the picker UI stays visually consistent.
+function previewThumb(media: GameBananaPreviewMedia | undefined): string | undefined {
+  return getModThumbnail({ previewMedia: media } as Parameters<typeof getModThumbnail>[0]);
+}
+
+export default function ImportCollectionModal({
+  hideNsfwPreviews,
+  installedIds,
+  queuedIds,
+  activeDeadlockPath,
+  onClose,
+}: ImportCollectionModalProps) {
+  const [input, setInput] = useState('');
+  const [collection, setCollection] = useState<GameBananaCollection | null>(null);
+  const [rows, setRows] = useState<ItemRow[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loadingItems, setLoadingItems] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  // We use a separate "submitting" flag rather than blocking on the
+  // submission loop — once items are in the main-process queue, the modal
+  // stays interactive (cancel buttons, variant pickers for not-yet-queued
+  // rows, etc.).
+  const [submitting, setSubmitting] = useState(false);
+  // Snapshot of which ids were submitted in the active batch. Determines
+  // which mods belong in a post-install profile if the user opts in.
+  const [batchIds, setBatchIds] = useState<Set<number>>(new Set());
+  const [profileStatus, setProfileStatus] = useState<
+    | { kind: 'idle' }
+    | { kind: 'creating' }
+    | { kind: 'created'; profileName: string }
+    | { kind: 'failed'; message: string }
+  >({ kind: 'idle' });
+
+  // Cancel token for in-flight pagination + submission. Bumping invalidates
+  // older in-flight loops so a second resolve/queue click doesn't race.
+  const loadTokenRef = useRef(0);
+  const submitTokenRef = useRef(0);
+  // Ref mirror of rows for event handlers that need current state without
+  // re-subscribing on every change.
+  const rowsRef = useRef<ItemRow[]>(rows);
+  useEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
+
+  // Track which mod ids this modal owns so global queue events don't bleed
+  // into rows that came from elsewhere (e.g. the user kicked off a download
+  // from Browse while the modal is open).
+  const trackedIdsRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    const next = new Set<number>();
+    for (const r of rows) next.add(r.item.id);
+    trackedIdsRef.current = next;
+  }, [rows]);
+
+  // ───────── Live state from main-process queue events ─────────
+
+  const updateRow = useCallback((id: number, patch: Partial<ItemRow>) => {
+    setRows((prev) => prev.map((r) => (r.item.id === id ? { ...r, ...patch } : r)));
+  }, []);
+
+  useEffect(() => {
+    const unsubQueue = window.electronAPI.onDownloadQueueUpdated((data) => {
+      const queuedHere = new Set(data.queue.map((q) => q.modId));
+      const currentId = data.currentDownload?.modId;
+      setRows((prev) =>
+        prev.map((r) => {
+          if (!trackedIdsRef.current.has(r.item.id)) return r;
+          // Don't clobber final states (installed / failed / cancelled).
+          if (r.status === 'installed' || r.status === 'failed' || r.status === 'cancelled') {
+            return r;
+          }
+          if (currentId === r.item.id) {
+            return r.status === 'downloading' ? r : { ...r, status: 'downloading' };
+          }
+          if (queuedHere.has(r.item.id)) {
+            return r.status === 'queued' ? r : { ...r, status: 'queued' };
+          }
+          // If we previously marked it 'queued' or 'downloading' but it's
+          // gone from the main queue now, leave it alone — a complete/error
+          // event will arrive (or already did) to set the terminal state.
+          return r;
+        })
+      );
+    });
+
+    const unsubComplete = window.electronAPI.onDownloadComplete(({ modId }) => {
+      if (!trackedIdsRef.current.has(modId)) return;
+      updateRow(modId, { status: 'installed', statusMessage: undefined });
+    });
+
+    const unsubError = window.electronAPI.onDownloadError(({ modId, message }) => {
+      if (!trackedIdsRef.current.has(modId)) return;
+      updateRow(modId, { status: 'failed', statusMessage: message });
+    });
+
+    return () => {
+      unsubQueue();
+      unsubComplete();
+      unsubError();
+    };
+  }, [updateRow]);
+
+  // Whether the active batch has settled (every submitted row is in a
+  // terminal state). Drives the post-install "save as profile" prompt.
+  const batchSettled = useMemo(() => {
+    if (batchIds.size === 0) return false;
+    const batchRows = rows.filter((r) => batchIds.has(r.item.id));
+    if (batchRows.length === 0) return false;
+    return batchRows.every(
+      (r) =>
+        r.status === 'installed' ||
+        r.status === 'failed' ||
+        r.status === 'cancelled' ||
+        // Rows flipped to a skip reason post-resolve (files-unavailable) count
+        // as terminal too: they were dropped from selection but tracked here.
+        !r.selectable
+    );
+  }, [batchIds, rows]);
+
+  // Ids that actually installed in this batch (the candidates for a profile).
+  const installedBatchIds = useMemo(
+    () =>
+      rows
+        .filter((r) => batchIds.has(r.item.id) && r.status === 'installed')
+        .map((r) => r.item.id),
+    [batchIds, rows]
+  );
+
+  const handleSaveProfile = useCallback(async () => {
+    if (!collection) return;
+    if (installedBatchIds.length === 0) return;
+    setProfileStatus({ kind: 'creating' });
+    try {
+      const profile = await createProfileFromGameBananaIds(collection.name, installedBatchIds);
+      setProfileStatus({ kind: 'created', profileName: profile.name });
+    } catch (err) {
+      setProfileStatus({
+        kind: 'failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [collection, installedBatchIds]);
+
+  // Escape closes — but only when we're not mid-submission (don't yank the
+  // modal out from under a running batch).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, submitting]);
+
+  // ───────── Fetching collection + items ─────────
+
+  const resolveCollection = useCallback(async () => {
+    const collectionId = parseCollectionId(input);
+    if (collectionId === null) {
+      setResolveError('Enter a collection URL like https://gamebanana.com/collections/164637 or its numeric id.');
+      return;
+    }
+
+    setResolveError(null);
+    setCollection(null);
+    setRows([]);
+    setSelected(new Set());
+    setTotalCount(0);
+    setLoadingItems(true);
+
+    const token = ++loadTokenRef.current;
+
+    try {
+      const meta = await getCollection(collectionId);
+      if (loadTokenRef.current !== token) return;
+      setCollection(meta);
+
+      const collected: GameBananaCollectionItem[] = [];
+      let page = 1;
+      while (page <= 100) {
+        const resp = await getCollectionItems(collectionId, page);
+        if (loadTokenRef.current !== token) return;
+        if (resp.records.length === 0) break;
+        collected.push(...resp.records);
+        setTotalCount(resp.totalCount);
+        setRows(buildRows(collected, installedIds, queuedIds));
+        if (resp.isComplete) break;
+        if (page === 1 && resp.totalCount && collected.length >= resp.totalCount) break;
+        page += 1;
+      }
+
+      const finalRows = buildRows(collected, installedIds, queuedIds);
+      if (loadTokenRef.current !== token) return;
+      setRows(finalRows);
+      // Pre-select every installable, not-already-handled item — the obvious
+      // intent when opening a collection is to grab the bulk of it.
+      setSelected(
+        new Set(
+          finalRows
+            .filter((r) => r.selectable && r.status === 'idle')
+            .map((r) => r.item.id)
+        )
+      );
+    } catch (err) {
+      if (loadTokenRef.current !== token) return;
+      setResolveError(String(err instanceof Error ? err.message : err));
+    } finally {
+      if (loadTokenRef.current === token) {
+        setLoadingItems(false);
+      }
+    }
+  }, [input, installedIds, queuedIds]);
+
+  // ───────── Variant picker (lazy resolve) ─────────
+
+  // Lazy-fetch a row's mod details so we know its file list. Cached on the
+  // row so subsequent opens are instant and queue-time doesn't re-fetch.
+  // If GameBanana returns no files (typically a DMCA/takedown: the Items
+  // endpoint still reports _bHasFiles=true but the detail endpoint has
+  // _aFiles=null), mark the row unavailable and drop it from selection so
+  // the user doesn't try to queue a download that can't succeed.
+  const ensureDetails = useCallback(
+    async (row: ItemRow): Promise<GameBananaModDetails | null> => {
+      if (row.details) return row.details;
+      updateRow(row.item.id, { detailsLoading: true, detailsError: undefined });
+      try {
+        const details = await getModDetails(row.item.id, row.item.modelName);
+        if (!details.files || details.files.length === 0) {
+          updateRow(row.item.id, {
+            details,
+            detailsLoading: false,
+            selectable: false,
+            skip: { kind: 'files-unavailable' },
+            status: 'idle',
+          });
+          setSelected((prev) => {
+            if (!prev.has(row.item.id)) return prev;
+            const next = new Set(prev);
+            next.delete(row.item.id);
+            return next;
+          });
+          return details;
+        }
+        updateRow(row.item.id, { details, detailsLoading: false });
+        return details;
+      } catch (err) {
+        updateRow(row.item.id, {
+          detailsLoading: false,
+          detailsError: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    },
+    [updateRow]
+  );
+
+  const toggleVariants = useCallback(
+    async (row: ItemRow) => {
+      const opening = !row.variantsOpen;
+      updateRow(row.item.id, { variantsOpen: opening });
+      if (opening) {
+        await ensureDetails(row);
+      }
+    },
+    [ensureDetails, updateRow]
+  );
+
+  const pickVariant = useCallback(
+    (row: ItemRow, file: GameBananaFile) => {
+      updateRow(row.item.id, { pickedFileId: file.id });
+    },
+    [updateRow]
+  );
+
+  // ───────── Selection ─────────
+
+  const eligibleRows = useMemo(
+    () => rows.filter((r) => r.selectable && r.status === 'idle'),
+    [rows]
+  );
+
+  const skippedCount = useMemo(
+    () => rows.filter((r) => !r.selectable).length,
+    [rows]
+  );
+
+  const allEligibleSelected =
+    eligibleRows.length > 0 && eligibleRows.every((r) => selected.has(r.item.id));
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelected((prev) => {
+      if (allEligibleSelected) return new Set();
+      const next = new Set(prev);
+      for (const r of eligibleRows) next.add(r.item.id);
+      return next;
+    });
+  }, [allEligibleSelected, eligibleRows]);
+
+  // ───────── Cancel ─────────
+
+  const cancelRow = useCallback(async (row: ItemRow) => {
+    if (row.status !== 'queued') return;
+    // removeFromQueue rejects the original downloadMod promise. Our submit
+    // loop catches that as a "Cancelled by user" message and skips marking
+    // it failed. We still optimistically mark the row cancelled here so the
+    // UI reacts immediately.
+    await window.electronAPI.removeFromQueue(row.item.id);
+    updateRow(row.item.id, { status: 'cancelled' });
+  }, [updateRow]);
+
+  const cancelAll = useCallback(async () => {
+    // Bump the submit token so the submission loop bails before queueing
+    // anything else.
+    submitTokenRef.current += 1;
+    const queuedNow = rowsRef.current.filter((r) => r.status === 'queued');
+    for (const row of queuedNow) {
+      await window.electronAPI.removeFromQueue(row.item.id);
+      updateRow(row.item.id, { status: 'cancelled' });
+    }
+    setSubmitting(false);
+  }, [updateRow]);
+
+  // ───────── Submission ─────────
+
+  const handleQueue = useCallback(async () => {
+    if (!activeDeadlockPath) return;
+    if (selected.size === 0) return;
+
+    setSubmitting(true);
+    setProfileStatus({ kind: 'idle' });
+    const token = ++submitTokenRef.current;
+    const toQueue = rowsRef.current.filter(
+      (r) => selected.has(r.item.id) && r.status === 'idle'
+    );
+    setBatchIds(new Set(toQueue.map((r) => r.item.id)));
+
+    for (const row of toQueue) {
+      if (submitTokenRef.current !== token) break;
+
+      // Resolve files if we don't have them cached yet, needed to map
+      // pickedFileId (or the default primary) to a real GameBananaFile.
+      let details = row.details ?? null;
+      if (!details) {
+        updateRow(row.item.id, { status: 'resolving' });
+        details = await ensureDetails(row);
+        if (submitTokenRef.current !== token) break;
+      }
+
+      if (!details?.files || details.files.length === 0) {
+        // ensureDetails already marked this row unavailable (and removed it
+        // from the selected set) when it discovered the empty file list, so
+        // we just skip. No need to flag it failed here.
+        continue;
+      }
+
+      const file =
+        (row.pickedFileId !== undefined
+          ? details.files.find((f) => f.id === row.pickedFileId)
+          : undefined) ?? getPrimaryFile(details.files);
+
+      // Fire-and-forget: the main-process queue serializes downloads, and
+      // we drive UI state off its events. The catch is only to detect the
+      // user-cancellation rejection so we don't double-mark as failed.
+      updateRow(row.item.id, { status: 'queued', statusMessage: undefined });
+      void downloadMod(
+        row.item.id,
+        file.id,
+        file.fileName,
+        row.item.modelName,
+        row.item.rootCategory?.id
+      ).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === 'Cancelled by user') {
+          // cancelRow / cancelAll already flipped the UI; nothing to do.
+          return;
+        }
+        // download-error event normally handles this, but if the rejection
+        // beats the event (or we lose the event), surface the failure.
+        const current = rowsRef.current.find((r) => r.item.id === row.item.id);
+        if (current && current.status !== 'failed' && current.status !== 'cancelled') {
+          updateRow(row.item.id, { status: 'failed', statusMessage: message });
+        }
+      });
+    }
+
+    setSubmitting(false);
+  }, [activeDeadlockPath, ensureDetails, selected, updateRow]);
+
+  // ───────── Footer summary ─────────
+
+  const counts = useMemo(() => {
+    let queued = 0;
+    let downloading = 0;
+    let installed = 0;
+    let failed = 0;
+    for (const r of rows) {
+      if (r.status === 'queued') queued += 1;
+      else if (r.status === 'downloading') downloading += 1;
+      else if (r.status === 'installed') installed += 1;
+      else if (r.status === 'failed') failed += 1;
+    }
+    return { queued, downloading, installed, failed };
+  }, [rows]);
+
+  const batchInFlight = counts.queued + counts.downloading > 0;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-collection-title"
+      onClick={submitting ? undefined : onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-4xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between p-6 border-b border-white/10">
+          <div className="min-w-0 flex items-start gap-3">
+            <Library className="w-6 h-6 text-accent flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <h2 id="import-collection-title" className="text-xl font-bold text-text-primary">
+                Import Collection
+              </h2>
+              <p className="text-sm text-text-secondary mt-1">
+                Paste a GameBanana collection URL or id. Items get queued through the same download pipeline as Browse.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Input */}
+        <div className="p-6 border-b border-white/10">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!loadingItems) resolveCollection();
+            }}
+            className="flex items-stretch gap-2"
+          >
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="https://gamebanana.com/collections/164637"
+              disabled={loadingItems}
+              className="flex-1 px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
+            />
+            <Button type="submit" disabled={loadingItems || !input.trim()}>
+              {loadingItems ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Fetch'}
+            </Button>
+          </form>
+          {resolveError && (
+            <p className="mt-2 text-xs text-red-400 flex items-center gap-1.5">
+              <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+              {resolveError}
+            </p>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {!collection && !loadingItems && (
+            <div className="p-10 text-center text-text-secondary text-sm">
+              No collection loaded yet.
+            </div>
+          )}
+
+          {collection && (
+            <div className="px-6 pt-4 pb-2">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <h3 className="text-base font-semibold text-text-primary">{collection.name}</h3>
+                  {collection.submitter && (
+                    <p className="text-xs text-text-secondary mt-0.5">
+                      by {collection.submitter.name}
+                    </p>
+                  )}
+                </div>
+                <a
+                  href={`https://gamebanana.com/collections/${collection.id}`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-xs text-text-secondary hover:text-accent flex items-center gap-1 flex-shrink-0"
+                >
+                  View on GameBanana
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              </div>
+              <div className="mt-3 text-xs text-text-secondary flex flex-wrap items-center gap-x-4 gap-y-1">
+                <span>{totalCount} item{totalCount === 1 ? '' : 's'} total</span>
+                <span>{eligibleRows.length} ready to queue</span>
+                {skippedCount > 0 && <span>{skippedCount} skipped</span>}
+              </div>
+            </div>
+          )}
+
+          {rows.length > 0 && (
+            <div className="px-6 py-3 sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10">
+              <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
+                <input
+                  type="checkbox"
+                  checked={allEligibleSelected}
+                  onChange={toggleSelectAll}
+                  disabled={eligibleRows.length === 0}
+                  className="accent-accent cursor-pointer"
+                />
+                <span>
+                  {allEligibleSelected ? 'Deselect all' : `Select all (${eligibleRows.length})`}
+                </span>
+              </label>
+            </div>
+          )}
+
+          <ul className="divide-y divide-white/5">
+            {rows.map((row) => {
+              const thumb = previewThumb(row.item.previewMedia);
+              const checked = selected.has(row.item.id);
+              const lockedRow = !row.selectable || row.status !== 'idle';
+
+              const fileCount = row.details?.files?.length ?? 0;
+              const pickedFile = row.pickedFileId !== undefined && row.details?.files
+                ? row.details.files.find((f) => f.id === row.pickedFileId)
+                : undefined;
+
+              return (
+                <li key={row.item.id} className="px-6 py-4">
+                  <div className="flex items-center gap-4">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleSelect(row.item.id)}
+                      disabled={lockedRow}
+                      className="w-4 h-4 accent-accent cursor-pointer disabled:cursor-not-allowed"
+                      aria-label={`Select ${row.item.name}`}
+                    />
+                    <ModThumbnail
+                      src={thumb}
+                      alt={row.item.name}
+                      nsfw={row.item.nsfw}
+                      hideNsfw={hideNsfwPreviews}
+                      className="w-20 h-14 flex-shrink-0 rounded-sm bg-bg-tertiary"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <a
+                        href={row.item.profileUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-base font-medium text-text-primary hover:text-accent truncate block"
+                        title={row.item.name}
+                      >
+                        {row.item.name}
+                      </a>
+                      <div className="text-xs text-text-secondary flex items-center flex-wrap gap-x-2 gap-y-1 mt-1">
+                        <span className="px-2 py-0.5 rounded-sm bg-white/5 border border-white/5 font-medium">
+                          {row.item.modelName}
+                        </span>
+                        {row.item.submitter && <span>by {row.item.submitter.name}</span>}
+                        {row.item.rootCategory?.name && <span>· {row.item.rootCategory.name}</span>}
+                        {/* Variants chevron sits inline with metadata so the
+                            right side only carries the status. Hides on
+                            non-selectable / non-idle rows where it would
+                            have no effect. */}
+                        {row.selectable && row.status === 'idle' && (
+                          <button
+                            type="button"
+                            onClick={() => toggleVariants(row)}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-sm text-text-secondary hover:text-text-primary hover:bg-white/5 cursor-pointer"
+                            title="Choose a variant"
+                          >
+                            {row.variantsOpen ? (
+                              <ChevronDown className="w-3.5 h-3.5" />
+                            ) : (
+                              <ChevronRight className="w-3.5 h-3.5" />
+                            )}
+                            {row.detailsLoading ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : fileCount > 1 ? (
+                              <span>{fileCount} variants</span>
+                            ) : fileCount === 1 ? (
+                              <span>1 file</span>
+                            ) : (
+                              <span>Files</span>
+                            )}
+                          </button>
+                        )}
+                        {pickedFile && (
+                          <span className="text-accent truncate max-w-[260px]" title={pickedFile.fileName}>
+                            · {pickedFile.fileName}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Status / cancel. Packs against the title block so
+                        the row doesn't carry a giant empty stripe. */}
+                    <div className="text-sm flex-shrink-0 text-right">
+                      {row.skip ? (
+                        <span className="text-text-tertiary">{skipReasonLabel(row.skip)}</span>
+                      ) : row.status === 'installed' ? (
+                        <span className="text-green-400 inline-flex items-center gap-1.5 justify-end">
+                          <CheckCircle2 className="w-4 h-4" /> Installed
+                        </span>
+                      ) : row.status === 'resolving' ? (
+                        <span className="text-text-secondary inline-flex items-center gap-1.5 justify-end">
+                          <Loader2 className="w-4 h-4 animate-spin" /> Resolving
+                        </span>
+                      ) : row.status === 'queued' ? (
+                        <button
+                          type="button"
+                          onClick={() => cancelRow(row)}
+                          className="text-accent inline-flex items-center gap-1.5 justify-end hover:text-red-400 cursor-pointer"
+                          title="Remove from queue"
+                        >
+                          <Ban className="w-4 h-4" /> Queued
+                        </button>
+                      ) : row.status === 'downloading' ? (
+                        <span className="text-accent inline-flex items-center gap-1.5 justify-end">
+                          <Loader2 className="w-4 h-4 animate-spin" /> Downloading
+                        </span>
+                      ) : row.status === 'cancelled' ? (
+                        <span className="text-text-tertiary inline-flex items-center gap-1.5 justify-end">
+                          Cancelled
+                        </span>
+                      ) : row.status === 'failed' ? (
+                        <span
+                          className="text-red-400 inline-flex items-center gap-1.5 justify-end"
+                          title={row.statusMessage}
+                        >
+                          <AlertTriangle className="w-4 h-4" /> Failed
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  {/* Variant picker */}
+                  {row.variantsOpen && (
+                    <div className="ml-[100px] mt-3 mb-1">
+                      {row.detailsLoading && (
+                        <div className="text-xs text-text-secondary flex items-center gap-1.5">
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          Loading files…
+                        </div>
+                      )}
+                      {row.detailsError && (
+                        <div className="text-xs text-red-400 flex items-center gap-1.5">
+                          <AlertTriangle className="w-3.5 h-3.5" />
+                          {row.detailsError}
+                        </div>
+                      )}
+                      {!row.detailsLoading && !row.detailsError && row.details && (!row.details.files || row.details.files.length === 0) && (
+                        <div className="text-xs text-text-tertiary flex items-start gap-1.5">
+                          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+                          <span>
+                            GameBanana returned no downloadable files for this mod.
+                            It may have been removed or taken down. The mod page is still browsable.
+                          </span>
+                        </div>
+                      )}
+                      {!row.detailsLoading && !row.detailsError && row.details?.files && row.details.files.length > 0 && (
+                        <ul className="space-y-1">
+                          {row.details.files.map((file) => {
+                            const isPicked =
+                              row.pickedFileId !== undefined
+                                ? row.pickedFileId === file.id
+                                : file.id === getPrimaryFile(row.details!.files!).id;
+                            return (
+                              <li key={file.id}>
+                                <label
+                                  className={`flex items-center gap-2.5 px-3 py-2 rounded-sm cursor-pointer text-sm border ${
+                                    isPicked
+                                      ? 'bg-accent/10 border-accent/40 text-text-primary'
+                                      : 'border-transparent hover:bg-white/5 text-text-secondary'
+                                  }`}
+                                >
+                                  <input
+                                    type="radio"
+                                    name={`variant-${row.item.id}`}
+                                    checked={isPicked}
+                                    onChange={() => pickVariant(row, file)}
+                                    className="accent-accent cursor-pointer"
+                                  />
+                                  <span className="truncate flex-1" title={file.fileName}>
+                                    {file.fileName}
+                                  </span>
+                                  {file.isArchived && (
+                                    <span className="text-text-tertiary text-[11px] uppercase tracking-wide">archived</span>
+                                  )}
+                                  <span
+                                    className="text-text-tertiary text-xs tabular-nums inline-flex items-center gap-1"
+                                    title={`${file.downloadCount.toLocaleString()} downloads`}
+                                  >
+                                    <Download className="w-3 h-3" />
+                                    {file.downloadCount.toLocaleString()}
+                                  </span>
+                                </label>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          {loadingItems && (
+            <div className="px-6 py-4 text-xs text-text-secondary flex items-center gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading items{totalCount > 0 ? ` (${rows.length}/${totalCount})` : ''}…
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-white/10">
+          {/* Post-install prompt: only appears once every submitted item has
+              reached a terminal state and at least one mod actually installed.
+              Lets the user save the batch as a profile without making the
+              decision up front. */}
+          {batchSettled && installedBatchIds.length > 0 && (
+            <div className="px-4 pt-3 pb-1 flex items-center justify-between gap-3 text-sm">
+              <div className="text-text-secondary min-w-0 flex items-center gap-2">
+                <span className="text-text-primary font-medium">
+                  Save these {installedBatchIds.length} mod{installedBatchIds.length === 1 ? '' : 's'} as a profile?
+                </span>
+                {collection && (
+                  <span className="text-text-tertiary truncate" title={collection.name}>
+                    (“{collection.name}”)
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {profileStatus.kind === 'idle' && (
+                  <Button size="sm" onClick={handleSaveProfile}>
+                    Save as profile
+                  </Button>
+                )}
+                {profileStatus.kind === 'creating' && (
+                  <span className="text-text-secondary inline-flex items-center gap-1.5 text-xs">
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    Creating profile…
+                  </span>
+                )}
+                {profileStatus.kind === 'created' && (
+                  <span className="text-green-400 inline-flex items-center gap-1.5 text-xs">
+                    <CheckCircle2 className="w-3.5 h-3.5" />
+                    Profile saved
+                  </span>
+                )}
+                {profileStatus.kind === 'failed' && (
+                  <span
+                    className="text-red-400 inline-flex items-center gap-1.5 text-xs"
+                    title={profileStatus.message}
+                  >
+                    <AlertTriangle className="w-3.5 h-3.5" />
+                    Profile failed
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="p-4 flex items-center justify-between gap-3">
+            <div className="text-xs text-text-secondary">
+              {submitting && counts.queued + counts.downloading === 0
+                ? 'Submitting…'
+                : batchInFlight
+                  ? `${counts.downloading} downloading · ${counts.queued} queued · ${counts.installed} installed${counts.failed > 0 ? ` · ${counts.failed} failed` : ''}`
+                  : counts.installed + counts.failed > 0
+                    ? `${counts.installed} installed${counts.failed > 0 ? ` · ${counts.failed} failed` : ''}`
+                    : selected.size > 0
+                      ? `${selected.size} selected`
+                      : 'Select items to queue'}
+            </div>
+            <div className="flex items-center gap-2">
+              {batchInFlight ? (
+                <Button variant="danger" onClick={cancelAll}>
+                  Cancel remaining
+                </Button>
+              ) : (
+                <Button variant="secondary" onClick={onClose}>
+                  {counts.installed > 0 || counts.failed > 0 ? 'Done' : 'Cancel'}
+                </Button>
+              )}
+              <Button
+                icon={Download}
+                onClick={handleQueue}
+                disabled={
+                  submitting ||
+                  selected.size === 0 ||
+                  !activeDeadlockPath ||
+                  rows.length === 0 ||
+                  !rowsRef.current.some(
+                    (r) => selected.has(r.item.id) && r.status === 'idle'
+                  )
+                }
+                isLoading={submitting && counts.queued + counts.downloading === 0}
+              >
+                Queue {selected.size > 0 ? selected.size : ''}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/DynamicSelect.tsx
+++ b/src/components/common/DynamicSelect.tsx
@@ -47,7 +47,7 @@ export function DynamicSelect({
                 onChange={(e) => onChange(e.target.value)}
                 disabled={disabled}
                 style={width ? { width: `${width}px` } : undefined}
-                className={`appearance-none pl-3 pr-8 py-2.5 bg-bg-secondary border border-border rounded-lg text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent transition-[width] duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+                className={`appearance-none h-10 pl-3 pr-8 bg-bg-secondary border border-border rounded-lg text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent transition-[width] duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
                 {...props}
             >
                 {options.map((opt) => (

--- a/src/index.css
+++ b/src/index.css
@@ -4,12 +4,18 @@
 /* Grenze Gotisch: https://fonts.google.com/specimen/Grenze+Gotisch */
 
 /* Deadlock Fonts */
+/* Radiance ships with a top-heavy line-box (ascent metric > descent), which
+   makes glyphs sit visually low when flex-centered next to icons. Overriding
+   the metrics rebalances the box so labels align with their adjacent icons. */
 @font-face {
   font-family: 'Radiance';
   src: url('/fonts/radiance-regular.otf') format('opentype');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
+  ascent-override: 85%;
+  descent-override: 25%;
+  line-gap-override: 0%;
 }
 
 @font-face {
@@ -18,6 +24,9 @@
   font-weight: 600;
   font-style: normal;
   font-display: swap;
+  ascent-override: 85%;
+  descent-override: 25%;
+  line-gap-override: 0%;
 }
 
 @font-face {
@@ -26,6 +35,9 @@
   font-weight: 700;
   font-style: normal;
   font-display: swap;
+  ascent-override: 85%;
+  descent-override: 25%;
+  line-gap-override: 0%;
 }
 
 @font-face {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,8 @@ import type {
   GameBananaCategoryNode,
   GameBananaMod,
   GameBananaCommentsResponse,
+  GameBananaCollection,
+  GameBananaCollectionItemsResponse,
 } from '../types/gamebanana';
 
 // Re-export types for convenience
@@ -15,6 +17,8 @@ export type {
   GameBananaSection,
   GameBananaCategoryNode,
   GameBananaMod,
+  GameBananaCollection,
+  GameBananaCollectionItemsResponse,
 };
 
 // Settings
@@ -187,6 +191,17 @@ export async function getGamebananaCategories(
   return window.electronAPI.getGameBananaCategories({ categoryModelName });
 }
 
+export async function getCollection(collectionId: number): Promise<GameBananaCollection> {
+  return window.electronAPI.getCollection({ collectionId });
+}
+
+export async function getCollectionItems(
+  collectionId: number,
+  page = 1
+): Promise<GameBananaCollectionItemsResponse> {
+  return window.electronAPI.getCollectionItems({ collectionId, page });
+}
+
 export async function setMinaPreset(presetFileName: string): Promise<void> {
   return window.electronAPI.setMinaPreset({ presetFileName });
 }
@@ -319,6 +334,13 @@ export async function getProfiles(): Promise<Profile[]> {
 
 export async function createProfile(name: string, crosshairSettings?: ProfileCrosshairSettings): Promise<Profile> {
   return window.electronAPI.createProfile(name, crosshairSettings);
+}
+
+export async function createProfileFromGameBananaIds(
+  name: string,
+  gameBananaIds: number[]
+): Promise<Profile> {
+  return window.electronAPI.createProfileFromGameBananaIds({ name, gameBananaIds });
 }
 
 export async function updateProfile(profileId: string, crosshairSettings?: ProfileCrosshairSettings): Promise<Profile> {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1145,7 +1145,7 @@ export default function Browse() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search mods..."
-                className="w-full bg-bg-secondary border border-border rounded-lg pl-3 pr-16 py-2 text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent"
+                className="w-full h-10 bg-bg-secondary border border-border rounded-lg pl-3 pr-16 text-sm text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent"
               />
               <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
                 {/* Inline spinner while debouncing or refetching with stale results.
@@ -1181,7 +1181,7 @@ export default function Browse() {
               type="button"
               onClick={handleRefresh}
               disabled={syncing}
-              className="p-2.5 bg-bg-secondary hover:bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary rounded-lg transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              className="h-10 w-10 flex items-center justify-center bg-bg-secondary hover:bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary rounded-lg transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
               title="Refresh from GameBanana"
             >
               {syncing ? (
@@ -1192,7 +1192,7 @@ export default function Browse() {
             </button>
 
             {/* View Mode Toggle - Icon Only */}
-            <div className="flex items-center rounded-lg border border-border bg-bg-secondary p-1">
+            <div className="flex items-center h-10 rounded-lg border border-border bg-bg-secondary p-1">
               <button
                 type="button"
                 onClick={() => setViewMode('grid')}
@@ -1233,7 +1233,7 @@ export default function Browse() {
 
             {/* Section toggle — Mods vs Sounds as icon buttons */}
             {sections.length > 1 && (
-              <div className="flex items-center rounded-lg border border-border bg-bg-secondary p-1" role="tablist" aria-label="Section">
+              <div className="flex items-center h-10 rounded-lg border border-border bg-bg-secondary p-1" role="tablist" aria-label="Section">
                 {sections.map((entry) => {
                   const Icon = entry.modelName === 'Sound' ? Music : Package;
                   const active = section === entry.modelName;
@@ -1261,7 +1261,7 @@ export default function Browse() {
 
             {/* Global Volume Slider - visible when Sound section is selected */}
             {section === 'Sound' && (
-              <div className="flex items-center gap-2 px-3 py-2 bg-bg-secondary border border-border rounded-lg">
+              <div className="flex items-center h-10 gap-2 px-3 bg-bg-secondary border border-border rounded-lg">
                 <Volume2 className="w-4 h-4 text-text-secondary flex-shrink-0" />
                 <input
                   type="range"
@@ -1302,7 +1302,7 @@ export default function Browse() {
                     onClick={() => setFiltersOpen((v) => !v)}
                     aria-haspopup="dialog"
                     aria-expanded={filtersOpen}
-                    className={`flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                    className={`flex items-center h-10 gap-2 px-3 rounded-lg border text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                       filterCount > 0
                         ? 'bg-accent/10 border-accent/40 text-accent hover:bg-accent/20'
                         : 'bg-bg-secondary border-border text-text-primary hover:bg-bg-tertiary'

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -17,6 +17,7 @@ import {
   Music,
   SlidersHorizontal,
   Power,
+  Library,
 } from 'lucide-react';
 import {
   browseMods,
@@ -41,6 +42,7 @@ import { DynamicSelect } from '../components/common/DynamicSelect';
 import { Button, Tag } from '../components/common/ui';
 import { EmptyState } from '../components/common/PageComponents';
 import ModDetailsModal from '../components/ModDetailsModal';
+import ImportCollectionModal from '../components/ImportCollectionModal';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition } from '../lib/lockerUtils';
 
 const DEFAULT_PER_PAGE = 20;
@@ -227,6 +229,7 @@ export default function Browse() {
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const filtersRef = useRef<HTMLDivElement>(null);
+  const [collectionModalOpen, setCollectionModalOpen] = useState(false);
 
   // Load settings on mount (needed for hideNsfwPreviews)
   useEffect(() => {
@@ -1176,6 +1179,16 @@ export default function Browse() {
               </div>
             </div>
 
+            {/* Import Collection Icon Button */}
+            <button
+              type="button"
+              onClick={() => setCollectionModalOpen(true)}
+              className="h-10 w-10 flex items-center justify-center bg-bg-secondary hover:bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary rounded-lg transition-colors cursor-pointer"
+              title="Import GameBanana collection"
+            >
+              <Library className="w-5 h-5" />
+            </button>
+
             {/* Refresh Icon Button */}
             <button
               type="button"
@@ -1510,6 +1523,16 @@ export default function Browse() {
           dateModified={selectedModDates?.dateModified}
           onClose={() => setSelectedMod(null)}
           onDownload={handleDownload}
+        />
+      )}
+
+      {collectionModalOpen && (
+        <ImportCollectionModal
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          installedIds={installedIds}
+          queuedIds={new Set(downloadQueue.map((q) => q.modId))}
+          activeDeadlockPath={activeDeadlockPath}
+          onClose={() => setCollectionModalOpen(false)}
         />
       )}
     </div>

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check } from 'lucide-react';
+import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X } from 'lucide-react';
 import {
   getProfiles,
   createProfile,
   applyProfile,
   updateProfile,
   deleteProfile,
+  renameProfile,
   getSettings,
 } from '../lib/api';
 import type { Profile, ProfileCrosshairSettings } from '../lib/api';
@@ -88,6 +89,9 @@ export default function Profiles() {
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [expandedProfiles, setExpandedProfiles] = useState<Set<string>>(new Set());
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [isRenaming, setIsRenaming] = useState(false);
 
   const { mods, loadMods } = useAppStore();
   const { getSettings: getCrosshairSettings, loadSettingsFromPreset } = useCrosshairStore();
@@ -177,6 +181,36 @@ export default function Profiles() {
     }
   };
 
+  const startRename = (profile: Profile) => {
+    setRenamingId(profile.id);
+    setRenameValue(profile.name);
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameValue('');
+  };
+
+  const submitRename = async () => {
+    if (!renamingId) return;
+    const trimmed = renameValue.trim();
+    const current = profiles.find(p => p.id === renamingId);
+    if (!trimmed || !current || trimmed === current.name) {
+      cancelRename();
+      return;
+    }
+    setIsRenaming(true);
+    try {
+      await renameProfile(renamingId, trimmed);
+      await loadProfileList();
+      cancelRename();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsRenaming(false);
+    }
+  };
+
   const handleDeleteProfile = async (profileId: string) => {
     try {
       await deleteProfile(profileId);
@@ -259,15 +293,61 @@ export default function Profiles() {
                 const profileModGroups = getProfileModGroups(profile.mods, modByFileName);
                 const profileFileCount = profile.mods.length;
 
+                const isRenamingThis = renamingId === profile.id;
+
                 return (
                   <Card
                     key={profile.id}
-                    title={profile.name}
+                    title={
+                      isRenamingThis ? (
+                        <input
+                          type="text"
+                          autoFocus
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') submitRename();
+                            else if (e.key === 'Escape') cancelRename();
+                          }}
+                          onBlur={submitRename}
+                          disabled={isRenaming}
+                          aria-label="Rename profile"
+                          className="w-full px-2 py-1 bg-bg-tertiary border border-white/10 rounded text-text-primary text-lg font-semibold font-reaver focus:outline-none focus:ring-2 focus:ring-accent"
+                        />
+                      ) : (
+                        profile.name
+                      )
+                    }
                     icon={Layers}
                     accentEdge={isActive ? 'active' : 'none'}
                     className={`transition-all duration-300 ${isActive ? '' : 'hover:border-white/10'}`}
                     action={
                       <div className="flex items-center gap-2">
+                        {!isRenamingThis && (
+                          <button
+                            type="button"
+                            onClick={() => startRename(profile)}
+                            disabled={isApplying || isUpdating}
+                            aria-label="Rename profile"
+                            title="Rename profile"
+                            className="p-1 text-text-secondary hover:text-text-primary hover:bg-white/5 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                        {isRenamingThis && (
+                          <button
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={cancelRename}
+                            disabled={isRenaming}
+                            aria-label="Cancel rename"
+                            title="Cancel"
+                            className="p-1 text-text-secondary hover:text-text-primary hover:bg-white/5 rounded transition-colors disabled:opacity-50"
+                          >
+                            <X className="w-3.5 h-3.5" />
+                          </button>
+                        )}
                         {isActive ? (
                           <Badge variant="success" className="animate-pulse">Active</Badge>
                         ) : (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
@@ -789,6 +789,30 @@ export default function Settings() {
               label="Crosshair Designer"
               description="Create custom crosshairs with a live preview."
             />
+          </div>
+        </Card>
+
+        {/* Support */}
+        <Card title="Support" icon={LifeBuoy} className="lg:col-span-2">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <p className="text-sm text-text-secondary">
+              Found a bug or have a feature request? Drop into our Discord.
+            </p>
+            <a
+              href="https://discord.gg/KgYGHEMq2P"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="w-4 h-4 fill-current"
+              >
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+              </svg>
+              Join Discord
+            </a>
           </div>
         </Card>
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -4,6 +4,8 @@ import type {
     GameBananaModDetails,
     GameBananaSection,
     GameBananaCategoryNode,
+    GameBananaCollection,
+    GameBananaCollectionItemsResponse,
 } from './gamebanana';
 
 export interface BrowseModsArgs {
@@ -297,6 +299,8 @@ export interface ElectronAPI {
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;
     getGameBananaCategories: (args: GetCategoriesArgs) => Promise<GameBananaCategoryNode[]>;
+    getCollection: (args: { collectionId: number }) => Promise<GameBananaCollection>;
+    getCollectionItems: (args: { collectionId: number; page?: number }) => Promise<GameBananaCollectionItemsResponse>;
 
     // Mina Variants
     setMinaPreset: (args: SetMinaPresetArgs) => Promise<void>;
@@ -357,6 +361,7 @@ export interface ElectronAPI {
     // Profiles
     getProfiles: () => Promise<Profile[]>;
     createProfile: (name: string, crosshairSettings?: ProfileCrosshairSettings) => Promise<Profile>;
+    createProfileFromGameBananaIds: (args: { name: string; gameBananaIds: number[] }) => Promise<Profile>;
     updateProfile: (profileId: string, crosshairSettings?: ProfileCrosshairSettings) => Promise<Profile>;
     applyProfile: (profileId: string) => Promise<Profile>;
     deleteProfile: (profileId: string) => Promise<void>;

--- a/src/types/gamebanana.ts
+++ b/src/types/gamebanana.ts
@@ -103,6 +103,65 @@ export interface GameBananaCommentsResponse {
   totalCount: number;
 }
 
+export interface GameBananaCollection {
+  id: number;
+  name: string;
+  description?: string;
+  dateAdded: number;
+  dateModified: number;
+  submitter?: GameBananaSubmitter;
+  previewMedia?: GameBananaPreviewMedia;
+}
+
+export interface GameBananaCollectionItem {
+  id: number;
+  modelName: string;
+  name: string;
+  profileUrl: string;
+  dateAdded: number;
+  dateModified: number;
+  likeCount: number;
+  viewCount: number;
+  hasFiles: boolean;
+  nsfw: boolean;
+  gameId?: number;
+  gameName?: string;
+  submitter?: GameBananaSubmitter;
+  previewMedia?: GameBananaPreviewMedia;
+  rootCategory?: GameBananaCategory;
+}
+
+export interface GameBananaCollectionItemsResponse {
+  records: GameBananaCollectionItem[];
+  totalCount: number;
+  isComplete: boolean;
+  perPage: number;
+}
+
+// Parse a collection identifier from either a numeric id or a GameBanana URL.
+// Mirrored from the main-process helper so the renderer can validate input
+// locally before firing an IPC call.
+export function parseCollectionId(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (!url.hostname.endsWith('gamebanana.com')) return null;
+    const match = url.pathname.match(/\/collections\/(\d+)/i);
+    if (!match) return null;
+    const n = Number(match[1]);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
 export function getModThumbnail(mod: GameBananaMod): string | undefined {
   const images = mod.previewMedia?.images;
   if (!images || images.length === 0) return undefined;
@@ -117,8 +176,13 @@ export function getSoundPreviewUrl(mod: GameBananaMod): string | undefined {
 }
 
 export function getPrimaryFile(files: GameBananaFile[]): GameBananaFile {
-  let primary = files[0];
-  for (const file of files) {
+  // Prefer non-archived files: an archived legacy file can outrank a current
+  // one on raw download count just because it's been around longer. Only fall
+  // back to archived files when every option is archived.
+  const live = files.filter((f) => !f.isArchived);
+  const pool = live.length > 0 ? live : files;
+  let primary = pool[0];
+  for (const file of pool) {
     if (file.downloadCount > primary.downloadCount) {
       primary = file;
     }


### PR DESCRIPTION
## Summary

Started as the v1.9.2 release commit; five more commits landed on the same branch and should ship together.

- `feat(browse)` Import GameBanana collections in bulk via the existing download queue, with per-row status, cancel, and variant picker (new `ImportCollectionModal` + collection endpoints in the `gamebanana` service).
- `feat(profiles)` Inline rename on profile cards (pencil button swaps the card title into an input; uses the existing `renameProfile` IPC).
- `fix(collections)` `applyProfile` now enables mods from a freshly imported collection (two related fixes uncovered by the "save as profile" flow).
- `style(ui)` Rebalance Radiance font metrics via `ascent-override` / `descent-override` so labels visually center next to icons.
- `feat(settings)` Add Support card with a Discord brand link for bug reports and feature requests.
- Also includes the original toolbar-height fix from the initial v1.9.2 release commit.

## Note on the version commit

This branch already contains `chore(release): v1.9.2` (1.9.1 -> 1.9.2 in `package.json`), but the five commits on top of it add real features beyond what was originally scoped for 1.9.2. Recommend amending to **v1.9.3** (or adding a new release commit) before tagging so the GitHub Release notes match what actually ships.

## Test plan

- [x] Browse: open Import Collection modal, paste a GameBanana collection URL/id, install a subset, watch per-row status (Resolving, Queued, Downloading, Installed, Failed, Cancelled)
- [x] Browse: cancel a single row mid-download, then cancel the whole batch
- [x] Profiles: rename a profile via the pencil button. Enter saves, Escape cancels, blur saves, empty/whitespace is rejected
- [x] Profiles: import a collection as a profile, hit Apply, confirm the mods actually enable
- [x] Sidebar: nav labels (Crosshair / Profiles / Settings) visually align with their icons
- [x] Settings: Support card renders; Join Discord opens the invite in the default browser
- [x] `pnpm lint` and `pnpm exec tsc --noEmit -p tsconfig.app.json` clean