### PR TITLE
ui(installed): make update-available cards obvious and one-click in the picker

### DIFF
--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -11,6 +11,7 @@ import {
     ChevronDown,
     GripVertical,
     AlertTriangle,
+    Download,
 } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import { ArchivedTag, Button, Tag } from './common/ui';
@@ -38,6 +39,16 @@ interface Props {
     onRenameVariant: (variant: Mod, label: string) => Promise<void> | void;
     /** Optional - open the GameBanana details modal for this mod. */
     onOpenModDetails?: () => void;
+    /** Local mod ids that have a newer version available on GameBanana.
+     *  Drives the per-row "Update" stamp and the group-level Update button. */
+    variantsWithUpdate?: Set<string>;
+    /** Trigger an in-place update for every flagged variant in this group.
+     *  Omitted when nothing in the group has an update. */
+    onUpdateGroup?: () => void | Promise<void>;
+    /** True while an update run is in progress (shared with the page-level
+     *  Update-all button) so this modal mirrors the same disabled/progress UX. */
+    isUpdating?: boolean;
+    updateProgress?: { done: number; total: number } | null;
     onClose: () => void;
 }
 
@@ -64,6 +75,10 @@ export default function VariantPickerModal({
     onDeleteVariant,
     onRenameVariant,
     onOpenModDetails,
+    variantsWithUpdate,
+    onUpdateGroup,
+    isUpdating = false,
+    updateProgress = null,
     onClose,
 }: Props) {
     const [pending, setPending] = useState<string | null>(null);
@@ -191,10 +206,35 @@ export default function VariantPickerModal({
                         </p>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
+                        {onUpdateGroup && variantsWithUpdate && variantsWithUpdate.size > 0 && (
+                            <button
+                                onClick={() => void onUpdateGroup()}
+                                disabled={isUpdating}
+                                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-text-primary bg-white/10 border border-white/30 hover:bg-white/15 hover:border-white/50 rounded cursor-pointer transition-colors disabled:cursor-default disabled:opacity-60"
+                                title={
+                                    isUpdating
+                                        ? 'Update already in progress'
+                                        : `Re-download ${variantsWithUpdate.size} file${variantsWithUpdate.size === 1 ? '' : 's'} and restore their enabled state`
+                                }
+                            >
+                                {isUpdating && updateProgress ? (
+                                    <>
+                                        <span className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                        Updating {updateProgress.done}/{updateProgress.total}
+                                    </>
+                                ) : (
+                                    <>
+                                        <Download className="w-3.5 h-3.5" />
+                                        Update {variantsWithUpdate.size}
+                                    </>
+                                )}
+                            </button>
+                        )}
                         {onOpenModDetails && (
                             <button
                                 onClick={onOpenModDetails}
-                                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary border border-border hover:border-accent/40 rounded cursor-pointer transition-colors"
+                                disabled={isUpdating}
+                                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-text-secondary hover:text-text-primary border border-border hover:border-accent/40 rounded cursor-pointer transition-colors disabled:cursor-default disabled:opacity-50"
                                 title="Open the GameBanana mod page"
                             >
                                 <Info className="w-3.5 h-3.5" />
@@ -227,6 +267,7 @@ export default function VariantPickerModal({
                         const isMoveDownPending = pending === `move:${v.id}:down`;
                         const isDragging = draggingId === v.id;
                         const isDropTarget = dropTargetId === v.id;
+                        const hasUpdate = variantsWithUpdate?.has(v.id) ?? false;
                         const conflictDetails = conflictsByVariantId[v.id] ?? [];
                         const primaryTitle =
                             v.variantLabel ??
@@ -294,7 +335,7 @@ export default function VariantPickerModal({
                                     isActive
                                         ? 'border-accent/40 bg-accent/5'
                                         : 'border-border bg-bg-tertiary hover:bg-white/5'
-                                } ${isDragging ? 'opacity-50' : ''}`}
+                                } ${hasUpdate ? 'update-stripes' : ''} ${isDragging ? 'opacity-50' : ''}`}
                             >
                                 {isDropTarget && dropPosition && (
                                     <span
@@ -365,6 +406,15 @@ export default function VariantPickerModal({
                                                         {primaryTitle}
                                                     </span>
                                                     {v.isArchived && <ArchivedTag />}
+                                                    {hasUpdate && (
+                                                        <span
+                                                            title="A newer version is available on GameBanana"
+                                                            className="flex-shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-white/10 border border-white/30 text-text-primary uppercase tracking-wide"
+                                                        >
+                                                            <Download className="w-3 h-3" />
+                                                            Update
+                                                        </span>
+                                                    )}
                                                     {conflictDetails.length > 0 && (
                                                         <Tag
                                                             tone="warning"

--- a/src/index.css
+++ b/src/index.css
@@ -208,6 +208,37 @@ body {
   animation: skeletonShimmer 1.4s ease-in-out infinite;
 }
 
+/* Update-available cards. Accent-agnostic: stripes are white at low opacity
+   so any user accent color (orange, blue, cyan, etc) reads cleanly on top.
+   The stripes slide slowly so the card pulls the eye without being noisy. */
+@keyframes updateStripes {
+  from { background-position: 0 0; }
+  to   { background-position: 28px 0; }
+}
+
+.update-stripes {
+  position: relative;
+  /* Create a stacking context so the ::before stripe layer with z-index:-1
+     stays scoped to this card (sits above the card background, below text). */
+  isolation: isolate;
+}
+
+.update-stripes::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.06) 0 8px,
+    transparent 8px 20px
+  );
+  background-size: 28px 28px;
+  animation: updateStripes 2.4s linear infinite;
+}
+
 /* Release notes — styles HTML rendered from GitHub release markdown
    inside UpdateModal. We don't ship @tailwindcss/typography, so headings,
    lists, and code blocks would otherwise be flattened by Tailwind preflight. */
@@ -349,5 +380,10 @@ body {
   .skeleton-shimmer {
     animation-duration: 0.01ms;
     animation-iteration-count: 1;
+  }
+
+  /* Keep the stripe pattern visible (it carries meaning) but stop the slide. */
+  .update-stripes::before {
+    animation: none;
   }
 }

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -327,17 +327,16 @@ export default function Installed() {
   };
 
   /**
-   * Bulk-update every mod currently flagged in updatesAvailable. Snapshots
-   * pre-update enabled state per mod and re-applies it after the new install
-   * lands — downloads always go to the disabled folder by default, so without
-   * this restore step the user would have to manually re-enable each one.
+   * Re-download each target mod and restore its pre-update enabled state.
+   * Downloads always go to the disabled folder by default, so without the
+   * restore step the user would have to manually re-enable every updated mod.
    * Failures are caught per-item so one bad mod doesn't halt the rest.
+   * Drives the same `updateAllProgress` state regardless of caller, so the
+   * Update-all button reflects per-group updates too.
    */
-  const handleUpdateAll = async () => {
-    setUpdateAllConfirmOpen(false);
-    setUpdateAllError(null);
-    const snapshots = mods
-      .filter((m) => updatesAvailable.has(m.id) && m.gameBananaId && typeof m.gameBananaFileId === 'number')
+  const runUpdate = async (targets: typeof mods) => {
+    const snapshots = targets
+      .filter((m) => m.gameBananaId && typeof m.gameBananaFileId === 'number')
       .map((m) => ({
         oldId: m.id,
         gameBananaId: m.gameBananaId!,
@@ -381,8 +380,25 @@ export default function Installed() {
     setUpdateAllProgress(null);
     if (failures.length > 0) {
       setUpdateAllError(`${failures.length} mod${failures.length === 1 ? '' : 's'} failed to update. See console for details.`);
-      console.warn('[Update all] failures:', failures);
+      console.warn('[Update] failures:', failures);
     }
+  };
+
+  const handleUpdateAll = async () => {
+    setUpdateAllConfirmOpen(false);
+    setUpdateAllError(null);
+    await runUpdate(mods.filter((m) => updatesAvailable.has(m.id)));
+  };
+
+  /**
+   * Update every flagged variant within one grouped mod. Invoked from the
+   * variant picker so the user doesn't have to bounce out to the mod page.
+   */
+  const handleUpdateGroup = async (gameBananaId: number) => {
+    setUpdateAllError(null);
+    await runUpdate(
+      mods.filter((m) => m.gameBananaId === gameBananaId && updatesAvailable.has(m.id)),
+    );
   };
 
   const exitSelectMode = () => {
@@ -1159,9 +1175,30 @@ export default function Installed() {
         title={`Update all (${updatesAvailable.size})?`}
         message={
           <>
-            Re-download every mod flagged with an available update. Each one's enabled state
-            will be restored after the install finishes. Downloads run one at a time and may
-            take a while.
+            <p className="mb-3">
+              Re-download every mod flagged with an available update. Each one's enabled state
+              will be restored after the install finishes. Downloads run one at a time and may
+              take a while.
+            </p>
+            {(() => {
+              const pending = mods.filter((m) => updatesAvailable.has(m.id));
+              if (pending.length === 0) return null;
+              return (
+                <div className="update-stripes border border-border bg-bg-tertiary/40 rounded-md px-3 py-2 max-h-48 overflow-y-auto">
+                  <div className="text-[11px] uppercase tracking-wider text-text-secondary mb-1.5 font-semibold">
+                    Mods receiving updates
+                  </div>
+                  <ul className="space-y-1 text-sm text-text-primary">
+                    {pending.map((m) => (
+                      <li key={m.id} className="flex items-center gap-2 min-w-0">
+                        <Download className="w-3.5 h-3.5 text-text-secondary flex-shrink-0" />
+                        <span className="truncate" title={m.name}>{m.name}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })()}
           </>
         }
         confirmLabel={`Update ${updatesAvailable.size}`}
@@ -1265,6 +1302,9 @@ export default function Installed() {
             return [variant.id, conflicts];
           })
         );
+        const variantsWithUpdate = new Set(
+          liveEntry.variants.filter((v) => updatesAvailable.has(v.id)).map((v) => v.id),
+        );
         return (
           <VariantPickerModal
             modName={liveEntry.primary.name}
@@ -1288,6 +1328,14 @@ export default function Installed() {
                   }
                 : undefined
             }
+            variantsWithUpdate={variantsWithUpdate}
+            onUpdateGroup={
+              variantsWithUpdate.size > 0
+                ? () => handleUpdateGroup(liveEntry.gameBananaId)
+                : undefined
+            }
+            isUpdating={!!updateAllProgress}
+            updateProgress={updateAllProgress}
             onClose={() => setPickerGroupId(null)}
           />
         );
@@ -1588,7 +1636,7 @@ function ModCard({
           : mod.enabled
             ? 'bg-accent/5 border-accent/40'
             : 'bg-bg-secondary/60 border-border/70 text-text-primary/80 hover:bg-bg-secondary hover:text-text-primary'
-      } ${viewMode === 'compact' ? 'p-2 flex flex-col gap-2' : viewMode === 'grid' ? 'p-3 flex flex-col gap-3' : 'flex items-start sm:items-center gap-3 p-3'} ${
+      } ${updateAvailable ? 'update-stripes' : ''} ${viewMode === 'compact' ? 'p-2 flex flex-col gap-2' : viewMode === 'grid' ? 'p-3 flex flex-col gap-3' : 'flex items-start sm:items-center gap-3 p-3'} ${
         isDragging ? 'opacity-40' : ''
       } ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
       draggable={draggable}
@@ -1692,14 +1740,13 @@ function ModCard({
                 </Tag>
               )}
               {updateAvailable && (
-                <Tag
-                  tone="info"
-                  variant="overlay"
-                  icon={Download}
+                <span
                   title="A newer version is available on GameBanana"
+                  className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold leading-none bg-black/75 backdrop-blur-sm border border-white/40 text-white shadow-[0_1px_2px_rgba(0,0,0,0.45)] uppercase tracking-wide"
                 >
+                  <Download className="w-3 h-3" />
                   Update
-                </Tag>
+                </span>
               )}
             </div>
           </>
@@ -1906,14 +1953,13 @@ function ModCard({
                 <Tag tone="danger" className="flex-shrink-0">18+</Tag>
               )}
               {updateAvailable && (
-                <Tag
-                  tone="info"
-                  icon={Download}
+                <span
                   title="A newer version is available on GameBanana"
-                  className="flex-shrink-0"
+                  className="flex-shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold leading-none bg-white/10 border border-white/30 text-text-primary uppercase tracking-wide"
                 >
+                  <Download className="w-3 h-3" />
                   Update
-                </Tag>
+                </span>
               )}
               {mod.enabled && (
                 <Tag


### PR DESCRIPTION
## Summary
- Update-available cards on the Installed page now show animated diagonal stripes (accent-agnostic — won't clash with Azure/Cyan themes) and a monochrome \"Update\" stamp instead of the old blue \`info\`-toned tag.
- The Update-all confirm modal lists every mod that's about to be re-downloaded so the user can sanity-check before triggering the run.
- The variant picker modal gets the same treatment per row, plus a header \"Update N\" button that re-downloads every flagged variant in that group in one click — no more bouncing through \"Mod page\" to trigger an update for a multi-variant mod.
- Refactor: the per-mod update loop is now a shared \`runUpdate()\` helper used by both the page-level \"Update all\" and the new per-group action, so they share progress state and can't fire concurrently.

## Test plan
- [ ] With at least one installed mod flagged for update, verify the card shows sliding diagonal stripes and a white \"Update\" stamp (no blue chip).
- [ ] Switch the accent color to Azure or Cyan in Settings → confirm the stripes and stamp still read clearly.
- [ ] Click \"Update all\" → the confirm modal lists every pending mod by name; cancel + confirm both work.
- [ ] On a grouped mod (multiple variants) with updates, open the picker → \"Update N\" appears in the header next to \"Mod page\"; flagged rows show the stripes + stamp.
- [ ] Click \"Update N\" in the picker → button shows progress, the run completes, stripes/stamps clear after \`updatesAvailable\` recomputes, previously-enabled variants are re-enabled.
- [ ] Toggle \`prefers-reduced-motion\` (OS-level) → stripe pattern stays visible but stops sliding.