### PR TITLE
chore(release): v1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Cuts v1.9.3. Bundles the bug fixes from #27 (metadata leak fix for #26, conflict detection improvements, variant install correctness) and a small Settings addition.

## Release notes (paste into GitHub Release body after tag push)

```markdown
## Grimoire v1.9.3

Grimoire is a mod manager and companion tool for Deadlock. Browse and install mods from GameBanana, manage installed mods with drag-and-drop priority ordering, organize hero skins in the Locker, design crosshairs with real-time preview, edit your autoexec.cfg, save and switch between mod profiles, and detect file conflicts between mods. Available for Windows and Linux.

A bug fix pass cleaning up mod metadata leaks, conflict detection false positives, and the variant install flow. The Conflicts and Update-all badges also moved out of the cramped top toolbar into the section header row.

## What's New

### New Features
- **GitHub Issues link in Settings.** The Support card now links to GitHub Issues alongside the Discord button, for users who'd rather file a tracked report than chat.

### Changed
- **Conflicts and Update-all badges moved below the page header.** They lived in the top action bar next to Search and view toggles, which got cramped when both were active. Now they sit on the Enabled section row beside Fix Order.

### Bug Fixes
- **Locally imported mods inheriting deleted mods' data.** Symptom: a freshly imported VPK showed a deleted mod's thumbnail and merged into its group on the Installed page. Cause: deleting a mod left its metadata behind keyed by filename, so the next mod assigned the same `pakNN_dir.vpk` slot picked up `gameBananaId`, thumbnail, and category via merge. Fix: deletes now purge metadata, and an orphan sweep on next launch heals existing leaks. (#26)
- **False conflicts on shared engine textures.** Symptom: two unrelated skin mods got flagged as conflicting on the Conflicts page. Cause: each VPK bundled a copy of Source 2's default fallback textures (`materials/default/default_*_tga_*.vtex_c`). Fix: those engine-default paths are now excluded from conflict detection.
- **Installed page conflict count rendered fractional or wrong.** Symptom: the "{n} conflicts" badge showed values like "1.5 conflicts" or undercounted. Cause: the count used `conflictMap.size / 2`, which only works when every mod is in exactly one pair. Fix: uses the raw pair count from the backend, matching the sidebar and Conflicts page.
- **Downloading a second variant left the mod disabled.** Symptom: enabling variant A then downloading variant B left both disabled and the mod fully off. Cause: 1.9.2's sibling-disable started actually firing, but downloads land in `/disabled` by default, so nothing was promoting the new pick. Fix: when an enabled sibling gets kicked, the freshly downloaded variant is promoted to enabled.

## Downloads

**Windows:**
- `Grimoire-Setup-1.9.3.exe`. Per-user NSIS installer. Adds Desktop and Start Menu shortcuts and registers the `grimoire:` URL handler.
- `Grimoire-Portable-1.9.3.exe`. Self-contained executable, no installation required.

**Linux:**
- AppImage: `Grimoire-1.9.3.AppImage`
- Debian/Ubuntu: `grimoire_1.9.3_amd64.deb`

**Requirements:** Deadlock installed via Steam. Existing 1.8.x/1.9.x installer/AppImage users will auto-update on next launch. `.deb` users should re-download from this page (apt-style updates aren't supported).

---

**Full Changelog:** https://github.com/Slush97/grimoire/compare/v1.9.2...v1.9.3
```

## Test plan

- [ ] CI green
- [ ] After merge, push `v1.9.3` annotated tag from `main` to kick the release workflow
- [ ] Edit the auto-generated Release body with the Markdown block above
- [ ] Smoke test: install a GameBanana mod, delete it, import a local mod, verify no metadata leak