### PR TITLE
fix(mods): metadata leak, conflict detection, variant swap

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -14,7 +14,7 @@ import {
     Mod,
 } from '../services/mods';
 import { getAddonsPath } from '../services/deadlock';
-import { getModMetadata, setModMetadata } from '../services/metadata';
+import { getModMetadata, setModMetadata, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 
 /**
@@ -77,6 +77,10 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
         return [];
     }
     const mods = await scanMods(deadlockPath);
+    // Self-heal users whose metadata.json still carries orphan entries from
+    // pre-fix deletes (issue #26). pruneOrphanMetadata is a no-op when there
+    // are none, so the steady-state cost is one JSON parse.
+    pruneOrphanMetadata(new Set(mods.map((m) => m.fileName)));
     return mods.map(enrichMod);
 });
 
@@ -313,6 +317,11 @@ ipcMain.handle(
             await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
         }
 
+        // Scrub any orphan metadata at this slot before writing. setModMetadata
+        // merges into the existing entry, so stale fields (gameBananaId,
+        // categoryName, etc.) from a prior occupant would otherwise stick to
+        // the new local mod and visually merge it with unrelated mods.
+        removeModMetadata(newDirFileName);
         setModMetadata(newDirFileName, {
             modName: name.trim(),
             thumbnailUrl: thumbnailDataUrl,

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -22,13 +22,27 @@ const IGNORED_CONFLICT_FILES = new Set([
     'info.txt',
 ]);
 
+// Path prefixes for files the VPK packer commonly bundles even when the mod
+// doesn't really touch them. Two mods both shipping a copy of the engine's
+// default fallback textures isn't a real conflict between them — it's just
+// the packer dragging in shared dependencies. Filtering these prevents false
+// positives like "Graves Shirt vs Ghost Bride Vindicta" caused entirely by
+// materials/default/default_*_tga_*.vtex_c overlaps.
+const IGNORED_CONFLICT_PREFIXES = [
+    'materials/default/default_',
+];
+
 /**
  * Check if a file path should be ignored for conflict detection
  */
 function shouldIgnoreFile(filePath: string): boolean {
     const normalizedPath = filePath.toLowerCase();
     const fileName = normalizedPath.split('/').pop() || normalizedPath;
-    return IGNORED_CONFLICT_FILES.has(fileName);
+    if (IGNORED_CONFLICT_FILES.has(fileName)) return true;
+    for (const prefix of IGNORED_CONFLICT_PREFIXES) {
+        if (normalizedPath.startsWith(prefix)) return true;
+    }
+    return false;
 }
 
 export interface ModConflict {
@@ -115,13 +129,16 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     const enabledMods = mods.filter(m => m.enabled);
     const conflicts: ModConflict[] = [];
 
-    console.log(`[detectConflicts] Enabled mods: ${enabledMods.length}`);
-
     if (enabledMods.length < 2) {
         return [];
     }
 
-    // Priority conflicts (same pak number)
+    // Priority conflicts (same pak number). Track which pairs are already
+    // reported so the later file-conflict pass skips them in O(1).
+    const reportedPairs = new Set<string>();
+    const markReported = (a: Mod, b: Mod) => reportedPairs.add(conflictPairKey(a.id, b.id));
+    const wasReported = (a: Mod, b: Mod) => reportedPairs.has(conflictPairKey(a.id, b.id));
+
     const priorityMap = new Map<number, Mod[]>();
     for (const mod of enabledMods) {
         const existing = priorityMap.get(mod.priority) || [];
@@ -133,12 +150,15 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         if (modsWithPriority.length > 1) {
             for (let i = 0; i < modsWithPriority.length; i++) {
                 for (let j = i + 1; j < modsWithPriority.length; j++) {
+                    const a = modsWithPriority[i];
+                    const b = modsWithPriority[j];
                     conflicts.push(createConflict(
-                        modsWithPriority[i],
-                        modsWithPriority[j],
+                        a,
+                        b,
                         'priority',
                         `Both use pak${String(priority).padStart(2, '0')}`
                     ));
+                    markReported(a, b);
                 }
             }
         }
@@ -150,11 +170,6 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         const files = parseVpkDirectory(mod.path);
         if (files && files.length > 0) {
             modFileLists.set(mod.id, new Set(files));
-            console.log(`[detectConflicts] ${mod.fileName}: ${files.length} files`);
-            // Log sample paths for debugging
-            console.log(`[detectConflicts]   Sample paths: ${files.slice(0, 5).join(', ')}`);
-        } else {
-            console.log(`[detectConflicts] ${mod.fileName}: failed to parse or empty`);
         }
     }
 
@@ -165,6 +180,8 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         for (let j = i + 1; j < modsWithFiles.length; j++) {
             const modA = modsWithFiles[i];
             const modB = modsWithFiles[j];
+            if (wasReported(modA, modB)) continue;
+
             const filesA = modFileLists.get(modA.id)!;
             const filesB = modFileLists.get(modB.id)!;
 
@@ -177,30 +194,13 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             }
 
             if (overlapping.length > 0) {
-                // Skip if already reported as priority conflict
-                const alreadyReported = conflicts.some(
-                    c => (c.modA === modA.id && c.modB === modB.id) ||
-                        (c.modA === modB.id && c.modB === modA.id)
-                );
-
-                if (!alreadyReported) {
-                    // Log the actual conflicting files for debugging
-                    console.log(`[detectConflicts] File conflict: ${modA.fileName} vs ${modB.fileName}`);
-                    console.log(`[detectConflicts] Overlapping files (${overlapping.length}):`);
-                    for (const file of overlapping.slice(0, 20)) { // Log first 20
-                        console.log(`[detectConflicts]   - ${file}`);
-                    }
-                    if (overlapping.length > 20) {
-                        console.log(`[detectConflicts]   ... and ${overlapping.length - 20} more`);
-                    }
-
-                    conflicts.push(createConflict(
-                        modA,
-                        modB,
-                        'file',
-                        `${overlapping.length} shared file(s): ${overlapping.slice(0, 3).join(', ')}${overlapping.length > 3 ? '...' : ''}`
-                    ));
-                }
+                conflicts.push(createConflict(
+                    modA,
+                    modB,
+                    'file',
+                    `${overlapping.length} shared file(s): ${overlapping.slice(0, 3).join(', ')}${overlapping.length > 3 ? '...' : ''}`
+                ));
+                markReported(modA, modB);
             }
         }
     }
@@ -210,7 +210,6 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     // post-filter — easy to reason about and easy to disable later.
     const settings = loadSettings();
     if (settings.ignoreConflictsByDefault) {
-        console.log(`[detectConflicts] Hiding all ${conflicts.length} conflicts — ignore-by-default is on`);
         return [];
     }
     const ignored = new Set(settings.ignoredConflicts ?? []);
@@ -221,6 +220,5 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             !ignored.has(conflictPairKey(c.modA, c.modB))
         );
 
-    console.log(`[detectConflicts] Found ${conflicts.length} conflicts (${conflicts.length - filtered.length} ignored)`);
     return filtered;
 }

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -8,7 +8,7 @@ import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles } f
 import { randomUUID } from 'crypto';
 import { setModMetadata, getModMetadata } from './metadata';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
-import { getUsedPriorities, scanMods, disableMod } from './mods';
+import { getUsedPriorities, scanMods, disableMod, enableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
 import { loadSettings } from './settings';
 import { getVpkLabels } from './vpk';
@@ -761,7 +761,24 @@ async function executeDownload(
                 await disableMod(deadlockPath, peer.id);
                 disabledPeers.push({ id: peer.id, name: peer.name, fileName: peer.fileName });
             }
-            if (disabledPeers.length > 0) {
+            // Downloads land in /disabled by default, so just disabling the
+            // previously-enabled sibling would leave the mod entirely off
+            // ("the newest pick is the active one" in the surrounding comment
+            // requires actually promoting the new pick). When we kick an
+            // enabled variant, move the freshly-downloaded VPK(s) into the
+            // addons folder so the user ends up with the new variant active.
+            if (disabledPeers.length > 0 && installedVpks.length > 0) {
+                const refreshed = await scanMods(deadlockPath);
+                for (const vpkFileName of installedVpks) {
+                    const newMod = refreshed.find((m) => m.fileName === vpkFileName);
+                    if (newMod && !newMod.enabled) {
+                        try {
+                            await enableMod(deadlockPath, newMod.id);
+                        } catch (err) {
+                            console.warn(`[downloadMod] Failed to enable new variant ${vpkFileName}:`, err);
+                        }
+                    }
+                }
                 mainWindow?.webContents.send('mods-auto-disabled', {
                     reason: 'sibling-variant',
                     modId,

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -88,6 +88,27 @@ export function removeModMetadata(fileName: string): void {
 export const deleteModMetadata = removeModMetadata;
 
 /**
+ * Drop metadata entries whose VPK no longer exists on disk.
+ *
+ * Older versions of deleteMod removed the .vpk file but left metadata behind,
+ * keyed by fileName. When the next mod was assigned the same pakNN_dir.vpk
+ * slot, setModMetadata's merge behavior leaked the dead mod's gameBananaId,
+ * categoryName, thumbnail, etc. onto the new install (issue #26). Callers
+ * pass the current valid set so users with pre-existing orphans self-heal
+ * the next time the mods list is scanned.
+ */
+export function pruneOrphanMetadata(validFileNames: Set<string>): void {
+    const metadata = loadMetadata();
+    const orphans = Object.keys(metadata).filter((key) => !validFileNames.has(key));
+    if (orphans.length === 0) return;
+
+    for (const key of orphans) {
+        delete metadata[key];
+    }
+    saveMetadata(metadata);
+}
+
+/**
  * Atomically migrate metadata for a batch of rename operations.
  *
  * Why batched: when several mods are renamed in one operation (e.g. reorder),

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -282,6 +282,11 @@ export async function deleteMod(deadlockPath: string, modId: string): Promise<vo
     } catch {
         // Ignore errors when cleaning up related files
     }
+
+    // Metadata is keyed by fileName. If we leave it behind, the next mod that
+    // is assigned the same pakNN_dir.vpk slot will inherit the deleted mod's
+    // gameBananaId, thumbnail, category, etc. via setModMetadata's merge.
+    removeModMetadata(targetMod.fileName);
 }
 
 /**

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
-import { scanMods, enableMod, disableMod, setModPriority } from './mods';
+import { scanMods, enableMod, disableMod, setModPriority, type Mod } from './mods';
 import { getModMetadata } from './metadata';
 import { readAutoexec, writeAutoexec } from './autoexec';
 
@@ -135,6 +135,12 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
  * so capturing live state would save the profile with everything disabled.
  * The user's intent in saving a collection as a profile is "make these the
  * active set when I apply this", so we encode that explicitly.
+ *
+ * Exactly one variant per gameBananaId is saved — the most recently
+ * installed. After a fresh collection import this is reliably the variant
+ * the collection author specified (the download just bumped its mtime).
+ * Including every sibling variant would re-enable both old and new at
+ * apply time, which conflicts on the same files.
  */
 export async function createProfileFromGameBananaIds(
     deadlockPath: string,
@@ -147,10 +153,23 @@ export async function createProfileFromGameBananaIds(
     // metadata sidecar (read at the IPC layer via enrichMod), so we look
     // it up per-mod here. Without this the filter never matches and the
     // profile saves zero mods.
-    const matching = mods.filter((mod) => {
+    const byGbId = new Map<number, Mod>();
+    for (const mod of mods) {
         const metadata = getModMetadata(mod.fileName);
-        return metadata?.gameBananaId !== undefined && idSet.has(metadata.gameBananaId);
-    });
+        const gbId = metadata?.gameBananaId;
+        if (gbId === undefined || !idSet.has(gbId)) continue;
+        const existing = byGbId.get(gbId);
+        if (!existing) {
+            byGbId.set(gbId, mod);
+            continue;
+        }
+        const candidateTs = Date.parse(mod.installedAt);
+        const existingTs = Date.parse(existing.installedAt);
+        if (Number.isFinite(candidateTs) && candidateTs > existingTs) {
+            byGbId.set(gbId, mod);
+        }
+    }
+    const matching = Array.from(byGbId.values());
 
     const autoexecData = readAutoexec(deadlockPath);
     const now = new Date().toISOString();

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
-import { scanMods, enableMod, disableMod, setModPriority, type Mod } from './mods';
+import { scanMods, enableMod, disableMod, setModPriority } from './mods';
 import { getModMetadata } from './metadata';
 import { readAutoexec, writeAutoexec } from './autoexec';
 
@@ -135,12 +135,6 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
  * so capturing live state would save the profile with everything disabled.
  * The user's intent in saving a collection as a profile is "make these the
  * active set when I apply this", so we encode that explicitly.
- *
- * Exactly one variant per gameBananaId is saved — the most recently
- * installed. After a fresh collection import this is reliably the variant
- * the collection author specified (the download just bumped its mtime).
- * Including every sibling variant would re-enable both old and new at
- * apply time, which conflicts on the same files.
  */
 export async function createProfileFromGameBananaIds(
     deadlockPath: string,
@@ -153,23 +147,10 @@ export async function createProfileFromGameBananaIds(
     // metadata sidecar (read at the IPC layer via enrichMod), so we look
     // it up per-mod here. Without this the filter never matches and the
     // profile saves zero mods.
-    const byGbId = new Map<number, Mod>();
-    for (const mod of mods) {
+    const matching = mods.filter((mod) => {
         const metadata = getModMetadata(mod.fileName);
-        const gbId = metadata?.gameBananaId;
-        if (gbId === undefined || !idSet.has(gbId)) continue;
-        const existing = byGbId.get(gbId);
-        if (!existing) {
-            byGbId.set(gbId, mod);
-            continue;
-        }
-        const candidateTs = Date.parse(mod.installedAt);
-        const existingTs = Date.parse(existing.installedAt);
-        if (Number.isFinite(candidateTs) && candidateTs > existingTs) {
-            byGbId.set(gbId, mod);
-        }
-    }
-    const matching = Array.from(byGbId.values());
+        return metadata?.gameBananaId !== undefined && idSet.has(metadata.gameBananaId);
+    });
 
     const autoexecData = readAutoexec(deadlockPath);
     const now = new Date().toISOString();

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -45,29 +45,22 @@ export function parseVpkDirectory(vpkPath: string): string[] | null {
         readSync(fd, headerBuffer, 0, 12, 0);
 
         const signature = headerBuffer.readUInt32LE(0);
-        console.log(`[parseVpkDirectory] Signature: 0x${signature.toString(16)}, expected: 0x${VPK_SIGNATURE.toString(16)}`);
-
         if (signature !== VPK_SIGNATURE) {
             closeSync(fd);
-            console.log(`[parseVpkDirectory] Invalid signature, not a VPK file`);
             return null;
         }
 
         const version = headerBuffer.readUInt32LE(4);
         const treeSize = headerBuffer.readUInt32LE(8);
-        console.log(`[parseVpkDirectory] Version: ${version}, TreeSize: ${treeSize}`);
 
         // VPK v2 has an extended header (28 bytes total vs 12 for v1)
         // After the first 12 bytes, v2 has: FileDataSectionSize(4) + ArchiveMD5SectionSize(4) + OtherMD5SectionSize(4) + SignatureSectionSize(4)
         const headerSize = version === 2 ? 28 : 12;
-        console.log(`[parseVpkDirectory] Using header size: ${headerSize} for version ${version}`);
 
         // Read the directory tree (starts after the full header)
         const treeBuffer = Buffer.alloc(treeSize);
         readSync(fd, treeBuffer, 0, treeSize, headerSize);
         closeSync(fd);
-
-        console.log(`[parseVpkDirectory] First 100 bytes of tree:`, treeBuffer.slice(0, 100).toString('utf-8').replace(/\0/g, '|'));
 
         const paths: string[] = [];
         let offset = 0;
@@ -147,7 +140,7 @@ export function parseVpkDirectory(vpkPath: string): string[] | null {
 
         // Validate tree was properly terminated
         if (!properlyTerminated) {
-            console.warn(`[parseVpkDirectory] Warning: VPK tree did not terminate properly - buffer exhausted at offset ${offset}/${treeBuffer.length}. Some files may be missing from conflict detection.`);
+            console.warn(`[parseVpkDirectory] ${vpkPath}: tree did not terminate properly (offset ${offset}/${treeBuffer.length}). Some files may be missing from conflict detection.`);
         }
 
         // Check if there's unexpected data after tree termination
@@ -155,11 +148,9 @@ export function parseVpkDirectory(vpkPath: string): string[] | null {
             const remainingBytes = treeBuffer.length - offset;
             // Small amount of padding is acceptable, but large amounts suggest parsing error
             if (remainingBytes > 16) {
-                console.warn(`[parseVpkDirectory] Warning: ${remainingBytes} bytes remaining after tree termination. Tree may have been parsed incorrectly.`);
+                console.warn(`[parseVpkDirectory] ${vpkPath}: ${remainingBytes} bytes remaining after tree termination.`);
             }
         }
-
-        console.log(`[parseVpkDirectory] Parsed ${paths.length} files, properly terminated: ${properlyTerminated}, final offset: ${offset}/${treeBuffer.length}`);
 
         return paths;
     } catch (error) {
@@ -270,12 +261,8 @@ export function getVpkContentSummary(vpkPath: string): {
     const paths = parseVpkDirectory(vpkPath);
 
     if (!paths) {
-        console.log(`[getVpkContentSummary] Failed to parse VPK: ${vpkPath}`);
         return { heroes: new Set(), fileCount: 0, samplePaths: [] };
     }
-
-    console.log(`[getVpkContentSummary] Parsed ${paths.length} paths from ${vpkPath}`);
-    console.log(`[getVpkContentSummary] Sample paths:`, paths.slice(0, 10));
 
     const heroes = new Set<string>();
 
@@ -285,8 +272,6 @@ export function getVpkContentSummary(vpkPath: string): {
             heroes.add(hero);
         }
     }
-
-    console.log(`[getVpkContentSummary] Detected heroes: ${[...heroes].join(', ') || 'none'}`);
 
     return {
         heroes,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -189,6 +189,10 @@ export default function Installed() {
   }, [viewMode]);
   const [search, setSearch] = useState('');
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
+  // Raw pair count from detectConflicts. conflictMap.size / 2 only works when
+  // every mod is in exactly one pair — when one mod conflicts with multiple
+  // peers, that math produces fractional or wrong totals.
+  const [conflictPairCount, setConflictPairCount] = useState(0);
   // Delete confirmation. `ids` is a list so the same prompt can drive
   // single-mod, group, and bulk-selection deletions.
   const [modToDelete, setModToDelete] = useState<{
@@ -638,8 +642,10 @@ export default function Installed() {
           map.set(conflict.modB, existingB);
         }
         setConflictMap(map);
+        setConflictPairCount(conflicts.length);
       } catch {
         setConflictMap(new Map());
+        setConflictPairCount(0);
       }
     };
     if (mods.length > 0) {
@@ -721,7 +727,7 @@ export default function Installed() {
     .filter((e) => !isEntryEnabled(e))
     .sort((a, b) => entrySortPriority(a) - entrySortPriority(b));
   const compactOrder = buildCompactPriorityOrder(allEntries);
-  const conflictCount = conflictMap.size > 0 ? new Set([...conflictMap.keys()]).size : 0;
+  const conflictCount = conflictPairCount;
 
   // Filter by search query (case-insensitive substring on name). Drag-and-drop
   // reorder is still correct because it targets the full enabled list order,
@@ -982,6 +988,40 @@ export default function Installed() {
     );
   }
 
+  // Conflicts and update-all buttons live on the section header row (next to
+  // Fix Order) rather than the top action bar — when both are active the top
+  // bar gets cramped, so move them to the line below where there's room.
+  const hasStatusButtons =
+    conflictCount > 0 || updatesAvailable.size > 0 || !!updateAllProgress;
+  const statusButtons = hasStatusButtons ? (
+    <div className="flex items-center gap-2">
+      {conflictCount > 0 && (
+        <Button
+          variant="warning"
+          size="sm"
+          onClick={() => navigate('/conflicts')}
+          icon={AlertTriangle}
+        >
+          {conflictPairCount} conflict{conflictPairCount === 1 ? '' : 's'}
+        </Button>
+      )}
+      {(updatesAvailable.size > 0 || updateAllProgress) && (
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setUpdateAllConfirmOpen(true)}
+          icon={Download}
+          isLoading={!!updateAllProgress}
+          title="Re-download every mod with a newer version on GameBanana and restore each one's enabled state"
+        >
+          {updateAllProgress
+            ? `Updating ${updateAllProgress.done}/${updateAllProgress.total}…`
+            : `Update all (${updatesAvailable.size})`}
+        </Button>
+      )}
+    </div>
+  ) : null;
+
   return (
     <div className="p-6">
       <PageHeader
@@ -1008,29 +1048,6 @@ export default function Installed() {
                 </button>
               )}
             </div>
-            {conflictCount > 0 && (
-              <Button
-                variant="warning"
-                size="sm"
-                onClick={() => navigate('/conflicts')}
-                icon={AlertTriangle}
-              >
-                {conflictMap.size / 2} conflicts
-              </Button>
-            )}
-            {(updatesAvailable.size > 0 || updateAllProgress) && (
-              <Button
-                variant="primary"
-                onClick={() => setUpdateAllConfirmOpen(true)}
-                icon={Download}
-                isLoading={!!updateAllProgress}
-                title="Re-download every mod with a newer version on GameBanana and restore each one's enabled state"
-              >
-                {updateAllProgress
-                  ? `Updating ${updateAllProgress.done}/${updateAllProgress.total}…`
-                  : `Update all (${updatesAvailable.size})`}
-              </Button>
-            )}
             <Button
               variant="secondary"
               onClick={() => setImportOpen(true)}
@@ -1088,16 +1105,19 @@ export default function Installed() {
         <div className="mb-6">
           <div className="flex items-baseline justify-between mb-3">
             <SectionHeader count={visibleEnabled.length} className="!mb-0">Enabled</SectionHeader>
-            {!searchNeedle && (
-              <button
-                type="button"
-                onClick={fixOrder}
-                title="Renumber all installed mods 1, 2, 3, … to tidy priority slots"
-                className="text-xs uppercase tracking-wider text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
-              >
-                Fix Order
-              </button>
-            )}
+            <div className="flex items-center gap-4">
+              {statusButtons}
+              {!searchNeedle && (
+                <button
+                  type="button"
+                  onClick={fixOrder}
+                  title="Renumber all installed mods 1, 2, 3, … to tidy priority slots"
+                  className="text-xs uppercase tracking-wider text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+                >
+                  Fix Order
+                </button>
+              )}
+            </div>
           </div>
           <div
             className={
@@ -1115,7 +1135,11 @@ export default function Installed() {
 
       {visibleDisabled.length > 0 && (
         <div>
-          <SectionHeader count={visibleDisabled.length}>Disabled</SectionHeader>
+          <div className="flex items-baseline justify-between mb-3">
+            <SectionHeader count={visibleDisabled.length} className="!mb-0">Disabled</SectionHeader>
+            {/* Fall back here when there's nothing in the Enabled section to host the status buttons. */}
+            {visibleEnabled.length === 0 && statusButtons}
+          </div>
           <div
             className={
               viewMode === 'compact'

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
@@ -796,23 +796,34 @@ export default function Settings() {
         <Card title="Support" icon={LifeBuoy} className="lg:col-span-2">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <p className="text-sm text-text-secondary">
-              Found a bug or have a feature request? Drop into our Discord.
+              Found a bug or have a feature request? File an issue on GitHub or drop into our Discord.
             </p>
-            <a
-              href="https://discord.gg/KgYGHEMq2P"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
-            >
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                className="w-4 h-4 fill-current"
+            <div className="flex flex-col sm:flex-row gap-2">
+              <a
+                href="https://github.com/Slush97/grimoire/issues"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60 whitespace-nowrap"
               >
-                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-              </svg>
-              Join Discord
-            </a>
+                <Github className="w-4 h-4" aria-hidden="true" />
+                GitHub Issues
+              </a>
+              <a
+                href="https://discord.gg/KgYGHEMq2P"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
+              >
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  className="w-4 h-4 fill-current"
+                >
+                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                </svg>
+                Join Discord
+              </a>
+            </div>
           </div>
         </Card>
 


### PR DESCRIPTION
## Summary

- **fix(mods)**: deleting a mod now purges its metadata, so the next download/import landing on the same `pakNN_dir.vpk` slot can't inherit the deleted mod's `gameBananaId`, thumbnail, category, etc. Heals existing leaks via a `pruneOrphanMetadata` sweep on every `get-mods` call. Resolves issue #26 (locally-imported mods showing up grouped with unrelated GameBanana mods).
- **fix(conflicts)**: ignore `materials/default/default_*` overlaps — those are Source 2 engine fallback textures, not real conflicts; fixes the Graves Shirt vs Ghost Bride Vindicta false positive. Replaces `conflicts.some(...)` dedupe with a `Set` (was O(n^4) on a hot path the sidebar polls). Drops per-scan logging that was flooding the dev console on every mods change.
- **fix(installed)**: the "{n} conflicts" button was using `conflictMap.size / 2` which goes fractional or undercounts when a mod is in multiple pairs. Now uses the raw `conflicts.length` returned by `detectConflicts`, with correct pluralization. Also moved the conditional Conflicts/Update-all buttons out of the cramped top action bar onto the section header row next to Fix Order.
- **fix(downloads)**: after #25 healed the sibling-disable filter, downloading a second variant disabled the old one without enabling the new one (downloads land in `/disabled`) — both ended up off. Now promotes the freshly downloaded variant when a previously-enabled peer is kicked, so the user always ends up with exactly one active variant.
- **feat(settings)**: GitHub Issues button on the Support card alongside Discord.

## Test plan

- [ ] Issue #26: install a GameBanana mod, delete it, import a local custom mod — verify the local mod shows its own name/thumbnail and isn't grouped with the deleted one. Re-launch and confirm `mod-metadata.json` no longer carries the orphan entry.
- [ ] Conflicts: with two unrelated character skin mods enabled, confirm `materials/default/default_*` overlaps no longer surface on the Conflicts page.
- [ ] Conflicts UI: trigger a scenario with 3+ mods mutually conflicting and verify the Installed page button label matches what the Conflicts page shows (and the sidebar badge).
- [ ] Variant swap: install one variant of a mod, then install a different variant of the same mod from GameBanana — confirm the original gets moved to `/disabled` and the new one ends up enabled in `/addons`.
- [ ] Settings: open Settings → Support, click GitHub Issues, confirm it opens the repo issues page.