### PR TITLE
fix(detect): discover Steam libraries via libraryfolders.vdf

### DIFF
--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { loadSettings, saveSettings, AppSettings } from '../services/settings';
-import { detectDeadlockPath, isValidDeadlockPath } from '../services/deadlock';
+import { detectDeadlockPath, looksLikeDeadlockPath } from '../services/deadlock';
 import { ensureDevDeadlockPath } from '../services/dev';
 
 // detect-deadlock
@@ -8,9 +8,11 @@ ipcMain.handle('detect-deadlock', (): string | null => {
     return detectDeadlockPath();
 });
 
-// validate-deadlock-path
+// validate-deadlock-path: loose check so users can configure a path even
+// when gameinfo.gi is missing; the Settings page surfaces a recovery
+// affordance in that state.
 ipcMain.handle('validate-deadlock-path', (_, path: string): boolean => {
-    return isValidDeadlockPath(path);
+    return looksLikeDeadlockPath(path);
 });
 
 // create-dev-deadlock-path

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -1,59 +1,140 @@
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { execFileSync } from 'child_process';
+
+const DEADLOCK_APP_ID = '1422450';
 
 /**
- * Get platform-specific Steam library paths to search for Deadlock
+ * Steam install locations to probe (the directory that contains steamapps/),
+ * in priority order. On Windows we ask the registry first so users with
+ * Steam installed off the C: default are handled correctly.
  */
-function getSteamLibraryPaths(): string[] {
-    const paths: string[] = [];
+function getSteamInstallPaths(): string[] {
     const home = homedir();
 
     if (process.platform === 'linux') {
-        // Common Steam locations on Linux
-        paths.push(join(home, '.steam/steam/steamapps/common'));
-        paths.push(join(home, '.local/share/Steam/steamapps/common'));
-        // Flatpak
-        paths.push(join(home, '.var/app/com.valvesoftware.Steam/.steam/steam/steamapps/common'));
-    } else if (process.platform === 'win32') {
-        // Common Steam locations on Windows
-        paths.push('C:\\Program Files (x86)\\Steam\\steamapps\\common');
-        paths.push('C:\\Program Files\\Steam\\steamapps\\common');
-        paths.push('D:\\Steam\\steamapps\\common');
-        paths.push('D:\\SteamLibrary\\steamapps\\common');
-    } else if (process.platform === 'darwin') {
-        // macOS
-        paths.push(join(home, 'Library/Application Support/Steam/steamapps/common'));
+        return [
+            join(home, '.steam/steam'),
+            join(home, '.local/share/Steam'),
+            join(home, '.var/app/com.valvesoftware.Steam/.steam/steam'),
+        ];
     }
 
-    return paths;
+    if (process.platform === 'darwin') {
+        return [join(home, 'Library/Application Support/Steam')];
+    }
+
+    if (process.platform === 'win32') {
+        const paths: string[] = [];
+        const push = (p: string | null) => {
+            if (!p) return;
+            const norm = p.replace(/\//g, '\\').replace(/\\+$/, '');
+            if (!paths.some((existing) => existing.toLowerCase() === norm.toLowerCase())) {
+                paths.push(norm);
+            }
+        };
+        push(queryWindowsRegistry('HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam', 'InstallPath'));
+        push(queryWindowsRegistry('HKCU\\SOFTWARE\\Valve\\Steam', 'SteamPath'));
+        push('C:\\Program Files (x86)\\Steam');
+        push('C:\\Program Files\\Steam');
+        return paths;
+    }
+
+    return [];
+}
+
+function queryWindowsRegistry(key: string, value: string): string | null {
+    try {
+        const stdout = execFileSync('reg', ['query', key, '/v', value], {
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 2000,
+        }).toString();
+        const match = stdout.match(/REG_SZ\s+(.+?)\s*$/m);
+        return match ? match[1].trim() : null;
+    } catch {
+        return null;
+    }
 }
 
 /**
- * Check if a path is a valid Deadlock installation
+ * Read every "path" entry from a Steam libraryfolders.vdf so we discover
+ * every Steam library on the machine, not just the default install dir.
+ */
+function readSteamLibraries(steamInstallPath: string): string[] {
+    const vdfPath = join(steamInstallPath, 'steamapps', 'libraryfolders.vdf');
+    if (!existsSync(vdfPath)) return [];
+    try {
+        const content = readFileSync(vdfPath, 'utf-8');
+        const libraries: string[] = [];
+        const re = /"path"\s+"([^"]+)"/g;
+        let match: RegExpExecArray | null;
+        while ((match = re.exec(content)) !== null) {
+            // VDF escapes backslashes; "C:\\SteamLibrary" -> "C:\SteamLibrary"
+            libraries.push(match[1].replace(/\\\\/g, '\\'));
+        }
+        return libraries;
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * A path is a valid Deadlock installation iff gameinfo.gi is present. The
+ * directory structure alone is insufficient because stale empty
+ * game/citadel/ folders can survive a move-library or partial uninstall
+ * and would otherwise masquerade as a real install.
  */
 export function isValidDeadlockPath(path: string): boolean {
-    const gameDir = join(path, 'game');
-    const citadelDir = join(gameDir, 'citadel');
-    return existsSync(gameDir) && existsSync(citadelDir);
+    return existsSync(join(path, 'game', 'citadel', 'gameinfo.gi'));
 }
 
 /**
- * Auto-detect Deadlock installation path
+ * Auto-detect Deadlock by walking every Steam library declared in
+ * libraryfolders.vdf. Libraries whose appmanifest_<APPID>.acf claims
+ * Deadlock are preferred, as that is Steam's authoritative record.
  */
 export function detectDeadlockPath(): string | null {
-    const paths = getSteamLibraryPaths();
-    console.log('[detectDeadlockPath] Searching paths:', paths);
+    const steamInstalls = getSteamInstallPaths();
+    const visited = new Set<string>();
+    const fallback: string[] = [];
 
-    for (const libraryPath of paths) {
-        const deadlockPath = join(libraryPath, 'Deadlock');
-        console.log('[detectDeadlockPath] Checking:', deadlockPath);
-        if (isValidDeadlockPath(deadlockPath)) {
-            console.log('[detectDeadlockPath] FOUND:', deadlockPath);
-            return deadlockPath;
+    console.log('[detectDeadlockPath] Steam installs:', steamInstalls);
+
+    for (const steamPath of steamInstalls) {
+        if (!existsSync(steamPath)) continue;
+        const libraries = readSteamLibraries(steamPath);
+        // Steam's own install dir is implicitly a library, even when the
+        // VDF is missing or doesn't list it.
+        if (!libraries.some((lib) => lib.toLowerCase() === steamPath.toLowerCase())) {
+            libraries.unshift(steamPath);
+        }
+        for (const lib of libraries) {
+            const key = lib.toLowerCase();
+            if (visited.has(key)) continue;
+            visited.add(key);
+
+            const candidate = join(lib, 'steamapps', 'common', 'Deadlock');
+            const manifest = join(lib, 'steamapps', `appmanifest_${DEADLOCK_APP_ID}.acf`);
+            if (existsSync(manifest) && isValidDeadlockPath(candidate)) {
+                console.log('[detectDeadlockPath] FOUND via manifest:', candidate);
+                return candidate;
+            }
+            fallback.push(candidate);
         }
     }
-    console.log('[detectDeadlockPath] Not found in any location');
+
+    // No library's appmanifest claims Deadlock; fall back to whichever
+    // candidate directory holds a valid install. Catches manually-copied
+    // installs that Steam doesn't know about.
+    for (const candidate of fallback) {
+        if (isValidDeadlockPath(candidate)) {
+            console.log('[detectDeadlockPath] FOUND via fallback scan:', candidate);
+            return candidate;
+        }
+    }
+
+    console.log('[detectDeadlockPath] Not found in any library');
     return null;
 }
 

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -80,13 +80,24 @@ function readSteamLibraries(steamInstallPath: string): string[] {
 }
 
 /**
- * A path is a valid Deadlock installation iff gameinfo.gi is present. The
- * directory structure alone is insufficient because stale empty
- * game/citadel/ folders can survive a move-library or partial uninstall
- * and would otherwise masquerade as a real install.
+ * Strict check: gameinfo.gi is present. Used by auto-detect so we only
+ * claim to have "found" Deadlock when the install is actually usable.
+ * Stale empty game/citadel/ folders can survive a move-library or partial
+ * uninstall and would otherwise masquerade as a real install.
  */
 export function isValidDeadlockPath(path: string): boolean {
     return existsSync(join(path, 'game', 'citadel', 'gameinfo.gi'));
+}
+
+/**
+ * Loose check: the folder layout looks like a Deadlock install, even if
+ * gameinfo.gi is missing. Used by the manual path picker so a user whose
+ * gameinfo.gi was removed (antivirus, another mod manager, partial
+ * verify) can still configure Grimoire and reach the recovery UI in
+ * Settings.
+ */
+export function looksLikeDeadlockPath(path: string): boolean {
+    return existsSync(join(path, 'game', 'citadel'));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replaces hardcoded drive guesses with the canonical Steam discovery chain: Windows registry (`HKLM\WOW6432Node\Valve\Steam:InstallPath`, falling back to `HKCU\Valve\Steam:SteamPath`) → parse every `path` in `steamapps/libraryfolders.vdf` → prefer libraries whose `appmanifest_1422450.acf` exists, with a candidate-scan fallback for manually-copied installs.
- Splits the path predicate so auto-detect stays strict (gameinfo.gi required) but the manual picker only requires `game/citadel/`. Keeps the recovery UI from #37 reachable when a user's gameinfo.gi has been removed (antivirus, partial verify, another mod manager).
- Flatpak entry now points at the Steam root so non-default libraries are honored there too.

## Why

The old detection only looked under `~/.steam/steam/steamapps/common`, `C:\Program Files (x86)\Steam\steamapps\common`, and a couple of guessed D:\ paths. Users with Steam installed on a non-default drive, additional Steam library folders, or Flatpak with custom libraries showed up as "Deadlock not found." The diagnostic from #37 surfaced this on a recent support thread.

## Test plan

- [ ] Linux (default `~/.steam`): auto-detect still finds Deadlock.
- [ ] Linux with an additional library declared in `libraryfolders.vdf`: install Deadlock to it, confirm detection.
- [ ] Windows VM with Steam on D:\: confirm registry lookup → libraryfolders.vdf chain resolves the install.
- [ ] Manual path picker (Welcome modal + Settings): pick a `Deadlock/` whose `gameinfo.gi` was renamed to `gameinfo.gi.bak`. Confirm validation accepts the path and Settings shows the Open Game Folder recovery affordance from #37.
- [ ] Auto-detect with the same renamed gameinfo.gi: confirm it does NOT silently auto-pick that install (stays strict).