### PR TITLE
feat: identify unknown local mods

### DIFF
--- a/docs/hero-sound-codenames.md
+++ b/docs/hero-sound-codenames.md
@@ -1,0 +1,126 @@
+# Hero sound codenames
+
+Reference dictionary for mapping Deadlock's internal hero codenames to display names, scoped to **sound-mods-in-Locker** work (organize sound mods by hero and ability slot).
+
+## Why two columns of codenames
+
+Deadlock uses **two parallel codename namespaces** that don't always agree:
+
+1. **`class_name`** (form: `hero_<name>`) — what `assets.deadlock-api.com/v2/heroes` returns. Used by HUD, panorama, scripts.
+2. **sound-path codename** — what the VPK actually uses inside `sounds/abilities/<codename>/a<1-4>_<ability>/`.
+
+For 33 of the 35 heroes that currently ship ability sounds, these two agree. The exceptions:
+
+| Display name | Sound-path codename | `class_name` |
+|---|---|---|
+| Abrams | `abrams` | `hero_atlas` |
+| Mo & Krill | `mokrill` | `hero_krill` |
+
+When matching a mod's VPK contents, use the **sound-path** column. When talking to deadlock-api or reading scripts, use **`class_name`**.
+
+## Ability slot convention
+
+```
+sounds/abilities/<sound_codename>/a<N>_<ability_internal_name>/...
+```
+
+- `a1` / `a2` / `a3` are the three base abilities (1/2/3 in UI).
+- `a4` is the ultimate.
+- `<ability_internal_name>` is descriptive (e.g. `a2_charge` for Abrams Shoulder Charge, `a4_leap` for his ult).
+
+A single sound mod's VPK can touch multiple `(hero, slot)` tuples (multi-ability replacement packs). Surface every tuple it modifies; don't pick one.
+
+### Caveat: rework leftovers
+
+Some heroes have multiple `a<N>_*` entries at the same slot because Valve kept old ability dirs after a rework. Mirage is the worst case:
+
+```
+mirage  a2  sand_phantom
+mirage  a2  tornado
+mirage  a3  bullet_burst
+mirage  a3  djinns_mark
+mirage  a4  dreamweaver
+mirage  a4  sunfire_cataclysm
+mirage  a4  teleport
+mirage  a4  whirling_dervish
+```
+
+Treat alternates at the same slot as aliases of that slot, not separate abilities. The currently-shipped ability name for each Mirage slot is the live one; the rest are dead paths that mods may still target. Surfacing them as the same slot keeps mods grouped sensibly.
+
+Other heroes with similar leftover entries (smaller scale): `tengu a1` (`ghost`, `stone_squall`), `wrecker a2` (`salvage`, `scrap_blast`), `wrecker a4` (`teleport`, `wrecking_crew`), `synth a2` (`flying_cloak`, `grasp`), `tokamak a3` (`breach`, `radiance`), `nano a4` (`bomb`, `tower`).
+
+## Coverage
+
+deadlock-api lists 61 heroes total (live + in-development + disabled). The core VPK currently ships ability sound directories for **35** of them. In-dev / disabled heroes that already have sound assets:
+
+- Fathom (`hero_slork`), Tokamak (`hero_tokamak`), Trapper (`hero_trapper`), Wrecker (`hero_wrecker`), Kali (`hero_kali`)
+
+UI rule (per product call): **hide heroes whose API record has `disabled: true` until Valve flips them on.** Don't show in the Locker hero list even if their sound dir exists.
+
+## Full dictionary (35 heroes with shipped ability sounds)
+
+Sorted by sound-path codename. Hidden-in-UI rows marked `[hide]`.
+
+| Sound codename | Display | `class_name` | API id | Notes |
+|---|---|---|---|---|
+| `abrams` | Abrams | `hero_atlas` | 6 | codename mismatch |
+| `astro` | Holliday | `hero_astro` | 14 | |
+| `bebop` | Bebop | `hero_bebop` | 15 | |
+| `bookworm` | Paige | `hero_bookworm` | 67 | |
+| `chrono` | Paradox | `hero_chrono` | 10 | |
+| `drifter` | Drifter | `hero_drifter` | 64 | |
+| `dynamo` | Dynamo | `hero_dynamo` | 11 | |
+| `fathom` | Fathom | `hero_slork` | 53 | `[hide]` in-dev |
+| `fencer` | Apollo | `hero_fencer` | 77 | |
+| `forge` | McGinnis | `hero_forge` | 8 | |
+| `ghost` | Lady Geist | `hero_ghost` | 4 | |
+| `gigawatt` | Seven | `hero_gigawatt` | 2 | |
+| `haze` | Haze | `hero_haze` | 13 | |
+| `hornet` | Vindicta | `hero_hornet` | 3 | |
+| `inferno` | Infernus | `hero_inferno` | 1 | |
+| `kali` | Kali | `hero_kali` | 21 | `[hide]` disabled |
+| `kelvin` | Kelvin | `hero_kelvin` | 12 | |
+| `lash` | Lash | `hero_lash` | 31 | |
+| `mirage` | Mirage | `hero_mirage` | 52 | rework leftovers (see caveat) |
+| `mokrill` | Mo & Krill | `hero_krill` | 18 | codename mismatch |
+| `nano` | Calico | `hero_nano` | 16 | |
+| `orion` | Grey Talon | `hero_orion` | 17 | |
+| `punkgoat` | Billy | `hero_punkgoat` | 72 | |
+| `shiv` | Shiv | `hero_shiv` | 19 | |
+| `synth` | Pocket | `hero_synth` | 50 | |
+| `tengu` | Ivy | `hero_tengu` | 20 | |
+| `tokamak` | Tokamak | `hero_tokamak` | 47 | `[hide]` in-dev |
+| `trapper` | Trapper | `hero_trapper` | 61 | `[hide]` in-dev |
+| `unicorn` | Celeste | `hero_unicorn` | 81 | |
+| `vampirebat` | Mina | `hero_vampirebat` | 63 | |
+| `viper` | Vyper | `hero_viper` | 58 | |
+| `viscous` | Viscous | `hero_viscous` | 35 | |
+| `werewolf` | Silver | `hero_werewolf` | 80 | |
+| `wrecker` | Wrecker | `hero_wrecker` | 48 | `[hide]` disabled |
+| `yamato` | Yamato | `hero_yamato` | 27 | |
+
+## How to refresh
+
+Plan of record (not yet implemented): a build-time script generates `electron/main/services/heroSoundCodenames.json` from `https://assets.deadlock-api.com/v2/heroes`. Sound-path codenames are scraped from the live `game/citadel/pak01_dir.vpk` (Deadlock core) using its directory tree; the two-namespace mismatches above are baked in as overrides for any case where the API's `class_name` differs from the live sound path.
+
+Until the script lands, this table is the source of truth. To re-verify by hand:
+
+```bash
+# 1) Pull current hero list
+curl -sS https://assets.deadlock-api.com/v2/heroes > /tmp/heroes.json
+
+# 2) Extract live sound-path codenames from the installed game
+strings -n 6 \
+  ~/.steam/steam/steamapps/common/Deadlock/game/citadel/pak01_dir.vpk \
+  | grep -ioE '^sounds/abilities/[a-z0-9_]+/' \
+  | sed -E 's|^sounds/abilities/([^/]+)/$|\1|' \
+  | sort -u
+```
+
+If a new hero shows up in step 2 that isn't in step 1, or if a sound-path codename diverges from a known `class_name`, add a row above and an override entry to the generator script.
+
+## Source
+
+- deadlock-api.com `/v2/heroes`: authoritative for hero roster, `class_name`, `disabled`, `in_development`.
+- Deadlock core VPK (`game/citadel/pak01_dir.vpk`) directory tree: authoritative for sound-path codenames and ability slot names.
+- Cross-referenced 2026-05-17 against a live Deadlock install. deadlock-api is community-run and not endorsed by Valve; the VPK is the ground truth if the two ever disagree.

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -49,6 +49,8 @@ import './ipc/diagnostics';
 
 import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';
+import { loadSettings } from './services/settings';
+import { backfillMissingMetadataHashes } from './services/metadata';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -68,6 +70,28 @@ function openExternalSafe(rawUrl: string): void {
         console.warn('[Main] blocked openExternal for scheme:', u.protocol);
     } catch {
         console.warn('[Main] blocked openExternal for malformed URL');
+    }
+}
+
+function getConfiguredDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+async function backfillStartupMetadataHashes(): Promise<void> {
+    const deadlockPath = getConfiguredDeadlockPath();
+    if (!deadlockPath) return;
+
+    try {
+        const updated = await backfillMissingMetadataHashes(deadlockPath);
+        if (updated > 0) {
+            console.log(`[Metadata] Backfilled SHA-256 for ${updated} mod metadata entr${updated === 1 ? 'y' : 'ies'}`);
+        }
+    } catch (error) {
+        console.warn('[Metadata] Startup SHA-256 backfill failed:', error);
     }
 }
 
@@ -249,8 +273,11 @@ if (!gotTheLock) {
         void hydrateSocialSession();
 
         // Recover from any half-finished vanilla launch (app was closed mid-session,
-        // or grimoire crashed while the user was playing vanilla). Runs in background.
-        void runStartupRecovery();
+        // or grimoire crashed while the user was playing vanilla), then fill in
+        // SHA-256 metadata for older entries that were written before hashing.
+        void runStartupRecovery().finally(() => {
+            void backfillStartupMetadataHashes();
+        });
 
         // Initialize auto-updater (production only). Skip the background check
         // for apt/AUR/snap installs since the package manager owns updates.

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { promises as fs, existsSync } from 'fs';
-import { basename, dirname, extname, join } from 'path';
+import { extname, join } from 'path';
 import { loadSettings, saveSettings } from '../services/settings';
 import {
     scanMods,
@@ -14,8 +14,14 @@ import {
     Mod,
 } from '../services/mods';
 import { getAddonsPath } from '../services/deadlock';
-import { getModMetadata, setModMetadata, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
+import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
+import { detectUnknownModFilters, type UnknownModFilterGuess } from '../services/unknownModDetection';
+import { downloadMod } from '../services/download';
+import { getMainWindow } from '../index';
+import type { ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs } from '../../../src/types/mod';
+
+const unknownDetectionControllers = new Map<string, AbortController>();
 
 /**
  * Get the active deadlock path from settings
@@ -33,6 +39,9 @@ function getActiveDeadlockPath(): string | null {
  */
 function enrichMod(mod: Mod): Mod {
     const metadata = getModMetadata(mod.fileName);
+    const isUnknown =
+        !metadata?.gameBananaId &&
+        !(typeof metadata?.modName === 'string' && metadata.modName.trim().length > 0);
     if (metadata) {
         return {
             ...mod,
@@ -47,12 +56,14 @@ function enrichMod(mod: Mod): Mod {
             sourceSection: metadata.sourceSection,
             nsfw: metadata.nsfw,
             isArchived: metadata.isArchived,
+            sha256: metadata.sha256,
+            isUnknown,
             variantLabel: metadata.variantLabel,
             fileDescription: metadata.fileDescription,
             sourceFileName: metadata.sourceFileName,
         };
     }
-    return mod;
+    return { ...mod, isUnknown };
 }
 
 function sameKeys(a: string[], b: string[]): boolean {
@@ -112,6 +123,132 @@ ipcMain.handle('delete-mod', async (_, modId: string): Promise<void> => {
     }
     await deleteMod(deadlockPath, modId);
 });
+
+// detect-unknown-mod-filters
+ipcMain.handle('detect-unknown-mod-filters', async (_, modId: string): Promise<UnknownModFilterGuess> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const mods = await scanMods(deadlockPath);
+    const mod = mods.find((m) => m.id === modId);
+    if (!mod) {
+        throw new Error(`Mod not found: ${modId}`);
+    }
+    unknownDetectionControllers.get(modId)?.abort();
+    const controller = new AbortController();
+    unknownDetectionControllers.set(modId, controller);
+    try {
+        return await detectUnknownModFilters(mod.id, mod.fileName, mod.path, { signal: controller.signal });
+    } finally {
+        if (unknownDetectionControllers.get(modId) === controller) {
+            unknownDetectionControllers.delete(modId);
+        }
+    }
+});
+
+// cancel-unknown-mod-detection
+ipcMain.handle('cancel-unknown-mod-detection', async (_, modId: string): Promise<void> => {
+    const controller = unknownDetectionControllers.get(modId);
+    if (controller) {
+        controller.abort();
+        unknownDetectionControllers.delete(modId);
+    }
+});
+
+// apply-unknown-mod-match
+ipcMain.handle(
+    'apply-unknown-mod-match',
+    async (_, modId: string, match: ApplyUnknownModMatchArgs): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        if (!match || !Number.isFinite(match.gameBananaId) || !match.modName?.trim()) {
+            throw new Error('Invalid GameBanana match');
+        }
+        if (!Number.isFinite(match.gameBananaFileId) || !match.sourceFileName?.trim()) {
+            throw new Error('The matched GameBanana file is missing download information');
+        }
+
+        const mods = await scanMods(deadlockPath);
+        const target = mods.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+
+        const wasEnabled = target.enabled;
+        const downloadResult = await downloadMod(deadlockPath, {
+            modId: match.gameBananaId,
+            fileId: match.gameBananaFileId,
+            fileName: match.sourceFileName,
+            section: match.sourceSection ?? 'Mod',
+        }, getMainWindow());
+        const installedFileNames = new Set(downloadResult.installedVpks);
+
+        const afterDownload = await scanMods(deadlockPath);
+        const downloaded = afterDownload
+            .filter((candidate) => {
+                if (candidate.id === target.id) return false;
+                return installedFileNames.has(candidate.fileName);
+            })
+            .sort((a, b) => downloadResult.installedVpks.indexOf(a.fileName) - downloadResult.installedVpks.indexOf(b.fileName));
+
+        if (downloaded.length === 0) {
+            throw new Error('Download completed, but the installed replacement VPK could not be found. The unknown mod was kept.');
+        }
+
+        await deleteMod(deadlockPath, target.id);
+
+        const finalFileNames: string[] = [];
+        if (wasEnabled) {
+            for (const replacement of downloaded) {
+                if (!replacement.enabled) {
+                    const enabled = await enableMod(deadlockPath, replacement.id);
+                    finalFileNames.push(enabled.fileName);
+                } else {
+                    finalFileNames.push(replacement.fileName);
+                }
+            }
+        } else {
+            finalFileNames.push(...downloaded.map((replacement) => replacement.fileName));
+        }
+
+        const finalMods = await scanMods(deadlockPath);
+        const finalReplacement =
+            finalMods.find((candidate) => candidate.fileName === finalFileNames[0]) ??
+            downloaded[0];
+        return enrichMod(finalReplacement ?? downloaded[0]);
+    }
+);
+
+// apply-unknown-custom-mod
+ipcMain.handle(
+    'apply-unknown-custom-mod',
+    async (_, modId: string, args: ApplyUnknownCustomModArgs): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        if (!args?.name?.trim()) {
+            throw new Error('A name is required');
+        }
+
+        const mods = await scanMods(deadlockPath);
+        const target = mods.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+
+        await setModMetadataWithHash(target.fileName, {
+            modName: args.name.trim(),
+            thumbnailUrl: args.thumbnailDataUrl,
+            nsfw: !!args.nsfw,
+        }, target.path);
+
+        return enrichMod(target);
+    }
+);
 
 // set-variant-label — user-facing rename of a single VPK (the "variant"
 // inside a grouped mod). Stored alongside the mod's other metadata so it
@@ -262,9 +399,8 @@ ipcMain.handle('read-image-data-url', async (_, imagePath: string): Promise<stri
 
 // import-custom-mod
 // The Deadlock engine requires strict `pakXX_dir.vpk` naming (see apply-mina-variant),
-// so custom imports always get a naked `pakNN_dir.vpk` filename — no slug. The
+// so custom imports always get a naked `pakNN_dir.vpk` filename - no slug. The
 // human-readable name lives in metadata.modName and is shown in the UI instead.
-// Multi-file VPKs keep their numbered siblings, remapped as `pakNN_000.vpk` etc.
 ipcMain.handle(
     'import-custom-mod',
     async (_, args: ImportCustomModArgs): Promise<Mod[]> => {
@@ -294,39 +430,18 @@ ipcMain.handle(
         const priorityStr = String(priority).padStart(2, '0');
         const newDirFileName = `pak${priorityStr}_dir.vpk`;
 
-        const srcDir = dirname(vpkPath);
-        const srcName = basename(vpkPath);
-
-        if (srcName.toLowerCase().endsWith('_dir.vpk')) {
-            const srcBase = srcName.slice(0, -'_dir.vpk'.length);
-            const entries = await fs.readdir(srcDir);
-            const siblings = entries.filter(
-                (e) => e.startsWith(`${srcBase}_`) && e.toLowerCase().endsWith('.vpk')
-            );
-            if (siblings.length === 0) {
-                await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
-            } else {
-                for (const s of siblings) {
-                    const dstName = s === srcName
-                        ? newDirFileName
-                        : `pak${priorityStr}${s.slice(srcBase.length)}`;
-                    await fs.copyFile(join(srcDir, s), join(addonsPath, dstName));
-                }
-            }
-        } else {
-            await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
-        }
+        await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
 
         // Scrub any orphan metadata at this slot before writing. setModMetadata
         // merges into the existing entry, so stale fields (gameBananaId,
         // categoryName, etc.) from a prior occupant would otherwise stick to
         // the new local mod and visually merge it with unrelated mods.
         removeModMetadata(newDirFileName);
-        setModMetadata(newDirFileName, {
+        await setModMetadataWithHash(newDirFileName, {
             modName: name.trim(),
             thumbnailUrl: thumbnailDataUrl,
             nsfw: !!nsfw,
-        });
+        }, join(addonsPath, newDirFileName));
 
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -28,7 +28,7 @@ import { getAddonsPath, getDisabledPath, getCitadelPath } from '../services/dead
 import { getUserDataPath } from '../utils/paths';
 import {
     getModMetadata,
-    setModMetadata,
+    setModMetadataWithHash,
     deleteModMetadata,
 } from '../services/metadata';
 
@@ -384,14 +384,14 @@ ipcMain.handle(
             console.log('[applyMinaVariant] Installed preset to:', destPath);
 
             // Save metadata with isMinaPreset flag so we can identify it later
-            setModMetadata(destFileName, {
+            await setModMetadataWithHash(destFileName, {
                 modName: `Midnight Mina — ${presetLabel}`,
                 categoryId: heroCategoryId,
                 categoryName: 'Mina',
                 sourceSection: 'Mod',
                 nsfw: true,
                 isMinaPreset: true,  // Flag to identify this as a Mina preset we created
-            });
+            }, destPath);
 
         } finally {
             // Cleanup temp directory

--- a/electron/main/services/archiveCrc.ts
+++ b/electron/main/services/archiveCrc.ts
@@ -1,0 +1,1336 @@
+import { createReadStream } from 'fs';
+import { validateDownloadUrl } from './security';
+
+export interface ArchiveVpkCrcEntry {
+    name: string;
+    crc32: string;
+    compressedSize: number;
+    uncompressedSize: number;
+}
+
+export interface ArchiveVpkCrcResult {
+    archiveType: 'zip' | 'rar' | '7z' | 'unknown';
+    entries: ArchiveVpkCrcEntry[];
+    bytesFetched: number;
+    unsupportedReason?: string;
+}
+
+export interface ArchiveVpkCrcOptions {
+    signal?: AbortSignal;
+}
+
+const ZIP_EOCD = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+const ZIP_CENTRAL_FILE = Buffer.from([0x50, 0x4b, 0x01, 0x02]);
+const RAR4_MARKER = Buffer.from([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x00]);
+const RAR5_MARKER = Buffer.from([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x01, 0x00]);
+const SEVEN_Z_SIGNATURE = Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]);
+const RAR_FILE_BLOCK = 0x74;
+const RAR_END_BLOCK = 0x7b;
+const RAR_LONG_BLOCK = 0x8000;
+const RAR5_BLOCK_FILE = 2;
+const RAR5_BLOCK_ENCRYPTION = 4;
+const RAR5_BLOCK_END = 5;
+const RAR5_HAS_EXTRA = 0x0001;
+const RAR5_HAS_DATA = 0x0002;
+const RAR5_FILE_DIRECTORY = 0x0001;
+const RAR5_FILE_UNIX_TIME = 0x0002;
+const RAR5_FILE_CRC32 = 0x0004;
+const DEFAULT_ZIP_TAIL_BYTES = 65_536;
+const MAX_ZIP_TAIL_BYTES = 4 * 1024 * 1024;
+const RAR_HEADER_BYTES = 4096;
+const SEVEN_Z_START_HEADER_BYTES = 32;
+const MAX_7Z_HEADER_BYTES = 8 * 1024 * 1024;
+const SEVEN_Z = {
+    END: 0x00,
+    HEADER: 0x01,
+    ARCHIVE_PROPERTIES: 0x02,
+    ADDITIONAL_STREAMS_INFO: 0x03,
+    MAIN_STREAMS_INFO: 0x04,
+    FILES_INFO: 0x05,
+    PACK_INFO: 0x06,
+    UNPACK_INFO: 0x07,
+    SUB_STREAMS_INFO: 0x08,
+    SIZE: 0x09,
+    CRC: 0x0a,
+    FOLDER: 0x0b,
+    CODERS_UNPACK_SIZE: 0x0c,
+    NUM_UNPACK_STREAM: 0x0d,
+    EMPTY_STREAM: 0x0e,
+    EMPTY_FILE: 0x0f,
+    NAME: 0x11,
+    ENCODED_HEADER: 0x17,
+} as const;
+const SEVEN_Z_LZMA = '030101';
+const SEVEN_Z_LZMA2 = '21';
+const LZMA_NUM_STATES = 12;
+const LZMA_NUM_POS_SLOT_BITS = 6;
+const LZMA_NUM_LEN_TO_POS_STATES = 4;
+const LZMA_MATCH_MIN_LEN = 2;
+const LZMA_NUM_ALIGN_BITS = 4;
+const LZMA_ALIGN_TABLE_SIZE = 1 << LZMA_NUM_ALIGN_BITS;
+const LZMA_END_POS_MODEL_INDEX = 14;
+const LZMA_NUM_FULL_DISTANCES = 1 << (LZMA_END_POS_MODEL_INDEX / 2);
+const CRC32_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let i = 0; i < table.length; i++) {
+        let value = i;
+        for (let bit = 0; bit < 8; bit++) {
+            value = (value & 1) ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+        }
+        table[i] = value >>> 0;
+    }
+    return table;
+})();
+
+class NeedMoreArchiveBytes extends Error { }
+
+function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw new Error('Unknown mod search cancelled');
+    }
+}
+
+function archiveTypeForName(fileName: string): ArchiveVpkCrcResult['archiveType'] {
+    const lower = fileName.toLowerCase();
+    if (lower.endsWith('.zip')) return 'zip';
+    if (lower.endsWith('.rar')) return 'rar';
+    if (lower.endsWith('.7z')) return '7z';
+    return 'unknown';
+}
+
+function isVpkArchiveEntry(name: string): boolean {
+    const normalized = name.replace(/\\/g, '/').toLowerCase();
+    return normalized.endsWith('.vpk') && !normalized.endsWith('/');
+}
+
+function readU16(buffer: Buffer, offset: number): number {
+    return buffer.readUInt16LE(offset);
+}
+
+function readU32(buffer: Buffer, offset: number): number {
+    return buffer.readUInt32LE(offset);
+}
+
+export async function crc32File(filePath: string): Promise<string> {
+    let crc = 0xffffffff;
+    const stream = createReadStream(filePath);
+
+    for await (const chunk of stream) {
+        const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+        for (const byte of buffer) {
+            crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+        }
+    }
+
+    return ((crc ^ 0xffffffff) >>> 0).toString(16).padStart(8, '0');
+}
+
+function decodeArchiveName(raw: Buffer): string {
+    const utf8 = raw.toString('utf8').replace(/\0+$/g, '');
+    if (!utf8.includes('\uFFFD')) return utf8;
+    return raw.toString('latin1').replace(/\0+$/g, '');
+}
+
+async function fetchArchiveRange(
+    url: string,
+    start: number,
+    end: number,
+    signal?: AbortSignal
+): Promise<Buffer> {
+    if (end < start) {
+        throw new Error(`Invalid archive byte range ${start}-${end}`);
+    }
+
+    throwIfAborted(signal);
+    validateDownloadUrl(url);
+
+    const expected = end - start + 1;
+    const response = await fetch(url, {
+        headers: {
+            Range: `bytes=${start}-${end}`,
+            'User-Agent': 'DeadlockModManager/1.0',
+        },
+        redirect: 'follow',
+        signal,
+    });
+    throwIfAborted(signal);
+
+    if (!response.ok && response.status !== 206) {
+        throw new Error(`Archive range request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (response.status === 200 && buffer.length > expected) {
+        throw new Error(`Archive server ignored range request (${buffer.length} bytes for ${expected} requested)`);
+    }
+
+    return buffer;
+}
+
+function parseZipCentralDirectory(tail: Buffer, totalSize: number): ArchiveVpkCrcEntry[] {
+    const eocd = tail.lastIndexOf(ZIP_EOCD);
+    if (eocd < 0 || eocd + 22 > tail.length) {
+        throw new NeedMoreArchiveBytes('ZIP end-of-central-directory was not found in fetched tail');
+    }
+
+    const entryCount = readU16(tail, eocd + 10);
+    const centralSize = readU32(tail, eocd + 12);
+    const centralOffset = readU32(tail, eocd + 16);
+    if (entryCount === 0xffff || centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+        throw new Error('ZIP64 central directories are not supported for CRC probing yet');
+    }
+
+    const tailStart = totalSize - tail.length;
+    const centralStart = centralOffset - tailStart;
+    if (centralStart < 0 || centralStart + centralSize > tail.length) {
+        throw new NeedMoreArchiveBytes('ZIP central directory is not fully in fetched tail');
+    }
+
+    const entries: ArchiveVpkCrcEntry[] = [];
+    let pos = centralStart;
+    for (let index = 0; index < entryCount; index++) {
+        if (pos + 46 > tail.length || !tail.subarray(pos, pos + 4).equals(ZIP_CENTRAL_FILE)) {
+            throw new Error(`ZIP central directory entry ${index} has an unexpected signature`);
+        }
+
+        const crc32 = readU32(tail, pos + 16);
+        const compressedSize = readU32(tail, pos + 20);
+        const uncompressedSize = readU32(tail, pos + 24);
+        const nameLen = readU16(tail, pos + 28);
+        const extraLen = readU16(tail, pos + 30);
+        const commentLen = readU16(tail, pos + 32);
+        const nameStart = pos + 46;
+        const nameEnd = nameStart + nameLen;
+        const name = decodeArchiveName(tail.subarray(nameStart, nameEnd)).replace(/\\/g, '/');
+
+        if (isVpkArchiveEntry(name)) {
+            entries.push({
+                name,
+                crc32: crc32.toString(16).padStart(8, '0'),
+                compressedSize,
+                uncompressedSize,
+            });
+        }
+
+        pos = nameEnd + extraLen + commentLen;
+    }
+
+    return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function fetchZipVpkCrcEntries(
+    downloadUrl: string,
+    fileSize: number,
+    signal?: AbortSignal
+): Promise<ArchiveVpkCrcResult> {
+    let bytesToFetch = Math.min(DEFAULT_ZIP_TAIL_BYTES, fileSize);
+    let bytesFetched = 0;
+
+    while (bytesToFetch <= Math.min(MAX_ZIP_TAIL_BYTES, fileSize)) {
+        throwIfAborted(signal);
+        const start = Math.max(0, fileSize - bytesToFetch);
+        const tail = await fetchArchiveRange(downloadUrl, start, fileSize - 1, signal);
+        bytesFetched += tail.length;
+
+        try {
+            return {
+                archiveType: 'zip',
+                entries: parseZipCentralDirectory(tail, fileSize),
+                bytesFetched,
+            };
+        } catch (err) {
+            if (!(err instanceof NeedMoreArchiveBytes) || bytesToFetch >= Math.min(MAX_ZIP_TAIL_BYTES, fileSize)) {
+                throw err;
+            }
+            bytesToFetch = Math.min(bytesToFetch * 2, MAX_ZIP_TAIL_BYTES, fileSize);
+        }
+    }
+
+    return { archiveType: 'zip', entries: [], bytesFetched };
+}
+
+function readU64LE(buffer: Buffer, offset: number): number {
+    const value = buffer.readBigUInt64LE(offset);
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error('7z header offset is too large to represent safely');
+    }
+    return Number(value);
+}
+
+class SevenZReader {
+    private offset = 0;
+
+    constructor(private readonly buffer: Buffer) { }
+
+    get position(): number {
+        return this.offset;
+    }
+
+    get remaining(): number {
+        return this.buffer.length - this.offset;
+    }
+
+    readByte(): number {
+        if (this.offset >= this.buffer.length) throw new NeedMoreArchiveBytes('7z metadata is truncated');
+        return this.buffer[this.offset++];
+    }
+
+    readBytes(length: number): Buffer {
+        if (length < 0 || this.offset + length > this.buffer.length) {
+            throw new NeedMoreArchiveBytes('7z metadata property is truncated');
+        }
+        const value = this.buffer.subarray(this.offset, this.offset + length);
+        this.offset += length;
+        return value;
+    }
+
+    readUInt32(): number {
+        if (this.offset + 4 > this.buffer.length) throw new NeedMoreArchiveBytes('7z CRC is truncated');
+        const value = readU32(this.buffer, this.offset);
+        this.offset += 4;
+        return value;
+    }
+
+    readNumber(): number {
+        const first = this.readByte();
+        let mask = 0x80;
+        let value = 0;
+
+        for (let i = 0; i < 8; i++) {
+            if ((first & mask) === 0) {
+                value += (first & (mask - 1)) * 2 ** (8 * i);
+                return value;
+            }
+            value += this.readByte() * 2 ** (8 * i);
+            mask >>= 1;
+        }
+
+        return value;
+    }
+
+    skip(length: number): void {
+        this.readBytes(length);
+    }
+}
+
+interface SevenZOptionalCrc {
+    defined: boolean;
+    crc32?: number;
+}
+
+interface SevenZCoder {
+    methodId: string;
+    properties: Buffer;
+    inStreams: number;
+    outStreams: number;
+}
+
+interface SevenZFolder {
+    coders: SevenZCoder[];
+    unpackSizes: number[];
+    crc?: SevenZOptionalCrc;
+}
+
+interface SevenZPackInfo {
+    packPos: number;
+    sizes: number[];
+}
+
+interface SevenZStreamInfo {
+    packInfo?: SevenZPackInfo;
+    folders: SevenZFolder[];
+    unpackStreams: Array<{ size: number; crc?: SevenZOptionalCrc }>;
+}
+
+function readSevenZBitVector(reader: SevenZReader, count: number): boolean[] {
+    const bits: boolean[] = [];
+    let mask = 0;
+    let byte = 0;
+
+    for (let i = 0; i < count; i++) {
+        if (mask === 0) {
+            byte = reader.readByte();
+            mask = 0x80;
+        }
+        bits.push((byte & mask) !== 0);
+        mask >>= 1;
+    }
+
+    return bits;
+}
+
+function readSevenZDefinedVector(reader: SevenZReader, count: number): boolean[] {
+    const allDefined = reader.readByte() !== 0;
+    return allDefined ? Array(count).fill(true) : readSevenZBitVector(reader, count);
+}
+
+function readSevenZCrcs(reader: SevenZReader, count: number): SevenZOptionalCrc[] {
+    const defined = readSevenZDefinedVector(reader, count);
+    return defined.map((isDefined) => ({
+        defined: isDefined,
+        crc32: isDefined ? reader.readUInt32() : undefined,
+    }));
+}
+
+function skipSevenZUnknownProperty(reader: SevenZReader, propertyName: string): never {
+    throw new Error(`Unsupported 7z metadata property in ${propertyName}`);
+}
+
+function parseSevenZPackInfo(reader: SevenZReader): SevenZPackInfo {
+    const packPos = reader.readNumber();
+    const numPackStreams = reader.readNumber();
+    const sizes: number[] = [];
+
+    while (true) {
+        const id = reader.readByte();
+        if (id === SEVEN_Z.END) break;
+        if (id === SEVEN_Z.SIZE) {
+            for (let i = 0; i < numPackStreams; i++) {
+                sizes.push(reader.readNumber());
+            }
+            continue;
+        }
+        if (id === SEVEN_Z.CRC) {
+            readSevenZCrcs(reader, numPackStreams);
+            continue;
+        }
+        skipSevenZUnknownProperty(reader, 'PackInfo');
+    }
+
+    return { packPos, sizes };
+}
+
+function parseSevenZFolder(reader: SevenZReader): SevenZFolder {
+    const numCoders = reader.readNumber();
+    const coders: SevenZCoder[] = [];
+    let totalInStreams = 0;
+    let totalOutStreams = 0;
+
+    for (let i = 0; i < numCoders; i++) {
+        const mainByte = reader.readByte();
+        const methodIdSize = mainByte & 0x0f;
+        const isComplex = (mainByte & 0x10) !== 0;
+        const hasAttributes = (mainByte & 0x20) !== 0;
+        const hasAlternativeMethods = (mainByte & 0x80) !== 0;
+        if (hasAlternativeMethods) throw new Error('7z folders with alternative methods are not supported');
+
+        let inStreams = 1;
+        let outStreams = 1;
+        if (isComplex) {
+            inStreams = reader.readNumber();
+            outStreams = reader.readNumber();
+        }
+
+        const methodId = reader.readBytes(methodIdSize).toString('hex');
+        const properties = hasAttributes ? reader.readBytes(reader.readNumber()) : Buffer.alloc(0);
+        coders.push({ methodId, properties, inStreams, outStreams });
+        totalInStreams += inStreams;
+        totalOutStreams += outStreams;
+    }
+
+    const bindPairs = Math.max(0, totalOutStreams - 1);
+    for (let i = 0; i < bindPairs; i++) {
+        reader.readNumber();
+        reader.readNumber();
+    }
+
+    const packedStreams = totalInStreams - bindPairs;
+    for (let i = 0; i < Math.max(0, packedStreams - 1); i++) {
+        reader.readNumber();
+    }
+
+    return { coders, unpackSizes: [] };
+}
+
+function parseSevenZUnpackInfo(reader: SevenZReader): SevenZFolder[] {
+    if (reader.readByte() !== SEVEN_Z.FOLDER) throw new Error('7z UnpackInfo is missing Folder data');
+    const numFolders = reader.readNumber();
+    const external = reader.readByte();
+    if (external !== 0) throw new Error('7z external folder metadata is not supported');
+
+    const folders: SevenZFolder[] = [];
+    for (let i = 0; i < numFolders; i++) {
+        folders.push(parseSevenZFolder(reader));
+    }
+
+    if (reader.readByte() !== SEVEN_Z.CODERS_UNPACK_SIZE) {
+        throw new Error('7z UnpackInfo is missing coder unpack sizes');
+    }
+    for (const folder of folders) {
+        const outStreams = folder.coders.reduce((sum, coder) => sum + coder.outStreams, 0);
+        folder.unpackSizes = [];
+        for (let i = 0; i < outStreams; i++) {
+            folder.unpackSizes.push(reader.readNumber());
+        }
+    }
+
+    const next = reader.readByte();
+    if (next === SEVEN_Z.CRC) {
+        const crcs = readSevenZCrcs(reader, folders.length);
+        folders.forEach((folder, index) => { folder.crc = crcs[index]; });
+        if (reader.readByte() !== SEVEN_Z.END) throw new Error('7z UnpackInfo has unexpected data after CRCs');
+    } else if (next !== SEVEN_Z.END) {
+        skipSevenZUnknownProperty(reader, 'UnpackInfo');
+    }
+
+    return folders;
+}
+
+function folderUnpackSize(folder: SevenZFolder): number {
+    return folder.unpackSizes[folder.unpackSizes.length - 1] ?? 0;
+}
+
+function defaultSevenZSubStreams(folders: SevenZFolder[]): Array<{ size: number; crc?: SevenZOptionalCrc }> {
+    return folders.map((folder) => ({ size: folderUnpackSize(folder), crc: folder.crc }));
+}
+
+function parseSevenZSubStreamsInfo(
+    reader: SevenZReader,
+    folders: SevenZFolder[]
+): Array<{ size: number; crc?: SevenZOptionalCrc }> {
+    let numUnpackStreams = Array(folders.length).fill(1) as number[];
+    let unpackSizes: number[] | null = null;
+    let streamCrcs: Array<SevenZOptionalCrc | undefined> | null = null;
+
+    while (true) {
+        const id = reader.readByte();
+        if (id === SEVEN_Z.END) break;
+
+        if (id === SEVEN_Z.NUM_UNPACK_STREAM) {
+            numUnpackStreams = folders.map(() => reader.readNumber());
+            continue;
+        }
+
+        if (id === SEVEN_Z.SIZE) {
+            unpackSizes = [];
+            for (let folderIndex = 0; folderIndex < folders.length; folderIndex++) {
+                const count = numUnpackStreams[folderIndex];
+                let sum = 0;
+                for (let streamIndex = 1; streamIndex < count; streamIndex++) {
+                    const size = reader.readNumber();
+                    unpackSizes.push(size);
+                    sum += size;
+                }
+                if (count > 0) {
+                    unpackSizes.push(folderUnpackSize(folders[folderIndex]) - sum);
+                }
+            }
+            continue;
+        }
+
+        if (id === SEVEN_Z.CRC) {
+            const digestCount = folders.reduce((sum, folder, index) => {
+                const count = numUnpackStreams[index];
+                return sum + (count === 1 && folder.crc?.defined ? 0 : count);
+            }, 0);
+            const digests = readSevenZCrcs(reader, digestCount);
+            streamCrcs = [];
+            let digestIndex = 0;
+            for (let folderIndex = 0; folderIndex < folders.length; folderIndex++) {
+                const count = numUnpackStreams[folderIndex];
+                const folder = folders[folderIndex];
+                if (count === 1 && folder.crc?.defined) {
+                    streamCrcs.push(folder.crc);
+                } else {
+                    for (let streamIndex = 0; streamIndex < count; streamIndex++) {
+                        streamCrcs.push(digests[digestIndex++]);
+                    }
+                }
+            }
+            continue;
+        }
+
+        skipSevenZUnknownProperty(reader, 'SubStreamsInfo');
+    }
+
+    if (!unpackSizes) {
+        unpackSizes = [];
+        for (let folderIndex = 0; folderIndex < folders.length; folderIndex++) {
+            const count = numUnpackStreams[folderIndex];
+            if (count === 0) continue;
+            if (count !== 1) throw new Error('7z substream sizes are missing');
+            unpackSizes.push(folderUnpackSize(folders[folderIndex]));
+        }
+    }
+
+    if (!streamCrcs) {
+        streamCrcs = [];
+        for (let folderIndex = 0; folderIndex < folders.length; folderIndex++) {
+            const count = numUnpackStreams[folderIndex];
+            const folder = folders[folderIndex];
+            for (let streamIndex = 0; streamIndex < count; streamIndex++) {
+                streamCrcs.push(count === 1 ? folder.crc : undefined);
+            }
+        }
+    }
+
+    return unpackSizes.map((size, index) => ({ size, crc: streamCrcs[index] }));
+}
+
+function parseSevenZStreamsInfo(reader: SevenZReader): SevenZStreamInfo {
+    let packInfo: SevenZPackInfo | undefined;
+    let folders: SevenZFolder[] = [];
+    let unpackStreams: Array<{ size: number; crc?: SevenZOptionalCrc }> = [];
+
+    while (true) {
+        const id = reader.readByte();
+        if (id === SEVEN_Z.END) break;
+        if (id === SEVEN_Z.PACK_INFO) {
+            packInfo = parseSevenZPackInfo(reader);
+        } else if (id === SEVEN_Z.UNPACK_INFO) {
+            folders = parseSevenZUnpackInfo(reader);
+            unpackStreams = defaultSevenZSubStreams(folders);
+        } else if (id === SEVEN_Z.SUB_STREAMS_INFO) {
+            unpackStreams = parseSevenZSubStreamsInfo(reader, folders);
+        } else {
+            skipSevenZUnknownProperty(reader, 'StreamsInfo');
+        }
+    }
+
+    return { packInfo, folders, unpackStreams };
+}
+
+function parseSevenZNames(raw: Buffer, numFiles: number): string[] {
+    const names: string[] = [];
+    let start = 0;
+    for (let pos = 0; pos + 1 < raw.length && names.length < numFiles; pos += 2) {
+        if (raw[pos] === 0 && raw[pos + 1] === 0) {
+            names.push(raw.subarray(start, pos).toString('utf16le').replace(/\\/g, '/'));
+            start = pos + 2;
+        }
+    }
+    return names;
+}
+
+function parseSevenZFilesInfo(
+    reader: SevenZReader,
+    streams: Array<{ size: number; crc?: SevenZOptionalCrc }>
+): ArchiveVpkCrcEntry[] {
+    const numFiles = reader.readNumber();
+    let names = Array.from({ length: numFiles }, (_, index) => `file-${index}`);
+    let emptyStreams: boolean[] = Array(numFiles).fill(false);
+
+    while (true) {
+        const id = reader.readByte();
+        if (id === SEVEN_Z.END) break;
+
+        const size = reader.readNumber();
+        const propertyEnd = reader.position + size;
+        if (id === SEVEN_Z.NAME) {
+            const external = reader.readByte();
+            if (external !== 0) throw new Error('7z external filename metadata is not supported');
+            names = parseSevenZNames(reader.readBytes(size - 1), numFiles);
+        } else if (id === SEVEN_Z.EMPTY_STREAM) {
+            emptyStreams = readSevenZBitVector(reader, numFiles);
+        } else if (id === SEVEN_Z.EMPTY_FILE) {
+            reader.skip(size);
+        } else {
+            reader.skip(size);
+        }
+
+        if (reader.position !== propertyEnd) {
+            if (reader.position > propertyEnd) throw new Error('7z file property parser over-read');
+            reader.skip(propertyEnd - reader.position);
+        }
+    }
+
+    const entries: ArchiveVpkCrcEntry[] = [];
+    let streamIndex = 0;
+    for (let fileIndex = 0; fileIndex < numFiles; fileIndex++) {
+        if (emptyStreams[fileIndex]) continue;
+
+        const stream = streams[streamIndex++];
+        const name = names[fileIndex] ?? `file-${fileIndex}`;
+        if (!stream || !isVpkArchiveEntry(name) || !stream.crc?.defined || stream.crc.crc32 === undefined) {
+            continue;
+        }
+
+        entries.push({
+            name,
+            crc32: stream.crc.crc32.toString(16).padStart(8, '0'),
+            compressedSize: 0,
+            uncompressedSize: stream.size,
+        });
+    }
+
+    return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+class LzmaRangeDecoder {
+    private range = 0xffffffff;
+    private code = 0;
+    private offset = 0;
+
+    constructor(private readonly input: Buffer) {
+        for (let i = 0; i < 5; i++) {
+            this.code = (this.code * 256 + this.readByte()) >>> 0;
+        }
+    }
+
+    private readByte(): number {
+        return this.offset < this.input.length ? this.input[this.offset++] : 0;
+    }
+
+    private normalize(): void {
+        if (this.range < 0x01000000) {
+            this.range = (this.range * 256) >>> 0;
+            this.code = (this.code * 256 + this.readByte()) >>> 0;
+        }
+    }
+
+    decodeBit(probs: Uint16Array, index: number): number {
+        const prob = probs[index];
+        const bound = (this.range >>> 11) * prob;
+        if (this.code < bound) {
+            this.range = bound >>> 0;
+            probs[index] = prob + ((2048 - prob) >> 5);
+            this.normalize();
+            return 0;
+        }
+
+        this.range = (this.range - bound) >>> 0;
+        this.code = (this.code - bound) >>> 0;
+        probs[index] = prob - (prob >> 5);
+        this.normalize();
+        return 1;
+    }
+
+    decodeDirectBits(count: number): number {
+        let result = 0;
+        for (let i = 0; i < count; i++) {
+            this.range >>>= 1;
+            let bit = 0;
+            if (this.code >= this.range) {
+                this.code = (this.code - this.range) >>> 0;
+                bit = 1;
+            }
+            this.normalize();
+            result = (result << 1) | bit;
+        }
+        return result;
+    }
+}
+
+function filledLzmaProbs(size: number): Uint16Array {
+    const probs = new Uint16Array(size);
+    probs.fill(1024);
+    return probs;
+}
+
+function decodeLzmaBitTree(decoder: LzmaRangeDecoder, probs: Uint16Array, start: number, bits: number): number {
+    let symbol = 1;
+    for (let i = 0; i < bits; i++) {
+        symbol = (symbol << 1) | decoder.decodeBit(probs, start + symbol);
+    }
+    return symbol - (1 << bits);
+}
+
+function decodeLzmaReverseBitTree(decoder: LzmaRangeDecoder, probs: Uint16Array, start: number, bits: number): number {
+    let symbol = 1;
+    let result = 0;
+    for (let i = 0; i < bits; i++) {
+        const bit = decoder.decodeBit(probs, start + symbol);
+        symbol = (symbol << 1) | bit;
+        result |= bit << i;
+    }
+    return result;
+}
+
+class LzmaLengthDecoder {
+    private readonly choice = filledLzmaProbs(2);
+    private readonly low: Uint16Array[];
+    private readonly mid: Uint16Array[];
+    private readonly high = filledLzmaProbs(1 << 8);
+
+    constructor(posStates: number) {
+        this.low = Array.from({ length: posStates }, () => filledLzmaProbs(1 << 3));
+        this.mid = Array.from({ length: posStates }, () => filledLzmaProbs(1 << 3));
+    }
+
+    decode(decoder: LzmaRangeDecoder, posState: number): number {
+        if (decoder.decodeBit(this.choice, 0) === 0) {
+            return decodeLzmaBitTree(decoder, this.low[posState], 0, 3);
+        }
+        if (decoder.decodeBit(this.choice, 1) === 0) {
+            return 8 + decodeLzmaBitTree(decoder, this.mid[posState], 0, 3);
+        }
+        return 16 + decodeLzmaBitTree(decoder, this.high, 0, 8);
+    }
+}
+
+function updateLzmaStateChar(state: number): number {
+    if (state < 4) return 0;
+    if (state < 10) return state - 3;
+    return state - 6;
+}
+
+function decodeLzmaRaw(properties: Buffer, input: Buffer, expectedSize: number): Buffer {
+    if (properties.length < 5) throw new Error('LZMA properties are missing');
+    const prop = properties[0];
+    const lc = prop % 9;
+    const remainder = Math.floor(prop / 9);
+    const lp = remainder % 5;
+    const pb = Math.floor(remainder / 5);
+    if (pb > 4) throw new Error('Unsupported LZMA pb value');
+
+    const posStateCount = 1 << pb;
+    const posStateMask = posStateCount - 1;
+    const literalContexts = 1 << (lc + lp);
+    const literalProbs = Array.from({ length: literalContexts }, () => filledLzmaProbs(0x300));
+    const isMatch = filledLzmaProbs(LZMA_NUM_STATES * posStateCount);
+    const isRep = filledLzmaProbs(LZMA_NUM_STATES);
+    const isRepG0 = filledLzmaProbs(LZMA_NUM_STATES);
+    const isRepG1 = filledLzmaProbs(LZMA_NUM_STATES);
+    const isRepG2 = filledLzmaProbs(LZMA_NUM_STATES);
+    const isRep0Long = filledLzmaProbs(LZMA_NUM_STATES * posStateCount);
+    const posSlot = Array.from({ length: LZMA_NUM_LEN_TO_POS_STATES }, () => filledLzmaProbs(1 << LZMA_NUM_POS_SLOT_BITS));
+    const posDecoders = filledLzmaProbs(LZMA_NUM_FULL_DISTANCES - LZMA_END_POS_MODEL_INDEX);
+    const posAlign = filledLzmaProbs(LZMA_ALIGN_TABLE_SIZE);
+    const lenDecoder = new LzmaLengthDecoder(posStateCount);
+    const repLenDecoder = new LzmaLengthDecoder(posStateCount);
+    const decoder = new LzmaRangeDecoder(input);
+    const output = Buffer.alloc(expectedSize);
+    const reps = [0, 0, 0, 0];
+    let state = 0;
+    let outPos = 0;
+
+    while (outPos < expectedSize) {
+        const posState = outPos & posStateMask;
+        if (decoder.decodeBit(isMatch, state * posStateCount + posState) === 0) {
+            const prevByte = outPos === 0 ? 0 : output[outPos - 1];
+            const literalState = ((outPos & ((1 << lp) - 1)) << lc) + (prevByte >> (8 - lc));
+            const probs = literalProbs[literalState];
+            let symbol = 1;
+
+            if (state < 7) {
+                while (symbol < 0x100) {
+                    symbol = (symbol << 1) | decoder.decodeBit(probs, symbol);
+                }
+            } else {
+                const matchByte = reps[0] < outPos ? output[outPos - reps[0] - 1] : 0;
+                for (let bitIndex = 7; bitIndex >= 0; bitIndex--) {
+                    const matchBit = (matchByte >> bitIndex) & 1;
+                    const bit = decoder.decodeBit(probs, ((1 + matchBit) << 8) + symbol);
+                    symbol = (symbol << 1) | bit;
+                    if (matchBit !== bit) {
+                        while (symbol < 0x100) {
+                            symbol = (symbol << 1) | decoder.decodeBit(probs, symbol);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            output[outPos++] = symbol - 0x100;
+            state = updateLzmaStateChar(state);
+            continue;
+        }
+
+        let len: number;
+        if (decoder.decodeBit(isRep, state) === 1) {
+            if (decoder.decodeBit(isRepG0, state) === 0) {
+                if (decoder.decodeBit(isRep0Long, state * posStateCount + posState) === 0) {
+                    if (reps[0] >= outPos) throw new Error('Invalid LZMA short repeat distance');
+                    output[outPos] = output[outPos - reps[0] - 1];
+                    outPos++;
+                    state = state < 7 ? 9 : 11;
+                    continue;
+                }
+            } else {
+                let distance: number;
+                if (decoder.decodeBit(isRepG1, state) === 0) {
+                    distance = reps[1];
+                } else {
+                    if (decoder.decodeBit(isRepG2, state) === 0) {
+                        distance = reps[2];
+                    } else {
+                        distance = reps[3];
+                        reps[3] = reps[2];
+                    }
+                    reps[2] = reps[1];
+                }
+                reps[1] = reps[0];
+                reps[0] = distance;
+            }
+            len = repLenDecoder.decode(decoder, posState) + LZMA_MATCH_MIN_LEN;
+            state = state < 7 ? 8 : 11;
+        } else {
+            reps[3] = reps[2];
+            reps[2] = reps[1];
+            reps[1] = reps[0];
+            len = lenDecoder.decode(decoder, posState) + LZMA_MATCH_MIN_LEN;
+            state = state < 7 ? 7 : 10;
+
+            const lenToPosState = Math.min(len - LZMA_MATCH_MIN_LEN, LZMA_NUM_LEN_TO_POS_STATES - 1);
+            const slot = decodeLzmaBitTree(decoder, posSlot[lenToPosState], 0, LZMA_NUM_POS_SLOT_BITS);
+            if (slot < 4) {
+                reps[0] = slot;
+            } else {
+                const directBits = (slot >> 1) - 1;
+                reps[0] = (2 | (slot & 1)) << directBits;
+                if (slot < LZMA_END_POS_MODEL_INDEX) {
+                    reps[0] += decodeLzmaReverseBitTree(decoder, posDecoders, reps[0] - slot - 1, directBits);
+                } else {
+                    reps[0] += decoder.decodeDirectBits(directBits - LZMA_NUM_ALIGN_BITS) << LZMA_NUM_ALIGN_BITS;
+                    reps[0] += decodeLzmaReverseBitTree(decoder, posAlign, 0, LZMA_NUM_ALIGN_BITS);
+                }
+            }
+        }
+
+        if (reps[0] >= outPos) throw new Error('Invalid LZMA match distance');
+        for (let i = 0; i < len && outPos < expectedSize; i++) {
+            output[outPos] = output[outPos - reps[0] - 1];
+            outPos++;
+        }
+    }
+
+    return output;
+}
+
+function lzma2DictionarySize(prop: number): number {
+    if (prop > 40) throw new Error('Invalid LZMA2 dictionary property');
+    if (prop === 40) return 0xffffffff;
+    return (2 | (prop & 1)) << (Math.floor(prop / 2) + 11);
+}
+
+function buildLzmaProps(prop0: number, dictionarySize: number): Buffer {
+    const props = Buffer.alloc(5);
+    props[0] = prop0;
+    props.writeUInt32LE(dictionarySize >>> 0, 1);
+    return props;
+}
+
+function decodeLzma2(properties: Buffer, input: Buffer, expectedSize: number): Buffer {
+    if (properties.length < 1) throw new Error('LZMA2 properties are missing');
+    const dictionarySize = lzma2DictionarySize(properties[0]);
+    const chunks: Buffer[] = [];
+    let produced = 0;
+    let pos = 0;
+    let lzmaProps: Buffer | null = null;
+
+    while (pos < input.length && produced < expectedSize) {
+        const control = input[pos++];
+        if (control === 0) break;
+
+        if (control === 1 || control === 2) {
+            if (pos + 2 > input.length) throw new NeedMoreArchiveBytes('LZMA2 uncompressed chunk is truncated');
+            const size = ((input[pos] << 8) | input[pos + 1]) + 1;
+            pos += 2;
+            if (pos + size > input.length) throw new NeedMoreArchiveBytes('LZMA2 uncompressed data is truncated');
+            chunks.push(input.subarray(pos, pos + size));
+            pos += size;
+            produced += size;
+            continue;
+        }
+
+        if (control < 0x80) throw new Error('Unsupported LZMA2 chunk control byte');
+        if (pos + 4 > input.length) throw new NeedMoreArchiveBytes('LZMA2 compressed chunk header is truncated');
+        const unpackSize = (((control & 0x1f) << 16) | (input[pos] << 8) | input[pos + 1]) + 1;
+        pos += 2;
+        const packSize = ((input[pos] << 8) | input[pos + 1]) + 1;
+        pos += 2;
+
+        if (control >= 0xc0) {
+            if (pos >= input.length) throw new NeedMoreArchiveBytes('LZMA2 properties are truncated');
+            lzmaProps = buildLzmaProps(input[pos++], dictionarySize);
+        }
+        if (!lzmaProps) throw new Error('LZMA2 chunk is missing decoder properties');
+        if (pos + packSize > input.length) throw new NeedMoreArchiveBytes('LZMA2 compressed data is truncated');
+
+        const decoded = decodeLzmaRaw(lzmaProps, input.subarray(pos, pos + packSize), unpackSize);
+        chunks.push(decoded);
+        pos += packSize;
+        produced += decoded.length;
+    }
+
+    return Buffer.concat(chunks, produced).subarray(0, expectedSize);
+}
+
+function decodeSevenZFolder(folder: SevenZFolder, packed: Buffer): Buffer {
+    if (folder.coders.length !== 1) throw new Error('7z encoded headers with filter chains are not supported');
+    const coder = folder.coders[0];
+    const unpackSize = folderUnpackSize(folder);
+
+    if (coder.methodId === SEVEN_Z_LZMA) {
+        return decodeLzmaRaw(coder.properties, packed, unpackSize);
+    }
+    if (coder.methodId === SEVEN_Z_LZMA2) {
+        return decodeLzma2(coder.properties, packed, unpackSize);
+    }
+
+    throw new Error(`Unsupported 7z encoded header method ${coder.methodId}`);
+}
+
+function parseSevenZHeaderEntries(header: Buffer): ArchiveVpkCrcEntry[] {
+    const reader = new SevenZReader(header);
+    const root = reader.readByte();
+    if (root !== SEVEN_Z.HEADER) throw new Error('7z decoded metadata did not contain a file header');
+
+    let streams: SevenZStreamInfo = { folders: [], unpackStreams: [] };
+    while (reader.remaining > 0) {
+        const id = reader.readByte();
+        if (id === SEVEN_Z.END) break;
+        if (id === SEVEN_Z.ARCHIVE_PROPERTIES) {
+            while (reader.readByte() !== SEVEN_Z.END) {
+                reader.skip(reader.readNumber());
+            }
+        } else if (id === SEVEN_Z.ADDITIONAL_STREAMS_INFO || id === SEVEN_Z.MAIN_STREAMS_INFO) {
+            streams = parseSevenZStreamsInfo(reader);
+        } else if (id === SEVEN_Z.FILES_INFO) {
+            return parseSevenZFilesInfo(reader, streams.unpackStreams);
+        } else {
+            skipSevenZUnknownProperty(reader, 'Header');
+        }
+    }
+
+    return [];
+}
+
+async function fetch7zVpkCrcEntries(
+    downloadUrl: string,
+    fileSize: number,
+    signal?: AbortSignal
+): Promise<ArchiveVpkCrcResult> {
+    const startHeader = await fetchArchiveRange(downloadUrl, 0, Math.min(SEVEN_Z_START_HEADER_BYTES - 1, fileSize - 1), signal);
+    let bytesFetched = startHeader.length;
+    if (!startHeader.subarray(0, SEVEN_Z_SIGNATURE.length).equals(SEVEN_Z_SIGNATURE)) {
+        throw new Error('7z signature was not found');
+    }
+    if (startHeader.length < SEVEN_Z_START_HEADER_BYTES) {
+        throw new NeedMoreArchiveBytes('7z start header is truncated');
+    }
+
+    const nextHeaderOffset = readU64LE(startHeader, 12);
+    const nextHeaderSize = readU64LE(startHeader, 20);
+    if (nextHeaderSize > MAX_7Z_HEADER_BYTES) {
+        return {
+            archiveType: '7z',
+            entries: [],
+            bytesFetched,
+            unsupportedReason: `7z metadata header is too large (${nextHeaderSize.toLocaleString()} bytes)`,
+        };
+    }
+
+    const headerStart = SEVEN_Z_START_HEADER_BYTES + nextHeaderOffset;
+    const header = await fetchArchiveRange(downloadUrl, headerStart, headerStart + nextHeaderSize - 1, signal);
+    bytesFetched += header.length;
+
+    try {
+        const reader = new SevenZReader(header);
+        const root = reader.readByte();
+        if (root === SEVEN_Z.HEADER) {
+            return {
+                archiveType: '7z',
+                entries: parseSevenZHeaderEntries(header),
+                bytesFetched,
+            };
+        }
+        if (root !== SEVEN_Z.ENCODED_HEADER) {
+            throw new Error('7z metadata has an unexpected root marker');
+        }
+
+        const encodedStreams = parseSevenZStreamsInfo(reader);
+        if (!encodedStreams.packInfo || encodedStreams.packInfo.sizes.length !== 1 || encodedStreams.folders.length !== 1) {
+            throw new Error('7z encoded header layout is not supported');
+        }
+
+        const packedStart = SEVEN_Z_START_HEADER_BYTES + encodedStreams.packInfo.packPos;
+        const packedSize = encodedStreams.packInfo.sizes[0];
+        const packed = await fetchArchiveRange(downloadUrl, packedStart, packedStart + packedSize - 1, signal);
+        bytesFetched += packed.length;
+        const decodedHeader = decodeSevenZFolder(encodedStreams.folders[0], packed);
+
+        return {
+            archiveType: '7z',
+            entries: parseSevenZHeaderEntries(decodedHeader),
+            bytesFetched,
+        };
+    } catch (err) {
+        throwIfAborted(signal);
+        return {
+            archiveType: '7z',
+            entries: [],
+            bytesFetched,
+            unsupportedReason: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+
+function readVint(buffer: Buffer, offset: number): { value: number; offset: number } {
+    let value = 0;
+    let shift = 0;
+    let pos = offset;
+
+    for (let i = 0; i < 10; i++) {
+        if (pos >= buffer.length) throw new NeedMoreArchiveBytes('RAR variable integer is truncated');
+        const byte = buffer[pos++];
+        value += (byte & 0x7f) * 2 ** shift;
+        if (byte < 0x80) return { value, offset: pos };
+        shift += 7;
+    }
+
+    throw new Error('RAR variable integer is too large');
+}
+
+function parseRar4FileHeader(block: Buffer): { packedSize: number; entry?: ArchiveVpkCrcEntry } {
+    if (block.length < 32) throw new NeedMoreArchiveBytes('RAR4 file header is truncated');
+
+    const flags = readU16(block, 3);
+    const headerSize = readU16(block, 5);
+    let packedSize = readU32(block, 7);
+    let unpackedSize = readU32(block, 11);
+    const crc32 = readU32(block, 16);
+    const nameSize = readU16(block, 26);
+    let nameOffset = 32;
+
+    if (flags & 0x0100) {
+        if (block.length < 40) throw new NeedMoreArchiveBytes('RAR4 high-size fields are truncated');
+        packedSize += readU32(block, 32) * 2 ** 32;
+        unpackedSize += readU32(block, 36) * 2 ** 32;
+        nameOffset = 40;
+    }
+
+    const nameEnd = nameOffset + nameSize;
+    if (nameEnd > Math.min(block.length, headerSize)) {
+        throw new NeedMoreArchiveBytes('RAR4 file name is truncated');
+    }
+
+    const name = decodeArchiveName(block.subarray(nameOffset, nameEnd)).replace(/\\/g, '/');
+    return {
+        packedSize,
+        entry: isVpkArchiveEntry(name)
+            ? {
+                name,
+                crc32: crc32.toString(16).padStart(8, '0'),
+                compressedSize: packedSize,
+                uncompressedSize: unpackedSize,
+            }
+            : undefined,
+    };
+}
+
+function parseRar5FileHeader(headerData: Buffer, pos: number, dataSize: number): ArchiveVpkCrcEntry | undefined {
+    const fileFlags = readVint(headerData, pos);
+    pos = fileFlags.offset;
+    const unpackedSize = readVint(headerData, pos);
+    pos = unpackedSize.offset;
+    const attributes = readVint(headerData, pos);
+    pos = attributes.offset;
+
+    if (fileFlags.value & RAR5_FILE_UNIX_TIME) {
+        if (pos + 4 > headerData.length) throw new NeedMoreArchiveBytes('RAR5 mtime is truncated');
+        pos += 4;
+    }
+
+    let crc32 = '';
+    if (fileFlags.value & RAR5_FILE_CRC32) {
+        if (pos + 4 > headerData.length) throw new NeedMoreArchiveBytes('RAR5 CRC32 is truncated');
+        crc32 = readU32(headerData, pos).toString(16).padStart(8, '0');
+        pos += 4;
+    }
+
+    pos = readVint(headerData, pos).offset; // compression info
+    pos = readVint(headerData, pos).offset; // host OS
+    const nameSize = readVint(headerData, pos);
+    pos = nameSize.offset;
+
+    const nameEnd = pos + nameSize.value;
+    if (nameEnd > headerData.length) throw new NeedMoreArchiveBytes('RAR5 file name is truncated');
+    const name = decodeArchiveName(headerData.subarray(pos, nameEnd)).replace(/\\/g, '/');
+
+    if ((fileFlags.value & RAR5_FILE_DIRECTORY) || !isVpkArchiveEntry(name)) {
+        return undefined;
+    }
+
+    return {
+        name,
+        crc32,
+        compressedSize: dataSize,
+        uncompressedSize: unpackedSize.value,
+    };
+}
+
+function parseRar5BlockHeader(block: Buffer): {
+    headerType: number;
+    dataSize: number;
+    headerDataEnd: number;
+    nextOffsetDelta: number;
+    fileHeaderStart: number;
+} {
+    if (block.length < 8) throw new NeedMoreArchiveBytes('RAR5 block header is truncated');
+
+    let pos = 4;
+    const headerSize = readVint(block, pos);
+    pos = headerSize.offset;
+    const headerDataStart = pos;
+    const headerDataEnd = headerDataStart + headerSize.value;
+    if (headerDataEnd > block.length) {
+        throw new NeedMoreArchiveBytes('RAR5 full block header is not in the fetched range');
+    }
+
+    const headerType = readVint(block, pos);
+    pos = headerType.offset;
+    const headerFlags = readVint(block, pos);
+    pos = headerFlags.offset;
+
+    if (headerFlags.value & RAR5_HAS_EXTRA) {
+        pos = readVint(block, pos).offset;
+    }
+
+    let dataSize = 0;
+    if (headerFlags.value & RAR5_HAS_DATA) {
+        const parsed = readVint(block, pos);
+        dataSize = parsed.value;
+        pos = parsed.offset;
+    }
+
+    return {
+        headerType: headerType.value,
+        dataSize,
+        headerDataEnd,
+        nextOffsetDelta: headerDataEnd + dataSize,
+        fileHeaderStart: pos,
+    };
+}
+
+async function fetchRar5VpkCrcEntries(
+    downloadUrl: string,
+    fileSize: number,
+    signal?: AbortSignal
+): Promise<ArchiveVpkCrcResult> {
+    const marker = await fetchArchiveRange(downloadUrl, 0, Math.min(RAR5_MARKER.length - 1, fileSize - 1), signal);
+    let bytesFetched = marker.length;
+    if (!marker.subarray(0, RAR5_MARKER.length).equals(RAR5_MARKER)) {
+        throw new Error('RAR5 marker was not found');
+    }
+
+    const entries: ArchiveVpkCrcEntry[] = [];
+    let offset = RAR5_MARKER.length;
+    let blocksSeen = 0;
+
+    while (offset < fileSize && blocksSeen < 10_000) {
+        throwIfAborted(signal);
+        blocksSeen++;
+        const previewEnd = Math.min(fileSize - 1, offset + RAR_HEADER_BYTES - 1);
+        let block = await fetchArchiveRange(downloadUrl, offset, previewEnd, signal);
+        bytesFetched += block.length;
+
+        let header;
+        try {
+            header = parseRar5BlockHeader(block);
+        } catch (err) {
+            if (!(err instanceof NeedMoreArchiveBytes) || block.length < 7) throw err;
+            const sizeProbe = readVint(block, 4);
+            const fullHeaderSize = sizeProbe.offset + sizeProbe.value;
+            block = await fetchArchiveRange(downloadUrl, offset, offset + fullHeaderSize - 1, signal);
+            bytesFetched += block.length;
+            header = parseRar5BlockHeader(block);
+        }
+
+        if (header.headerType === RAR5_BLOCK_ENCRYPTION) {
+            return {
+                archiveType: 'rar',
+                entries,
+                bytesFetched,
+                unsupportedReason: 'RAR5 archive headers are encrypted',
+            };
+        }
+        if (header.headerType === RAR5_BLOCK_FILE) {
+            const entry = parseRar5FileHeader(block.subarray(0, header.headerDataEnd), header.fileHeaderStart, header.dataSize);
+            if (entry) entries.push(entry);
+        }
+
+        offset += header.nextOffsetDelta;
+        if (header.headerType === RAR5_BLOCK_END) break;
+    }
+
+    return {
+        archiveType: 'rar',
+        entries: entries.sort((a, b) => a.name.localeCompare(b.name)),
+        bytesFetched,
+    };
+}
+
+async function fetchRar4VpkCrcEntries(
+    downloadUrl: string,
+    fileSize: number,
+    signal?: AbortSignal
+): Promise<ArchiveVpkCrcResult> {
+    const marker = await fetchArchiveRange(downloadUrl, 0, Math.min(RAR5_MARKER.length - 1, fileSize - 1), signal);
+    let bytesFetched = marker.length;
+    if (marker.subarray(0, RAR5_MARKER.length).equals(RAR5_MARKER)) {
+        const result = await fetchRar5VpkCrcEntries(downloadUrl, fileSize, signal);
+        return result;
+    }
+    if (!marker.subarray(0, RAR4_MARKER.length).equals(RAR4_MARKER)) {
+        throw new Error('RAR marker was not found');
+    }
+
+    const entries: ArchiveVpkCrcEntry[] = [];
+    let offset = RAR4_MARKER.length;
+    let blocksSeen = 0;
+
+    while (offset < fileSize && blocksSeen < 10_000) {
+        throwIfAborted(signal);
+        blocksSeen++;
+        const previewEnd = Math.min(fileSize - 1, offset + RAR_HEADER_BYTES - 1);
+        let block = await fetchArchiveRange(downloadUrl, offset, previewEnd, signal);
+        bytesFetched += block.length;
+
+        if (block.length < 7) break;
+        const blockType = block[2];
+        const flags = readU16(block, 3);
+        const headerSize = readU16(block, 5);
+        if (headerSize < 7) throw new Error(`Invalid RAR4 block header size at offset ${offset}: ${headerSize}`);
+        if (headerSize > block.length) {
+            block = await fetchArchiveRange(downloadUrl, offset, offset + headerSize - 1, signal);
+            bytesFetched += block.length;
+        }
+
+        let dataSize = 0;
+        if (blockType === RAR_FILE_BLOCK) {
+            const parsed = parseRar4FileHeader(block);
+            dataSize = parsed.packedSize;
+            if (parsed.entry) entries.push(parsed.entry);
+        } else if (flags & RAR_LONG_BLOCK) {
+            if (block.length < 11) throw new NeedMoreArchiveBytes('RAR4 long block size is truncated');
+            dataSize = readU32(block, 7);
+        }
+
+        offset += headerSize + dataSize;
+        if (blockType === RAR_END_BLOCK) break;
+    }
+
+    return {
+        archiveType: 'rar',
+        entries: entries.sort((a, b) => a.name.localeCompare(b.name)),
+        bytesFetched,
+    };
+}
+
+export async function fetchGameBananaArchiveVpkCrcEntries(file: {
+    fileName: string;
+    fileSize: number;
+    downloadUrl: string;
+}, options: ArchiveVpkCrcOptions = {}): Promise<ArchiveVpkCrcResult> {
+    const archiveType = archiveTypeForName(file.fileName);
+    throwIfAborted(options.signal);
+
+    if (archiveType === 'zip') {
+        return fetchZipVpkCrcEntries(file.downloadUrl, file.fileSize, options.signal);
+    }
+    if (archiveType === 'rar') {
+        return fetchRar4VpkCrcEntries(file.downloadUrl, file.fileSize, options.signal);
+    }
+    if (archiveType === '7z') {
+        return fetch7zVpkCrcEntries(file.downloadUrl, file.fileSize, options.signal);
+    }
+
+    return {
+        archiveType,
+        entries: [],
+        bytesFetched: 0,
+        unsupportedReason: `Unsupported archive type for ${file.fileName}`,
+    };
+}
+

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -6,7 +6,7 @@ import { BrowserWindow } from 'electron';
 import { getDisabledPath } from './deadlock';
 import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles } from './extract';
 import { randomUUID } from 'crypto';
-import { setModMetadata, getModMetadata } from './metadata';
+import { setModMetadataWithHash, getModMetadata } from './metadata';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
 import { getUsedPriorities, scanMods, disableMod, enableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
@@ -21,6 +21,10 @@ export interface DownloadModArgs {
     fileName: string;
     section?: string;
     categoryId?: number;
+}
+
+export interface DownloadInstallResult {
+    installedVpks: string[];
 }
 
 export interface OneClickInstallArgs {
@@ -129,7 +133,7 @@ interface QueuedDownload {
     directUrl?: string;
     enrichedDetails?: GameBananaModDetails;
     mainWindow: BrowserWindow | null;
-    resolve: () => void;
+    resolve: (result: DownloadInstallResult) => void;
     reject: (error: Error) => void;
 }
 
@@ -192,12 +196,12 @@ export function downloadMod(
     deadlockPath: string,
     args: DownloadModArgs,
     mainWindow: BrowserWindow | null
-): Promise<void> {
+): Promise<DownloadInstallResult> {
     // Check if this mod is already in the queue (prevent duplicates)
     const alreadyQueued = downloadQueue.some(q => q.args.modId === args.modId);
     if (alreadyQueued) {
         console.log(`[downloadMod] Mod ${args.modId} already in queue, skipping`);
-        return Promise.resolve();
+        return Promise.resolve({ installedVpks: [] });
     }
 
     return new Promise((resolve, reject) => {
@@ -217,7 +221,7 @@ export function downloadModFromUrl(
     deadlockPath: string,
     oneClick: OneClickInstallArgs,
     mainWindow: BrowserWindow | null
-): Promise<void> {
+): Promise<DownloadInstallResult> {
     validateDownloadUrl(oneClick.archiveUrl);
 
     const fileName = deriveFileNameFromUrl(oneClick.archiveUrl);
@@ -231,7 +235,7 @@ export function downloadModFromUrl(
     );
     if (alreadyQueued) {
         console.log(`[downloadModFromUrl] Already queued: ${oneClick.archiveUrl}`);
-        return Promise.resolve();
+        return Promise.resolve({ installedVpks: [] });
     }
 
     const args: DownloadModArgs = {
@@ -290,18 +294,16 @@ async function processQueue(): Promise<void> {
         };
         emitQueueUpdate(); // Notify UI that queue changed and current download started
         try {
-            if (item.directUrl) {
-                await executeOneClickDownload(
+            const result = item.directUrl
+                ? await executeOneClickDownload(
                     item.deadlockPath,
                     item.args,
                     item.directUrl,
                     item.enrichedDetails,
                     item.mainWindow
-                );
-            } else {
-                await executeDownload(item.deadlockPath, item.args, item.mainWindow);
-            }
-            item.resolve();
+                )
+                : await executeDownload(item.deadlockPath, item.args, item.mainWindow);
+            item.resolve(result);
         } catch (error) {
             item.reject(error instanceof Error ? error : new Error(String(error)));
         }
@@ -492,7 +494,7 @@ async function executeDownload(
     deadlockPath: string,
     args: DownloadModArgs,
     mainWindow: BrowserWindow | null
-): Promise<void> {
+): Promise<DownloadInstallResult> {
     const { modId, fileId, fileName, section = 'Mod' } = args;
 
     console.log(`[downloadMod] Starting download: modId=${modId}, fileId=${fileId}, fileName=${fileName}`);
@@ -728,7 +730,7 @@ async function executeDownload(
     console.log(`[downloadMod] Saving metadata for ${installedVpks.length} VPKs`);
     for (const vpkFileName of installedVpks) {
         console.log(`[downloadMod] Saving metadata for: ${vpkFileName}`);
-        setModMetadata(vpkFileName, metadata);
+        await setModMetadataWithHash(vpkFileName, metadata, join(targetPath, vpkFileName));
     }
 
     // Auto-disable previously installed variants of the same GameBanana mod so
@@ -794,6 +796,7 @@ async function executeDownload(
     // Notify completion
     console.log(`[downloadMod] Sending download-complete event`);
     mainWindow?.webContents.send('download-complete', { modId, fileId });
+    return { installedVpks };
     } finally {
         await cleanupDownloadWorkDir(workDir);
     }
@@ -904,7 +907,7 @@ async function executeOneClickDownload(
     archiveUrl: string,
     enrichedDetails: GameBananaModDetails | undefined,
     mainWindow: BrowserWindow | null
-): Promise<void> {
+): Promise<DownloadInstallResult> {
     const { modId, fileId, fileName, section = 'Mod' } = args;
 
     console.log(
@@ -1179,10 +1182,11 @@ async function executeOneClickDownload(
     }
 
     for (const vpkFileName of installedVpks) {
-        setModMetadata(vpkFileName, metadata);
+        await setModMetadataWithHash(vpkFileName, metadata, join(targetPath, vpkFileName));
     }
 
     mainWindow?.webContents.send('download-complete', { modId, fileId });
+    return { installedVpks };
     } finally {
         await cleanupDownloadWorkDir(workDir);
     }

--- a/electron/main/services/fileMatch.ts
+++ b/electron/main/services/fileMatch.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'crypto';
+import { createReadStream } from 'fs';
+import { promises as fs } from 'fs';
+
+export interface FileFingerprint {
+    path: string;
+    size: number;
+    sha256: string;
+}
+
+export type FileContentComparison =
+    | {
+        matches: true;
+        left: FileFingerprint;
+        right: FileFingerprint;
+    }
+    | {
+        matches: false;
+        reason: 'size';
+        left: Pick<FileFingerprint, 'path' | 'size'>;
+        right: Pick<FileFingerprint, 'path' | 'size'>;
+    }
+    | {
+        matches: false;
+        reason: 'sha256';
+        left: FileFingerprint;
+        right: FileFingerprint;
+    };
+
+export async function fingerprintFile(path: string): Promise<FileFingerprint> {
+    const stats = await fs.stat(path);
+    const hash = createHash('sha256');
+
+    await new Promise<void>((resolve, reject) => {
+        const stream = createReadStream(path);
+        stream.on('data', (chunk) => hash.update(chunk));
+        stream.on('error', reject);
+        stream.on('end', resolve);
+    });
+
+    return {
+        path,
+        size: stats.size,
+        sha256: hash.digest('hex'),
+    };
+}
+
+export async function compareFileContents(leftPath: string, rightPath: string): Promise<FileContentComparison> {
+    const [leftStats, rightStats] = await Promise.all([
+        fs.stat(leftPath),
+        fs.stat(rightPath),
+    ]);
+
+    if (leftStats.size !== rightStats.size) {
+        return {
+            matches: false,
+            reason: 'size',
+            left: { path: leftPath, size: leftStats.size },
+            right: { path: rightPath, size: rightStats.size },
+        };
+    }
+
+    const [left, right] = await Promise.all([
+        fingerprintFile(leftPath),
+        fingerprintFile(rightPath),
+    ]);
+
+    if (left.sha256 !== right.sha256) {
+        return { matches: false, reason: 'sha256', left, right };
+    }
+
+    return { matches: true, left, right };
+}

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -1,6 +1,8 @@
 import { gamebananaRateLimiter } from './rateLimiter';
 
 const GAMEBANANA_API_BASE = 'https://gamebanana.com/apiv11';
+const GAMEBANANA_API_V12_BASE = 'https://gamebanana.com/apiv12';
+const GAMEBANANA_CORE_ITEM_DATA = 'https://api.gamebanana.com/Core/Item/Data';
 const DEADLOCK_GAME_ID = 20948;
 
 // Types for GameBanana API responses
@@ -82,6 +84,12 @@ export interface GameBananaFile {
     downloadCount: number;
     description?: string;
     isArchived: boolean;
+}
+
+export interface GameBananaFileWithRawPaths extends GameBananaFile {
+    rawVpkPaths: string[];
+    rawVpkPathsError?: string;
+    md5?: string;
 }
 
 export interface GameBananaComment {
@@ -213,7 +221,10 @@ interface FileRaw {
     _nDownloadCount: number;
     _sDescription?: string;
     _bIsArchived?: boolean;
+    _sMd5Checksum?: string;
 }
+
+type CoreFileRaw = FileRaw;
 
 interface PostRaw {
     _idRow: number;
@@ -292,13 +303,39 @@ interface CollectionItemsResponseRaw {
  * Helper to fetch JSON from GameBanana API
  * Includes timeout (P1 fix #5) and rate limiting (P2 fix #13)
  */
-async function fetchJson<T>(url: string, timeoutMs = 30000): Promise<T> {
-    // Apply rate limiting before making request
-    await gamebananaRateLimiter.acquire();
+interface GameBananaRequestOptions {
+    signal?: AbortSignal;
+}
 
-    // Create abort controller for timeout
+function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw new Error('GameBanana request cancelled');
+    }
+}
+
+function createTimeoutSignal(timeoutMs: number, externalSignal?: AbortSignal): { signal: AbortSignal; cleanup: () => void } {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const abort = () => controller.abort();
+    externalSignal?.addEventListener('abort', abort, { once: true });
+
+    return {
+        signal: controller.signal,
+        cleanup: () => {
+            clearTimeout(timeoutId);
+            externalSignal?.removeEventListener('abort', abort);
+        },
+    };
+}
+
+async function fetchJson<T>(url: string, timeoutMs = 30000, options: GameBananaRequestOptions = {}): Promise<T> {
+    throwIfAborted(options.signal);
+    // Apply rate limiting before making request
+    await gamebananaRateLimiter.acquire();
+    throwIfAborted(options.signal);
+
+    // Create abort controller for timeout
+    const request = createTimeoutSignal(timeoutMs, options.signal);
 
     try {
         const response = await fetch(url, {
@@ -306,7 +343,7 @@ async function fetchJson<T>(url: string, timeoutMs = 30000): Promise<T> {
                 Accept: 'application/json',
                 'User-Agent': 'DeadlockModManager/1.0',
             },
-            signal: controller.signal,
+            signal: request.signal,
         });
 
         if (!response.ok) {
@@ -327,11 +364,48 @@ async function fetchJson<T>(url: string, timeoutMs = 30000): Promise<T> {
         }
     } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
+            if (options.signal?.aborted) {
+                throw new Error('GameBanana request cancelled');
+            }
             throw new Error(`GameBanana API request timed out after ${timeoutMs / 1000} seconds`);
         }
         throw err;
     } finally {
-        clearTimeout(timeoutId);
+        request.cleanup();
+    }
+}
+
+async function fetchText(url: string, timeoutMs = 30000, options: GameBananaRequestOptions = {}): Promise<string> {
+    throwIfAborted(options.signal);
+    await gamebananaRateLimiter.acquire();
+    throwIfAborted(options.signal);
+
+    const request = createTimeoutSignal(timeoutMs, options.signal);
+
+    try {
+        const response = await fetch(url, {
+            headers: {
+                Accept: 'text/plain',
+                'User-Agent': 'DeadlockModManager/1.0',
+            },
+            signal: request.signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`GameBanana API error: ${response.status} ${response.statusText}`);
+        }
+
+        return response.text();
+    } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+            if (options.signal?.aborted) {
+                throw new Error('GameBanana request cancelled');
+            }
+            throw new Error(`GameBanana API request timed out after ${timeoutMs / 1000} seconds`);
+        }
+        throw err;
+    } finally {
+        request.cleanup();
     }
 }
 
@@ -459,12 +533,13 @@ export async function fetchSections(): Promise<GameBananaSection[]> {
  * Fetch category tree for a section
  */
 export async function fetchCategoryTree(
-    categoryModel: string
+    categoryModel: string,
+    options: GameBananaRequestOptions = {}
 ): Promise<GameBananaCategoryNode[]> {
     // Rust: /Util/{model}/NestedStructure?_idGameRow={id}
     const url = `${GAMEBANANA_API_BASE}/Util/${categoryModel}/NestedStructure?_idGameRow=${DEADLOCK_GAME_ID}`;
     console.log('[fetchCategoryTree] URL:', url);
-    const raw = await fetchJson<CategoryNodeRaw[] | Record<string, CategoryNodeRaw>>(url);
+    const raw = await fetchJson<CategoryNodeRaw[] | Record<string, CategoryNodeRaw>>(url, 30000, options);
 
     // Handle both array and object response formats
     const categories = Array.isArray(raw) ? raw : Object.values(raw);
@@ -480,7 +555,8 @@ export async function fetchSubmissions(
     perPage: number,
     search?: string,
     categoryId?: number,
-    sort?: string
+    sort?: string,
+    options: GameBananaRequestOptions = {}
 ): Promise<GameBananaModsResponse> {
     let url: string;
     // GameBanana v11 API only reliably supports likes/views sorting
@@ -537,7 +613,7 @@ export async function fetchSubmissions(
     }
 
     console.log('[fetchSubmissions] URL:', url);
-    const raw = await fetchJson<ApiResponseRaw>(url);
+    const raw = await fetchJson<ApiResponseRaw>(url, 30000, options);
     console.log('[fetchSubmissions] Response:', JSON.stringify(raw).slice(0, 500));
 
     // Handle case where response is an array instead of object
@@ -599,8 +675,88 @@ export async function fetchModDetails(
                     ? { audioUrl: raw._aPreviewMedia._aMetadata._sAudioUrl }
                     : undefined,
             }
-            : undefined,
+        : undefined,
     };
+}
+
+function isVpkPath(path: string): boolean {
+    const normalized = path.replace(/\\/g, '/').trim().toLowerCase();
+    return normalized.endsWith('.vpk') && !normalized.endsWith('/');
+}
+
+function parseRawVpkPaths(rawFileList: string): string[] {
+    return [...new Set(
+        rawFileList
+            .split(/\r?\n/)
+            .map((line) => line.trim().replace(/\\/g, '/'))
+            .filter(isVpkPath)
+    )].sort((a, b) => a.localeCompare(b));
+}
+
+export async function fetchRawVpkPaths(fileId: number, options: GameBananaRequestOptions = {}): Promise<string[]> {
+    const text = await fetchText(`${GAMEBANANA_API_V12_BASE}/File/${fileId}/RawFileList`, 30000, options);
+    return parseRawVpkPaths(text);
+}
+
+export async function fetchModFilesWithRawPaths(
+    modId: number,
+    section = 'Mod',
+    includeArchived = true,
+    options: GameBananaRequestOptions = {}
+): Promise<GameBananaFileWithRawPaths[]> {
+    const params = new URLSearchParams({
+        itemtype: section,
+        itemid: String(modId),
+        fields: 'name,Files().aFiles()',
+        return_keys: '1',
+        format: 'json_min',
+    });
+    const raw = await fetchJson<Record<string, unknown>>(`${GAMEBANANA_CORE_ITEM_DATA}?${params.toString()}`, 30000, options);
+    const filesRaw = raw['Files().aFiles()'];
+    if (!filesRaw || typeof filesRaw !== 'object') {
+        return [];
+    }
+
+    const files: Array<Omit<GameBananaFileWithRawPaths, 'rawVpkPaths'>> = [];
+    for (const [key, value] of Object.entries(filesRaw as Record<string, CoreFileRaw>)) {
+        if (!value || typeof value !== 'object') continue;
+
+        const id = Number(value._idRow ?? key);
+        if (!Number.isFinite(id) || id <= 0) continue;
+
+        const isArchived = !!value._bIsArchived;
+        if (isArchived && !includeArchived) continue;
+
+        files.push({
+            id,
+            fileName: value._sFile || `gamebanana-${id}.download`,
+            fileSize: Number(value._nFilesize) || 0,
+            downloadUrl: value._sDownloadUrl || `https://gamebanana.com/dl/${id}`,
+            downloadCount: Number(value._nDownloadCount) || 0,
+            description: value._sDescription,
+            isArchived,
+            md5: value._sMd5Checksum,
+        });
+    }
+
+    const filesWithRawPaths = await Promise.all(
+        files.map(async (file) => {
+            try {
+                return {
+                    ...file,
+                    rawVpkPaths: await fetchRawVpkPaths(file.id, options),
+                };
+            } catch (err) {
+                return {
+                    ...file,
+                    rawVpkPaths: [],
+                    rawVpkPathsError: err instanceof Error ? err.message : String(err),
+                };
+            }
+        })
+    );
+
+    return filesWithRawPaths.sort((a, b) => Number(a.isArchived) - Number(b.isArchived));
 }
 
 function mapSubmitter(raw: ModRaw['_aSubmitter']): GameBananaSubmitter | undefined {

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -1,4 +1,8 @@
-import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'fs';
+import { createHash } from 'crypto';
+import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'fs';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { getAddonsPath, getDisabledPath } from './deadlock';
 import { getMetadataPath } from '../utils/paths';
 
 export interface ModMetadata {
@@ -13,6 +17,7 @@ export interface ModMetadata {
     nsfw?: boolean;
     isArchived?: boolean;   // True when the downloaded GameBanana file is from the archived files list
     isMinaPreset?: boolean; // Flag for Mina presets we extracted from the 7z
+    sha256?: string;       // SHA-256 hash of the installed VPK file contents
     variantLabel?: string;  // User-provided label to disambiguate variants of the same mod
     fileDescription?: string;  // GameBanana file "header" (_sDescription) — author's per-file label, used as fallback when the user hasn't named the variant
     sourceFileName?: string;   // Original GameBanana filename stem (e.g. "galaxy_rem_gold") — used as a label fallback when the author didn't set a file header
@@ -73,6 +78,95 @@ export function setModMetadata(fileName: string, data: ModMetadata): void {
     const metadata = loadMetadata();
     metadata[fileName] = { ...metadata[fileName], ...data };
     saveMetadata(metadata);
+}
+
+/**
+ * Set metadata and attach a SHA-256 fingerprint for the installed VPK.
+ * Callers pass the path because metadata is keyed by logical pak filename and
+ * the same filename may exist in either addons or .disabled.
+ */
+export async function setModMetadataWithHash(
+    fileName: string,
+    data: ModMetadata,
+    filePath: string
+): Promise<void> {
+    const sha256 = await hashFileSha256(filePath);
+    setModMetadata(fileName, {
+        ...data,
+        sha256,
+    });
+}
+
+/**
+ * Backfill SHA-256 values for metadata written before hashes existed.
+ * This runs without renaming/moving files; entries whose VPK no longer exists
+ * are skipped and can still be pruned by the normal metadata cleanup path.
+ */
+export async function backfillMissingMetadataHashes(deadlockPath: string): Promise<number> {
+    const metadata = loadMetadata();
+    const missing = Object.entries(metadata).filter(([, data]) => !isValidSha256(data.sha256));
+    if (missing.length === 0) return 0;
+
+    const filesByName = await collectInstalledVpkPaths(deadlockPath);
+    let updated = 0;
+
+    for (const [fileName, data] of missing) {
+        const filePath = filesByName.get(fileName.toLowerCase());
+        if (!filePath) continue;
+
+        try {
+            data.sha256 = await hashFileSha256(filePath);
+            updated++;
+        } catch (error) {
+            console.warn(`[Metadata] Failed to backfill SHA-256 for ${fileName}:`, error);
+        }
+    }
+
+    if (updated > 0) {
+        saveMetadata(metadata);
+    }
+
+    return updated;
+}
+
+async function collectInstalledVpkPaths(deadlockPath: string): Promise<Map<string, string>> {
+    const filesByName = new Map<string, string>();
+
+    for (const folder of [getAddonsPath(deadlockPath), getDisabledPath(deadlockPath)]) {
+        let entries: import('fs').Dirent[];
+        try {
+            entries = await fs.readdir(folder, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+
+        for (const entry of entries) {
+            if (!entry.isFile() || !entry.name.toLowerCase().endsWith('_dir.vpk')) continue;
+            const key = entry.name.toLowerCase();
+            if (!filesByName.has(key)) {
+                filesByName.set(key, join(folder, entry.name));
+            }
+        }
+    }
+
+    return filesByName;
+}
+
+function isValidSha256(value: string | undefined): boolean {
+    return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value);
+}
+
+async function hashFileSha256(filePath: string): Promise<string> {
+    const hash = createHash('sha256');
+
+    await new Promise<void>((resolve, reject) => {
+        const stream = createReadStream(filePath);
+        stream.on('data', (chunk) => hash.update(chunk));
+        stream.on('error', reject);
+        stream.on('end', resolve);
+    });
+
+    return hash.digest('hex');
 }
 
 /**

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -90,10 +90,9 @@ export async function setModMetadataWithHash(
     data: ModMetadata,
     filePath: string
 ): Promise<void> {
-    const sha256 = await hashFileSha256(filePath);
     setModMetadata(fileName, {
         ...data,
-        sha256,
+        sha256: await hashFileSha256(filePath),
     });
 }
 
@@ -133,17 +132,9 @@ async function collectInstalledVpkPaths(deadlockPath: string): Promise<Map<strin
     const filesByName = new Map<string, string>();
 
     for (const folder of [getAddonsPath(deadlockPath), getDisabledPath(deadlockPath)]) {
-        let entries: import('fs').Dirent[];
-        try {
-            entries = await fs.readdir(folder, { withFileTypes: true });
-        } catch {
-            continue;
-        }
-
-        for (const entry of entries) {
-            if (!entry.isFile() || !entry.name.toLowerCase().endsWith('_dir.vpk')) continue;
+        for (const entry of await fs.readdir(folder, { withFileTypes: true }).catch(() => [])) {
             const key = entry.name.toLowerCase();
-            if (!filesByName.has(key)) {
+            if (entry.isFile() && key.endsWith('_dir.vpk') && !filesByName.has(key)) {
                 filesByName.set(key, join(folder, entry.name));
             }
         }

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -4,6 +4,7 @@ import { join, dirname } from 'path';
 import { createHash, randomBytes } from 'crypto';
 import { getAddonsPath, getDisabledPath } from './deadlock';
 import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
+import { compareFileContents, fingerprintFile } from './fileMatch';
 
 /** Minimum VPK priority number */
 const MIN_VPK_PRIORITY = 1;
@@ -11,6 +12,8 @@ const MIN_VPK_PRIORITY = 1;
 const MAX_VPK_PRIORITY = 99;
 /** Default priority for mods without pak## prefix */
 const DEFAULT_MOD_PRIORITY = 50;
+
+type CollisionMetadataOwner = 'enabled' | 'disabled';
 
 export interface Mod {
     id: string;
@@ -31,6 +34,8 @@ export interface Mod {
     sourceSection?: string;
     nsfw?: boolean;
     isArchived?: boolean;
+    sha256?: string;
+    isUnknown?: boolean;
     /** User-given name for this VPK, used to disambiguate variants of the
      *  same GameBanana mod (e.g. "Red preset" vs "Blue preset"). Optional. */
     variantLabel?: string;
@@ -40,7 +45,7 @@ export interface Mod {
     fileDescription?: string;
     /** Original GameBanana filename stem (e.g. "galaxy_rem_gold"). Captured
      *  so variants from mods whose author left descriptions empty still get
-     *  a meaningful label — falls between fileDescription and the local
+     *  a meaningful label - falls between fileDescription and the local
      *  pakNN_dir.vpk filename in the picker's display chain. */
     sourceFileName?: string;
 }
@@ -109,8 +114,7 @@ async function scanFolder(folder: string, enabled: boolean): Promise<Mod[]> {
             const stats = await fs.stat(fullPath);
             if (!stats.isFile()) continue;
 
-            // Only process VPK files
-            if (!entry.endsWith('_dir.vpk') && !entry.endsWith('.vpk')) continue;
+            if (!isDeadlockModVpk(entry)) continue;
 
             const priority = parseVpkPriority(entry) ?? DEFAULT_MOD_PRIORITY;
 
@@ -139,6 +143,8 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
     const addonsPath = getAddonsPath(deadlockPath);
     const disabledPath = getDisabledPath(deadlockPath);
 
+    await reconcileEnabledDisabledCollisions(deadlockPath, addonsPath, disabledPath);
+
     const [enabledMods, disabledMods] = await Promise.all([
         scanFolder(addonsPath, true),
         scanFolder(disabledPath, false),
@@ -150,6 +156,164 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
     mods.sort((a, b) => a.priority - b.priority);
 
     return mods;
+}
+
+async function reconcileEnabledDisabledCollisions(
+    deadlockPath: string,
+    addonsPath: string,
+    disabledPath: string
+): Promise<void> {
+    if (!existsSync(addonsPath) || !existsSync(disabledPath)) return;
+
+    const [enabledEntries, disabledEntries] = await Promise.all([
+        listPrimaryVpkFiles(addonsPath),
+        listPrimaryVpkFiles(disabledPath),
+    ]);
+    const enabledByName = new Map(enabledEntries.map((entry) => [entry.toLowerCase(), entry]));
+
+    for (const disabledEntry of disabledEntries) {
+        const enabledEntry = enabledByName.get(disabledEntry.toLowerCase());
+        if (!enabledEntry) continue;
+
+        const identical = await sameFileContents(
+            join(addonsPath, enabledEntry),
+            join(disabledPath, disabledEntry)
+        );
+        if (identical) {
+            await fs.unlink(join(disabledPath, disabledEntry));
+            console.warn(
+                `[mods] Removed duplicate disabled VPK for ${enabledEntry}: ${disabledEntry}`
+            );
+            continue;
+        }
+
+        const priority = await findNextAvailablePriority(deadlockPath);
+        const metadata = getModMetadata(enabledEntry);
+        const owner = await getCollisionMetadataOwner(metadata?.sha256, join(disabledPath, disabledEntry));
+        const renamedFileName = await renameModFileToPriority(disabledPath, disabledEntry, priority);
+        moveCollisionMetadata(enabledEntry, renamedFileName, owner, metadata);
+        console.warn(
+            `[mods] Renamed conflicting disabled VPK ${disabledEntry} to ${renamedFileName}; contents differ from enabled copy.`
+        );
+    }
+}
+
+async function listPrimaryVpkFiles(folder: string): Promise<string[]> {
+    const entries = await fs.readdir(folder, { withFileTypes: true });
+    return entries
+        .filter((entry) => entry.isFile() && isDeadlockModVpk(entry.name))
+        .map((entry) => entry.name);
+}
+
+function isDeadlockModVpk(fileName: string): boolean {
+    return fileName.toLowerCase().endsWith('_dir.vpk');
+}
+
+async function sameFileContents(leftPath: string, rightPath: string): Promise<boolean> {
+    const comparison = await compareFileContents(leftPath, rightPath);
+    return comparison.matches;
+}
+
+function moveCollisionMetadata(
+    enabledFileName: string,
+    renamedFileName: string,
+    owner: CollisionMetadataOwner,
+    metadata: ReturnType<typeof getModMetadata>
+): void {
+    removeModMetadata(renamedFileName);
+    if (owner !== 'disabled' || !metadata) return;
+
+    setModMetadata(renamedFileName, metadata);
+    removeModMetadata(enabledFileName);
+}
+
+async function getCollisionMetadataOwner(
+    sha256: string | undefined,
+    disabledPath: string
+): Promise<CollisionMetadataOwner> {
+    if (!sha256) return 'enabled';
+
+    const disabledHash = await fingerprintFile(disabledPath);
+    return disabledHash.sha256.toLowerCase() === sha256.toLowerCase() ? 'disabled' : 'enabled';
+}
+
+async function renameModFileToPriority(
+    folder: string,
+    fileName: string,
+    priority: number
+): Promise<string> {
+    const finalName = fileNameForPriority(fileName, priority);
+    if (existsSync(join(folder, finalName))) {
+        throw new Error(`Cannot rename conflicting disabled mod: target already exists (${finalName})`);
+    }
+
+    await fs.rename(join(folder, fileName), join(folder, finalName));
+    return finalName;
+}
+
+function fileNameForPriority(fileName: string, priority: number): string {
+    const renamed = renameWithPriority(fileName, priority);
+    if (renamed !== fileName) return renamed;
+
+    const priorityStr = String(Math.min(MAX_VPK_PRIORITY, priority)).padStart(2, '0');
+    return `pak${priorityStr}_dir.vpk`;
+}
+
+async function moveModToFolder(
+    deadlockPath: string,
+    targetMod: Mod,
+    destinationFolder: string,
+    enabled: boolean
+): Promise<Mod> {
+    let destinationFileName = targetMod.fileName;
+    let collisionMetadata: ReturnType<typeof getModMetadata> | undefined;
+    let collisionMetadataOwner: CollisionMetadataOwner | undefined;
+    const destinationPath = join(destinationFolder, destinationFileName);
+    const hasConflict = targetMod.path !== destinationPath && existsSync(destinationPath);
+
+    if (hasConflict) {
+        const identical = await sameFileContents(
+            targetMod.path,
+            join(destinationFolder, destinationFileName)
+        );
+
+        if (identical) {
+            await fs.unlink(targetMod.path);
+            return {
+                ...targetMod,
+                enabled,
+                path: join(destinationFolder, destinationFileName),
+            };
+        }
+
+        const priority = await findNextAvailablePriority(deadlockPath);
+        collisionMetadata = getModMetadata(targetMod.fileName);
+        collisionMetadataOwner = await getCollisionMetadataOwner(
+            collisionMetadata?.sha256,
+            targetMod.path
+        );
+        destinationFileName = fileNameForPriority(targetMod.fileName, priority);
+    }
+
+    await fs.mkdir(destinationFolder, { recursive: true });
+    await fs.rename(targetMod.path, join(destinationFolder, destinationFileName));
+
+    if (destinationFileName !== targetMod.fileName) {
+        if (collisionMetadataOwner) {
+            moveCollisionMetadata(targetMod.fileName, destinationFileName, collisionMetadataOwner, collisionMetadata);
+        } else {
+            migrateModMetadata([{ from: targetMod.fileName, to: destinationFileName }]);
+        }
+    }
+
+    return {
+        ...targetMod,
+        id: generateModId(destinationFileName),
+        fileName: destinationFileName,
+        enabled,
+        priority: parseVpkPriority(destinationFileName) ?? targetMod.priority,
+        path: join(destinationFolder, destinationFileName),
+    };
 }
 
 /**
@@ -217,15 +381,7 @@ export async function enableMod(deadlockPath: string, modId: string): Promise<Mo
     }
 
     const addonsPath = getAddonsPath(deadlockPath);
-    const destPath = join(addonsPath, targetMod.fileName);
-
-    await fs.rename(targetMod.path, destPath);
-
-    return {
-        ...targetMod,
-        enabled: true,
-        path: destPath,
-    };
+    return moveModToFolder(deadlockPath, targetMod, addonsPath, true);
 }
 
 /**
@@ -244,19 +400,11 @@ export async function disableMod(deadlockPath: string, modId: string): Promise<M
     }
 
     const disabledPath = getDisabledPath(deadlockPath);
-    const destPath = join(disabledPath, targetMod.fileName);
-
-    await fs.rename(targetMod.path, destPath);
-
-    return {
-        ...targetMod,
-        enabled: false,
-        path: destPath,
-    };
+    return moveModToFolder(deadlockPath, targetMod, disabledPath, false);
 }
 
 /**
- * Delete a mod completely (including related VPK files) (async)
+ * Delete a mod completely (async)
  */
 export async function deleteMod(deadlockPath: string, modId: string): Promise<void> {
     const mods = await scanMods(deadlockPath);
@@ -266,36 +414,12 @@ export async function deleteMod(deadlockPath: string, modId: string): Promise<vo
         throw new Error(`Mod not found: ${modId}`);
     }
 
-    // Delete the main file
     await fs.unlink(targetMod.path);
-
-    // Also remove related VPK files (pak##_000.vpk, pak##_001.vpk, etc.)
-    const baseName = targetMod.fileName.replace(/_dir\.vpk$/, '');
-    const parentDir = join(targetMod.path, '..');
-
-    try {
-        const siblings = await fs.readdir(parentDir);
-        const deletePromises = siblings
-            .filter(sibling => sibling.startsWith(baseName) && sibling.endsWith('.vpk'))
-            .map(sibling => fs.unlink(join(parentDir, sibling)));
-        await Promise.all(deletePromises);
-    } catch {
-        // Ignore errors when cleaning up related files
-    }
 
     // Metadata is keyed by fileName. If we leave it behind, the next mod that
     // is assigned the same pakNN_dir.vpk slot will inherit the deleted mod's
     // gameBananaId, thumbnail, category, etc. via setModMetadata's merge.
     removeModMetadata(targetMod.fileName);
-}
-
-/**
- * Find all VPK sibling files for a given _dir.vpk (e.g. pak05_foo_000.vpk, pak05_foo_001.vpk)
- */
-async function findVpkSiblings(parentDir: string, dirFileName: string): Promise<string[]> {
-    const baseName = dirFileName.replace(/_dir\.vpk$/, '');
-    const entries = await fs.readdir(parentDir);
-    return entries.filter((e) => e.startsWith(`${baseName}_`) && e.endsWith('.vpk'));
 }
 
 /**
@@ -307,7 +431,7 @@ function renameWithPriority(fileName: string, priority: number): string {
 }
 
 /**
- * Set the priority of a mod by renaming it and all its VPK siblings (async).
+ * Set the priority of a mod by renaming its VPK file (async).
  * Also migrates metadata to the new filename.
  */
 export async function setModPriority(
@@ -329,22 +453,10 @@ export async function setModPriority(
         return targetMod;
     }
 
-    const siblings = await findVpkSiblings(parentDir, targetMod.fileName);
-
-    // Collision check across all siblings
-    for (const sibling of siblings) {
-        const newSiblingName = renameWithPriority(sibling, newPriority);
-        if (newSiblingName === sibling) continue;
-        if (existsSync(join(parentDir, newSiblingName))) {
-            throw new Error(`Priority ${newPriority} is already in use`);
-        }
+    if (existsSync(join(parentDir, newFileName))) {
+        throw new Error(`Priority ${newPriority} is already in use`);
     }
-
-    for (const sibling of siblings) {
-        const newSiblingName = renameWithPriority(sibling, newPriority);
-        if (newSiblingName === sibling) continue;
-        await fs.rename(join(parentDir, sibling), join(parentDir, newSiblingName));
-    }
+    await fs.rename(join(parentDir, targetMod.fileName), join(parentDir, newFileName));
 
     const oldMeta = getModMetadata(targetMod.fileName);
     if (oldMeta) {
@@ -408,19 +520,13 @@ export async function reorderMods(
     type RenameStep = { fromPath: string; tmpPath: string; finalPath: string };
     const steps: RenameStep[] = [];
 
-    for (const { mod, newPriority } of assignments) {
+    for (const { mod, newFileName } of assignments) {
         const parentDir = dirname(mod.path);
-        const siblings = await findVpkSiblings(parentDir, mod.fileName);
-
-        for (const sibling of siblings) {
-            const finalName = renameWithPriority(sibling, newPriority);
-            if (finalName === sibling) continue;
-            steps.push({
-                fromPath: join(parentDir, sibling),
-                tmpPath: join(parentDir, `tmp${tmpId}_${sibling}`),
-                finalPath: join(parentDir, finalName),
-            });
-        }
+        steps.push({
+            fromPath: join(parentDir, mod.fileName),
+            tmpPath: join(parentDir, `tmp${tmpId}_${mod.fileName}`),
+            finalPath: join(parentDir, newFileName),
+        });
     }
 
     const phase1Done: RenameStep[] = [];
@@ -509,26 +615,19 @@ export async function swapModPriority(
 async function directSwap(a: Mod, b: Mod): Promise<void> {
     const parentA = dirname(a.path);
     const parentB = dirname(b.path);
-    const aSiblings = await findVpkSiblings(parentA, a.fileName);
-    const bSiblings = await findVpkSiblings(parentB, b.fileName);
-
     const tmpId = randomBytes(4).toString('hex');
-    const steps: { from: string; tmp: string; final: string }[] = [];
-
-    for (const s of aSiblings) {
-        steps.push({
-            from: join(parentA, s),
-            tmp: join(parentA, `tmp${tmpId}_${s}`),
-            final: join(parentA, renameWithPriority(s, b.priority)),
-        });
-    }
-    for (const s of bSiblings) {
-        steps.push({
-            from: join(parentB, s),
-            tmp: join(parentB, `tmp${tmpId}_${s}`),
-            final: join(parentB, renameWithPriority(s, a.priority)),
-        });
-    }
+    const steps = [
+        {
+            from: join(parentA, a.fileName),
+            tmp: join(parentA, `tmp${tmpId}_${a.fileName}`),
+            final: join(parentA, renameWithPriority(a.fileName, b.priority)),
+        },
+        {
+            from: join(parentB, b.fileName),
+            tmp: join(parentB, `tmp${tmpId}_${b.fileName}`),
+            final: join(parentB, renameWithPriority(b.fileName, a.priority)),
+        },
+    ];
 
     for (const step of steps) await fs.rename(step.from, step.tmp);
     for (const step of steps) await fs.rename(step.tmp, step.final);

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -162,7 +162,7 @@ export async function buildPortableProfile(
 
     for (const profileMod of profile.mods) {
         const installedMod = modByFileName.get(profileMod.fileName);
-        const metadata = getModMetadata(profileMod.fileName);
+        const metadata = installedMod ? getModMetadata(installedMod.fileName) : getModMetadata(profileMod.fileName);
         const gbId = metadata?.gameBananaId ?? installedMod?.gameBananaId;
         const fileId = metadata?.gameBananaFileId ?? installedMod?.gameBananaFileId;
 

--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -1,0 +1,689 @@
+import { promises as fs } from 'fs';
+import { basename } from 'path';
+import {
+    fetchCategoryTree,
+    fetchModFilesWithRawPaths,
+    fetchSubmissions,
+    type GameBananaCategoryNode,
+    type GameBananaFileWithRawPaths,
+    type GameBananaMod,
+} from './gamebanana';
+import {
+    crc32File,
+    fetchGameBananaArchiveVpkCrcEntries,
+    type ArchiveVpkCrcEntry,
+} from './archiveCrc';
+import { parseVpkDirectory } from './vpk';
+import type { UnknownModCrcMatchResult, UnknownModFilterGuess } from '../../../src/types/mod';
+
+export type { UnknownModFilterGuess };
+
+type UnknownModFilterBase = Omit<UnknownModFilterGuess, 'crcMatch'>;
+
+export interface UnknownModDetectionOptions {
+    signal?: AbortSignal;
+}
+
+type SignalStrength = 'strong' | 'medium' | 'weak';
+
+interface HeroNamePair {
+    name: string;
+    fileName: string;
+}
+
+interface HeroSignal {
+    hero: HeroNamePair;
+    strength: SignalStrength;
+    clue: string;
+}
+
+interface SignalPattern {
+    pattern: RegExp;
+    strength: SignalStrength;
+    label: string;
+}
+
+// These names mirror the current GameBanana Deadlock > Mods > Skins categories.
+// Each hero intentionally has only two names: the GameBanana display name and
+// the common VPK folder/file token used by Deadlock assets.
+const HERO_NAME_PAIRS: HeroNamePair[] = [
+    { name: 'Abrams', fileName: 'atlas' },
+    { name: 'Apollo', fileName: 'fencer' },
+    { name: 'Bebop', fileName: 'bebop' },
+    { name: 'Billy', fileName: 'punkgoat' },
+    { name: 'Calico', fileName: 'nano' },
+    { name: 'Celeste', fileName: 'unicorn' },
+    { name: 'Doorman', fileName: 'doorman' },
+    { name: 'Drifter', fileName: 'drifter' },
+    { name: 'Dynamo', fileName: 'dynamo' },
+    { name: 'Graves', fileName: 'necro' },
+    { name: 'Grey Talon', fileName: 'orion' },
+    { name: 'Haze', fileName: 'haze' },
+    { name: 'Holliday', fileName: 'astro' },
+    { name: 'Infernus', fileName: 'inferno' },
+    { name: 'Ivy', fileName: 'tengu' },
+    { name: 'Kelvin', fileName: 'kelvin' },
+    { name: 'Lady Geist', fileName: 'geist' },
+    { name: 'Lash', fileName: 'lash' },
+    { name: 'McGinnis', fileName: 'forge' },
+    { name: 'Mina', fileName: 'vampirebat' },
+    { name: 'Mirage', fileName: 'mirage' },
+    { name: 'Mo & Krill', fileName: 'krill' },
+    { name: 'Paige', fileName: 'bookworm' },
+    { name: 'Paradox', fileName: 'chrono' },
+    { name: 'Pocket', fileName: 'synth' },
+    { name: 'Rem', fileName: 'familiar' },
+    { name: 'Seven', fileName: 'gigawatt' },
+    { name: 'Shiv', fileName: 'shiv' },
+    { name: 'Silver', fileName: 'werewolf' },
+    { name: 'Sinclair', fileName: 'magician' },
+    { name: 'Venator', fileName: 'priest' },
+    { name: 'Victor', fileName: 'frank' },
+    { name: 'Vindicta', fileName: 'hornet' },
+    { name: 'Viscous', fileName: 'viscous' },
+    { name: 'Vyper', fileName: 'viper' },
+    { name: 'Warden', fileName: 'warden' },
+    { name: 'Wraith', fileName: 'wraith' },
+    { name: 'Yamato', fileName: 'yamato' },
+];
+
+const HERO_BY_KEY = new Map<string, HeroNamePair>();
+for (const hero of HERO_NAME_PAIRS) {
+    HERO_BY_KEY.set(normalizeHeroKey(hero.name), hero);
+    HERO_BY_KEY.set(normalizeHeroKey(hero.fileName), hero);
+}
+
+const HERO_SIGNAL_PATTERNS: SignalPattern[] = [
+    { pattern: /(?:^|\/)models\/heroes(?:_wip|_staging)?\/([^/]+)/i, strength: 'strong', label: 'model hero folder' },
+    { pattern: /(?:^|\/)materials\/models\/heroes(?:_wip|_staging)?\/([^/]+)/i, strength: 'strong', label: 'model material folder' },
+    { pattern: /(?:^|\/)materials\/heroes(?:_wip|_staging)?\/([^/]+)/i, strength: 'medium', label: 'hero material folder' },
+    { pattern: /(?:^|\/)animgraphs\/animgraph2\/hero\/([^/]+)/i, strength: 'medium', label: 'hero animgraph folder' },
+    { pattern: /(?:^|\/)panorama\/images\/heroes\/(?:backgrounds|hero_names)\/([^/]+)/i, strength: 'medium', label: 'hero select UI' },
+    { pattern: /(?:^|\/)panorama\/images\/hud\/abilities\/([^/]+)/i, strength: 'medium', label: 'ability UI' },
+    { pattern: /(?:^|\/)particles\/abilities\/([^/]+)/i, strength: 'medium', label: 'ability particles' },
+    { pattern: /(?:^|\/)materials\/particle\/abilities\/([^/]+)/i, strength: 'medium', label: 'ability particle materials' },
+    { pattern: /(?:^|\/)soundevents\/hero\/([^/]+)/i, strength: 'medium', label: 'hero sound events' },
+    { pattern: /(?:^|\/)sounds\/vo\/([^/]+)/i, strength: 'medium', label: 'voice folder' },
+    { pattern: /(?:^|\/)sounds\/abilities\/([^/]+)/i, strength: 'medium', label: 'ability sounds' },
+    { pattern: /(?:^|\/)sounds\/weapons\/([^/]+)/i, strength: 'medium', label: 'weapon sounds' },
+    { pattern: /(?:^|\/)scripts\/tagged_sounds\/([^/.]+)/i, strength: 'weak', label: 'tagged sound script' },
+];
+
+const SCORE: Record<SignalStrength, number> = {
+    strong: 100,
+    medium: 40,
+    weak: 15,
+};
+
+export async function detectUnknownModFilters(
+    modId: string,
+    fileName: string,
+    vpkPath: string,
+    options: UnknownModDetectionOptions = {}
+): Promise<UnknownModFilterGuess> {
+    throwIfAborted(options.signal);
+    const paths = parseVpkDirectory(vpkPath) ?? [];
+    const normalizedPaths = paths.map(normalizePath);
+    const contentHints = detectContentHints(normalizedPaths);
+    const heroSignals = detectHeroSignals(normalizedPaths);
+    const detectedHeroes = summarizeHeroSignals(heroSignals);
+    const primaryHero = choosePrimaryHero(detectedHeroes);
+    const kind = chooseFilterKind(contentHints, primaryHero);
+
+    const search = primaryHero?.name ?? kind.searchFallback ?? null;
+    const reasons = buildReasons(kind, primaryHero, detectedHeroes, contentHints);
+
+    const guessWithoutMatch: UnknownModFilterBase = {
+        modId,
+        fileName,
+        fileCount: paths.length,
+        section: kind.section,
+        search,
+        heroName: primaryHero?.name,
+        heroFileName: primaryHero?.fileName,
+        categoryName: kind.categoryName,
+        confidence: chooseConfidence(primaryHero, kind, paths.length),
+        contentHints,
+        reasons,
+        detectedHeroes,
+        samplePaths: paths.slice(0, 8),
+    };
+
+    return {
+        ...guessWithoutMatch,
+        crcMatch: await findUnknownModCrcMatch(vpkPath, guessWithoutMatch, options),
+    };
+}
+
+interface LocalVpkFingerprint {
+    size: number;
+    crc32: string;
+}
+
+interface CandidateBucket {
+    section: 'Mod' | 'Sound';
+    categoryId?: number;
+    search?: string;
+    label: string;
+}
+
+let modCategoryTreePromise: Promise<GameBananaCategoryNode[]> | null = null;
+const MAX_CRC_ERROR_MESSAGES = 8;
+const CANDIDATE_CHECK_CONCURRENCY = 4;
+
+async function findUnknownModCrcMatch(
+    vpkPath: string,
+    guess: UnknownModFilterBase,
+    options: UnknownModDetectionOptions
+): Promise<UnknownModCrcMatchResult> {
+    const empty = (status: UnknownModCrcMatchResult['status'], reason?: string): UnknownModCrcMatchResult => ({
+        status,
+        reason,
+        searchedBuckets: [],
+        checkedMods: 0,
+        checkedFiles: 0,
+        bytesFetched: 0,
+        skipped7z: 0,
+        errors: [],
+    });
+
+    if (!guess.heroName && !guess.categoryName) {
+        return empty('not-found', 'No useful hero or category clue was found, so CRC matching was not attempted.');
+    }
+
+    try {
+        throwIfAborted(options.signal);
+        const buckets = await buildCandidateBuckets(guess, options);
+        if (buckets.length === 0) {
+            return empty('not-found', 'No GameBanana candidate bucket could be inferred from this VPK.');
+        }
+
+        const localFile = await getLocalVpkFingerprint(vpkPath);
+        if (!localFile) {
+            return empty('not-found', 'No local VPK file was found.');
+        }
+
+        const result: UnknownModCrcMatchResult = {
+            status: 'not-found',
+            reason: 'No GameBanana file matched this local VPK by CRC-32.',
+            searchedBuckets: buckets.map((bucket) => bucket.label),
+            checkedMods: 0,
+            checkedFiles: 0,
+            bytesFetched: 0,
+            skipped7z: 0,
+            errors: [],
+        };
+
+        for (const bucket of buckets) {
+            throwIfAborted(options.signal);
+            const candidates = await fetchBucketCandidates(bucket, options);
+            for (let start = 0; start < candidates.length; start += CANDIDATE_CHECK_CONCURRENCY) {
+                throwIfAborted(options.signal);
+                const batch = candidates.slice(start, start + CANDIDATE_CHECK_CONCURRENCY);
+                const checks = await Promise.all(
+                    batch.map((candidate) => checkCandidateForCrcMatch(candidate, bucket, localFile, options))
+                );
+
+                for (const check of checks) {
+                    result.checkedMods += 1;
+                    result.checkedFiles += check.checkedFiles;
+                    result.bytesFetched += check.bytesFetched;
+                    result.skipped7z += check.skipped7z;
+                    for (const message of check.errors) {
+                        appendCrcError(result, message);
+                    }
+                }
+
+                const match = checks.find((check) => check.match)?.match;
+                if (match) {
+                    return {
+                        ...result,
+                        ...match,
+                        status: 'found',
+                        confidence: 'exact',
+                        reason: 'CRC-32 matched the local VPK file.',
+                    };
+                }
+            }
+        }
+
+        return result;
+    } catch (err) {
+        return {
+            status: 'error',
+            reason: errorMessage(err),
+            searchedBuckets: [],
+            checkedMods: 0,
+            checkedFiles: 0,
+            bytesFetched: 0,
+            skipped7z: 0,
+            errors: [errorMessage(err)],
+        };
+    }
+}
+
+async function getLocalVpkFingerprint(vpkPath: string): Promise<LocalVpkFingerprint | null> {
+    const primaryFileName = basename(vpkPath);
+    if (!primaryFileName.toLowerCase().endsWith('_dir.vpk')) return null;
+
+    const [stats, crc32] = await Promise.all([
+        fs.stat(vpkPath),
+        crc32File(vpkPath),
+    ]);
+    return { size: stats.size, crc32 };
+}
+
+async function buildCandidateBuckets(
+    guess: UnknownModFilterBase,
+    options: UnknownModDetectionOptions
+): Promise<CandidateBucket[]> {
+    throwIfAborted(options.signal);
+    const modCategories = await getModCategoryTree(options);
+    throwIfAborted(options.signal);
+    const buckets: CandidateBucket[] = [];
+    const add = (bucket: CandidateBucket) => {
+        const key = candidateBucketKey(bucket);
+        if (!buckets.some((existing) => candidateBucketKey(existing) === key)) {
+            buckets.push(bucket);
+        }
+    };
+
+    if (guess.heroName && guess.section === 'Sound') {
+        add({ section: 'Sound', search: guess.heroName, label: `Sounds search: ${guess.heroName}` });
+        add({ section: 'Mod', search: guess.heroName, label: `Mods search: ${guess.heroName}` });
+        return buckets;
+    }
+
+    if (guess.heroName) {
+        const skins = findCategoryByName(modCategories, 'Skins');
+        const heroCategory = skins?.children?.find(
+            (category) => normalizeHeroKey(category.name) === normalizeHeroKey(guess.heroName!)
+        );
+
+        if (heroCategory) {
+            add({ section: 'Mod', categoryId: heroCategory.id, label: `Mods / Skins / ${heroCategory.name}` });
+        }
+        add({ section: 'Mod', search: guess.heroName, label: `Mods search: ${guess.heroName}` });
+        add({ section: 'Sound', search: guess.heroName, label: `Sounds search: ${guess.heroName}` });
+        return buckets;
+    }
+
+    if (guess.categoryName) {
+        const category = findCategoryByName(modCategories, guess.categoryName);
+        if (category) {
+            add({ section: 'Mod', categoryId: category.id, label: `Mods / ${category.name}` });
+        }
+    }
+    if (guess.search) {
+        add({ section: 'Mod', search: guess.search, label: `Mods search: ${guess.search}` });
+    }
+
+    return buckets;
+}
+
+function candidateBucketKey(bucket: CandidateBucket): string {
+    return `${bucket.section}|${bucket.categoryId ?? ''}|${bucket.search ?? ''}`;
+}
+
+function appendCrcError(result: UnknownModCrcMatchResult, message: string): void {
+    if (result.errors.length < MAX_CRC_ERROR_MESSAGES) {
+        result.errors.push(message);
+    }
+}
+
+interface CandidateCrcCheck {
+    checkedFiles: number;
+    bytesFetched: number;
+    skipped7z: number;
+    errors: string[];
+    match?: Pick<
+        UnknownModCrcMatchResult,
+        'modId' | 'modName' | 'thumbnailUrl' | 'nsfw' | 'fileId' | 'fileName' | 'section' | 'categoryName'
+    >;
+}
+
+async function checkCandidateForCrcMatch(
+    candidate: GameBananaMod,
+    bucket: CandidateBucket,
+    localFile: LocalVpkFingerprint,
+    options: UnknownModDetectionOptions
+): Promise<CandidateCrcCheck> {
+    const result: CandidateCrcCheck = {
+        checkedFiles: 0,
+        bytesFetched: 0,
+        skipped7z: 0,
+        errors: [],
+    };
+
+    let files: GameBananaFileWithRawPaths[];
+    try {
+        throwIfAborted(options.signal);
+        files = await fetchModFilesWithRawPaths(candidate.id, bucket.section, true, { signal: options.signal });
+    } catch (err) {
+        result.errors.push(`${candidate.name}: failed to read files (${errorMessage(err)})`);
+        return result;
+    }
+
+    for (const file of files) {
+        throwIfAborted(options.signal);
+        if (file.rawVpkPathsError) {
+            result.errors.push(`${candidate.name} / ${file.fileName}: RawFileList failed (${file.rawVpkPathsError})`);
+            continue;
+        }
+        if (!rawVpkPathsCouldMatch(file.rawVpkPaths)) {
+            continue;
+        }
+
+        result.checkedFiles++;
+        try {
+            const archive = await fetchGameBananaArchiveVpkCrcEntries(file, { signal: options.signal });
+            result.bytesFetched += archive.bytesFetched;
+            if (archive.archiveType === '7z' && archive.unsupportedReason) {
+                result.skipped7z++;
+            }
+            if (archiveMatchesLocalVpk(localFile, archive.entries)) {
+                result.match = {
+                    modId: candidate.id,
+                    modName: candidate.name,
+                    thumbnailUrl: thumbnailUrlForCandidate(candidate),
+                    nsfw: candidate.nsfw,
+                    fileId: file.id,
+                    fileName: file.fileName,
+                    section: bucket.section,
+                    categoryName: candidate.rootCategory?.name,
+                };
+                return result;
+            }
+        } catch (err) {
+            result.errors.push(`${candidate.name} / ${file.fileName}: ${errorMessage(err)}`);
+        }
+    }
+
+    return result;
+}
+
+function thumbnailUrlForCandidate(candidate: GameBananaMod): string | undefined {
+    const image = candidate.previewMedia?.images?.[0];
+    if (!image?.baseUrl) return undefined;
+
+    const file = image.file530 || image.file || image.file220;
+    return file ? `${image.baseUrl}/${file}` : undefined;
+}
+
+async function getModCategoryTree(options: UnknownModDetectionOptions = {}): Promise<GameBananaCategoryNode[]> {
+    if (options.signal) {
+        return fetchCategoryTree('ModCategory', { signal: options.signal });
+    }
+    modCategoryTreePromise ??= fetchCategoryTree('ModCategory');
+    return modCategoryTreePromise;
+}
+
+function findCategoryByName(
+    categories: GameBananaCategoryNode[],
+    name: string
+): GameBananaCategoryNode | undefined {
+    for (const category of categories) {
+        if (category.name.toLowerCase() === name.toLowerCase()) {
+            return category;
+        }
+        const child = category.children ? findCategoryByName(category.children, name) : undefined;
+        if (child) return child;
+    }
+    return undefined;
+}
+
+async function fetchBucketCandidates(
+    bucket: CandidateBucket,
+    options: UnknownModDetectionOptions
+): Promise<GameBananaMod[]> {
+    const perPage = 50;
+    const maxPages = 4;
+    const byId = new Map<number, GameBananaMod>();
+
+    for (let page = 1; page <= maxPages; page++) {
+        throwIfAborted(options.signal);
+        const response = await fetchSubmissions(
+            bucket.section,
+            page,
+            perPage,
+            bucket.search,
+            bucket.categoryId,
+            undefined,
+            { signal: options.signal }
+        );
+
+        for (const mod of response.records) {
+            if (mod.hasFiles) byId.set(mod.id, mod);
+        }
+
+        if (response.isComplete || response.records.length < perPage) {
+            break;
+        }
+    }
+
+    return [...byId.values()];
+}
+
+function rawVpkPathsCouldMatch(rawPaths: string[]): boolean {
+    if (rawPaths.length === 0) return false;
+    return rawPaths.some((rawPath) => rawPath.toLowerCase().endsWith('_dir.vpk'));
+}
+
+function archiveMatchesLocalVpk(localFile: LocalVpkFingerprint, archiveEntries: ArchiveVpkCrcEntry[]): boolean {
+    return archiveEntries.some((entry) => (
+        entry.name.toLowerCase().endsWith('_dir.vpk') &&
+        entry.uncompressedSize === localFile.size &&
+        entry.crc32.toLowerCase() === localFile.crc32
+    ));
+}
+
+function errorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw new Error('Unknown mod search cancelled');
+    }
+}
+
+function normalizePath(path: string): string {
+    return path.replace(/\\/g, '/').toLowerCase();
+}
+
+function normalizeHeroKey(value: string): string {
+    return value
+        .replace(/^hero_/i, '')
+        .replace(/&/g, ' and ')
+        .replace(/[^a-z0-9]+/gi, ' ')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, ' ');
+}
+
+function tokenVariants(raw: string): string[] {
+    const normalized = normalizeHeroKey(raw);
+    const compact = normalized.replace(/\s+/g, '');
+    const first = normalized.split(' ')[0] ?? normalized;
+    const withoutSuffix = normalized
+        .replace(/\s+(?:v\d+|copy|alt|temp|test)\b.*$/i, '')
+        .trim();
+    const withoutNumberSuffix = normalized
+        .replace(/\s+v?\d+\b.*$/i, '')
+        .trim();
+
+    return [...new Set([normalized, compact, withoutSuffix, withoutNumberSuffix, first].filter(Boolean))];
+}
+
+function findHeroFromToken(raw: string): HeroNamePair | null {
+    for (const variant of tokenVariants(raw)) {
+        const exact = HERO_BY_KEY.get(variant);
+        if (exact) return exact;
+    }
+
+    const normalized = ` ${normalizeHeroKey(raw)} `;
+    for (const hero of HERO_NAME_PAIRS) {
+        const displayName = normalizeHeroKey(hero.name);
+        const fileName = normalizeHeroKey(hero.fileName);
+        if (normalized.includes(` ${displayName} `) || normalized.includes(` ${fileName} `)) {
+            return hero;
+        }
+    }
+
+    return null;
+}
+
+function detectHeroSignals(paths: string[]): HeroSignal[] {
+    const signals: HeroSignal[] = [];
+
+    for (const path of paths) {
+        for (const { pattern, strength, label } of HERO_SIGNAL_PATTERNS) {
+            const match = path.match(pattern);
+            if (!match?.[1]) continue;
+
+            const hero = findHeroFromToken(match[1]);
+            if (!hero) continue;
+            signals.push({
+                hero,
+                strength,
+                clue: `${label}: ${match[1]}`,
+            });
+        }
+    }
+
+    return signals;
+}
+
+function summarizeHeroSignals(signals: HeroSignal[]): UnknownModFilterGuess['detectedHeroes'] {
+    const byHero = new Map<string, {
+        name: string;
+        fileName: string;
+        score: number;
+        strongestSignal: SignalStrength;
+        clues: Set<string>;
+    }>();
+
+    for (const signal of signals) {
+        const existing = byHero.get(signal.hero.name) ?? {
+            name: signal.hero.name,
+            fileName: signal.hero.fileName,
+            score: 0,
+            strongestSignal: signal.strength,
+            clues: new Set<string>(),
+        };
+        existing.score += SCORE[signal.strength];
+        if (SCORE[signal.strength] > SCORE[existing.strongestSignal]) {
+            existing.strongestSignal = signal.strength;
+        }
+        if (existing.clues.size < 5) existing.clues.add(signal.clue);
+        byHero.set(signal.hero.name, existing);
+    }
+
+    return [...byHero.values()]
+        .map((hero) => ({
+            ...hero,
+            clues: [...hero.clues],
+        }))
+        .sort((a, b) => b.score - a.score);
+}
+
+function choosePrimaryHero(
+    heroes: UnknownModFilterGuess['detectedHeroes']
+): UnknownModFilterGuess['detectedHeroes'][number] | undefined {
+    const strong = heroes.filter((hero) => hero.strongestSignal === 'strong');
+    if (strong.length > 0) return strong[0];
+    return heroes[0];
+}
+
+function detectContentHints(paths: string[]): string[] {
+    const hints = new Set<string>();
+
+    for (const path of paths) {
+        if (/^models\/|\/models\//i.test(path) || /^materials\/models\//i.test(path)) hints.add('Model');
+        if (/^sounds\/|^soundevents\//i.test(path)) hints.add('Sound');
+        if (/^panorama\//i.test(path)) hints.add('UI');
+        if (/^panorama\/images\/heroes\/(?:backgrounds|hero_names)\//i.test(path)) hints.add('Hero Select UI');
+        if (/^particles\/|^materials\/particle\//i.test(path)) hints.add('VFX');
+        if (/^postprocessing\//i.test(path) || /\.vpost_c$/i.test(path)) hints.add('Post Processing');
+        if (/^maps\//i.test(path)) hints.add('Map');
+        if (/^materials\/skybox\//i.test(path)) hints.add('Skybox');
+        if (/weapons?\//i.test(path)) hints.add('Weapon');
+    }
+
+    return [...hints];
+}
+
+function chooseFilterKind(
+    hints: string[],
+    primaryHero: UnknownModFilterGuess['detectedHeroes'][number] | undefined
+): { section: 'Mod' | 'Sound'; categoryName?: string; searchFallback?: string } {
+    const has = (hint: string) => hints.includes(hint);
+    const modelLike = has('Model') || has('VFX');
+    const soundOnly = has('Sound') && !modelLike && !has('UI') && !has('Map') && !has('Skybox');
+
+    if (soundOnly) {
+        return { section: 'Sound' };
+    }
+
+    if (has('Map') || has('Skybox')) {
+        return { section: 'Mod', categoryName: 'Maps', searchFallback: has('Skybox') ? 'skybox' : 'map' };
+    }
+
+    if (has('UI') && !modelLike) {
+        return { section: 'Mod', categoryName: 'HUD', searchFallback: primaryHero ? undefined : 'hud' };
+    }
+
+    if (has('Post Processing')) {
+        return { section: 'Mod', categoryName: 'Other/Misc', searchFallback: 'postprocess' };
+    }
+
+    if (modelLike) {
+        return { section: 'Mod', categoryName: primaryHero ? 'Skins' : 'Model Replacement' };
+    }
+
+    return { section: 'Mod', categoryName: 'Other/Misc' };
+}
+
+function chooseConfidence(
+    primaryHero: UnknownModFilterGuess['detectedHeroes'][number] | undefined,
+    kind: { categoryName?: string },
+    fileCount: number
+): UnknownModFilterGuess['confidence'] {
+    if (primaryHero?.strongestSignal === 'strong') return 'high';
+    if (primaryHero || kind.categoryName) return 'medium';
+    if (fileCount > 0) return 'low';
+    return 'low';
+}
+
+function buildReasons(
+    kind: { section: 'Mod' | 'Sound'; categoryName?: string },
+    primaryHero: UnknownModFilterGuess['detectedHeroes'][number] | undefined,
+    detectedHeroes: UnknownModFilterGuess['detectedHeroes'],
+    hints: string[]
+): string[] {
+    const reasons: string[] = [];
+
+    if (primaryHero) {
+        reasons.push(
+            `Detected ${primaryHero.name} from ${primaryHero.strongestSignal} VPK path clues (${primaryHero.fileName}).`
+        );
+    }
+    if (detectedHeroes.length > 1) {
+        reasons.push(
+            `Using ${primaryHero?.name ?? detectedHeroes[0].name} first because it has the strongest/most repeated clues.`
+        );
+    }
+    if (kind.section === 'Sound') {
+        reasons.push('Sound-only contents map best to the Browser Sound section.');
+    } else {
+        reasons.push('Contents map best to the Browser Mods section.');
+    }
+    if (kind.categoryName) {
+        reasons.push(`Suggested category filter: ${kind.categoryName}.`);
+    }
+    if (hints.length > 0) {
+        reasons.push(`Content hints: ${hints.join(', ')}.`);
+    }
+
+    return reasons;
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -8,6 +8,14 @@ import type {
 import type { SnapshotSummary, SnapshotTrigger } from '../../src/types/snapshot';
 import type { SocialSessionStatus } from '../../src/types/social';
 import type {
+    AppSettings,
+    ApplyUnknownCustomModArgs,
+    ApplyUnknownModMatchArgs,
+    Mod,
+    ModConflict,
+    UnknownModFilterGuess,
+} from '../../src/types/mod';
+import type {
     LikeResponse,
     ListProfilesResponse,
     MeResponse,
@@ -34,7 +42,15 @@ export interface ElectronAPI {
     enableMod: (modId: string) => Promise<Mod>;
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
+    detectUnknownModFilters: (modId: string) => Promise<UnknownModFilterGuess>;
+    cancelUnknownModDetection: (modId: string) => Promise<void>;
+    applyUnknownModMatch: (modId: string, args: ApplyUnknownModMatchArgs) => Promise<Mod>;
+    applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
+    backfillGameBananaFileId: (
+        modId: string,
+        payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
+    ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
@@ -338,47 +354,11 @@ type ScoreboardSortBy =
     | 'max_net_worth_per_match' | 'avg_net_worth_per_match' | 'net_worth'
     | 'max_player_damage_per_match' | 'avg_player_damage_per_match' | 'player_damage';
 
-// Minimal type stubs (full types are in renderer)
-interface AppSettings {
-    deadlockPath: string | null;
-    devMode: boolean;
-    devDeadlockPath: string | null;
-    hideNsfwPreviews: boolean;
-    hideOutdatedMods: boolean;
-    autoDisableSiblingVariants: boolean;
-    steamLaunchOptions: string;
-    activeProfileId: string | null;
-    autoSaveProfile: boolean;
-    experimentalStats: boolean;
-    experimentalCrosshair: boolean;
-    experimentalSocial: boolean;
-    hasCompletedSetup: boolean;
-}
-
 interface SteamLaunchOptionsStatus {
     available: boolean;
     configPath: string | null;
     currentValue: string | null;
     steamRunning: boolean;
-}
-
-interface Mod {
-    id: string;
-    name: string;
-    fileName: string;
-    path: string;
-    enabled: boolean;
-    priority: number;
-    size: number;
-    installedAt: string;
-    description?: string;
-    thumbnailUrl?: string;
-    gameBananaId?: number;
-    gameBananaFileId?: number;
-    categoryId?: number;
-    sourceSection?: string;
-    nsfw?: boolean;
-    isArchived?: boolean;
 }
 
 interface BrowseModsArgs {
@@ -603,18 +583,6 @@ interface GameBananaCollectionItemsResponse {
     perPage: number;
 }
 
-interface ModConflict {
-    modA: string;
-    modAName: string;
-    modB: string;
-    modBName: string;
-    modAIdentity: string;
-    modBIdentity: string;
-    ignoreKey: string;
-    conflictType: 'priority' | 'file';
-    details: string;
-}
-
 interface ProfileCrosshairSettings {
     pipGap: number;
     pipHeight: number;
@@ -778,6 +746,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     enableMod: (modId: string) => ipcRenderer.invoke('enable-mod', modId),
     disableMod: (modId: string) => ipcRenderer.invoke('disable-mod', modId),
     deleteMod: (modId: string) => ipcRenderer.invoke('delete-mod', modId),
+    detectUnknownModFilters: (modId: string) =>
+        ipcRenderer.invoke('detect-unknown-mod-filters', modId),
+    cancelUnknownModDetection: (modId: string) =>
+        ipcRenderer.invoke('cancel-unknown-mod-detection', modId),
+    applyUnknownModMatch: (modId: string, args: ApplyUnknownModMatchArgs) =>
+        ipcRenderer.invoke('apply-unknown-mod-match', modId, args),
+    applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) =>
+        ipcRenderer.invoke('apply-unknown-custom-mod', modId, args),
     setVariantLabel: (modId: string, label: string) =>
         ipcRenderer.invoke('set-variant-label', modId, label),
     backfillGameBananaFileId: (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings } from '../types/mod';
+import type { Mod, AppSettings, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs } from '../types/mod';
 import type {
   GameBananaModsResponse,
   GameBananaModDetails,
@@ -57,6 +57,25 @@ export async function disableMod(modId: string): Promise<Mod> {
 
 export async function deleteMod(modId: string): Promise<void> {
   return window.electronAPI.deleteMod(modId);
+}
+
+export async function detectUnknownModFilters(modId: string): Promise<UnknownModFilterGuess> {
+  return window.electronAPI.detectUnknownModFilters(modId);
+}
+
+export async function cancelUnknownModDetection(modId: string): Promise<void> {
+  return window.electronAPI.cancelUnknownModDetection(modId);
+}
+
+export async function applyUnknownModMatch(modId: string, args: ApplyUnknownModMatchArgs): Promise<Mod> {
+  return window.electronAPI.applyUnknownModMatch(modId, args);
+}
+
+export async function applyUnknownCustomMod(modId: string, args: ApplyUnknownCustomModArgs): Promise<Mod> {
+  if (typeof window.electronAPI.applyUnknownCustomMod !== 'function') {
+    throw new Error('Make Custom Mod is not available in the current Electron preload. Restart pnpm dev so the new main/preload API is loaded.');
+  }
+  return window.electronAPI.applyUnknownCustomMod(modId, args);
 }
 
 export async function setVariantLabel(modId: string, label: string): Promise<Mod> {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -13,19 +13,22 @@ import {
   Search,
   Volume2,
   Download,
+  Info,
   UploadCloud,
   List,
   LayoutGrid,
   Grid3x3,
   Check,
   CheckSquare,
+  RotateCcw,
+  Wrench,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod } from '../lib/api';
 import type { ModConflict } from '../lib/api';
-import type { Mod } from '../types/mod';
+import type { Mod, UnknownModFilterGuess } from '../types/mod';
 import type { GameBananaModDetails } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
@@ -209,6 +212,7 @@ export default function Installed() {
     isGroup: boolean;
     isBulk?: boolean;
   } | null>(null);
+  const [customUnknownMod, setCustomUnknownMod] = useState<Mod | null>(null);
 
   // Multi-select state. `selectedIds` always stores mod ids (variants of a
   // selected group expand to every variant id) so bulk handlers can iterate
@@ -228,6 +232,19 @@ export default function Installed() {
   // picker reflect immediately without juggling a separate snapshot.
   const [pickerGroupId, setPickerGroupId] = useState<number | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+  const [unknownFilterGuess, setUnknownFilterGuess] = useState<{
+    mod: Mod;
+    loading: boolean;
+    result?: UnknownModFilterGuess;
+    error?: string;
+    cancelled?: boolean;
+  } | null>(null);
+  const [unknownFixMode, setUnknownFixMode] = useState<'single' | 'bulk' | null>(null);
+  const [unknownFilterCache, setUnknownFilterCache] = useState<Record<string, UnknownModFilterGuess>>({});
+  const [unknownFilterPendingIds, setUnknownFilterPendingIds] = useState<Set<string>>(new Set());
+  const [unknownFilterErrors, setUnknownFilterErrors] = useState<Record<string, string>>({});
+  const unknownRequestSeqRef = useRef(0);
+  const unknownRequestIdsRef = useRef<Record<string, number>>({});
 
   // Drag-and-drop reorder state. `draggingSection` scopes drops so dragging
   // an enabled card can't drop onto a disabled card and vice-versa.
@@ -314,6 +331,185 @@ export default function Installed() {
     setDetailsSourceModId(null);
     setDetailsActiveFileIds(new Set());
     setDetailsDates(null);
+  };
+
+  const inspectUnknownModFilters = async (
+    mod: Mod,
+    force = false,
+    mode: 'single' | 'bulk' = 'single',
+    focus = true
+  ) => {
+    setUnknownFixMode(mode);
+    if (unknownFilterPendingIds.has(mod.id) && !force) {
+      if (focus) setUnknownFilterGuess({ mod, loading: true });
+      return;
+    }
+
+    const cached = unknownFilterCache[mod.id];
+    if (cached && !force) {
+      if (focus) setUnknownFilterGuess({ mod, loading: false, result: cached });
+      return;
+    }
+
+    const requestId = ++unknownRequestSeqRef.current;
+    unknownRequestIdsRef.current[mod.id] = requestId;
+    setUnknownFilterPendingIds((prev) => new Set(prev).add(mod.id));
+    setUnknownFilterErrors((prev) => {
+      const next = { ...prev };
+      delete next[mod.id];
+      return next;
+    });
+    if (focus) setUnknownFilterGuess({ mod, loading: true });
+    try {
+      const result = await detectUnknownModFilters(mod.id);
+      if (unknownRequestIdsRef.current[mod.id] !== requestId) return;
+      delete unknownRequestIdsRef.current[mod.id];
+      setUnknownFilterPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(mod.id);
+        return next;
+      });
+      if (result.crcMatch.status !== 'error') {
+        setUnknownFilterCache((prev) => ({ ...prev, [mod.id]: result }));
+      }
+      setUnknownFilterGuess((current) =>
+        current?.mod.id === mod.id ? { mod: current.mod, loading: false, result } : current
+      );
+    } catch (err) {
+      if (unknownRequestIdsRef.current[mod.id] !== requestId) return;
+      delete unknownRequestIdsRef.current[mod.id];
+      const message = err instanceof Error ? err.message : String(err);
+      setUnknownFilterPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(mod.id);
+        return next;
+      });
+      setUnknownFilterErrors((prev) => ({ ...prev, [mod.id]: message }));
+      setUnknownFilterGuess((current) => {
+        if (current?.mod.id !== mod.id) return current;
+        return {
+          mod: current.mod,
+          loading: false,
+          error: message,
+        };
+      });
+    }
+  };
+
+  const openUnknownModFix = (mod: Mod, mode: 'single' | 'bulk' = 'single') => {
+    setUnknownFixMode(mode);
+    setUnknownFilterGuess({ mod, loading: unknownFilterPendingIds.has(mod.id) });
+  };
+
+  const applyUnknownMatch = async (mod: Mod, match: FoundUnknownMatch) => {
+    if (!match.modId || !match.modName) {
+      throw new Error('Matched mod is missing GameBanana metadata');
+    }
+    await applyUnknownModMatch(mod.id, {
+      gameBananaId: match.modId,
+      modName: match.modName,
+      gameBananaFileId: match.fileId,
+      sourceFileName: match.fileName,
+      sourceSection: match.section,
+      categoryName: match.categoryName,
+      thumbnailUrl: match.thumbnailUrl,
+      nsfw: match.nsfw,
+    });
+    await loadMods();
+    setUnknownFilterCache((prev) => {
+      const next = { ...prev };
+      delete next[mod.id];
+      return next;
+    });
+    setUnknownFilterErrors((prev) => {
+      const next = { ...prev };
+      delete next[mod.id];
+      return next;
+    });
+    delete unknownRequestIdsRef.current[mod.id];
+    setUnknownFilterPendingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(mod.id);
+      return next;
+    });
+    if (unknownFixMode === 'bulk') {
+      const nextUnknown = unknownMods.find((candidate) => candidate.id !== mod.id);
+      if (nextUnknown) {
+        openUnknownModFix(nextUnknown, 'bulk');
+      } else {
+        closeUnknownFix();
+      }
+    } else {
+      closeUnknownFix();
+    }
+  };
+
+  const closeUnknownFix = () => {
+    setUnknownFilterGuess(null);
+    setUnknownFixMode(null);
+  };
+
+  const cancelUnknownMatch = (mod: Mod) => {
+    delete unknownRequestIdsRef.current[mod.id];
+    void cancelUnknownModDetection(mod.id).catch(() => undefined);
+    setUnknownFilterPendingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(mod.id);
+      return next;
+    });
+    setUnknownFilterErrors((prev) => {
+      const next = { ...prev };
+      delete next[mod.id];
+      return next;
+    });
+    setUnknownFilterGuess((current) =>
+      current?.mod.id === mod.id ? { mod: current.mod, loading: false, cancelled: true } : current
+    );
+  };
+
+  const openBulkUnknownFix = (unknowns: Mod[]) => {
+    const first = unknowns[0];
+    if (!first) return;
+    openUnknownModFix(first, 'bulk');
+  };
+
+  const findAllUnknownMods = (unknowns: Mod[]) => {
+    const queued = unknowns.filter(
+      (mod) => !unknownFilterPendingIds.has(mod.id) && !unknownFilterCache[mod.id]
+    );
+    void runUnknownFindQueue(queued);
+  };
+
+  const runUnknownFindQueue = async (queued: Mod[]) => {
+    let nextIndex = 0;
+    const workerCount = Math.min(2, queued.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (nextIndex < queued.length) {
+        const mod = queued[nextIndex++];
+        await inspectUnknownModFilters(mod, false, 'bulk', false);
+      }
+    });
+    await Promise.all(workers);
+  };
+
+  const viewUnknownMatch = (mod: Mod, match: FoundUnknownMatch) => {
+    if (!match.modId) return;
+    closeUnknownFix();
+    void openModDetails({
+      ...mod,
+      name: match.modName ?? mod.name,
+      gameBananaId: match.modId,
+      gameBananaFileId: match.fileId,
+      sourceSection: match.section,
+      categoryName: match.categoryName,
+      thumbnailUrl: match.thumbnailUrl,
+      nsfw: match.nsfw,
+    });
+  };
+
+  const makeUnknownCustomMod = (mod: Mod) => {
+    closeUnknownFix();
+    setCustomUnknownMod(mod);
   };
 
   const handleDetailsDownload = async (fileId: number, fileName: string) => {
@@ -883,7 +1079,22 @@ export default function Installed() {
     .sort((a, b) => entrySortPriority(a) - entrySortPriority(b));
   const compactOrder = buildCompactPriorityOrder(allEntries);
   const conflictCount = conflictPairCount;
-
+  const unknownMods = mods
+    .filter((mod) => mod.isUnknown)
+    .sort((a, b) => a.priority - b.priority);
+  const selectedUnknownState = unknownFilterGuess
+    ? {
+        mod: unknownFilterGuess.mod,
+        loading: unknownFilterPendingIds.has(unknownFilterGuess.mod.id),
+        result: unknownFilterPendingIds.has(unknownFilterGuess.mod.id)
+          ? undefined
+          : unknownFilterCache[unknownFilterGuess.mod.id] ?? unknownFilterGuess.result,
+        error: unknownFilterPendingIds.has(unknownFilterGuess.mod.id)
+          ? undefined
+          : unknownFilterErrors[unknownFilterGuess.mod.id] ?? unknownFilterGuess.error,
+        cancelled: unknownFilterPendingIds.has(unknownFilterGuess.mod.id) ? false : unknownFilterGuess.cancelled,
+      }
+    : null;
   // Filter by search query (case-insensitive substring on name). Drag-and-drop
   // reorder is still correct because it targets the full enabled list order,
   // not the filtered view.
@@ -989,6 +1200,8 @@ export default function Installed() {
           onOpenDetails={mod.gameBananaId ? () => openModDetails(mod) : undefined}
           onToggle={() => toggleMod(mod.id)}
           onDelete={() => setModToDelete({ ids: [mod.id], name: mod.name, isGroup: false })}
+          onFixUnknown={mod.isUnknown ? () => openUnknownModFix(mod, 'single') : undefined}
+          fixingUnknown={unknownFilterPendingIds.has(mod.id)}
           selectMode={selectMode}
           selected={entrySelected}
           onSelectToggle={() => toggleEntrySelection(entry)}
@@ -1147,7 +1360,7 @@ export default function Installed() {
   // Fix Order) rather than the top action bar — when both are active the top
   // bar gets cramped, so move them to the line below where there's room.
   const hasStatusButtons =
-    conflictCount > 0 || updatesAvailable.size > 0 || !!updateAllProgress;
+    conflictCount > 0 || updatesAvailable.size > 0 || !!updateAllProgress || unknownMods.length > 0;
   const statusButtons = hasStatusButtons ? (
     <div className="flex items-center gap-2">
       {conflictCount > 0 && (
@@ -1174,6 +1387,17 @@ export default function Installed() {
             : `Update all (${updatesAvailable.size})`}
         </Button>
       )}
+      {unknownMods.length > 0 && (
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => openBulkUnknownFix(unknownMods)}
+          icon={Wrench}
+          title="Find GameBanana matches or add custom metadata for unknown local mods"
+        >
+          Fix unknown ({unknownMods.length})
+        </Button>
+      )}
     </div>
   ) : null;
 
@@ -1190,7 +1414,7 @@ export default function Installed() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search installed..."
-                className="bg-bg-secondary border border-border rounded-lg pl-8 pr-8 py-2 text-sm text-text-primary placeholder:text-text-secondary/60 focus:outline-none focus:ring-2 focus:ring-accent w-40"
+                className={`bg-bg-secondary border border-border rounded-lg pl-8 ${search ? 'pr-8' : 'pr-3'} py-2 text-sm text-text-primary placeholder:text-text-primary/55 focus:outline-none focus:ring-2 focus:ring-accent w-40`}
               />
               {search && (
                 <button
@@ -1532,6 +1756,73 @@ export default function Installed() {
         />
       )}
 
+      {selectedUnknownState && unknownFixMode === 'single' && (
+        <UnknownFilterGuessModal
+          state={selectedUnknownState}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          onApplyMatch={applyUnknownMatch}
+          onViewMatch={viewUnknownMatch}
+          onMakeCustom={makeUnknownCustomMod}
+          onFind={(mod) => void inspectUnknownModFilters(mod, false, 'single')}
+          onRetry={(mod) => void inspectUnknownModFilters(mod, true, 'single')}
+          onCancel={cancelUnknownMatch}
+          onClose={closeUnknownFix}
+        />
+      )}
+
+      {selectedUnknownState && unknownFixMode === 'bulk' && (
+        <BulkUnknownFixModal
+          unknownMods={unknownMods}
+          state={selectedUnknownState}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          cache={unknownFilterCache}
+          pendingIds={unknownFilterPendingIds}
+          errors={unknownFilterErrors}
+          onSelect={(mod) => openUnknownModFix(mod, 'bulk')}
+          onApplyMatch={applyUnknownMatch}
+          onViewMatch={viewUnknownMatch}
+          onMakeCustom={makeUnknownCustomMod}
+          onFindAll={findAllUnknownMods}
+          onFind={(mod) => void inspectUnknownModFilters(mod, false, 'bulk')}
+          onRetry={(mod) => void inspectUnknownModFilters(mod, true, 'bulk')}
+          onCancel={cancelUnknownMatch}
+          onClose={closeUnknownFix}
+        />
+      )}
+
+      {customUnknownMod && (
+        <ImportCustomModModal
+          title="Make Custom Mod"
+          submitLabel="Save Custom Mod"
+          initialVpkPath={customUnknownMod.path}
+          initialName={deriveModNameFromPath(customUnknownMod.fileName)}
+          lockVpk
+          vpkHelpText="This VPK is already installed. Saving will only add custom metadata to it."
+          onClose={() => setCustomUnknownMod(null)}
+          onImport={async ({ name, thumbnailDataUrl, nsfw }) => {
+            await applyUnknownCustomMod(customUnknownMod.id, { name, thumbnailDataUrl, nsfw });
+            await loadMods();
+            setUnknownFilterCache((prev) => {
+              const next = { ...prev };
+              delete next[customUnknownMod.id];
+              return next;
+            });
+            setUnknownFilterErrors((prev) => {
+              const next = { ...prev };
+              delete next[customUnknownMod.id];
+              return next;
+            });
+            delete unknownRequestIdsRef.current[customUnknownMod.id];
+            setUnknownFilterPendingIds((prev) => {
+              const next = new Set(prev);
+              next.delete(customUnknownMod.id);
+              return next;
+            });
+            setCustomUnknownMod(null);
+          }}
+        />
+      )}
+
       {selectMode && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-xl shadow-lg shadow-black/40 px-3 py-2 flex flex-wrap items-center gap-2">
           {bulkProgress ? (
@@ -1662,6 +1953,508 @@ function InstalledSkeleton({ viewMode }: { viewMode: ViewMode }) {
   );
 }
 
+function UnknownFilterGuessModal({
+  state,
+  hideNsfwPreviews,
+  onApplyMatch,
+  onViewMatch,
+  onMakeCustom,
+  onFind,
+  onRetry,
+  onCancel,
+  onClose,
+}: {
+  state: {
+    mod: Mod;
+    loading: boolean;
+    result?: UnknownModFilterGuess;
+    error?: string;
+    cancelled?: boolean;
+  };
+  hideNsfwPreviews: boolean;
+  onApplyMatch: (mod: Mod, match: FoundUnknownMatch) => Promise<void>;
+  onViewMatch: (mod: Mod, match: FoundUnknownMatch) => void;
+  onMakeCustom: (mod: Mod) => void;
+  onFind: (mod: Mod) => void;
+  onRetry: (mod: Mod) => void;
+  onCancel: (mod: Mod) => void;
+  onClose: () => void;
+}) {
+  const { mod } = state;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="unknown-filter-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-white/10">
+          <div className="min-w-0">
+            <h2 id="unknown-filter-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
+              <Wrench className="w-4 h-4 text-orange-400" />
+              Fix Unknown Mod
+            </h2>
+            <p className="text-xs text-text-secondary mt-1 truncate" title={mod.fileName}>
+              {mod.fileName}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <UnknownMatchPanel
+          key={mod.id}
+          state={state}
+          hideNsfwPreviews={hideNsfwPreviews}
+          onApplyMatch={onApplyMatch}
+          onViewMatch={onViewMatch}
+          onMakeCustom={onMakeCustom}
+          onFind={onFind}
+          onRetry={onRetry}
+          onCancel={onCancel}
+        />
+
+      </div>
+    </div>
+  );
+}
+
+function BulkUnknownFixModal({
+  unknownMods,
+  state,
+  hideNsfwPreviews,
+  cache,
+  pendingIds,
+  errors,
+  onSelect,
+  onApplyMatch,
+  onViewMatch,
+  onMakeCustom,
+  onFindAll,
+  onFind,
+  onRetry,
+  onCancel,
+  onClose,
+}: {
+  unknownMods: Mod[];
+  state: {
+    mod: Mod;
+    loading: boolean;
+    result?: UnknownModFilterGuess;
+    error?: string;
+    cancelled?: boolean;
+  };
+  hideNsfwPreviews: boolean;
+  cache: Record<string, UnknownModFilterGuess>;
+  pendingIds: Set<string>;
+  errors: Record<string, string>;
+  onSelect: (mod: Mod) => void;
+  onApplyMatch: (mod: Mod, match: FoundUnknownMatch) => Promise<void>;
+  onViewMatch: (mod: Mod, match: FoundUnknownMatch) => void;
+  onMakeCustom: (mod: Mod) => void;
+  onFindAll: (mods: Mod[]) => void;
+  onFind: (mod: Mod) => void;
+  onRetry: (mod: Mod) => void;
+  onCancel: (mod: Mod) => void;
+  onClose: () => void;
+}) {
+  const findableCount = unknownMods.filter((mod) => !pendingIds.has(mod.id) && !cache[mod.id]).length;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulk-unknown-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-5xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-white/10">
+          <div className="min-w-0">
+            <h2 id="bulk-unknown-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
+              <Wrench className="w-4 h-4 text-orange-400" />
+              Fix Unknown Mods
+            </h2>
+            <p className="text-xs text-text-secondary mt-1">
+              {unknownMods.length} unknown mod{unknownMods.length === 1 ? '' : 's'}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <Button
+              variant="primary"
+              size="sm"
+              icon={Search}
+              disabled={findableCount === 0}
+              onClick={() => onFindAll(unknownMods)}
+              title="Search every unknown mod that has not already been checked"
+            >
+              Find all
+            </Button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+              aria-label="Close"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="grid min-h-0 grid-cols-[240px_1fr] flex-1">
+          <div className="border-r border-white/10 p-3 overflow-y-auto space-y-1.5">
+            {unknownMods.map((mod) => {
+              const cached = cache[mod.id];
+              const cachedMatch = cached?.crcMatch;
+              const isSelected = state.mod.id === mod.id;
+              const isLoading = pendingIds.has(mod.id);
+              const hasError = !!errors[mod.id];
+              const statusLabel = isLoading
+                ? 'Searching'
+                : hasError
+                  ? 'Error'
+                : cachedMatch?.status === 'found'
+                  ? 'Found'
+                  : cachedMatch?.status === 'not-found'
+                    ? 'No match'
+                    : 'Unknown';
+              const statusTone = cachedMatch?.status === 'found'
+                ? 'text-state-success'
+                : hasError
+                  ? 'text-state-danger'
+                : cachedMatch?.status === 'not-found'
+                  ? 'text-text-tertiary'
+                  : 'text-text-secondary';
+
+              return (
+                <button
+                  key={mod.id}
+                  type="button"
+                  onClick={() => onSelect(mod)}
+                  className={`w-full text-left rounded-md border px-3 py-2 transition-colors cursor-pointer ${
+                    isSelected
+                      ? 'bg-accent/10 border-accent/40'
+                      : 'bg-bg-tertiary/40 border-white/5 hover:bg-bg-tertiary hover:border-white/10'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-text-primary truncate">{mod.name}</span>
+                    {isLoading && <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 text-[11px] min-w-0">
+                    <span className="font-mono text-text-tertiary truncate" title={mod.fileName}>{mod.fileName}</span>
+                    <span className={`flex-shrink-0 ${statusTone}`}>{statusLabel}</span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          <UnknownMatchPanel
+            key={state.mod.id}
+            state={state}
+            hideNsfwPreviews={hideNsfwPreviews}
+            onApplyMatch={onApplyMatch}
+            onViewMatch={onViewMatch}
+            onMakeCustom={onMakeCustom}
+            onFind={onFind}
+            onRetry={onRetry}
+            onCancel={onCancel}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UnknownMatchPanel({
+  state,
+  hideNsfwPreviews,
+  onApplyMatch,
+  onViewMatch,
+  onMakeCustom,
+  onFind,
+  onRetry,
+  onCancel,
+}: {
+  state: {
+    mod: Mod;
+    loading: boolean;
+    result?: UnknownModFilterGuess;
+    error?: string;
+    cancelled?: boolean;
+  };
+  hideNsfwPreviews: boolean;
+  onApplyMatch: (mod: Mod, match: FoundUnknownMatch) => Promise<void>;
+  onViewMatch: (mod: Mod, match: FoundUnknownMatch) => void;
+  onMakeCustom: (mod: Mod) => void;
+  onFind: (mod: Mod) => void;
+  onRetry: (mod: Mod) => void;
+  onCancel: (mod: Mod) => void;
+}) {
+  const { mod, loading, result, error, cancelled } = state;
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const match = result?.crcMatch;
+  const foundMatch = isFoundUnknownMatch(match) ? match : null;
+
+  const handleApply = async (matchToApply: FoundUnknownMatch) => {
+    if (applying) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      await onApplyMatch(mod, matchToApply);
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleRetry = () => {
+    if (applying) return;
+    setApplyError(null);
+    onRetry(mod);
+  };
+
+  const handleFind = () => {
+    if (applying) return;
+    setApplyError(null);
+    onFind(mod);
+  };
+
+  const handleCancel = () => {
+    if (applying) return;
+    setApplyError(null);
+    onCancel(mod);
+  };
+
+  return (
+    <div className="p-5 overflow-y-auto space-y-4">
+      {loading && (
+        <div className="rounded-md bg-bg-tertiary/50 border border-white/5 px-4 py-4 text-sm text-text-secondary flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Loader2 className="w-4 h-4 animate-spin text-accent flex-shrink-0" />
+            <span>Finding a matching mod...</span>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={X}
+            onClick={handleCancel}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {foundMatch && (
+        <UnknownMatchCard
+          match={foundMatch}
+          hideNsfwPreviews={hideNsfwPreviews}
+          applying={applying}
+          onApply={() => void handleApply(foundMatch)}
+          onView={() => onViewMatch(mod, foundMatch)}
+          onRetry={handleRetry}
+        />
+      )}
+
+      {applyError && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <span>{applyError}</span>
+        </div>
+      )}
+
+      {result && match && !foundMatch && (
+        <div className="rounded-md bg-bg-tertiary/50 border border-white/5 overflow-hidden">
+          <div className="p-4">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 text-text-tertiary flex-shrink-0 mt-0.5" />
+              <div className="min-w-0">
+                <div className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+                  {match.status === 'error' ? 'Match Check Failed' : 'No Match Found'}
+                </div>
+                <p className="text-sm text-text-secondary mt-1">
+                  {match.reason ?? 'No GameBanana archive matched this local VPK by CRC-32.'}
+                </p>
+                <div className="flex flex-wrap gap-2 mt-3 text-[11px] text-text-tertiary">
+                  <span>{match.checkedMods} mods checked</span>
+                  <span>{match.checkedFiles} files checked</span>
+                  <span>{match.bytesFetched.toLocaleString()} bytes fetched</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="border-t border-white/5 px-4 py-3 bg-black/10 flex flex-wrap justify-end gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={RotateCcw}
+              onClick={handleRetry}
+            >
+              Retry
+            </Button>
+            {match.status !== 'error' && (
+              <Button
+                variant="secondary"
+                size="sm"
+                icon={FilePlus}
+                onClick={() => onMakeCustom(mod)}
+              >
+                Make Custom Mod
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && !result && (
+        <div className="rounded-md bg-bg-tertiary/50 border border-white/5 px-4 py-4 text-sm text-text-secondary flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            {cancelled ? (
+              <X className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+            ) : (
+              <Search className="w-4 h-4 text-accent flex-shrink-0" />
+            )}
+            <span>{cancelled ? 'Search cancelled.' : 'Look for a matching mod from GameBanana.'}</span>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            icon={Search}
+            onClick={handleFind}
+          >
+            Search
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type FoundUnknownMatch = UnknownModFilterGuess['crcMatch'] & { status: 'found' };
+
+function isFoundUnknownMatch(match: UnknownModFilterGuess['crcMatch'] | undefined): match is FoundUnknownMatch {
+  return match?.status === 'found';
+}
+
+function UnknownMatchCard({
+  match,
+  hideNsfwPreviews,
+  applying,
+  onApply,
+  onView,
+  onRetry,
+}: {
+  match: FoundUnknownMatch;
+  hideNsfwPreviews: boolean;
+  applying: boolean;
+  onApply: () => void;
+  onView: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-state-success/35 bg-state-success/10 overflow-hidden">
+      <div className="p-4">
+        <div className="flex items-start gap-4">
+          <ModThumbnail
+            src={match.thumbnailUrl}
+            alt={match.modName ?? 'GameBanana mod'}
+            nsfw={match.nsfw}
+            hideNsfw={hideNsfwPreviews}
+            className="w-24 h-16 rounded-md bg-bg-primary border border-white/10 flex-shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-semibold uppercase tracking-wider text-state-success">
+              Likely Match
+            </div>
+            <h3 className="text-base font-semibold text-text-primary mt-1 truncate" title={match.modName}>
+              {match.modName ?? 'GameBanana mod'}
+            </h3>
+            {match.fileName && (
+              <p className="text-sm text-text-secondary mt-1 truncate" title={match.fileName}>
+                {match.fileName}
+              </p>
+            )}
+          </div>
+          <Tag tone="success">Exact CRC</Tag>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          {match.section && <Tag tone="neutral">{match.section === 'Mod' ? 'Mods' : 'Sounds'}</Tag>}
+          {match.categoryName && <Tag tone="neutral">{match.categoryName}</Tag>}
+          {typeof match.modId === 'number' && <Tag tone="neutral">Mod #{match.modId}</Tag>}
+          {typeof match.fileId === 'number' && <Tag tone="neutral">File #{match.fileId}</Tag>}
+        </div>
+
+        {match.reason && (
+          <p className="text-xs text-text-secondary mt-3">{match.reason}</p>
+        )}
+
+        <div className="flex flex-wrap gap-2 mt-3 text-[11px] text-text-tertiary">
+          <span>{match.checkedMods} mods checked</span>
+          <span>{match.checkedFiles} files checked</span>
+          <span>{match.bytesFetched.toLocaleString()} bytes fetched</span>
+          {match.skipped7z > 0 && <span>{match.skipped7z} 7z skipped</span>}
+        </div>
+      </div>
+
+      <div className="border-t border-state-success/20 px-4 py-3 bg-black/10 flex flex-wrap justify-end gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={Info}
+          disabled={applying}
+          onClick={onView}
+        >
+          View Mod
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={RotateCcw}
+          disabled={applying}
+          onClick={onRetry}
+        >
+          Retry
+        </Button>
+        <Button
+          variant="success"
+          size="sm"
+          icon={Check}
+          isLoading={applying}
+          onClick={onApply}
+        >
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 interface ModCardProps {
   mod: {
     id: string;
@@ -1677,6 +2470,7 @@ interface ModCardProps {
     categoryName?: string;
     nsfw?: boolean;
     gameBananaId?: number;
+    isUnknown?: boolean;
   };
   viewMode: ViewMode;
   hideNsfwPreviews: boolean;
@@ -1686,6 +2480,8 @@ interface ModCardProps {
   onOpenDetails?: () => void;
   onToggle: () => void;
   onDelete: () => void;
+  onFixUnknown?: () => void;
+  fixingUnknown?: boolean;
   /** When true, the card renders a selection checkbox overlay and clicks
    *  anywhere on the card route to `onSelectToggle` instead of opening
    *  details / firing toggle / delete. */
@@ -1723,6 +2519,8 @@ function ModCard({
   onOpenDetails,
   onToggle,
   onDelete,
+  onFixUnknown,
+  fixingUnknown,
   selectMode,
   selected,
   onSelectToggle,
@@ -1752,7 +2550,7 @@ function ModCard({
   const listHeroFacePos = listHeroName ? getHeroFacePosition(listHeroName) : 50;
   const hasListTags =
     viewMode === 'list' &&
-    (hasConflicts || mod.sourceSection === 'Sound' || mod.nsfw || updateAvailable || mod.enabled);
+    (hasConflicts || mod.isUnknown || mod.sourceSection === 'Sound' || mod.nsfw || updateAvailable || mod.enabled);
 
   const indicatorClasses = (() => {
     if (!isDropTarget || !dropPosition) return '';
@@ -1876,6 +2674,16 @@ function ModCard({
                   title={conflicts.map((c) => c.details).join(', ')}
                 >
                   Conflict
+                </Tag>
+              )}
+              {mod.isUnknown && (
+                <Tag
+                  variant="overlay"
+                  icon={Wrench}
+                  title="This local mod has no saved GameBanana or custom metadata"
+                  className="border-cyan-300/70 text-cyan-200"
+                >
+                  Unknown
                 </Tag>
               )}
               {updateAvailable && (
@@ -2083,6 +2891,15 @@ function ModCard({
                   Conflict
                 </Tag>
               )}
+              {mod.isUnknown && (
+                <Tag
+                  icon={Wrench}
+                  title="This local mod has no saved GameBanana or custom metadata"
+                  className="flex-shrink-0 bg-cyan-400/10 border-cyan-300/40 text-cyan-200"
+                >
+                  Unknown
+                </Tag>
+              )}
               {mod.sourceSection === 'Sound' && (
                 <Tag tone="accent" icon={Volume2} className="flex-shrink-0">
                   Sound
@@ -2136,13 +2953,34 @@ function ModCard({
               : 'flex-col items-center gap-1.5'
           }`}
         >
-          <button
-            onClick={onDelete}
-            className="p-1 text-text-secondary hover:text-red-500 transition-colors cursor-pointer"
-            title="Delete mod"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+          <div className={viewMode === 'list' ? 'contents' : 'flex items-center gap-1.5'}>
+            {mod.isUnknown && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onFixUnknown?.();
+                }}
+                disabled={!onFixUnknown}
+                className="p-1 text-text-secondary hover:text-orange-500 transition-colors cursor-pointer disabled:opacity-60"
+                title="Fix unknown mod"
+                aria-label={`Fix unknown mod ${mod.name}`}
+              >
+                {fixingUnknown ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Wrench className="w-4 h-4" />
+                )}
+              </button>
+            )}
+            <button
+              onClick={onDelete}
+              className="p-1 text-text-secondary hover:text-red-500 transition-colors cursor-pointer"
+              title="Delete mod"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
           <button
             onClick={onToggle}
             aria-pressed={mod.enabled}
@@ -2169,6 +3007,12 @@ function ModCard({
 interface ImportCustomModModalProps {
   onClose: () => void;
   onImport: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
+  title?: string;
+  submitLabel?: string;
+  initialVpkPath?: string;
+  initialName?: string;
+  lockVpk?: boolean;
+  vpkHelpText?: string;
 }
 
 const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
@@ -2183,9 +3027,18 @@ function deriveModNameFromPath(p: string): string {
     .trim();
 }
 
-function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) {
-  const [vpkPath, setVpkPath] = useState<string>('');
-  const [name, setName] = useState<string>('');
+function ImportCustomModModal({
+  onClose,
+  onImport,
+  title = 'Import Custom Mod',
+  submitLabel = 'Import',
+  initialVpkPath = '',
+  initialName = '',
+  lockVpk = false,
+  vpkHelpText = 'The file will be copied into your addons folder and renamed with the next available pak## priority.',
+}: ImportCustomModModalProps) {
+  const [vpkPath, setVpkPath] = useState<string>(initialVpkPath);
+  const [name, setName] = useState<string>(initialName || (initialVpkPath ? deriveModNameFromPath(initialVpkPath) : ''));
   const [imagePath, setImagePath] = useState<string>('');
   const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string>('');
   const [nsfw, setNsfw] = useState<boolean>(false);
@@ -2213,6 +3066,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
   };
 
   const pickVpk = async () => {
+    if (lockVpk) return;
     const picked = await showOpenDialog({
       title: 'Select VPK file',
       filters: [{ name: 'VPK files', extensions: ['vpk'] }],
@@ -2232,6 +3086,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
     e.preventDefault();
     e.stopPropagation();
     setVpkDragActive(false);
+    if (lockVpk) return;
     const file = e.dataTransfer.files?.[0];
     if (!file) return;
     if (!/\.vpk$/i.test(file.name)) {
@@ -2298,7 +3153,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
         <div className="flex items-center justify-between p-5 border-b border-border">
           <h3 className="text-lg font-semibold text-text-primary flex items-center gap-2">
             <FilePlus className="w-5 h-5" />
-            Import Custom Mod
+            {title}
           </h3>
           <button
             onClick={onClose}
@@ -2317,18 +3172,18 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
             <div
               role="button"
               tabIndex={0}
-              aria-label={vpkPath ? `VPK selected: ${vpkPath}. Press Enter to change.` : 'Drop a VPK file here or press Enter to browse'}
+              aria-label={vpkPath ? `VPK selected: ${vpkPath}${lockVpk ? '' : '. Press Enter to change.'}` : 'Drop a VPK file here or press Enter to browse'}
               onClick={pickVpk}
               onKeyDown={(e) => onZoneKeyDown(e, pickVpk)}
-              onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setVpkDragActive(true); }}
-              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setVpkDragActive(true); }}
+              onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); if (!lockVpk) setVpkDragActive(true); }}
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = lockVpk ? 'none' : 'copy'; if (!lockVpk) setVpkDragActive(true); }}
               onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setVpkDragActive(false); }}
               onDrop={handleVpkDrop}
-              className={`relative flex flex-col items-center justify-center gap-1.5 px-4 py-5 rounded-lg border border-dashed text-center cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${
+              className={`relative flex flex-col items-center justify-center gap-1.5 px-4 py-5 rounded-lg border border-dashed text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${
                 vpkDragActive
                   ? 'border-accent bg-accent/10'
                   : vpkPath
-                    ? 'border-accent/40 bg-bg-tertiary/60 hover:bg-bg-tertiary'
+                    ? `border-accent/40 bg-bg-tertiary/60 ${lockVpk ? 'cursor-default' : 'cursor-pointer hover:bg-bg-tertiary'}`
                     : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
               }`}
             >
@@ -2339,7 +3194,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
                     {vpkPath.split(/[\\/]/).pop()}
                   </span>
                   <span className="text-xs text-text-secondary font-mono truncate max-w-full">{vpkPath}</span>
-                  <span className="text-xs text-accent">Click or drop another to replace</span>
+                  {!lockVpk && <span className="text-xs text-accent">Click or drop another to replace</span>}
                 </>
               ) : (
                 <>
@@ -2352,7 +3207,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
               )}
             </div>
             <p className="mt-1 text-xs text-text-secondary">
-              The file will be copied into your addons folder and renamed with the next available pak## priority.
+              {vpkHelpText}
             </p>
           </div>
 
@@ -2446,7 +3301,7 @@ function ImportCustomModModal({ onClose, onImport }: ImportCustomModModalProps) 
             className="px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-            Import
+            {submitLabel}
           </button>
         </div>
       </div>

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -640,6 +640,9 @@ function HeroGalleryCard({
         )}
         {renderSrc && fallbackStep < 3 && (
           <img
+            ref={(el) => {
+              if (el && el.complete && el.naturalWidth > 0) setRenderLoaded(true);
+            }}
             src={renderSrc}
             alt={hero.name}
             className={`absolute inset-0 h-full w-full object-cover will-change-transform backface-visibility-hidden group-hover:scale-[1.06] scale-100 ${renderLoaded ? 'opacity-100' : 'opacity-0'} transition-[opacity,transform] duration-500`}
@@ -689,6 +692,12 @@ function HeroGalleryCard({
               <div className="absolute inset-0 skeleton-shimmer bg-white/10 rounded-sm" aria-hidden />
             )}
             <img
+              ref={(el) => {
+                // Sub-100KB PNGs over file:// can finish loading before React
+                // attaches onLoad, leaving the image cached but stuck at
+                // opacity-0. Sync the state from img.complete on every mount.
+                if (el && el.complete && el.naturalWidth > 0) setNameLoaded(true);
+              }}
               src={namePath}
               alt={hero.name}
               className={`absolute inset-0 w-full h-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] will-change-transform backface-visibility-hidden group-hover:scale-105 scale-100 ${nameLoaded ? 'opacity-100' : 'opacity-0'} transition-[opacity,transform] duration-500`}

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -121,7 +121,7 @@ export default function Profiles() {
   const { getSettings: getCrosshairSettings, loadSettingsFromPreset } = useCrosshairStore();
   const socialSignedIn = useSocialStore((s) => s.status.signedIn);
 
-  const modByFileName = new Map(mods.map(m => [m.fileName, m]));
+  const modByFileName = new Map(mods.map((m) => [m.fileName, m]));
 
   const loadProfileList = async (opts?: { silent?: boolean }) => {
     // Silent refresh leaves the page rendered: needed for in-modal flows

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,4 +1,11 @@
-import type { Mod, AppSettings } from './mod';
+import type {
+    Mod,
+    AppSettings,
+    ModConflict,
+    UnknownModFilterGuess,
+    ApplyUnknownModMatchArgs,
+    ApplyUnknownCustomModArgs,
+} from './mod';
 import type {
     GameBananaModsResponse,
     GameBananaModDetails,
@@ -273,6 +280,10 @@ export interface ElectronAPI {
     enableMod: (modId: string) => Promise<Mod>;
     disableMod: (modId: string) => Promise<Mod>;
     deleteMod: (modId: string) => Promise<void>;
+    detectUnknownModFilters: (modId: string) => Promise<UnknownModFilterGuess>;
+    cancelUnknownModDetection: (modId: string) => Promise<void>;
+    applyUnknownModMatch: (modId: string, args: ApplyUnknownModMatchArgs) => Promise<Mod>;
+    applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     backfillGameBananaFileId: (
       modId: string,
@@ -564,18 +575,6 @@ export interface ElectronAPI {
         checkApiHealth: () => Promise<unknown>;
         getApiInfo: () => Promise<unknown>;
     };
-}
-
-export interface ModConflict {
-    modA: string;
-    modAName: string;
-    modB: string;
-    modBName: string;
-    modAIdentity: string;
-    modBIdentity: string;
-    ignoreKey: string;
-    conflictType: 'priority' | 'file';
-    details: string;
 }
 
 export interface ProfileMod {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,9 +17,71 @@ export interface Mod {
   sourceSection?: string;
   nsfw?: boolean;
   isArchived?: boolean;
+  sha256?: string;
+  isUnknown?: boolean;
   variantLabel?: string;
   fileDescription?: string;
   sourceFileName?: string;
+}
+
+export interface UnknownModFilterGuess {
+  modId: string;
+  fileName: string;
+  fileCount: number;
+  section: 'Mod' | 'Sound';
+  search: string | null;
+  heroName?: string;
+  heroFileName?: string;
+  categoryName?: string;
+  confidence: 'high' | 'medium' | 'low';
+  contentHints: string[];
+  reasons: string[];
+  detectedHeroes: Array<{
+    name: string;
+    fileName: string;
+    score: number;
+    strongestSignal: 'strong' | 'medium' | 'weak';
+    clues: string[];
+  }>;
+  samplePaths: string[];
+  crcMatch: UnknownModCrcMatchResult;
+}
+
+export interface UnknownModCrcMatchResult {
+  status: 'found' | 'not-found' | 'error';
+  modId?: number;
+  modName?: string;
+  thumbnailUrl?: string;
+  nsfw?: boolean;
+  fileId?: number;
+  fileName?: string;
+  section?: 'Mod' | 'Sound';
+  categoryName?: string;
+  confidence?: 'exact';
+  reason?: string;
+  searchedBuckets: string[];
+  checkedMods: number;
+  checkedFiles: number;
+  bytesFetched: number;
+  skipped7z: number;
+  errors: string[];
+}
+
+export interface ApplyUnknownModMatchArgs {
+  gameBananaId: number;
+  modName: string;
+  gameBananaFileId?: number;
+  sourceFileName?: string;
+  sourceSection?: 'Mod' | 'Sound';
+  categoryName?: string;
+  thumbnailUrl?: string;
+  nsfw?: boolean;
+}
+
+export interface ApplyUnknownCustomModArgs {
+  name: string;
+  thumbnailDataUrl?: string;
+  nsfw?: boolean;
 }
 
 export interface Profile {


### PR DESCRIPTION
Adds a Fix Unknown flow for local VPKs that do not have saved GameBanana or custom metadata.

## Added
- Detects metadata-less installed VPKs as unknown mods.
- Adds Fix Unknown actions for single and bulk unknown mods.
- Matches unknown VPKs using content clues and GameBanana archive CRC checks.
- Adds SHA-256 metadata for installed VPKs, with startup backfill for older metadata.

## Changed
- Unknown match apply re-downloads the matched GameBanana file, then removes the unknown only after the replacement succeeds.
- Unknown searches can be cancelled, and bulk searching is throttled.
- File comparison and metadata collision handling use stored hashes when available.

## Fixed
- Prevents enabled/disabled same-filename mods from leaking or inheriting the wrong metadata.
- Fixes metadata hash backfill directory scanning.
- Fixes the Installed search input placeholder spacing.