### PR TITLE
feat(discover): publish flow from Discover (picker + header CTA)

### DIFF
--- a/src/components/social/MyPublishedSection.tsx
+++ b/src/components/social/MyPublishedSection.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
   Pencil,
   Globe2,
+  Upload,
 } from 'lucide-react';
 import { Button, Badge } from '../common/ui';
 import { EmptyState } from '../common/PageComponents';
@@ -26,6 +27,10 @@ interface MyPublishedSectionProps {
   // section refetches without remounting.
   refreshKey?: number;
   onOpenProfile?: (profileId: string) => void;
+  // Opens the parent's "pick a local profile to publish" flow. Surfaced from
+  // both the empty state and the list header so a signed-in user can start a
+  // new post from this tab.
+  onPublishNew?: () => void;
   // Notify parent when a profile was unpublished so the main Discover list
   // can drop the row optimistically.
   onUnpublished?: (profileId: string) => void;
@@ -47,6 +52,7 @@ type EditTarget = {
 export default function MyPublishedSection({
   refreshKey,
   onOpenProfile,
+  onPublishNew,
   onUnpublished,
   onUpdated,
 }: MyPublishedSectionProps) {
@@ -144,8 +150,23 @@ export default function MyPublishedSection({
         <EmptyState
           icon={Globe2}
           title="You haven't published anything yet"
-          description="Open Profiles, pick one, and click Publish to Discover."
+          description="Pick one of your local profiles and post it to Discover."
+          action={
+            onPublishNew ? (
+              <Button icon={Upload} onClick={onPublishNew}>
+                Publish a profile
+              </Button>
+            ) : undefined
+          }
         />
+      )}
+
+      {data && data.profiles.length > 0 && onPublishNew && (
+        <div className="flex justify-end">
+          <Button size="sm" variant="secondary" icon={Upload} onClick={onPublishNew}>
+            Publish another
+          </Button>
+        </div>
       )}
 
       {data && data.profiles.length > 0 && (

--- a/src/components/social/PublishPickerDialog.tsx
+++ b/src/components/social/PublishPickerDialog.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import { X, Loader2, AlertTriangle, Boxes, Globe, FolderOpen } from 'lucide-react';
+import { Button } from '../common/ui';
+import { EmptyState } from '../common/PageComponents';
+import { getProfiles, type Profile } from '../../lib/api';
+import { formatRelativeDate } from '../../lib/dates';
+
+interface PublishPickerDialogProps {
+  onClose: () => void;
+  onPick: (profile: { id: string; name: string }) => void;
+}
+
+export default function PublishPickerDialog({ onClose, onPick }: PublishPickerDialogProps) {
+  const [profiles, setProfiles] = useState<Profile[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    getProfiles()
+      .then((p) => { if (!cancelled) setProfiles(p); })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Most recently updated first so the profile the user just finished
+  // tweaking is at the top.
+  const sorted = useMemo(() => {
+    if (!profiles) return null;
+    return [...profiles].sort((a, b) => {
+      const ta = Date.parse(a.updatedAt) || 0;
+      const tb = Date.parse(b.updatedAt) || 0;
+      return tb - ta;
+    });
+  }, [profiles]);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="publish-pick-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-lg max-h-[80vh] flex flex-col overflow-hidden shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between p-6 border-b border-white/10">
+          <div className="min-w-0">
+            <h2 id="publish-pick-title" className="text-xl font-bold text-text-primary flex items-center gap-2">
+              <Globe className="w-5 h-5 text-accent" />
+              Publish a profile
+            </h2>
+            <p className="text-sm text-text-secondary mt-1">
+              Pick which local profile to share on Discover.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-4 overflow-y-auto">
+          {loading && (
+            <div className="text-sm text-text-secondary inline-flex items-center gap-2 p-3">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading your profiles...
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+              <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {!loading && !error && sorted && sorted.length === 0 && (
+            <EmptyState
+              icon={FolderOpen}
+              title="No local profiles yet"
+              description="Create a profile under Profiles, add some mods, then come back to publish."
+            />
+          )}
+
+          {sorted && sorted.length > 0 && (
+            <ul className="divide-y divide-white/5 border border-white/10 rounded-lg bg-bg-tertiary/30 overflow-hidden">
+              {sorted.map((p) => {
+                const modCount = p.mods.length;
+                const noMods = modCount === 0;
+                return (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      onClick={() => onPick({ id: p.id, name: p.name })}
+                      disabled={noMods}
+                      className={`w-full text-left px-4 py-3 flex items-center gap-3 transition-colors ${
+                        noMods
+                          ? 'opacity-50 cursor-not-allowed'
+                          : 'hover:bg-white/[0.04] cursor-pointer'
+                      }`}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm text-text-primary font-medium truncate" title={p.name}>
+                          {p.name}
+                        </div>
+                        <div className="text-xs text-text-secondary flex items-center gap-x-3 mt-0.5 flex-wrap">
+                          <span className="inline-flex items-center gap-1">
+                            <Boxes className="w-3 h-3" />
+                            {modCount} {modCount === 1 ? 'mod' : 'mods'}
+                          </span>
+                          <span className="text-text-tertiary">
+                            updated {formatRelativeDate(p.updatedAt)}
+                          </span>
+                          {noMods && (
+                            <span className="text-text-tertiary italic">empty</span>
+                          )}
+                        </div>
+                      </div>
+                      <span className="text-xs text-accent shrink-0">
+                        {noMods ? '' : 'Publish →'}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="px-6 py-3 border-t border-white/10 flex justify-end">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -11,6 +11,7 @@ import {
   X,
   ExternalLink,
   ShieldCheck,
+  Upload,
   User as UserIcon,
 } from 'lucide-react';
 import { SteamIcon } from '../components/social/SteamIcon';
@@ -27,6 +28,8 @@ import { Card, Button } from '../components/common/ui';
 import { EmptyState, PageHeader } from '../components/common/PageComponents';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import MyPublishedSection from '../components/social/MyPublishedSection';
+import PublishPickerDialog from '../components/social/PublishPickerDialog';
+import PublishDialog from '../components/social/PublishDialog';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatRelativeDate } from '../lib/dates';
 
@@ -81,6 +84,14 @@ export default function Discover() {
   // The active card-import target: profileId + a seed row from the list so the
   // dialog's left rail can render instantly while /v1/profiles/:id loads.
   const [importTarget, setImportTarget] = useState<CardProfile | null>(null);
+
+  // Publish flow: picker -> publish dialog. Two-stage so users can back out of
+  // the picker without committing to a specific local profile.
+  const [showPicker, setShowPicker] = useState(false);
+  const [publishTarget, setPublishTarget] = useState<{ id: string; name: string } | null>(null);
+  // Bumped on every successful publish so MyPublishedSection refetches without
+  // remounting (otherwise the new row only appears after a manual tab switch).
+  const [publishedTick, setPublishedTick] = useState(0);
 
   // Merge the viewer_has_liked field from a response into our local map.
   // Pulled out so loadProfiles and loadMore can share it.
@@ -226,23 +237,33 @@ export default function Discover() {
   // chip (signed-in). The pulse class fires when a signed-out user clicks a
   // card's like button so the right action is obvious.
   const headerAction = signedIn && user ? (
-    <div
-      className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-secondary border border-white/10"
-      title={`Signed in as ${user.display_name}`}
-    >
-      {user.avatar_url ? (
-        <img
-          src={user.avatar_url}
-          alt=""
-          referrerPolicy="no-referrer"
-          className="w-5 h-5 rounded-full"
-        />
-      ) : (
-        <UserIcon className="w-4 h-4 text-text-secondary" />
-      )}
-      <span className="text-xs text-text-primary truncate max-w-[10rem]">
-        {user.display_name}
-      </span>
+    <div className="flex items-center gap-2">
+      <Button
+        size="sm"
+        icon={Upload}
+        onClick={() => setShowPicker(true)}
+        title="Pick a local profile and publish it to Discover"
+      >
+        Publish profile
+      </Button>
+      <div
+        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-secondary border border-white/10"
+        title={`Signed in as ${user.display_name}`}
+      >
+        {user.avatar_url ? (
+          <img
+            src={user.avatar_url}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="w-5 h-5 rounded-full"
+          />
+        ) : (
+          <UserIcon className="w-4 h-4 text-text-secondary" />
+        )}
+        <span className="text-xs text-text-primary truncate max-w-[10rem]">
+          {user.display_name}
+        </span>
+      </div>
     </div>
   ) : (
     <div
@@ -269,16 +290,57 @@ export default function Discover() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-6 space-y-6 max-w-7xl mx-auto">
-      <PageHeader
-        title="Discover"
-        description="Mod profiles published by other Grimoire users."
-        stats={
-          tab !== 'mine' && data
-            ? `${data.total} ${data.total === 1 ? 'profile' : 'profiles'}`
-            : undefined
-        }
-        action={headerAction}
-      />
+      <div>
+        <PageHeader
+          title="Discover"
+          description="Mod profiles published by other Grimoire users."
+          className="border-b-0 pb-3"
+        />
+        <div className="flex items-end justify-between gap-3 border-b border-border flex-wrap">
+          <div className="flex items-center gap-1">
+            {BROWSE_TABS.map(({ key, label, icon: Icon }) => {
+              const active = tab === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setTab(key)}
+                  className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
+                    active
+                      ? 'border-accent text-text-primary'
+                      : 'border-transparent text-text-secondary hover:text-text-primary'
+                  }`}
+                >
+                  <Icon className="w-4 h-4" />
+                  {label}
+                </button>
+              );
+            })}
+            {signedIn && (
+              <button
+                type="button"
+                onClick={() => setTab('mine')}
+                className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
+                  tab === 'mine'
+                    ? 'border-accent text-text-primary'
+                    : 'border-transparent text-text-secondary hover:text-text-primary'
+                }`}
+              >
+                <UserIcon className="w-4 h-4" />
+                Your profile
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-3 pb-2">
+            {tab !== 'mine' && data && (
+              <span className="text-sm text-text-secondary">
+                {data.total} {data.total === 1 ? 'profile' : 'profiles'}
+              </span>
+            )}
+            {headerAction}
+          </div>
+        </div>
+      </div>
 
       {!signedIn && signInBusy && (
         <div className="text-xs text-text-secondary flex items-start gap-1.5">
@@ -309,43 +371,10 @@ export default function Discover() {
         </div>
       )}
 
-      <div className="flex items-center gap-1 border-b border-border">
-        {BROWSE_TABS.map(({ key, label, icon: Icon }) => {
-          const active = tab === key;
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => setTab(key)}
-              className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
-                active
-                  ? 'border-accent text-text-primary'
-                  : 'border-transparent text-text-secondary hover:text-text-primary'
-              }`}
-            >
-              <Icon className="w-4 h-4" />
-              {label}
-            </button>
-          );
-        })}
-        {signedIn && (
-          <button
-            type="button"
-            onClick={() => setTab('mine')}
-            className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
-              tab === 'mine'
-                ? 'border-accent text-text-primary'
-                : 'border-transparent text-text-secondary hover:text-text-primary'
-            }`}
-          >
-            <UserIcon className="w-4 h-4" />
-            Your profile
-          </button>
-        )}
-      </div>
-
       {tab === 'mine' && signedIn && (
         <MyPublishedSection
+          refreshKey={publishedTick}
+          onPublishNew={() => setShowPicker(true)}
           onOpenProfile={(id) => {
             // Prefer the discover-list seed if it's there; otherwise the
             // dialog refetches detail and fills in the header from /v1/profiles/:id.
@@ -595,6 +624,28 @@ export default function Discover() {
       )}
 
       </div>
+      {showPicker && (
+        <PublishPickerDialog
+          onClose={() => setShowPicker(false)}
+          onPick={(picked) => {
+            setShowPicker(false);
+            setPublishTarget(picked);
+          }}
+        />
+      )}
+      {publishTarget && (
+        <PublishDialog
+          profileId={publishTarget.id}
+          profileName={publishTarget.name}
+          onClose={() => setPublishTarget(null)}
+          onPublished={() => {
+            // Reveal the new post immediately: jump to "Your profile" and
+            // bump the refresh tick so MyPublishedSection refetches.
+            setPublishedTick((n) => n + 1);
+            setTab('mine');
+          }}
+        />
+      )}
       {importTarget && (
         <ImportProfileDialog
           activeDeadlockPath={getActiveDeadlockPath(settings)}


### PR DESCRIPTION
## Summary
- New `PublishPickerDialog` lists local profiles (most-recently-updated first), disables empty profiles, and hands the picked one off to the existing `PublishDialog`.
- Discover header gains a "Publish profile" button for signed-in users; `MyPublishedSection` empty/populated states both surface a matching CTA so the entry point is discoverable from either tab.
- On successful publish, jump to the "Your profile" tab and bump `MyPublishedSection`'s refresh tick so the new row appears immediately.

## Test plan
- [ ] Signed-in: click "Publish profile" in the Discover header — picker lists local profiles, empty profiles are disabled, picking opens `PublishDialog` with prefilled name + ID.
- [ ] Sign out: header button is hidden.
- [ ] Switch to "Your profile" tab with no published profiles — empty-state Publish button works.
- [ ] After publishing, tab auto-switches to "Your profile" and the new row appears without remount.