### PR TITLE
Discover top bar + update resilience + sanitized bug-report form

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,6 +2,14 @@ import { app, BrowserWindow, shell, session } from 'electron';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
+
+// Initialize the file logger before anything else so console.* calls in IPC
+// and service modules (imported below) flow into the rolling log file from
+// the very first line. The "Save diagnostic report" button in Settings hands
+// the user that file to attach to bug reports.
+import { initLogger } from './services/diagnostics';
+initLogger();
+
 import {
     GRIMOIRE_PROTOCOL,
     findGrimoireUrlInArgv,
@@ -36,6 +44,7 @@ import './ipc/stats';
 import './ipc/updater';
 import './ipc/launch';
 import './ipc/social';
+import './ipc/diagnostics';
 
 import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';

--- a/electron/main/ipc/diagnostics.ts
+++ b/electron/main/ipc/diagnostics.ts
@@ -1,0 +1,24 @@
+import { ipcMain } from 'electron';
+import {
+    buildReportText,
+    getLogFilePath,
+    openLogsFolder,
+    saveDiagnosticReport,
+    type DiagnosticReport,
+} from '../services/diagnostics';
+
+ipcMain.handle('diagnostics:getLogPath', (): string => {
+    return getLogFilePath();
+});
+
+ipcMain.handle('diagnostics:openLogsFolder', (): void => {
+    openLogsFolder();
+});
+
+ipcMain.handle('diagnostics:saveReport', (): Promise<DiagnosticReport | null> => {
+    return saveDiagnosticReport();
+});
+
+ipcMain.handle('diagnostics:buildReport', (_, description: unknown): Promise<string> => {
+    return buildReportText(typeof description === 'string' ? description : '');
+});

--- a/electron/main/services/diagnostics.ts
+++ b/electron/main/services/diagnostics.ts
@@ -1,0 +1,186 @@
+// Centralized logging + bug-report bundler.
+//
+// initLogger() wires electron-log as the destination for every console.* call
+// in the main process so an installed user has a single rolling file
+// (~/.config/grimoire/logs/main.log on Linux, %AppData%\grimoire\logs\main.log
+// on Windows) we can ask them to attach when they file a bug. We deliberately
+// do NOT auto-upload anything — every transfer is user-initiated, consistent
+// with the zero-telemetry rule in the workspace CLAUDE.md.
+
+import log from 'electron-log';
+import { app, dialog, shell } from 'electron';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { getInstallSource } from './updater';
+
+// Tail size for the diagnostic report. 256 KB is ~3-5k log lines: plenty of
+// context for the typical "I just hit a bug" report without ballooning the
+// attachment past what Discord/GitHub accept inline.
+const REPORT_TAIL_BYTES = 256 * 1024;
+
+let loggerInitialized = false;
+
+export function initLogger(): void {
+    if (loggerInitialized) return;
+    loggerInitialized = true;
+
+    log.transports.file.level = 'info';
+    log.transports.console.level = 'debug';
+    // Rotate at ~5 MB. electron-log keeps one archived copy (main.old.log) by
+    // default, so total log footprint is capped around 10 MB.
+    log.transports.file.maxSize = 5 * 1024 * 1024;
+    log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+
+    // Route every console.* in the main process through electron-log so the
+    // existing 100+ console.log/warn/error call sites land in the rolling
+    // file with zero per-site changes.
+    Object.assign(console, log.functions);
+
+    log.info(
+        `[diagnostics] logger ready; version=${app.getVersion()} ` +
+        `platform=${process.platform}/${process.arch} ` +
+        `electron=${process.versions.electron} node=${process.versions.node}`
+    );
+}
+
+export function getLogFilePath(): string {
+    return log.transports.file.getFile().path;
+}
+
+/** Highlight the log file in the user's file manager. Works on Windows
+ *  Explorer, macOS Finder, and most freedesktop-compliant Linux DEs. */
+export function openLogsFolder(): void {
+    shell.showItemInFolder(getLogFilePath());
+}
+
+// Redaction rules applied to every report body and to the saved .txt file.
+// Order matters: more-specific patterns (Authorization headers) run before
+// generic ones (bearer tokens). All replacements use opaque placeholders so a
+// reader can tell a value was redacted versus simply absent.
+const SANITIZERS: Array<{ pattern: RegExp; replacement: string }> = [
+    // Linux/macOS home paths: keep the path structure, drop the username.
+    // The path after the home dir (a SteamLibrary mount, for example) isn't
+    // PII; the username is.
+    { pattern: /\/home\/[^/\s"'`]+/g, replacement: '/home/<user>' },
+    { pattern: /\/Users\/[^/\s"'`]+/g, replacement: '/Users/<user>' },
+    // Windows: `C:\Users\Alice\...` -> `C:\Users\<user>\...`.
+    { pattern: /([A-Za-z]:\\Users\\)[^\\\s"'`]+/g, replacement: '$1<user>' },
+
+    // SteamID64 — real Steam user IDs start 7656119 and are 17 digits.
+    { pattern: /\b7656119\d{10}\b/g, replacement: '<steamid64>' },
+    // 32-bit account id in deadlock-api / Steam URLs.
+    { pattern: /(account_id=|\/players?\/)(\d{4,12})/g, replacement: '$1<accountid>' },
+
+    // Authorization headers / bearer tokens / JWTs / Steam OpenID secrets.
+    { pattern: /(Authorization:\s*Bearer\s+)\S+/gi, replacement: '$1<token>' },
+    { pattern: /(Bearer\s+)[A-Za-z0-9._-]{10,}/g, replacement: '$1<token>' },
+    { pattern: /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g, replacement: '<jwt>' },
+
+    // Emails (in case a user pastes one into the description).
+    { pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, replacement: '<email>' },
+];
+
+/** Strip PII / secrets from a diagnostic-bound string. The patterns above
+ *  cover the structured shapes; we also do a final pass that wipes any
+ *  literal occurrence of the running user's home dir, which catches edge
+ *  cases like a custom Windows username with spaces that the regex misses. */
+export function sanitize(text: string): string {
+    let out = text;
+    for (const { pattern, replacement } of SANITIZERS) {
+        out = out.replace(pattern, replacement);
+    }
+    const home = os.homedir();
+    if (home && home.length > 3) {
+        const escaped = home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        out = out.replace(new RegExp(escaped, 'g'), '<home>');
+    }
+    return out;
+}
+
+/** Build the full sanitized report body shared by the in-app copy-to-clipboard
+ *  flow and the save-to-file flow. Description is what the user typed in the
+ *  "what happened" textarea; pass '' when there isn't one. */
+export async function buildReportText(description: string): Promise<string> {
+    const logPath = getLogFilePath();
+    const rawTail = await readLogTail(logPath, REPORT_TAIL_BYTES);
+    const sanitizedTail = sanitize(rawTail);
+    const sanitizedDesc = sanitize((description ?? '').trim());
+
+    const headerLines = [
+        '=== Grimoire diagnostic report ===',
+        `Generated:    ${new Date().toISOString()}`,
+        `App version:  ${app.getVersion()}`,
+        `Install:      ${getInstallSource()}`,
+        `Platform:     ${process.platform} ${process.arch}`,
+        `OS release:   ${os.release()}`,
+        `Electron:     ${process.versions.electron}`,
+        `Chrome:       ${process.versions.chrome}`,
+        `Node:         ${process.versions.node}`,
+    ];
+
+    const parts = [headerLines.join('\n')];
+    if (sanitizedDesc) {
+        parts.push('--- what happened ---', sanitizedDesc);
+    }
+    parts.push(
+        `--- last ${Math.round(REPORT_TAIL_BYTES / 1024)} KB of main.log (sanitized) ---`,
+        sanitizedTail || '<log file empty>',
+    );
+    return parts.join('\n\n');
+}
+
+export interface DiagnosticReport {
+    path: string;
+}
+
+/** Bundle app version, OS info, and the tail of main.log into a single .txt
+ *  the user can attach to a bug report. Prompts for save location, defaulting
+ *  to the desktop. Returns the saved path, or null if the user cancelled. */
+export async function saveDiagnosticReport(): Promise<DiagnosticReport | null> {
+    const body = await buildReportText('');
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+    const defaultName = `grimoire-diagnostic-${stamp}.txt`;
+    const defaultDir = safeDesktopPath() ?? app.getPath('userData');
+
+    const result = await dialog.showSaveDialog({
+        title: 'Save diagnostic report',
+        defaultPath: join(defaultDir, defaultName),
+        filters: [{ name: 'Text', extensions: ['txt'] }],
+    });
+    if (result.canceled || !result.filePath) return null;
+
+    await fs.writeFile(result.filePath, body, 'utf8');
+    log.info('[diagnostics] saved diagnostic report to', result.filePath);
+    return { path: result.filePath };
+}
+
+async function readLogTail(path: string, maxBytes: number): Promise<string> {
+    try {
+        const stat = await fs.stat(path);
+        const start = Math.max(0, stat.size - maxBytes);
+        const length = stat.size - start;
+        if (length <= 0) return '';
+        const fh = await fs.open(path, 'r');
+        try {
+            const buf = Buffer.alloc(length);
+            await fh.read(buf, 0, length, start);
+            return buf.toString('utf8');
+        } finally {
+            await fh.close();
+        }
+    } catch (err) {
+        return `<could not read log file: ${err instanceof Error ? err.message : String(err)}>`;
+    }
+}
+
+function safeDesktopPath(): string | null {
+    // app.getPath('desktop') throws if the OS has no resolved desktop dir
+    // (rare on Linux with minimal XDG configs). Fall back gracefully.
+    try {
+        return app.getPath('desktop');
+    } catch {
+        return null;
+    }
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -171,6 +171,14 @@ export interface ElectronAPI {
         onStatus: (callback: (status: UpdateStatus) => void) => () => void;
     };
 
+    // Diagnostics (logs + bug-report bundle)
+    diagnostics: {
+        getLogPath: () => Promise<string>;
+        openLogsFolder: () => Promise<void>;
+        saveReport: () => Promise<{ path: string } | null>;
+        buildReport: (description: string) => Promise<string>;
+    };
+
     // Grimoire Social (publish + discover + likes). Session token lives in
     // the main process; this surface never returns it to the renderer.
     social: {
@@ -961,6 +969,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
             ipcRenderer.on('updater:status', handler);
             return () => ipcRenderer.removeListener('updater:status', handler);
         },
+    },
+
+    // Diagnostics
+    diagnostics: {
+        getLogPath: () => ipcRenderer.invoke('diagnostics:getLogPath'),
+        openLogsFolder: () => ipcRenderer.invoke('diagnostics:openLogsFolder'),
+        saveReport: () => ipcRenderer.invoke('diagnostics:saveReport'),
+        buildReport: (description: string) => ipcRenderer.invoke('diagnostics:buildReport', description),
     },
 
     // Grimoire Social

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -250,6 +250,23 @@ export async function openGameFolder(): Promise<void> {
   return window.electronAPI.openGameFolder();
 }
 
+// Diagnostics
+export async function getLogPath(): Promise<string> {
+  return window.electronAPI.diagnostics.getLogPath();
+}
+
+export async function openLogsFolder(): Promise<void> {
+  return window.electronAPI.diagnostics.openLogsFolder();
+}
+
+export async function saveDiagnosticReport(): Promise<{ path: string } | null> {
+  return window.electronAPI.diagnostics.saveReport();
+}
+
+export async function buildDiagnosticReport(description: string): Promise<string> {
+  return window.electronAPI.diagnostics.buildReport(description);
+}
+
 // Dialog helper for Settings page
 export async function showOpenDialog(options: {
   directory?: boolean;

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
   X,
   ExternalLink,
-  ShieldCheck,
   Upload,
   User as UserIcon,
 } from 'lucide-react';
@@ -233,11 +232,11 @@ export default function Discover() {
   );
 
 
-  // Top-right header action: either a sign-in CTA (signed-out) or the user
-  // chip (signed-in). The pulse class fires when a signed-out user clicks a
-  // card's like button so the right action is obvious.
+  // Page header action: either a sign-in CTA (signed-out) or the publish
+  // button + user chip (signed-in). The pulse ring fires when a signed-out
+  // user clicks a card's like button so the right action is obvious.
   const headerAction = signedIn && user ? (
-    <div className="flex items-center gap-2">
+    <>
       <Button
         size="sm"
         icon={Upload}
@@ -264,7 +263,7 @@ export default function Discover() {
           {user.display_name}
         </span>
       </div>
-    </div>
+    </>
   ) : (
     <div
       className={`flex items-center gap-2 rounded-md transition-shadow ${signInPulse ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary shadow-[0_0_0_4px_rgba(56,189,248,0.25)] animate-pulse' : ''}`}
@@ -287,16 +286,27 @@ export default function Discover() {
     </div>
   );
 
+  const headerDescription = (
+    <>
+      Mod profiles published by other Grimoire users.
+      {!signedIn && (
+        <span className="text-text-tertiary">
+          {' '}Sign in to like and publish; importing works without an account.
+        </span>
+      )}
+    </>
+  );
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-6 space-y-6 max-w-7xl mx-auto">
       <div>
         <PageHeader
           title="Discover"
-          description="Mod profiles published by other Grimoire users."
-          className="border-b-0 pb-3"
+          description={headerDescription}
+          action={headerAction}
         />
-        <div className="flex items-end justify-between gap-3 border-b border-border flex-wrap">
+        <div className="flex items-center justify-between gap-3 border-b border-border">
           <div className="flex items-center gap-1">
             {BROWSE_TABS.map(({ key, label, icon: Icon }) => {
               const active = tab === key;
@@ -305,7 +315,7 @@ export default function Discover() {
                   key={key}
                   type="button"
                   onClick={() => setTab(key)}
-                  className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
+                  className={`px-3 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
                     active
                       ? 'border-accent text-text-primary'
                       : 'border-transparent text-text-secondary hover:text-text-primary'
@@ -320,7 +330,7 @@ export default function Discover() {
               <button
                 type="button"
                 onClick={() => setTab('mine')}
-                className={`px-4 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
+                className={`px-3 py-2 -mb-px border-b-2 inline-flex items-center gap-2 text-sm transition-colors cursor-pointer ${
                   tab === 'mine'
                     ? 'border-accent text-text-primary'
                     : 'border-transparent text-text-secondary hover:text-text-primary'
@@ -331,14 +341,11 @@ export default function Discover() {
               </button>
             )}
           </div>
-          <div className="flex items-center gap-3 pb-2">
-            {tab !== 'mine' && data && (
-              <span className="text-sm text-text-secondary">
-                {data.total} {data.total === 1 ? 'profile' : 'profiles'}
-              </span>
-            )}
-            {headerAction}
-          </div>
+          {tab !== 'mine' && data && (
+            <span className="text-xs text-text-tertiary tabular-nums pr-1">
+              {data.total} {data.total === 1 ? 'profile' : 'profiles'}
+            </span>
+          )}
         </div>
       </div>
 
@@ -362,12 +369,6 @@ export default function Discover() {
           >
             Dismiss
           </button>
-        </div>
-      )}
-      {!signedIn && (
-        <div className="text-[11px] text-text-tertiary flex items-center gap-1.5">
-          <ShieldCheck className="w-3.5 h-3.5" />
-          Sign in to like and publish. Importing works without an account.
         </div>
       )}
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -347,33 +347,118 @@ export default function Installed() {
         wasEnabled: m.enabled,
       }));
     if (snapshots.length === 0) return;
+
+    // Group by GameBanana mod id so we fetch fresh file metadata once per
+    // mod. Reusing each row's stored fileId would 404 whenever an author
+    // replaced their upload (new file id) — the most common cause of
+    // "update failed" reports.
+    const groups = new Map<number, typeof snapshots>();
+    for (const s of snapshots) {
+      const arr = groups.get(s.gameBananaId) ?? [];
+      arr.push(s);
+      groups.set(s.gameBananaId, arr);
+    }
+
     setUpdateAllProgress({ done: 0, total: snapshots.length });
     const failures: string[] = [];
-    for (let i = 0; i < snapshots.length; i++) {
-      const s = snapshots[i];
+    // Track the (gameBananaId, fileId) actually downloaded so re-enable can
+    // still find the new install even when we redirected a stale snapshot.
+    const completed: { gameBananaId: number; gameBananaFileId: number; wasEnabled: boolean; fileName: string }[] = [];
+    let progress = 0;
+
+    for (const [, group] of groups) {
+      let details: GameBananaModDetails;
       try {
-        await deleteMod(s.oldId);
-        await downloadMod(s.gameBananaId, s.gameBananaFileId, s.fileName, s.section, s.categoryId);
+        details = await getModDetails(group[0].gameBananaId, group[0].section);
       } catch (err) {
-        failures.push(`${s.fileName}: ${String(err)}`);
+        for (const s of group) {
+          failures.push(`${s.fileName}: failed to fetch mod details (${String(err)})`);
+          progress += 1;
+          setUpdateAllProgress({ done: progress, total: snapshots.length });
+        }
+        continue;
       }
-      setUpdateAllProgress({ done: i + 1, total: snapshots.length });
+
+      const liveFiles = details.files ?? [];
+      const liveFileIds = new Set(liveFiles.map((f) => f.id));
+
+      // Resolve every snapshot to a target file *before* any delete/download
+      // runs, so an unrecoverable row keeps its existing install rather than
+      // getting deleted into a failed re-download.
+      //
+      // Pass 1: rows whose stored fileId is still on GameBanana (genuine
+      // multi-file mods stay 1:1).
+      // Pass 2: rows whose fileId is gone. Fall back to a single-file
+      // consolidation only when the mod now ships exactly one file and no
+      // other row already claimed it.
+      type Resolution =
+        | { ok: true; snapshot: (typeof snapshots)[number]; fileId: number; fileName: string }
+        | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };
+      const resolutions: Resolution[] = [];
+      const claimedIds = new Set<number>();
+      for (const s of group) {
+        if (liveFileIds.has(s.gameBananaFileId)) {
+          resolutions.push({ ok: true, snapshot: s, fileId: s.gameBananaFileId, fileName: s.fileName });
+          claimedIds.add(s.gameBananaFileId);
+        }
+      }
+      for (const s of group) {
+        if (liveFileIds.has(s.gameBananaFileId)) continue;
+        if (liveFiles.length === 1 && !claimedIds.has(liveFiles[0].id)) {
+          resolutions.push({ ok: true, snapshot: s, fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
+          claimedIds.add(liveFiles[0].id);
+        } else {
+          resolutions.push({
+            ok: false,
+            snapshot: s,
+            reason: 'file no longer on GameBanana; mod files changed. Reinstall from Browse.',
+          });
+        }
+      }
+
+      for (const r of resolutions) {
+        if (!r.ok) {
+          failures.push(`${r.snapshot.fileName}: ${r.reason}`);
+        } else {
+          try {
+            await deleteMod(r.snapshot.oldId);
+            await downloadMod(
+              r.snapshot.gameBananaId,
+              r.fileId,
+              r.fileName,
+              r.snapshot.section,
+              r.snapshot.categoryId,
+            );
+            completed.push({
+              gameBananaId: r.snapshot.gameBananaId,
+              gameBananaFileId: r.fileId,
+              wasEnabled: r.snapshot.wasEnabled,
+              fileName: r.fileName,
+            });
+          } catch (err) {
+            failures.push(`${r.snapshot.fileName}: ${String(err)}`);
+          }
+        }
+        progress += 1;
+        setUpdateAllProgress({ done: progress, total: snapshots.length });
+      }
     }
+
     // Refresh once so the new installs are in the store with their new ids,
-    // then re-enable anything that was enabled before. Match-by GB ids; the
+    // then re-enable anything that was enabled before. Match by GB ids; the
     // local mod id changes on reinstall.
     await loadMods();
     const refreshed = useAppStore.getState().mods;
-    for (const s of snapshots) {
-      if (!s.wasEnabled) continue;
+    for (const c of completed) {
+      if (!c.wasEnabled) continue;
       const newMod = refreshed.find(
-        (m) => m.gameBananaId === s.gameBananaId && m.gameBananaFileId === s.gameBananaFileId,
+        (m) => m.gameBananaId === c.gameBananaId && m.gameBananaFileId === c.gameBananaFileId,
       );
       if (newMod && !newMod.enabled) {
         try {
           await toggleMod(newMod.id);
         } catch (err) {
-          failures.push(`re-enable ${s.fileName}: ${String(err)}`);
+          failures.push(`re-enable ${c.fileName}: ${String(err)}`);
         }
       }
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,15 +1,19 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe, FileText, ScrollText, Bug, Copy } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
 import {
+  buildDiagnosticReport,
   cleanupAddons,
   createDevDeadlockPath,
   fixGameinfo,
   getGameinfoStatus,
+  getLogPath,
   openGameFolder,
+  openLogsFolder,
+  saveDiagnosticReport,
   validateDeadlockPath,
   showOpenDialog,
 } from '../lib/api';
@@ -59,6 +63,18 @@ export default function Settings() {
   const [showChangelog, setShowChangelog] = useState(false);
   const [upToDate, setUpToDate] = useState(false);
   const [installSource, setInstallSource] = useState<'managed' | 'appimage' | 'standard'>('standard');
+
+  // Diagnostics
+  const [logPath, setLogPath] = useState<string | null>(null);
+  const [isSavingReport, setIsSavingReport] = useState(false);
+  const [reportResult, setReportResult] = useState<string | null>(null);
+
+  // Bug report form (copy-paste flow, separate from save-to-file)
+  const [bugDescription, setBugDescription] = useState('');
+  const [bugReportText, setBugReportText] = useState<string | null>(null);
+  const [isBuildingReport, setIsBuildingReport] = useState(false);
+  const [bugReportError, setBugReportError] = useState<string | null>(null);
+  const [bugCopyState, setBugCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   const isDevMode = settings?.devMode ?? false;
   const activeDeadlockPath = getActiveDeadlockPath(settings);
@@ -286,6 +302,89 @@ export default function Settings() {
       setIsFixingGameinfo(false);
     }
   };
+
+  useEffect(() => {
+    let active = true;
+    getLogPath()
+      .then((p) => {
+        if (active) setLogPath(p);
+      })
+      .catch(() => {
+        // Non-fatal — the buttons still work, the path label just won't render.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleOpenLogs = async () => {
+    try {
+      await openLogsFolder();
+    } catch (err) {
+      setReportResult(`Could not open logs folder: ${String(err)}`);
+    }
+  };
+
+  const handleSaveReport = async () => {
+    setIsSavingReport(true);
+    setReportResult(null);
+    try {
+      const result = await saveDiagnosticReport();
+      setReportResult(result ? `Saved to ${result.path}` : 'Save cancelled.');
+    } catch (err) {
+      setReportResult(`Failed to save report: ${String(err)}`);
+    } finally {
+      setIsSavingReport(false);
+    }
+  };
+
+  const handleGenerateBugReport = async () => {
+    setIsBuildingReport(true);
+    setBugReportError(null);
+    setBugCopyState('idle');
+    try {
+      const text = await buildDiagnosticReport(bugDescription);
+      setBugReportText(text);
+    } catch (err) {
+      setBugReportError(`Couldn't build report: ${String(err)}`);
+    } finally {
+      setIsBuildingReport(false);
+    }
+  };
+
+  const handleCopyBugReport = async () => {
+    if (!bugReportText) return;
+    try {
+      await navigator.clipboard.writeText(bugReportText);
+      setBugCopyState('copied');
+      window.setTimeout(() => setBugCopyState('idle'), 2000);
+    } catch {
+      setBugCopyState('failed');
+    }
+  };
+
+  // Prefill the GitHub "new issue" URL with the user's description as the
+  // title and a stub body that tells them to paste the diagnostic. We can't
+  // jam the full sanitized report into the URL (GitHub caps issue-create
+  // URLs around 8 KB and our log tail is up to 256 KB), so the contract is:
+  // "copy the report, then click the button, then paste."
+  const githubIssueUrl = useMemo(() => {
+    const firstLine = bugDescription.split('\n').find((l) => l.trim().length > 0) ?? '';
+    const title = firstLine.trim().slice(0, 100) || 'Bug report';
+    const body = [
+      bugDescription.trim() || '<!-- describe what happened -->',
+      '',
+      '---',
+      '',
+      'Diagnostic report (copied from Grimoire → Settings → Share a bug report):',
+      '',
+      '```',
+      'paste the report here',
+      '```',
+    ].join('\n');
+    const q = `?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+    return `https://github.com/Slush97/grimoire/issues/new${q}`;
+  }, [bugDescription]);
 
   // Load sync status
   useEffect(() => {
@@ -527,28 +626,28 @@ export default function Settings() {
         {/* Updates */}
         <Card title="Updates" icon={Download} className="lg:col-span-2">
           <div className="space-y-4">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div>
+            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">Current Version</span>
                   <Badge variant="info">v{appVersion || '...'}</Badge>
                 </div>
-                {updateStatus?.error && (
-                  <p className="text-xs text-red-400 mt-1">{updateStatus.error}</p>
-                )}
                 {updateStatus?.available && !updateStatus.downloaded && (
-                  <p className="text-xs text-accent mt-1">
+                  <span className="text-xs text-accent">
                     v{updateStatus.updateInfo?.version} available!
-                  </p>
+                  </span>
                 )}
                 {updateStatus?.downloaded && (
-                  <p className="text-xs text-green-400 mt-1 flex items-center gap-1">
+                  <span className="text-xs text-green-400 inline-flex items-center gap-1">
                     <Sparkles className="w-3 h-3" />
                     v{updateStatus.updateInfo?.version} ready to install
-                  </p>
+                  </span>
                 )}
                 {upToDate && !updateStatus?.available && !updateStatus?.checking && (
-                  <p className="text-xs text-green-400 mt-1">✓ You're up to date!</p>
+                  <span className="text-xs text-green-400">✓ You're up to date!</span>
+                )}
+                {updateStatus?.error && (
+                  <span className="text-xs text-red-400 basis-full">{updateStatus.error}</span>
                 )}
               </div>
               <div className="flex flex-wrap gap-2">
@@ -843,35 +942,164 @@ export default function Settings() {
 
         {/* Support */}
         <Card title="Support" icon={LifeBuoy} className="lg:col-span-2">
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-            <p className="text-sm text-text-secondary">
-              Found a bug or have a feature request? File an issue on GitHub or drop into our Discord.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-2">
-              <a
-                href="https://github.com/Slush97/grimoire/issues"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60 whitespace-nowrap"
-              >
-                <Github className="w-4 h-4" aria-hidden="true" />
-                GitHub Issues
-              </a>
-              <a
-                href="https://discord.gg/KgYGHEMq2P"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
-              >
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 24 24"
-                  className="w-4 h-4 fill-current"
+          <div className="space-y-6">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+              <p className="text-sm text-text-secondary">
+                Found a bug or have a feature request? File an issue on GitHub or drop into our Discord.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <a
+                  href="https://github.com/Slush97/grimoire/issues"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60 whitespace-nowrap"
                 >
-                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-                </svg>
-                Join Discord
-              </a>
+                  <Github className="w-4 h-4" aria-hidden="true" />
+                  GitHub Issues
+                </a>
+                <a
+                  href="https://discord.gg/KgYGHEMq2P"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
+                >
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    className="w-4 h-4 fill-current"
+                  >
+                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                  </svg>
+                  Join Discord
+                </a>
+              </div>
+            </div>
+
+            <div className="h-px bg-white/5" />
+
+            <div className="space-y-3">
+              <div>
+                <h4 className="font-medium text-sm flex items-center gap-2">
+                  <Bug className="w-4 h-4 text-text-secondary" aria-hidden="true" />
+                  Share a bug report
+                </h4>
+                <p className="text-xs text-text-secondary mt-1">
+                  Describe what went wrong, generate a sanitized report, then paste it into Discord or a GitHub issue. The report bundles app and OS info plus the tail of your log; home paths, Steam IDs, bearer tokens, and emails are stripped before it leaves the app.
+                </p>
+              </div>
+
+              <textarea
+                value={bugDescription}
+                onChange={(e) => setBugDescription(e.target.value)}
+                placeholder="What were you doing when it broke? (Optional but helpful.)"
+                rows={3}
+                className="w-full px-3 py-2 text-sm bg-bg-tertiary border border-white/5 rounded-sm text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+              />
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  onClick={handleGenerateBugReport}
+                  isLoading={isBuildingReport}
+                  size="sm"
+                  variant="secondary"
+                  icon={FileText}
+                >
+                  {bugReportText ? 'Regenerate report' : 'Generate report'}
+                </Button>
+              </div>
+
+              {bugReportError && (
+                <p className="text-xs text-red-400 break-all">{bugReportError}</p>
+              )}
+
+              {bugReportText && (
+                <div className="space-y-2 animate-fade-in">
+                  <p className="text-[11px] text-text-secondary/70">
+                    Review before sharing. Nothing is sent automatically.
+                  </p>
+                  <textarea
+                    value={bugReportText}
+                    readOnly
+                    rows={10}
+                    className="w-full px-3 py-2 text-[11px] font-mono leading-relaxed bg-bg-tertiary/60 border border-white/5 rounded-sm text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      onClick={handleCopyBugReport}
+                      size="sm"
+                      icon={bugCopyState === 'copied' ? Check : Copy}
+                    >
+                      {bugCopyState === 'copied'
+                        ? 'Copied'
+                        : bugCopyState === 'failed'
+                          ? 'Copy failed: select and Ctrl+C'
+                          : 'Copy report'}
+                    </Button>
+                    <a
+                      href="https://discord.gg/KgYGHEMq2P"
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" className="w-4 h-4 fill-current">
+                        <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                      </svg>
+                      Open Discord
+                    </a>
+                    <a
+                      href={githubIssueUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60"
+                    >
+                      <Github className="w-4 h-4" aria-hidden="true" />
+                      Open GitHub issue
+                    </a>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="h-px bg-white/5" />
+
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+              <div className="min-w-0">
+                <h4 className="font-medium text-sm">Diagnostic logs</h4>
+                <p className="text-xs text-text-secondary mt-1">
+                  Save a diagnostic report (app version, OS info, recent log) and attach it when filing a bug.
+                </p>
+                {logPath && (
+                  <p
+                    className="text-[11px] text-text-secondary/70 mt-2 font-mono truncate"
+                    title={logPath}
+                  >
+                    {logPath}
+                  </p>
+                )}
+                {reportResult && (
+                  <p className="text-xs text-accent mt-2 animate-fade-in break-all">{reportResult}</p>
+                )}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+                <Button
+                  onClick={handleOpenLogs}
+                  variant="secondary"
+                  size="sm"
+                  icon={ScrollText}
+                >
+                  Open logs folder
+                </Button>
+                <Button
+                  onClick={handleSaveReport}
+                  isLoading={isSavingReport}
+                  variant="secondary"
+                  size="sm"
+                  icon={FileText}
+                >
+                  Save diagnostic report
+                </Button>
+              </div>
             </div>
           </div>
         </Card>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -418,6 +418,14 @@ export interface ElectronAPI {
         onStatus: (callback: (status: UpdateStatus) => void) => () => void;
     };
 
+    // Diagnostics
+    diagnostics: {
+        getLogPath: () => Promise<string>;
+        openLogsFolder: () => Promise<void>;
+        saveReport: () => Promise<{ path: string } | null>;
+        buildReport: (description: string) => Promise<string>;
+    };
+
     // Grimoire Social
     social: {
         getSessionStatus: () => Promise<import('./social').SocialSessionStatus>;


### PR DESCRIPTION
## Summary

Three small, independent changes bundled into one PR to ride a single CI pass. Each commit is self-contained and can be reviewed on its own.

### 1. `fix(installed)`: update-all resilient to replaced/removed GameBanana files
- Group snapshots by `gameBananaId`, fetch `getModDetails` once per group.
- Resolve every row to a target file **before** any `deleteMod`/`downloadMod` runs, so unrecoverable rows keep their existing install instead of getting deleted into a failed re-download.
- Rows whose stored `fileId` is still live update 1:1 (real multi-file mods unchanged); rows whose `fileId` is gone fall back to a single-file consolidation only when the mod now ships exactly one file and no other row already claimed it; otherwise skipped with a clear `"file no longer on GameBanana; mod files changed. Reinstall from Browse."` failure.
- Re-enable matches by the actually-downloaded `(gameBananaId, fileId)` so redirected rows still come back enabled.
- Fixes `File X not found in mod Y` 404s that hit whenever a mod author replaced their upload with a new file id.

### 2. `ui(discover)`: tighter top bar
- Sign-in / publish / user-chip action moves into `PageHeader`'s action slot, sharing the title row.
- Sign-in nudge folded into the description as a muted inline continuation (signed-out only).
- Filter row slimmed to tabs on the left + small count on the right with `items-center` alignment.
- Drops the dead horizontal space the old layout had.

### 3. `feat(diagnostics)`: in-app sanitized bug-report form
- New service helpers `sanitize()` + `buildReportText()` shared by both the existing save-to-file flow (now sanitized too) and the new copy-paste flow.
- IPC `diagnostics:buildReport` → preload → renderer helper `buildDiagnosticReport(description)`.
- New row in **Settings → Support → "Share a bug report"**: optional description textarea, Generate report, read-only review textarea, then Copy report + Open Discord + Open GitHub issue (the GitHub URL prefills title from the description and a body stub asking the user to paste the report).
- Sanitizer strips: Linux/macOS/Windows home dirs (username only, path structure preserved so gameinfo.gi locations stay diagnosable), SteamID64s, 32-bit account ids in `account_id=` / `/players/` URLs, `Authorization`/`Bearer` tokens, JWTs, emails, and any literal occurrence of the running user's home dir as a final pass. Mod file names and localhost IPs are intentionally kept for debug value.
- Also collapses the **Updates** row in Settings to a single line (version + status inline).

## Test plan

- [ ] CI green
- [ ] `fix(installed)`: trigger Update on mod 677551 (or any group where one local row's `gameBananaFileId` is stale): live-id row should update 1:1, dead-id row should be skipped with a clear failure (and its install preserved)
- [ ] `fix(installed)` regression: a healthy multi-file mod still updates 1:1 with no failures
- [ ] `ui(discover)`: top row reads `Discover    [Publish] [user-chip]` (signed-in) or `Discover    [Steam Sign in]` (signed-out); filter row reads `[Top] [New]                 N profiles`
- [ ] `feat(diagnostics)`: paste a path like `/home/<you>/foo` and an email into the description, Generate, confirm both are redacted in the output textarea
- [ ] `feat(diagnostics)`: Copy report → paste into a text editor → grep for your username, `@`, `7656119` → none should appear
- [ ] `feat(diagnostics)`: Open GitHub issue → opens a new-issue page with the description as title and a paste-stub body
- [ ] **Manual rebase note**: conflicts with #37/#38 (`openGameFolder` import + new `diagnostics.*` block in `api.ts` and `Settings.tsx`) were resolved by keeping both