### PR TITLE
ci: checkout grimoire-social as sibling so @grimoire/social-types resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
           cache: pnpm
           cache-dependency-path: grimoire/pnpm-lock.yaml
 
+      # @grimoire/social-types declares zod as a peer dependency. Locally that
+      # resolves via grimoire-social/node_modules/zod (each repo runs its own
+      # pnpm install). In CI we have to mirror that — installing only in
+      # grimoire leaves the workspace-shared package unable to resolve zod
+      # when typecheck follows the symlink.
+      - name: Install grimoire-social deps (for the shared workspace package)
+        working-directory: grimoire-social
+        run: pnpm install --frozen-lockfile
+
       - name: Install dependencies
         working-directory: grimoire
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,27 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout grimoire
         uses: actions/checkout@v4
+        with:
+          path: grimoire
+
+      # pnpm-workspace.yaml resolves @grimoire/social-types from
+      # ../grimoire-social/packages/*. Local dev works because both repos sit
+      # side-by-side; CI has to mirror that or every social import becomes an
+      # implicit-any and the build fails on the workspace dep.
+      #
+      # grimoire-social is private, so the default GITHUB_TOKEN can't read it.
+      # WORKSPACE_PAT is a fine-grained PAT scoped to Slush97/grimoire-social
+      # with Contents:Read. Set it under
+      # https://github.com/Slush97/grimoire/settings/secrets/actions
+      - name: Checkout grimoire-social (sibling for shared types)
+        uses: actions/checkout@v4
+        with:
+          repository: Slush97/grimoire-social
+          token: ${{ secrets.WORKSPACE_PAT }}
+          path: grimoire-social
+          ref: main
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -23,15 +42,25 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: grimoire/pnpm-lock.yaml
 
       - name: Install dependencies
+        working-directory: grimoire
         run: pnpm install --frozen-lockfile
 
       - name: Lint
+        working-directory: grimoire
         run: pnpm lint
 
       - name: Typecheck
+        working-directory: grimoire
         run: pnpm exec tsc -b --noEmit
 
+      # The prod-build gate refuses to build without GRIMOIRE_SOCIAL_BASE_URL
+      # set to an https URL. CI uses a placeholder to exercise the build
+      # pipeline; the value is meaningless at runtime (CI doesn't run the app).
       - name: Build
+        working-directory: grimoire
+        env:
+          GRIMOIRE_SOCIAL_BASE_URL: https://grimoire-social.ci.workers.dev
         run: pnpm exec electron-vite build


### PR DESCRIPTION
## Summary

Fixes the CI red on `main`. Root cause: when `@grimoire/social-types` was extracted into a workspace package living in the private `Slush97/grimoire-social` repo, this CI workflow kept checking out only this repo. The pnpm workspace dep at `../grimoire-social/packages/*` silently failed to resolve, every social import became an implicit-any, the build collapsed.

The fix is two checkouts:

```yaml
- uses: actions/checkout@v4
  with:
    path: grimoire
- uses: actions/checkout@v4
  with:
    repository: Slush97/grimoire-social
    token: ${{ secrets.WORKSPACE_PAT }}
    path: grimoire-social
    ref: main
```

All subsequent steps run with `working-directory: grimoire`. The `Build` step gets a placeholder `GRIMOIRE_SOCIAL_BASE_URL` so the prod-URL gate from `electron.vite.config.ts` is satisfied — the value doesn't matter because CI never runs the app.

## REQUIRED setup before merge

Because `grimoire-social` is private, the default `GITHUB_TOKEN` can't read it. You need to add a PAT secret to **this** repo:

1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - **Repository access:** Only select repositories → `Slush97/grimoire-social`
   - **Permissions:** Repository permissions → Contents → **Read-only**
   - Expiration: whatever you're comfortable with; CI will keep working until it expires
2. Add it as a repo secret named `WORKSPACE_PAT` at
   https://github.com/Slush97/grimoire/settings/secrets/actions

Once `WORKSPACE_PAT` is set, the CI on this PR will go green and the merge is safe.

## Why not vendor the types instead?

Considered. Vendoring means two copies that can silently drift (the exact thing ADR-015 fixed). Publishing `@grimoire/social-types` to npm would also work but isn't worth it for a single internal consumer. A PAT scoped to read-only on one repo is the cheapest defensible option.

## Test plan

- [ ] Add `WORKSPACE_PAT` secret per the steps above
- [ ] Re-run CI on this PR, confirm it goes green
- [ ] Merge, confirm `main`'s CI is now green