### PR TITLE
fix(browse): build 'View on GameBanana' link from section

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -575,7 +575,7 @@ export default function ModDetailsModal({
               </section>
 
               <a
-                href={`https://gamebanana.com/mods/${mod.id}`}
+                href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"


### PR DESCRIPTION
## Summary
- The "View on GameBanana" link in `ModDetailsModal` was hardcoded to `gamebanana.com/mods/<id>`, so Sound items resolved to whatever ancient Mod happens to share that numeric id (often a 13+ year-old CS1.6 page).
- Pluralize the existing `section` prop instead (`Sound` → `sounds`, `Mod` → `mods`) so each item links to its own canonical GameBanana page.

## Test plan
- [ ] Browse → Sound section → open any sound pack → click "View on GameBanana" → lands on `gamebanana.com/sounds/<id>` (the correct page).
- [ ] Browse → Mod section → still resolves to `gamebanana.com/mods/<id>`.
- [ ] Installed → open a previously-installed mod → link still works (falls back to `mods/<id>` for legacy installs without a recorded `sourceSection`, which matches today's behavior).