### PR TITLE
fix(social): CSRF defense, gzip cap, pagination, prod URL gate, polish

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,12 +3,36 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
 
-// Bake the social Worker URL at build time so packaged releases have a stable
-// endpoint. Override via env var at build (CI sets prod URL); dev runs default
-// to wrangler's local port. Substituted into the main bundle by Vite's define.
-const SOCIAL_BASE_URL = process.env['GRIMOIRE_SOCIAL_BASE_URL'] ?? 'http://localhost:8787';
+// Bake the social Worker URL at build time. Dev runs (electron-vite dev) fall
+// back to wrangler's local port. Production builds (electron-vite build, used
+// by all package:* scripts) REQUIRE GRIMOIRE_SOCIAL_BASE_URL to be set —
+// otherwise we'd ship installers that try to talk to localhost:8787 in user
+// homes. The build fails loudly rather than silently producing a broken
+// social experience.
+function resolveSocialBaseUrl(mode: string): string {
+    const env = process.env['GRIMOIRE_SOCIAL_BASE_URL'];
+    if (mode === 'production') {
+        if (!env) {
+            throw new Error(
+                'GRIMOIRE_SOCIAL_BASE_URL must be set for production builds. ' +
+                'Set it to your Cloudflare Worker URL (e.g. ' +
+                'https://grimoire-social.example.workers.dev) before running ' +
+                'electron-vite build / pnpm package:*.'
+            );
+        }
+        if (!env.startsWith('https://')) {
+            throw new Error(
+                `GRIMOIRE_SOCIAL_BASE_URL must be https:// in production builds (got "${env}").`
+            );
+        }
+        return env.replace(/\/+$/, '');
+    }
+    return env?.replace(/\/+$/, '') ?? 'http://localhost:8787';
+}
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+    const SOCIAL_BASE_URL = resolveSocialBaseUrl(mode);
+    return {
     main: {
         plugins: [
             externalizeDepsPlugin({
@@ -61,4 +85,5 @@ export default defineConfig({
             port: 5173,
         },
     },
+    };
 });

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { gzipSync, gunzipSync } from 'zlib';
+import { gzipSync, gunzipSync, constants as zlibConstants } from 'zlib';
 import { addProfile, generateProfileId, loadProfiles, type Profile, type ProfileMod } from './profiles';
 import { scanMods } from './mods';
 import { getModMetadata } from './metadata';
@@ -39,12 +39,33 @@ export function encodeShareCode(json: string): string {
     return PORTABLE_PROFILE_SHARE_PREFIX + base64UrlEncode(compressed);
 }
 
+// Mirror the server-side cap so a malicious / corrupted share code can't
+// inflate into a multi-MB allocation in the Electron main process. The
+// previous implementation called gunzipSync with no maxOutputLength, which
+// let a 16 KB compressed payload expand up to ~16 MB before failing.
+const MAX_INFLATED_SHARE_CODE_BYTES = 16 * 1024;
+
 export function decodeShareCode(code: string): string {
     if (!code.startsWith(PORTABLE_PROFILE_SHARE_PREFIX)) {
         throw new Error(`Share code missing "${PORTABLE_PROFILE_SHARE_PREFIX}" prefix`);
     }
     const body = code.slice(PORTABLE_PROFILE_SHARE_PREFIX.length).trim();
-    const decompressed = gunzipSync(base64UrlDecode(body));
+    let decompressed: Buffer;
+    try {
+        decompressed = gunzipSync(base64UrlDecode(body), {
+            // Hard ceiling: zlib raises ERR_BUFFER_TOO_LARGE when an output
+            // chunk would push the buffer past this. Caught below to surface
+            // a friendly error instead of a Node-internal message.
+            maxOutputLength: MAX_INFLATED_SHARE_CODE_BYTES,
+            // Match the server-side stream cap so behavior is symmetric.
+            finishFlush: zlibConstants.Z_FINISH,
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `Invalid share code (gzip payload rejected: ${msg.slice(0, 120)})`
+        );
+    }
     return decompressed.toString('utf8');
 }
 

--- a/electron/main/services/socialAuth.ts
+++ b/electron/main/services/socialAuth.ts
@@ -10,6 +10,7 @@
 // to the social IPC handlers, which delegate here.
 
 import { app, safeStorage, shell } from 'electron';
+import { randomBytes } from 'crypto';
 import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -152,6 +153,7 @@ export async function hydrateOnBoot(): Promise<void> {
 interface AuthCallbackParts {
     token: string;
     expiresAt: number;
+    state: string | null;
 }
 
 function parseGrimoireAuthUrl(url: string): AuthCallbackParts | null {
@@ -162,9 +164,9 @@ function parseGrimoireAuthUrl(url: string): AuthCallbackParts | null {
     } catch {
         return null;
     }
-    // grimoire://auth/done?token=...&expires_at=... is the canonical shape.
-    // Be lenient on which segment the OS gives us — host vs first path part
-    // can vary slightly across platforms when an app handles the protocol.
+    // grimoire://auth/done?token=...&expires_at=...&state=... is the canonical
+    // shape. Be lenient on which segment the OS gives us — host vs first path
+    // part can vary slightly across platforms when an app handles the protocol.
     const segments = [parsed.host, ...parsed.pathname.split('/')].filter(Boolean);
     if (segments[0] !== 'auth' || segments[1] !== 'done') return null;
     const token = parsed.searchParams.get('token');
@@ -174,7 +176,18 @@ function parseGrimoireAuthUrl(url: string): AuthCallbackParts | null {
     return {
         token,
         expiresAt: Number.isFinite(expiresAt) ? expiresAt : defaultExpiry(),
+        state: parsed.searchParams.get('state'),
     };
+}
+
+/** Constant-time compare for the OAuth-style state nonce. Same shape as the
+ *  Worker's compare; the strings are short hex so a non-CT compare leaks
+ *  almost nothing, but we keep the pattern uniform. */
+function timingSafeEqualStr(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
 }
 
 function defaultExpiry(): number {
@@ -195,6 +208,11 @@ interface ActiveLogin {
     resolve: (parts: AuthCallbackParts) => void;
     reject: (err: Error) => void;
     timer: NodeJS.Timeout;
+    // 32-byte hex nonce minted at login() time and round-tripped through Steam
+    // + the Worker. We refuse any grimoire://auth/done URL whose state doesn't
+    // match this — defends against an attacker handing the OS a crafted
+    // callback URL while no real login is in flight (or while one is).
+    state: string;
 }
 
 let activeLoginResolver: ActiveLogin | null = null;
@@ -225,6 +243,11 @@ export async function login(): Promise<SessionStatus> {
         throw new Error('A Grimoire Social login is already in progress');
     }
 
+    // 32 bytes of entropy hex-encoded (64 chars). The Worker validates the
+    // shape and round-trips it through Steam's openid.return_to; we verify the
+    // returned URL carries this exact value before accepting any token.
+    const state = randomBytes(32).toString('hex');
+
     const result = await new Promise<AuthCallbackParts>((resolve, reject) => {
         const timer = setTimeout(() => {
             rejectActiveLogin(
@@ -233,9 +256,10 @@ export async function login(): Promise<SessionStatus> {
                 )
             );
         }, LOGIN_TIMEOUT_MS);
-        activeLoginResolver = { resolve, reject, timer };
+        activeLoginResolver = { resolve, reject, timer, state };
 
-        shell.openExternal(getAuthBeginUrl()).catch((err) => {
+        const beginUrl = `${getAuthBeginUrl()}?state=${encodeURIComponent(state)}`;
+        shell.openExternal(beginUrl).catch((err) => {
             rejectActiveLogin(err instanceof Error ? err : new Error(String(err)));
         });
     });
@@ -294,38 +318,33 @@ export async function clearLocalAfterAccountDeletion(): Promise<void> {
 }
 
 /** Handle a grimoire://auth/done URL that arrived via the OS protocol
- *  handler (cold-launch argv or second-instance event). This is the primary
- *  return path for the external-browser sign-in flow; if a login() promise is
- *  in flight it resolves that, otherwise (e.g. cold launch via deep link) the
- *  session is hydrated here directly. */
+ *  handler (cold-launch argv or second-instance event). This is the return
+ *  path for the external-browser sign-in flow.
+ *
+ *  CSRF defense: we ONLY accept the callback when (a) a login() is in flight
+ *  AND (b) the URL's state matches the nonce we minted for that login. Any
+ *  other shape — including a callback that arrives when nothing is in flight,
+ *  which used to be silently accepted — is dropped. Without this, a victim
+ *  who clicks an attacker-crafted grimoire://auth/done?token=... URL would
+ *  unknowingly adopt the attacker's session. */
 export async function handleProtocolAuthCallback(url: string): Promise<void> {
     const parts = parseGrimoireAuthUrl(url);
     if (!parts) return;
     const current = activeLoginResolver;
-    if (current) {
-        activeLoginResolver = null;
-        clearTimeout(current.timer);
-        current.resolve(parts);
+    if (!current) {
+        console.warn('[socialAuth] dropping auth callback with no active login');
         return;
     }
-    setSessionToken(parts.token);
-    sessionExpiresAt = parts.expiresAt;
-    if (canPersistSecurely()) {
-        try {
-            await persistSession({ token: parts.token, expires_at: parts.expiresAt });
-        } catch (err) {
-            console.warn('[socialAuth] Failed to persist OS-callback session:', err);
-        }
+    if (!parts.state || !timingSafeEqualStr(parts.state, current.state)) {
+        // Mismatch could be a race (stale callback from a previous abandoned
+        // login) or a CSRF attempt. Either way: reject loudly enough to log
+        // but don't reveal which case it was.
+        rejectActiveLogin(
+            new Error('Sign-in callback did not match this login. Try again.')
+        );
+        return;
     }
-    try {
-        const me = await getMe();
-        cachedUser = me.user;
-        emitChange();
-    } catch (err) {
-        setSessionToken(null);
-        sessionExpiresAt = null;
-        await clearPersistedSession();
-        emitChange();
-        console.warn('[socialAuth] /me failed after OS-callback auth:', err);
-    }
+    activeLoginResolver = null;
+    clearTimeout(current.timer);
+    current.resolve(parts);
 }

--- a/src/components/social/EditProfileDialog.tsx
+++ b/src/components/social/EditProfileDialog.tsx
@@ -135,7 +135,7 @@ export default function EditProfileDialog({
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  maxLength={120}
+                  maxLength={80}
                   placeholder="Short, memorable title"
                   className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
                 />
@@ -158,7 +158,7 @@ export default function EditProfileDialog({
                   id="edit-profile-description"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  maxLength={1200}
+                  maxLength={1000}
                   rows={4}
                   placeholder="What's the vibe? Who's it for?"
                   className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-none"

--- a/src/components/social/PublishDialog.tsx
+++ b/src/components/social/PublishDialog.tsx
@@ -195,7 +195,7 @@ export default function PublishDialog({
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  maxLength={120}
+                  maxLength={80}
                   placeholder="Short, memorable title"
                   className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
                 />
@@ -213,7 +213,7 @@ export default function PublishDialog({
                   id="publish-description"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  maxLength={1200}
+                  maxLength={1000}
                   rows={4}
                   placeholder="What's the vibe? Who's it for?"
                   className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-none"

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -1,6 +1,11 @@
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { Mod } from '../types/mod';
 import { getAssetPath } from './assetPath';
+import {
+  HERO_NAMES as SHARED_HERO_NAMES,
+  HERO_ALIASES as SHARED_HERO_ALIASES,
+  inferHeroFromTitle as sharedInferHeroFromTitle,
+} from '@grimoire/social-types/heroes';
 
 export type HeroCategory = {
   id: number;
@@ -78,65 +83,20 @@ export function getHeroFacePosition(name: string): number {
 /**
  * Known hero names — drives fuzzy matching for sound/voice mods whose titles
  * tend to mention a hero (e.g. "Drifter ult replacement", "Pocket - VO").
- * Superset of HERO_FACE_POSITION; includes newer heroes whose portrait assets
- * exist in /locker/heroes/ but don't yet have a tuned face-crop position.
+ *
+ * Sourced from @grimoire/social-types/heroes so the Worker and client share
+ * one roster; adding a new Deadlock hero only requires updating that file.
+ * Re-exported here so existing callers (`import { HERO_NAMES } from
+ * './lockerUtils'`) keep working.
  */
-export const HERO_NAMES: string[] = [
-  ...Object.keys(HERO_FACE_POSITION),
-  'Apollo',
-  'Celeste',
-  'Graves',
-  'Rem',
-  'Silver',
-  'The Doorman',
-  'Venator',
-];
+export const HERO_NAMES = SHARED_HERO_NAMES;
+export const HERO_ALIASES = SHARED_HERO_ALIASES;
 
 /**
- * Alternate spellings / common shorthand. Keys are canonical names from
- * HERO_FACE_POSITION; values are lowercase needles to search inside a title.
+ * Infer the Deadlock hero associated with a mod title. Re-exported from the
+ * shared package; see @grimoire/social-types/heroes for the matcher details.
  */
-const HERO_ALIASES: Record<string, string[]> = {
-  'Mo & Krill': ['mo & krill', 'mo and krill', 'mo+krill', 'mokrill'],
-  'Grey Talon': ['grey talon', 'greytalon', 'grey-talon'],
-  'Lady Geist': ['lady geist', 'ladygeist', 'geist'],
-  McGinnis: ['mcginnis', 'mc ginnis'],
-  'Yamato': ['yamato'],
-};
-
-function escapeRegex(s: string): string {
-  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-}
-
-/**
- * Infer the Deadlock hero associated with a mod title. Uses case-insensitive
- * substring match for multi-word heroes and word-boundary match for single
- * tokens, so "Haze ULT" matches "Haze" but "Hazelnut" does not. Returns the
- * canonical hero name (matching HERO_FACE_POSITION keys) or null.
- */
-export function inferHeroFromTitle(title: string): string | null {
-  if (!title) return null;
-  const needle = title.toLowerCase();
-  // Longest hero names first so "Grey Talon" wins over "Grey".
-  const sorted = [...HERO_NAMES].sort((a, b) => b.length - a.length);
-
-  for (const hero of sorted) {
-    const lower = hero.toLowerCase();
-    const aliases = [lower, ...(HERO_ALIASES[hero] ?? [])];
-    for (const alias of aliases) {
-      if (alias.includes(' ') || alias.includes('&') || alias.includes('+')) {
-        // Multi-word / symbol aliases: plain substring is fine.
-        if (needle.includes(alias)) return hero;
-      } else {
-        // Single-token: require word boundary to avoid false positives
-        // (e.g. "mira" won't match "Mirage").
-        const re = new RegExp(`\\b${escapeRegex(alias)}\\b`, 'i');
-        if (re.test(needle)) return hero;
-      }
-    }
-  }
-  return null;
-}
+export const inferHeroFromTitle = sharedInferHeroFromTitle;
 
 export type MinaPreset = {
   fileName: string;

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Globe2,
   Heart,
@@ -7,6 +7,7 @@ import {
   Clock,
   Flame,
   CloudOff,
+  Loader2,
   X,
   ExternalLink,
   ShieldCheck,
@@ -66,12 +67,13 @@ export default function Discover() {
   const [tab, setTab] = useState<TabKey>('top');
   const [data, setData] = useState<SocialListProfilesResponse | null>(null);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [likingId, setLikingId] = useState<string | null>(null);
-  // Tracks the viewer's like state per profile so toggling works without
-  // depending on the server returning an error on duplicate Like. The list
-  // endpoint doesn't include viewer_has_liked, so we start empty and learn
-  // the truth from each like/unlike response.
+  // Tracks the viewer's like state per profile. Seeded from the list response
+  // when the server returns viewer_has_liked (only when authenticated), and
+  // kept in sync by each like/unlike response. Cards without an entry default
+  // to "not liked" — same as before the field existed on the wire.
   const [viewerLiked, setViewerLiked] = useState<Record<string, boolean>>({});
   // Pulses the header sign-in button when a signed-out user clicks Like.
   const [signInPulse, setSignInPulse] = useState(false);
@@ -80,23 +82,84 @@ export default function Discover() {
   // dialog's left rail can render instantly while /v1/profiles/:id loads.
   const [importTarget, setImportTarget] = useState<CardProfile | null>(null);
 
+  // Merge the viewer_has_liked field from a response into our local map.
+  // Pulled out so loadProfiles and loadMore can share it.
+  const mergeViewerLiked = useCallback((profiles: SocialListProfilesResponse['profiles']) => {
+    setViewerLiked((prev) => {
+      const next = { ...prev };
+      for (const p of profiles) {
+        if (typeof p.viewer_has_liked === 'boolean') {
+          next[p.id] = p.viewer_has_liked;
+        }
+      }
+      return next;
+    });
+  }, []);
+
   const loadProfiles = useCallback(async () => {
     if (tab === 'mine') return;
     setLoading(true);
     setError(null);
     try {
-      const res = await socialListProfiles({ sort: tab, hideNsfw });
+      const res = await socialListProfiles({ sort: tab, hideNsfw, page: 1 });
       setData(res);
+      mergeViewerLiked(res.profiles);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [tab, hideNsfw]);
+  }, [tab, hideNsfw, mergeViewerLiked]);
 
   useEffect(() => {
     void loadProfiles();
   }, [loadProfiles]);
+
+  // Are more profiles available beyond what's currently in `data.profiles`?
+  // Drives both the observer sentinel rendering and the early-out in loadMore.
+  const hasMore = !!(data && data.profiles.length < data.total);
+
+  const loadMore = useCallback(async () => {
+    if (!data || loading || loadingMore || tab === 'mine' || !hasMore) return;
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const nextPage = data.page + 1;
+      const res = await socialListProfiles({ sort: tab, hideNsfw, page: nextPage });
+      setData((prev) => {
+        // Tab/filter changed mid-fetch: drop the response, let the fresh
+        // loadProfiles win. Comparing the snapshot identity catches resets.
+        if (!prev || prev !== data) return prev;
+        // De-dupe defensively in case a new publish shifted offsets between
+        // pages. id is the primary key.
+        const seen = new Set(prev.profiles.map((p) => p.id));
+        const merged = prev.profiles.concat(res.profiles.filter((p) => !seen.has(p.id)));
+        return { ...res, profiles: merged };
+      });
+      mergeViewerLiked(res.profiles);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [data, hasMore, hideNsfw, loading, loadingMore, mergeViewerLiked, tab]);
+
+  // IntersectionObserver-driven infinite scroll. Mirrors the pattern Browse
+  // uses so the two pages feel the same.
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (tab === 'mine' || !hasMore) return;
+    const node = loadMoreRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) void loadMore();
+      },
+      { rootMargin: '600px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [tab, hasMore, loadMore]);
 
   // If a signed-in user lands on Your profile and then signs out, fall back
   // to Top so they don't end up staring at an empty owner-only view.
@@ -513,10 +576,21 @@ export default function Discover() {
         </div>
       )}
 
-      {tab !== 'mine' && data && data.profiles.length > 0 && data.total > data.profiles.length && (
-        <div className="text-xs text-text-secondary text-center pt-2 inline-flex items-center gap-2 justify-center w-full">
-          <AlertTriangle className="w-3 h-3" />
-          Pagination not wired up yet (showing first {data.page_size} of {data.total}).
+      {tab !== 'mine' && hasMore && (
+        <div
+          ref={loadMoreRef}
+          className="text-xs text-text-secondary text-center pt-2 inline-flex items-center gap-2 justify-center w-full"
+        >
+          {loadingMore ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Loading more...
+            </>
+          ) : (
+            <span className="opacity-60">
+              Showing {data!.profiles.length} of {data!.total}
+            </span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Client side of the audit hardening pass. Pairs with `Slush97/grimoire-social#1`; merge that first so the new wire-format field (`viewer_has_liked` on list rows) and the `state` query passthrough are deployed before this ships.

- **Login-CSRF defense (audit #1).** `handleProtocolAuthCallback` now refuses any `grimoire://auth/done` URL that arrives outside a pending `login()`, and requires the URL's `state` to match the nonce minted when that login started. Previously a victim clicking an attacker-crafted callback URL would silently adopt the attacker's session.
- **Client-side gzip-bomb cap (audit #5b).** `decodeShareCode` uses `gunzipSync` with `maxOutputLength: 16 KB`. A malicious server response can no longer OOM the Electron main process.
- **Production base URL gate (audit #3).** `electron-vite build` (used by all `package:*` scripts) refuses to produce a build without `GRIMOIRE_SOCIAL_BASE_URL` set to an `https://` URL. Verified: the build fails loudly without the env var, succeeds when set.
- **Discover infinite scroll (audit #9).** Mirrors the Browse pattern (IntersectionObserver sentinel at 600px rootMargin). Removes the visible "pagination not wired up yet" warning.
- **`viewer_has_liked` seeding (audit #8 client side).** Discover seeds its `viewerLiked` map from the list response so card hearts paint correctly on first render for returning users.
- **Title / description polish (audit #15, #16).** Input `maxLength` aligned with server caps (80 / 1000). Empty descriptions are passed as `undefined` so they store as NULL.
- **Shared hero roster (audit #17).** `lockerUtils` re-exports `HERO_NAMES` / `HERO_ALIASES` / `inferHeroFromTitle` from `@grimoire/social-types/heroes`. Adding a Deadlock hero is now a one-file change.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean on both `tsconfig.app.json` and `tsconfig.node.json`
- [x] `pnpm lint` shows only the 3 pre-existing warnings (`AudioPreviewPlayer.tsx`, `Stats.tsx`) — none introduced by this PR
- [x] `electron-vite build` fails without `GRIMOIRE_SOCIAL_BASE_URL`, succeeds with `https://example.workers.dev`
- [ ] Manual smoke: `pnpm dev` against local `wrangler dev`
  - [ ] Sign in with Steam, verify callback succeeds with state nonce
  - [ ] Sign in, then attempt to inject a `grimoire://auth/done?token=...` URL via second-instance — verify it's rejected
  - [ ] Discover loads, scroll to bottom triggers next page
  - [ ] Like / unlike a profile, refresh, heart state persists
  - [ ] Publish a profile with empty description, verify it stores as null
  - [ ] Open an existing profile, verify pasting an oversized share code shows the gzip cap error rather than hanging