### PR TITLE
chore(release): v1.10.0

### DIFF
--- a/.github/workflows/discord-announce.yml
+++ b/.github/workflows/discord-announce.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release tag to announce (e.g. v1.9.3). Defaults to latest published release.'
         required: false
         type: string
+      everyone:
+        description: '@everyone ping (use sparingly: minor releases only, not patch hotfixes).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   announce:
@@ -54,6 +59,7 @@ jobs:
           TAG: ${{ steps.rel.outputs.tag }}
           NAME: ${{ steps.rel.outputs.name }}
           URL: ${{ steps.rel.outputs.url }}
+          EVERYONE: ${{ inputs.everyone }}
         run: |
           set -euo pipefail
 
@@ -67,13 +73,26 @@ jobs:
           # Title falls back to the tag when the release has no name set.
           TITLE="${NAME:-$TAG}"
 
+          # @everyone is opt-in. Discord webhooks suppress the ping by default
+          # unless allowed_mentions explicitly parses "everyone". Mention goes
+          # at the front of content so the ping notification preview reads it.
+          if [ "$EVERYONE" = "true" ]; then
+            CONTENT="@everyone A new version of Grimoire is out: **$TAG**"
+            ALLOWED='{"parse":["everyone"]}'
+          else
+            CONTENT="A new version of Grimoire is out: **$TAG**"
+            ALLOWED='{"parse":[]}'
+          fi
+
           PAYLOAD="$(jq -n \
             --arg title "$TITLE" \
             --arg url "$URL" \
             --arg body "$BODY" \
-            --arg tag "$TAG" \
+            --arg content "$CONTENT" \
+            --argjson allowed "$ALLOWED" \
             '{
-              content: ("A new version of Grimoire is out: **" + $tag + "**"),
+              content: $content,
+              allowed_mentions: $allowed,
               embeds: [{
                 title: $title,
                 url: $url,
@@ -86,4 +105,4 @@ jobs:
             -d "$PAYLOAD" \
             "$WEBHOOK_URL"
 
-          echo "Announcement posted for $TAG."
+          echo "Announcement posted for $TAG (everyone=$EVERYONE)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,23 @@ jobs:
       attestations: write
 
     steps:
-      - name: Checkout
+      - name: Checkout grimoire
         uses: actions/checkout@v4
+        with:
+          path: grimoire
+
+      # pnpm-workspace.yaml resolves @grimoire/social-types from
+      # ../grimoire-social/packages/*. Without this sibling checkout the
+      # workspace dep fails to resolve and pnpm install bails out.
+      # WORKSPACE_PAT is a fine-grained PAT scoped to Slush97/grimoire-social
+      # with Contents:Read (private repo, default GITHUB_TOKEN can't read it).
+      - name: Checkout grimoire-social (sibling for shared types)
+        uses: actions/checkout@v4
+        with:
+          repository: Slush97/grimoire-social
+          token: ${{ secrets.WORKSPACE_PAT }}
+          path: grimoire-social
+          ref: main
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -43,11 +58,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
+          cache-dependency-path: grimoire/pnpm-lock.yaml
+
+      # @grimoire/social-types declares zod as a peer dependency; the symlinked
+      # workspace package needs its own node_modules so the import resolves
+      # from the Electron build.
+      - name: Install grimoire-social deps (for the shared workspace package)
+        working-directory: grimoire-social
+        run: pnpm install --frozen-lockfile
 
       - name: Install dependencies
-        run: pnpm install
+        working-directory: grimoire
+        run: pnpm install --frozen-lockfile
 
       - name: Clean previous builds
+        working-directory: grimoire
         shell: bash
         run: |
           rm -rf dist release
@@ -55,6 +81,7 @@ jobs:
 
       - name: Build and package
         id: build
+        working-directory: grimoire
         shell: bash
         env:
           # Baked into the renderer by electron.vite.config.ts. Production
@@ -70,6 +97,7 @@ jobs:
 
       - name: List release directory
         if: always()
+        working-directory: grimoire
         shell: bash
         run: |
           echo "=== Release directory contents ==="
@@ -83,6 +111,7 @@ jobs:
           fi
 
       - name: Generate SHA256 checksums
+        working-directory: grimoire
         shell: bash
         run: |
           cd release
@@ -101,15 +130,15 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            release/*.exe
-            release/*.AppImage
-            release/*.deb
+            grimoire/release/*.exe
+            grimoire/release/*.AppImage
+            grimoire/release/*.deb
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build
-          path: release/*
+          path: grimoire/release/*
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Build and package
         id: build
         shell: bash
+        env:
+          # Baked into the renderer by electron.vite.config.ts. Production
+          # builds refuse to start without this set to an https:// URL so
+          # installers can't ship pointing at localhost:8787.
+          GRIMOIRE_SOCIAL_BASE_URL: https://grimoire-social.slusheliott.workers.dev
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             pnpm exec electron-vite build && pnpm exec electron-builder --linux --publish never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 All notable changes to this project are documented here. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/), and the project adheres to semantic versioning.
 
+## [1.10.0] - 2026-05
+
+### Added
+- **Grimoire Social: Discover page.** Browse mod profiles published by other Grimoire users behind the *experimentalSocial* setting (off by default). Cards are image-led with hero/variant badges and a viewer-aware Like toggle; click opens a detail dialog and Import hands the profile off to the existing `ImportProfileDialog` flow
+- **Steam sign-in.** OpenID flow launches in the user's default browser, the Worker mints a session token, and the main process catches it via the `grimoire://auth/done` callback. The token never crosses into the renderer
+- **Publish profile.** Header button on Discover (signed-in only) opens a picker of local profiles, then the existing publish dialog. After a successful publish the view jumps to *Your profile* and the new row appears without remount
+- **Edit profile dialog.** Owner-only inline edit of a published profile's title/description
+- **Manage uploads** on Discover with unpublish, social-aware import, and a CSRF-defended sign-in path
+- **Portable profile export/import.** Share profiles via short `mp1:` codes or `.modprofile.json` files (Grimoire-only format, see `docs/profile-spec.md`). Schema 1.1 adds `vpkStem` + `alreadyInstalled` so an import dialog can highlight files the user already has
+- Manual Discord release-announcement workflow
+
+### Changed
+- **Discover production URL is locked at build time.** `electron.vite.config.ts` now refuses to produce a production build without `GRIMOIRE_SOCIAL_BASE_URL` set to an `https://` URL, so installers can never ship pointing at `localhost:8787`
+- **Downloads indicator** modernized: pill button with expandable panel listing in-flight downloads
+- **Installed page** Fix Order button restyled as a pill so it reads as clickable
+
+### Fixed
+- **Social hardening pass** (audit follow-up): OpenID state nonce verified on the `grimoire://auth/done` callback (rejects login-CSRF), gunzip output capped at 16 KB on share-code import (gzip-bomb defense), Discover infinite scroll switched to IntersectionObserver, paginated requests bounded, and the prod URL gate above
+
+## [1.9.3] - 2026-05
+
+### Fixed
+- **Conflict-pair count** on the Installed page now reflects the deduped set; status row moved beneath the page header
+- **Conflicts detector** runs O(1) dedupe, ignores engine defaults, and emits quieter logs
+- **Orphan metadata** is purged on mod delete so slots don't leak across reinstalls
+- **Sibling-variant swap** keeps the newest variant active instead of falling back to the previous winner
+- **GameBanana collection import** restored to the prior `createProfileFromGameBananaIds` behavior after a regression in 1.9.2
+
+### Changed
+- Settings → Support card links GitHub Issues alongside Discord
+
+## [1.9.2] - 2026-05
+
+### Added
+- **Bulk select on the Installed page.** Multi-select rows then delete, enable, or disable in one action
+- **GameBanana collection bulk import.** Paste a collection URL on Browse and queue every mod for download in one pass
+- **Inline profile rename** directly on the profile card
+- Settings → Support card with a Discord link
+
+### Changed
+- Header spacing tightened; control heights normalized across pages
+- Radiance font metrics rebalanced so labels align with icons
+
+### Removed
+- Apt-publish job dropped from the release pipeline until a host with 100 MB+ artifact support is picked
+
+## [1.9.1] - 2026-05
+
+### Added
+- **Managed-install detection** in the auto-updater: when Grimoire is installed via a system package manager (deb, AUR, etc.) the in-app updater routes the user to the package manager instead of trying to overwrite the binary
+
+### Changed
+- Signed apt repo published to `gh-pages` (later reverted in 1.9.2 pending a larger-artifact host)
+
+## [1.9.0] - 2026-05
+
+### Added
+- **Configurable accent color.** Settings → Appearance picker writes a custom accent across the app; HUD-style active card preview reflects the choice live
+
+### Fixed
+- Installs and download flows hardened: progress accounting, retry behavior, and mod-card polish
+- Variant and locker interactions further refined on the back of 1.8.x work
+- Settings/Profiles appearance row inlined and the picker converted to a modal so the layout doesn't shift while choosing
+
+## [1.8.1] - 2026-05
+
+### Added
+- **AUR auto-publish.** Tag releases now bump and push `grimoire-bin` to the AUR automatically (PKGBUILD + .SRCINFO)
+- **Install date** shown on mod cards and variant rows
+
+### Security
+- **Renderer sandbox** enabled in the Electron BrowserWindow
+- **`shell.openExternal` URL scheme allowlist** so a malicious link inside a mod description can't open arbitrary protocols
+
+### Fixed
+- Linux/Proton: `deadlock.exe` is now detected via `pgrep -f` so the "Is the game running?" status matches reality
+
+## [1.8.0] - 2026-05
+
+### Added
+- **Collapsible sidebar** with a thematic icon set and refined hierarchy
+- **Frosted-glass hero page** in the Locker with natural-aspect previews and toggle-off for the active skin
+- **Multi-variant skin prompt** in the Locker so users explicitly pick a variant before applying
+- **Aggregated release notes** in the updater modal (consolidates every version skipped since the user's last update)
+- **Wand icon** for Launch Modded; in-app links re-route to the system browser
+- **Variant pills** + Browse deep-link from the Conflicts page; default behavior is "ignore" until the user opts in
+
+### Changed
+- App-wide tinted CTA style and larger Locker thumbnails for parity with the new sidebar
+- Sidebar/toolbar chrome refined; view-toggle height aligned to siblings
+- Profile-card action buttons sized to fit their labels
+
+### Fixed
+- Browse: zero counts render as `0` instead of `NaNm` for likes/views/downloads
+- Locker favorites persist correctly, hover-to-favorite works, and navigation hardening fixes the hero-portrait zoom regression
+
+## [1.7.3] - 2026-05
+
+### Added
+- **1-Click lifecycle toast.** GameBanana 1-Click installs surface a real-time download/extract toast (recovering the file id and labels along the way), so the user can see progress instead of guessing
+
+### Fixed
+- Mod Details modal hides the "modified" date when it matches the "added" date instead of showing the same line twice
+
 ## [1.7.2] - 2026-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Bump `package.json` to **1.10.0**.
- Backfill `CHANGELOG.md` entries for 1.7.3 → 1.10.0 (file was stuck at 1.7.2 across the entire Social rollout, profile share/import, bulk-select, accent-picker, AUR auto-publish, and managed-install detection work).
- Add `GRIMOIRE_SOCIAL_BASE_URL` to the release.yml `Build and package` step so the production gate in `electron.vite.config.ts` resolves. Without this the prod build would refuse to start and the tag would burn.

## Headline release contents
- **Grimoire Social: Discover** (experimental, off by default). Steam OpenID via external browser, publish flow with picker, edit/manage uploads, image-led cards, infinite scroll.
- **Portable profile export/import** with `mp1:` share codes and `.modprofile.json` files. Schema 1.1.
- **Audit hardening pass:** OpenID state nonce (login-CSRF defense), 16 KB gunzip cap (gzip-bomb defense), prod URL gate above, pagination/CSP cleanup.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, tag `v1.10.0`. Release workflow builds Linux + Windows artifacts, attests provenance, and the `aur-publish` job bumps `grimoire-bin`.
- [ ] Smoke test the Linux AppImage: launch, sidebar renders, Browse loads. Toggle `experimentalSocial` on in Settings → Discover tab appears → header shows sign-in CTA.
- [ ] Smoke test on Windows installer: same path.