### PR TITLE
fix(settings): recover UX when gameinfo.gi is missing + Windows diagnostic

### DIFF
--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -24,7 +24,7 @@ import { spawn } from 'child_process';
 import { tmpdir } from 'os';
 import https from 'https';
 import http from 'http';
-import { getAddonsPath, getDisabledPath } from '../services/deadlock';
+import { getAddonsPath, getDisabledPath, getCitadelPath } from '../services/deadlock';
 import { getUserDataPath } from '../utils/paths';
 import {
     getModMetadata,
@@ -107,10 +107,25 @@ ipcMain.handle('get-gameinfo-status', (): GameinfoStatus => {
     if (!deadlockPath) {
         return {
             configured: false,
+            missing: false,
             message: 'No Deadlock path configured',
+            candidates: [],
         };
     }
     return getGameinfoStatus(deadlockPath);
+});
+
+// open-game-folder (opens the citadel/ directory so the user can inspect
+// gameinfo.gi siblings when it's missing)
+ipcMain.handle('open-game-folder', async (): Promise<void> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const error = await shell.openPath(getCitadelPath(deadlockPath));
+    if (error) {
+        throw new Error(error);
+    }
 });
 
 // Always on top
@@ -134,7 +149,9 @@ ipcMain.handle('fix-gameinfo', (): GameinfoStatus => {
     if (!deadlockPath) {
         return {
             configured: false,
+            missing: false,
             message: 'No Deadlock path configured',
+            candidates: [],
         };
     }
     return fixGameinfo(deadlockPath);

--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join, extname } from 'path';
-import { getGameinfoPath, getAddonsPath, getDisabledPath } from './deadlock';
+import { getGameinfoPath, getAddonsPath, getDisabledPath, getCitadelPath } from './deadlock';
 
 // The canonical SearchPaths block for Deadlock with mod support
 const SEARCH_PATHS_BLOCK = `SearchPaths
@@ -19,6 +19,24 @@ const SEARCH_PATHS_BLOCK = `SearchPaths
 export interface GameinfoStatus {
     configured: boolean;
     message: string;
+    missing: boolean;
+    candidates: string[];
+}
+
+// Scan citadel/ for files named like gameinfo.* (case-insensitive, excluding
+// the canonical name itself). Surfaces backups another mod manager may have
+// left behind (e.g. gameinfo.gi.bak, gameinfo_orig.gi).
+function findGameinfoCandidates(deadlockPath: string): string[] {
+    const citadelPath = getCitadelPath(deadlockPath);
+    if (!existsSync(citadelPath)) return [];
+    try {
+        return readdirSync(citadelPath).filter((name) => {
+            const lower = name.toLowerCase();
+            return lower !== 'gameinfo.gi' && /^gameinfo[._]/.test(lower);
+        });
+    } catch {
+        return [];
+    }
 }
 
 export interface CleanupResult {
@@ -38,7 +56,9 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
     if (!existsSync(gameinfoPath)) {
         return {
             configured: false,
+            missing: true,
             message: 'gameinfo.gi not found',
+            candidates: findGameinfoCandidates(deadlockPath),
         };
     }
 
@@ -48,18 +68,24 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
         if (content.includes('citadel/addons')) {
             return {
                 configured: true,
+                missing: false,
                 message: 'Addon search paths are configured correctly',
+                candidates: [],
             };
         }
 
         return {
             configured: false,
+            missing: false,
             message: 'Addon search paths are missing from gameinfo.gi',
+            candidates: [],
         };
     } catch (err) {
         return {
             configured: false,
+            missing: false,
             message: `Failed to read gameinfo.gi: ${err}`,
+            candidates: [],
         };
     }
 }
@@ -74,7 +100,9 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
     if (!existsSync(gameinfoPath)) {
         return {
             configured: false,
+            missing: true,
             message: 'gameinfo.gi not found',
+            candidates: findGameinfoCandidates(deadlockPath),
         };
     }
 
@@ -85,7 +113,9 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         if (content.includes('citadel/addons')) {
             return {
                 configured: true,
+                missing: false,
                 message: 'Addon search paths were already configured',
+                candidates: [],
             };
         }
 
@@ -96,7 +126,9 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         if (!searchPathsRegex.test(content)) {
             return {
                 configured: false,
+                missing: false,
                 message: 'Could not find SearchPaths section in gameinfo.gi',
+                candidates: [],
             };
         }
 
@@ -107,12 +139,16 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
 
         return {
             configured: true,
+            missing: false,
             message: 'Successfully configured addon search paths',
+            candidates: [],
         };
     } catch (err) {
         return {
             configured: false,
+            missing: false,
             message: `Failed to fix gameinfo.gi: ${err}`,
+            candidates: [],
         };
     }
 }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -71,6 +71,7 @@ export interface ElectronAPI {
     getGameinfoStatus: () => Promise<GameinfoStatus>;
     fixGameinfo: () => Promise<GameinfoStatus>;
     openModsFolder: () => Promise<void>;
+    openGameFolder: () => Promise<void>;
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => Promise<boolean>;
@@ -434,6 +435,8 @@ interface CleanupResult {
 interface GameinfoStatus {
     configured: boolean;
     message: string;
+    missing: boolean;
+    candidates: string[];
 }
 
 interface OpenDialogOptions {
@@ -813,6 +816,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getGameinfoStatus: () => ipcRenderer.invoke('get-gameinfo-status'),
     fixGameinfo: () => ipcRenderer.invoke('fix-gameinfo'),
     openModsFolder: () => ipcRenderer.invoke('open-mods-folder'),
+    openGameFolder: () => ipcRenderer.invoke('open-game-folder'),
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => ipcRenderer.invoke('set-always-on-top', enabled),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -234,16 +234,20 @@ export async function cleanupAddons(): Promise<{
   return window.electronAPI.cleanupAddons();
 }
 
-export async function getGameinfoStatus(): Promise<{ configured: boolean; message: string }> {
+export async function getGameinfoStatus(): Promise<{ configured: boolean; message: string; missing: boolean; candidates: string[] }> {
   return window.electronAPI.getGameinfoStatus();
 }
 
-export async function fixGameinfo(): Promise<{ configured: boolean; message: string }> {
+export async function fixGameinfo(): Promise<{ configured: boolean; message: string; missing: boolean; candidates: string[] }> {
   return window.electronAPI.fixGameinfo();
 }
 
 export async function openModsFolder(): Promise<void> {
   return window.electronAPI.openModsFolder();
+}
+
+export async function openGameFolder(): Promise<void> {
+  return window.electronAPI.openGameFolder();
 }
 
 // Dialog helper for Settings page

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import {
   createDevDeadlockPath,
   fixGameinfo,
   getGameinfoStatus,
+  openGameFolder,
   validateDeadlockPath,
   showOpenDialog,
 } from '../lib/api';
@@ -28,6 +29,8 @@ export default function Settings() {
   const [isCleaning, setIsCleaning] = useState(false);
   const [gameinfoStatus, setGameinfoStatus] = useState<string | null>(null);
   const [gameinfoConfigured, setGameinfoConfigured] = useState<boolean | null>(null);
+  const [gameinfoMissing, setGameinfoMissing] = useState(false);
+  const [gameinfoCandidates, setGameinfoCandidates] = useState<string[]>([]);
   const [isFixingGameinfo, setIsFixingGameinfo] = useState(false);
   const [syncStatus, setSyncStatus] = useState<Record<string, { lastSync: number; count: number } | null> | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -87,6 +90,8 @@ export default function Settings() {
       if (!activeDeadlockPath) {
         setGameinfoStatus(null);
         setGameinfoConfigured(null);
+        setGameinfoMissing(false);
+        setGameinfoCandidates([]);
         return;
       }
       try {
@@ -94,10 +99,14 @@ export default function Settings() {
         if (!active) return;
         setGameinfoStatus(status.message);
         setGameinfoConfigured(status.configured);
+        setGameinfoMissing(status.missing);
+        setGameinfoCandidates(status.candidates);
       } catch (err) {
         if (!active) return;
         setGameinfoStatus(String(err));
         setGameinfoConfigured(false);
+        setGameinfoMissing(false);
+        setGameinfoCandidates([]);
       }
     };
     loadStatus();
@@ -478,16 +487,39 @@ export default function Settings() {
                 <p className="text-xs text-text-secondary mt-1 max-w-md">
                   {gameinfoStatus ?? 'Checking gameinfo.gi status...'}
                 </p>
+                {gameinfoMissing && (
+                  <div className="mt-2 max-w-md space-y-1">
+                    <p className="text-xs text-text-secondary">
+                      In Steam: right-click Deadlock {'>'} Properties {'>'} Installed Files {'>'} Verify integrity of game files.
+                    </p>
+                    {gameinfoCandidates.length > 0 && (
+                      <p className="text-xs text-amber-300">
+                        Found nearby: {gameinfoCandidates.join(', ')}. Rename one to gameinfo.gi to restore.
+                      </p>
+                    )}
+                  </div>
+                )}
               </div>
-              <Button
-                onClick={handleFixGameinfo}
-                disabled={isFixingGameinfo || !activeDeadlockPath}
-                isLoading={isFixingGameinfo}
-                variant={gameinfoConfigured ? 'secondary' : 'primary'}
-                icon={Wrench}
-              >
-                Fix Configuration
-              </Button>
+              {gameinfoMissing ? (
+                <Button
+                  onClick={openGameFolder}
+                  disabled={!activeDeadlockPath}
+                  variant="primary"
+                  icon={FolderOpen}
+                >
+                  Open Game Folder
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleFixGameinfo}
+                  disabled={isFixingGameinfo || !activeDeadlockPath}
+                  isLoading={isFixingGameinfo}
+                  variant={gameinfoConfigured ? 'secondary' : 'primary'}
+                  icon={Wrench}
+                >
+                  Fix Configuration
+                </Button>
+              )}
             </div>
           </div>
         </Card>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -60,6 +60,8 @@ export interface CleanupResult {
 export interface GameinfoStatus {
     configured: boolean;
     message: string;
+    missing: boolean;
+    candidates: string[];
 }
 
 export interface OpenDialogOptions {
@@ -313,6 +315,7 @@ export interface ElectronAPI {
     getGameinfoStatus: () => Promise<GameinfoStatus>;
     fixGameinfo: () => Promise<GameinfoStatus>;
     openModsFolder: () => Promise<void>;
+    openGameFolder: () => Promise<void>;
 
     // Window control
     setAlwaysOnTop: (enabled: boolean) => Promise<boolean>;

--- a/tools/diagnose-gameinfo/README.md
+++ b/tools/diagnose-gameinfo/README.md
@@ -1,0 +1,29 @@
+# Grimoire gameinfo.gi diagnostic
+
+Hand this to a Windows user when Grimoire reports `gameinfo.gi not found`
+and Steam's Verify integrity of game files isn't resolving it.
+
+## What it does
+
+Read-only. Modifies nothing. Collects, in one report:
+
+- Steam install path (registry) and library list (`libraryfolders.vdf`)
+- Which library `appmanifest_1422450.acf` lives in
+- Whether `<deadlock>\game\citadel\gameinfo.gi` actually exists on disk
+- Per-directory case-sensitivity flag (`fsutil`)
+- Every file in `citadel\` whose name starts with `gameinfo` (catches
+  `gameinfo.gi.bak`, `GameInfo.gi`, etc.)
+- ACLs on `citadel\` and `gameinfo.gi`
+- Windows Defender protection history entries that mention gameinfo /
+  citadel / Deadlock (best-effort; some entries need admin to read)
+- Grimoire's saved `deadlockPath` from `%APPDATA%\Grimoire\settings.json`
+
+The report is written to the Desktop as
+`grimoire-gameinfo-diagnostic.txt` and opened in Notepad.
+
+## How to ask the user to run it
+
+1. Download both files (`Run-Diagnostic.cmd` + `diagnose-gameinfo.ps1`) to
+   the same folder, e.g. their Downloads folder.
+2. Double-click `Run-Diagnostic.cmd`.
+3. Notepad opens with the report. Send it back.

--- a/tools/diagnose-gameinfo/Run-Diagnostic.cmd
+++ b/tools/diagnose-gameinfo/Run-Diagnostic.cmd
@@ -1,8 +1,12 @@
 @echo off
 setlocal
 set "SCRIPT=%~dp0diagnose-gameinfo.ps1"
+if not exist "%SCRIPT%" set "SCRIPT=%~dp0diagnosegameinfo.ps1"
+if not exist "%SCRIPT%" set "SCRIPT=%~dp0diagnose_gameinfo.ps1"
 if not exist "%SCRIPT%" (
     echo Could not find diagnose-gameinfo.ps1 next to this file.
+    echo Looked for: diagnose-gameinfo.ps1, diagnosegameinfo.ps1, diagnose_gameinfo.ps1
+    echo Make sure both files are in the same folder.
     pause
     exit /b 1
 )

--- a/tools/diagnose-gameinfo/Run-Diagnostic.cmd
+++ b/tools/diagnose-gameinfo/Run-Diagnostic.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+set "SCRIPT=%~dp0diagnose-gameinfo.ps1"
+if not exist "%SCRIPT%" (
+    echo Could not find diagnose-gameinfo.ps1 next to this file.
+    pause
+    exit /b 1
+)
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT%"
+echo.
+echo Done. The report opened in Notepad and is saved on your Desktop as
+echo grimoire-gameinfo-diagnostic.txt
+echo.
+pause

--- a/tools/diagnose-gameinfo/diagnose-gameinfo.ps1
+++ b/tools/diagnose-gameinfo/diagnose-gameinfo.ps1
@@ -1,0 +1,203 @@
+# Grimoire gameinfo.gi diagnostic
+# Read-only. Does not modify Steam, Deadlock, or any file.
+# Writes a plain-text report to the Desktop and opens it in Notepad.
+
+$ErrorActionPreference = 'Continue'
+$report = New-Object System.Text.StringBuilder
+
+function W($line) { [void]$report.AppendLine([string]$line) }
+function Section($name) { W ''; W ("===== {0} =====" -f $name) }
+
+W 'Grimoire gameinfo.gi diagnostic'
+W ("Generated: {0}" -f (Get-Date -Format o))
+W ("Host: {0} ({1})" -f $env:COMPUTERNAME, $env:USERNAME)
+try {
+    $os = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+    W ("Windows: {0} build {1}" -f $os.Caption, $os.BuildNumber)
+} catch {
+    W ("Windows: (could not query: {0})" -f $_.Exception.Message)
+}
+W ("PowerShell: {0}" -f $PSVersionTable.PSVersion)
+
+# Steam install location (registry)
+Section 'Steam install'
+$steamPath = $null
+try {
+    $steamPath = (Get-ItemProperty 'HKLM:\SOFTWARE\WOW6432Node\Valve\Steam' -ErrorAction Stop).InstallPath
+} catch {
+    try {
+        $steamPath = (Get-ItemProperty 'HKCU:\SOFTWARE\Valve\Steam' -ErrorAction Stop).SteamPath
+    } catch {}
+}
+W ("InstallPath: {0}" -f $steamPath)
+
+# Library folders
+Section 'Steam libraries'
+$libraries = @()
+if ($steamPath) {
+    $libVdf = Join-Path $steamPath 'steamapps\libraryfolders.vdf'
+    if (Test-Path $libVdf) {
+        $vdf = Get-Content $libVdf -Raw
+        [regex]::Matches($vdf, '"path"\s+"([^"]+)"') | ForEach-Object {
+            $libraries += ($_.Groups[1].Value -replace '\\\\', '\')
+        }
+        W 'Libraries found:'
+        foreach ($lib in $libraries) { W ("  {0}" -f $lib) }
+    } else {
+        W ("libraryfolders.vdf not found at: {0}" -f $libVdf)
+    }
+} else {
+    W 'Skipped (no Steam install path).'
+}
+
+# Locate Deadlock via appmanifest (appid 1422450)
+Section 'Deadlock location (via appmanifest)'
+$deadlockAppId = '1422450'
+$activeLib = $null
+foreach ($lib in $libraries) {
+    $manifest = Join-Path $lib ("steamapps\appmanifest_{0}.acf" -f $deadlockAppId)
+    if (Test-Path $manifest) {
+        $activeLib = $lib
+        $size = (Get-Item $manifest).Length
+        W ("appmanifest_{0}.acf in: {1}  ({2} bytes)" -f $deadlockAppId, $lib, $size)
+        $content = Get-Content $manifest -Raw
+        if ($content -match '"installdir"\s+"([^"]+)"')  { W ("  installdir:  {0}" -f $Matches[1]) }
+        if ($content -match '"StateFlags"\s+"([^"]+)"')  { W ("  StateFlags:  {0}" -f $Matches[1]) }
+        if ($content -match '"SizeOnDisk"\s+"([^"]+)"')  { W ("  SizeOnDisk:  {0}" -f $Matches[1]) }
+        if ($content -match '"LastUpdated"\s+"([^"]+)"') { W ("  LastUpdated: {0}" -f $Matches[1]) }
+        break
+    }
+}
+if (-not $activeLib) {
+    W ("appmanifest_{0}.acf not found in any known library." -f $deadlockAppId)
+}
+
+# Resolve game folder
+Section 'Game folder'
+$deadlockPath = $null
+if ($activeLib) {
+    $deadlockPath = Join-Path $activeLib 'steamapps\common\Deadlock'
+}
+W ("Expected path: {0}" -f $deadlockPath)
+if ($deadlockPath -and (Test-Path $deadlockPath)) {
+    $item = Get-Item -LiteralPath $deadlockPath -Force
+    W 'Exists: yes'
+    W ("Attributes: {0}" -f $item.Attributes)
+    if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+        W '  *** ReparsePoint detected (junction/symlink).'
+        try { W ("  Target: {0}" -f $item.Target) } catch {}
+    }
+} else {
+    W 'Exists: NO'
+}
+
+# gameinfo.gi check
+Section 'gameinfo.gi check'
+$citadelPath = $null
+$gameinfoPath = $null
+if ($deadlockPath) {
+    $citadelPath = Join-Path $deadlockPath 'game\citadel'
+    $gameinfoPath = Join-Path $citadelPath 'gameinfo.gi'
+}
+W ("citadel path:    {0}" -f $citadelPath)
+W ("gameinfo.gi:     {0}" -f $gameinfoPath)
+W ("Test-Path citadel/:    {0}" -f (Test-Path $citadelPath))
+W ("Test-Path gameinfo.gi: {0}" -f (Test-Path $gameinfoPath))
+
+if ($citadelPath -and (Test-Path $citadelPath)) {
+    # Per-directory case sensitivity flag
+    try {
+        $cs = & fsutil.exe file queryCaseSensitiveInfo $citadelPath 2>&1 | Out-String
+        W ("fsutil case-sensitivity: {0}" -f $cs.Trim())
+    } catch {
+        W ("fsutil failed: {0}" -f $_.Exception.Message)
+    }
+
+    # List anything that looks like gameinfo
+    W 'Entries in citadel/ matching gameinfo* (case-insensitive):'
+    $hits = @()
+    try {
+        $hits = Get-ChildItem -LiteralPath $citadelPath -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '(?i)^gameinfo' }
+    } catch {}
+    if ($hits.Count -gt 0) {
+        foreach ($m in $hits) {
+            W ("  {0}  size={1}  attrs={2}  modified={3}" -f $m.Name, $m.Length, $m.Attributes, $m.LastWriteTime.ToString('o'))
+        }
+    } else {
+        W '  (none)'
+    }
+}
+
+# Permissions
+Section 'Permissions'
+if ($citadelPath -and (Test-Path $citadelPath)) {
+    try {
+        $acl = Get-Acl -LiteralPath $citadelPath
+        W ("citadel/ Owner: {0}" -f $acl.Owner)
+        foreach ($a in $acl.Access) {
+            W ("  {0}  {1}  {2}" -f $a.IdentityReference, $a.AccessControlType, $a.FileSystemRights)
+        }
+    } catch {
+        W ("Failed to read citadel/ ACL: {0}" -f $_.Exception.Message)
+    }
+}
+if ($gameinfoPath -and (Test-Path $gameinfoPath)) {
+    try {
+        $acl = Get-Acl -LiteralPath $gameinfoPath
+        W ''
+        W ("gameinfo.gi Owner: {0}" -f $acl.Owner)
+        foreach ($a in $acl.Access) {
+            W ("  {0}  {1}  {2}" -f $a.IdentityReference, $a.AccessControlType, $a.FileSystemRights)
+        }
+    } catch {
+        W ("Failed to read gameinfo.gi ACL: {0}" -f $_.Exception.Message)
+    }
+}
+
+# Windows Defender Protection History (best-effort; may need admin)
+Section 'Defender Protection History (best-effort)'
+try {
+    if (Get-Command Get-MpThreatDetection -ErrorAction SilentlyContinue) {
+        $detections = Get-MpThreatDetection -ErrorAction Stop
+        $hits = $detections | Where-Object { ($_.Resources -join ' ') -match '(?i)(gameinfo|citadel|Deadlock)' }
+        if ($hits) {
+            foreach ($h in $hits) {
+                W ("  {0}  ThreatID={1}" -f $h.InitialDetectionTime.ToString('o'), $h.ThreatID)
+                foreach ($r in $h.Resources) { W ("    {0}" -f $r) }
+            }
+        } else {
+            W '  No Defender detections referencing gameinfo / citadel / Deadlock.'
+        }
+    } else {
+        W '  Get-MpThreatDetection not available (Defender module not present).'
+    }
+} catch {
+    W ("  Could not read Defender history (may need admin): {0}" -f $_.Exception.Message)
+}
+
+# Grimoire's own settings (best-effort, to see what path Grimoire is configured for)
+Section 'Grimoire settings (best-effort)'
+$grimoireSettings = Join-Path $env:APPDATA 'Grimoire\settings.json'
+W ("Path: {0}" -f $grimoireSettings)
+if (Test-Path $grimoireSettings) {
+    try {
+        $s = Get-Content $grimoireSettings -Raw | ConvertFrom-Json
+        W ("  deadlockPath:    {0}" -f $s.deadlockPath)
+        W ("  devMode:         {0}" -f $s.devMode)
+        W ("  devDeadlockPath: {0}" -f $s.devDeadlockPath)
+    } catch {
+        W ("  Failed to parse settings.json: {0}" -f $_.Exception.Message)
+    }
+} else {
+    W '  (settings.json not found; Grimoire may not have been run yet)'
+}
+
+# Write the report
+$reportPath = Join-Path ([Environment]::GetFolderPath('Desktop')) 'grimoire-gameinfo-diagnostic.txt'
+$report.ToString() | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+Write-Host ''
+Write-Host ("Report saved to: {0}" -f $reportPath) -ForegroundColor Green
+Write-Host ''
+try { Start-Process notepad.exe $reportPath } catch {}


### PR DESCRIPTION
## Summary

- Distinguishes "gameinfo.gi missing" from "gameinfo.gi misconfigured" so Settings can offer the right next step. When missing, swaps the Fix button for Open Game Folder, surfaces the Steam "Verify integrity of game files" hint, and lists any `gameinfo.*` siblings found in `citadel/` (catches `gameinfo.gi.bak`, `gameinfo_orig.gi`, etc. left behind by other mod managers or partial verifies).
- Adds a read-only PowerShell diagnostic under `tools/diagnose-gameinfo/` for handing to Windows users when Verify Files doesn't resolve the issue. Bundles Steam registry path, `libraryfolders.vdf`, the appmanifest, `citadel/` listing, fsutil case-sensitivity flag, ACLs, Defender history, and Grimoire's saved settings into one Desktop text file. Modifies nothing.
- `Run-Diagnostic.cmd` tolerates hyphen-stripped filenames (some download paths flatten `diagnose-gameinfo.ps1` to `diagnosegameinfo.ps1`).

## Schema change

`GameinfoStatus` gains two additive fields, threaded through preload, `electron.d.ts`, `api.ts`, and `Settings.tsx`:

```ts
interface GameinfoStatus {
  configured: boolean;
  message: string;
  missing: boolean;       // new
  candidates: string[];   // new
}
```

## Test plan

- [ ] Linux: confirm Settings still shows "Addon search paths are configured correctly" / "missing from gameinfo.gi" states with the new `missing: false` shape.
- [ ] Linux: rename `citadel/gameinfo.gi` to `gameinfo.gi.bak`. Confirm Settings flips to Open Game Folder + lists `gameinfo.gi.bak` as a candidate.
- [ ] Windows VM: run `Run-Diagnostic.cmd`, confirm `grimoire-gameinfo-diagnostic.txt` lands on Desktop and Notepad opens.
- [ ] Windows VM: rename the script to `diagnosegameinfo.ps1` and confirm the `.cmd` still finds it.