### PR TITLE
feat(snapshots): auto recovery points before mod updates and profile applies

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -38,6 +38,7 @@ import './ipc/gamebanana';
 import './ipc/system';
 import './ipc/conflicts';
 import './ipc/profiles';
+import './ipc/snapshots';
 import './ipc/modDatabase';
 import './ipc/crosshairPresets';
 import './ipc/stats';

--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -17,6 +17,7 @@ import {
     resolvePortableProfile,
     createProfileFromPortable,
 } from '../services/portableProfile';
+import { writeSnapshot } from '../services/snapshots';
 import type {
     PortableProfile,
     PortableResolvedMod,
@@ -85,6 +86,16 @@ ipcMain.handle('apply-profile', async (_, profileId: string): Promise<Profile> =
     if (!deadlockPath) {
         throw new Error('No Deadlock path configured');
     }
+
+    // Capture a recovery snapshot before applyProfile rewrites enable/disable
+    // state across every installed mod. Failure is non-fatal — we never want
+    // a snapshot bug to block the apply the user just clicked.
+    try {
+        await writeSnapshot(deadlockPath, 'pre-apply-profile');
+    } catch (err) {
+        console.warn('[ApplyProfile] failed to capture pre-apply snapshot:', err);
+    }
+
     const profile = await applyProfile(deadlockPath, profileId);
 
     // Save as active profile

--- a/electron/main/ipc/snapshots.ts
+++ b/electron/main/ipc/snapshots.ts
@@ -1,0 +1,47 @@
+import { ipcMain } from 'electron';
+import { loadSettings } from '../services/settings';
+import {
+    writeSnapshot,
+    listSnapshots,
+    loadSnapshot,
+    deleteSnapshot,
+    type SnapshotSummary,
+    type SnapshotTrigger,
+} from '../services/snapshots';
+
+function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+// snapshot-create — capture the current installed mod set as a recovery
+// snapshot. Used automatically by the update path (trigger = "pre-update").
+ipcMain.handle('snapshot-create', async (_, trigger: SnapshotTrigger): Promise<SnapshotSummary> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const snap = await writeSnapshot(deadlockPath, trigger);
+    return {
+        snapshotId: snap.snapshotId,
+        createdAt: snap.createdAt,
+        trigger: snap.trigger,
+        modCount: snap.modCount,
+        profileName: snap.profile.profile.name,
+    };
+});
+
+// snapshot-list — newest first; bad files are dropped silently.
+ipcMain.handle('snapshot-list', (): SnapshotSummary[] => listSnapshots());
+
+// snapshot-load — returns the embedded PortableProfile JSON so the renderer
+// can feed it to the existing portable-import flow.
+ipcMain.handle('snapshot-load', (_, snapshotId: string): string => loadSnapshot(snapshotId));
+
+// snapshot-delete
+ipcMain.handle('snapshot-delete', (_, snapshotId: string): void => {
+    deleteSnapshot(snapshotId);
+});

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -69,6 +69,80 @@ export function decodeShareCode(code: string): string {
     return decompressed.toString('utf8');
 }
 
+/** Build a portable profile from the live installed mod set, without
+ *  requiring a saved Grimoire profile. Used by the snapshot service so we can
+ *  capture a recovery point even when no profile is selected. Local mods (no
+ *  gameBananaFileId) are skipped and reported via warnings so the caller can
+ *  log how many entries were dropped. */
+export async function buildPortableProfileFromInstalled(
+    deadlockPath: string,
+    profileName: string
+): Promise<PortableExportResult> {
+    const installed = await scanMods(deadlockPath);
+
+    const mods: PortableModEntry[] = [];
+    const warnings: string[] = [];
+
+    for (const installedMod of installed) {
+        const metadata = getModMetadata(installedMod.fileName);
+        const gbId = metadata?.gameBananaId ?? installedMod.gameBananaId;
+        const fileId = metadata?.gameBananaFileId ?? installedMod.gameBananaFileId;
+
+        if (!gbId || !fileId) {
+            const label = metadata?.modName || installedMod.name || installedMod.fileName;
+            warnings.push(`Skipped local mod: ${label}`);
+            continue;
+        }
+
+        const fileLabel =
+            metadata?.variantLabel ||
+            metadata?.fileDescription ||
+            metadata?.sourceFileName ||
+            undefined;
+
+        const vpkStem = vpkStemOf(installedMod.fileName);
+        mods.push({
+            source: 'gamebanana',
+            ref: {
+                submissionId: gbId,
+                fileId,
+                section: metadata?.sourceSection || 'Mod',
+                ...(vpkStem !== null ? { vpkStem } : {}),
+            },
+            enabled: installedMod.enabled,
+            priority: installedMod.priority,
+            hint: {
+                name: metadata?.modName || installedMod.name,
+                category: metadata?.categoryName,
+                fileLabel,
+                originalFileName: metadata?.sourceFileName,
+                thumbnailUrl: metadata?.thumbnailUrl,
+                nsfw: metadata?.nsfw,
+                isArchived: metadata?.isArchived,
+            },
+        });
+    }
+
+    const portable: PortableProfile = {
+        format: PORTABLE_PROFILE_FORMAT,
+        schemaVersion: PORTABLE_PROFILE_SCHEMA_VERSION,
+        game: {
+            steamAppId: DEADLOCK_STEAM_APP_ID,
+            gameBananaGameId: DEADLOCK_GAMEBANANA_GAME_ID,
+            name: 'Deadlock',
+        },
+        exportedAt: new Date().toISOString(),
+        exportedBy: { tool: 'grimoire', version: app.getVersion() },
+        profile: { name: profileName },
+        mods,
+    };
+
+    const json = JSON.stringify(portable, null, 2);
+    const shareCode = encodeShareCode(json);
+
+    return { profile: portable, json, shareCode, warnings };
+}
+
 /** Build a portable profile from a stored Grimoire profile. Local mods (no
  *  gameBananaFileId) are skipped and reported via warnings so the UI can tell
  *  the user without scanning the file again. */

--- a/electron/main/services/snapshots.ts
+++ b/electron/main/services/snapshots.ts
@@ -1,0 +1,188 @@
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    renameSync,
+    unlinkSync,
+    writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { getUserDataPath } from '../utils/paths';
+import { buildPortableProfileFromInstalled } from './portableProfile';
+import type { PortableProfile } from '../../../src/types/portableProfile';
+import type { SnapshotSummary, SnapshotTrigger } from '../../../src/types/snapshot';
+export type { SnapshotSummary, SnapshotTrigger };
+
+/** Persisted snapshot envelope. Carries the full portable profile inline so
+ *  the file is self-contained — a user can copy it out and re-import without
+ *  the surrounding metadata. */
+export interface Snapshot {
+    snapshotId: string;
+    createdAt: string;
+    trigger: SnapshotTrigger;
+    modCount: number;
+    profile: PortableProfile;
+}
+
+function getSnapshotsDir(): string {
+    return join(getUserDataPath(), 'snapshots');
+}
+
+function ensureDir(): string {
+    const dir = getSnapshotsDir();
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    return dir;
+}
+
+/** ISO timestamp safe for use in a filename across Windows/macOS/Linux:
+ *  replaces `:` with `-` so Windows tolerates it. */
+function filenameTimestamp(iso: string): string {
+    return iso.replace(/:/g, '-');
+}
+
+function snapshotFilename(snapshot: Snapshot): string {
+    return `${filenameTimestamp(snapshot.createdAt)}_${snapshot.trigger}_${snapshot.snapshotId}.json`;
+}
+
+function snapshotPath(filename: string): string {
+    return join(getSnapshotsDir(), filename);
+}
+
+function generateSnapshotId(): string {
+    return `snap_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Atomic write via temp+rename, matching the pattern in metadata.ts so a
+ *  crash mid-write can't leave a half-written snapshot on disk. */
+function writeSnapshotFile(snapshot: Snapshot): string {
+    const dir = ensureDir();
+    const filename = snapshotFilename(snapshot);
+    const finalPath = join(dir, filename);
+    const tempPath = `${finalPath}.tmp`;
+    try {
+        writeFileSync(tempPath, JSON.stringify(snapshot, null, 2), 'utf-8');
+        renameSync(tempPath, finalPath);
+    } catch (err) {
+        try {
+            if (existsSync(tempPath)) unlinkSync(tempPath);
+        } catch {
+            /* ignore cleanup failure */
+        }
+        throw err;
+    }
+    return filename;
+}
+
+function readSnapshotFile(filename: string): Snapshot | null {
+    const full = snapshotPath(filename);
+    try {
+        const raw = readFileSync(full, 'utf-8');
+        const parsed = JSON.parse(raw) as Snapshot;
+        if (!parsed.snapshotId || !parsed.createdAt || !parsed.profile) {
+            return null;
+        }
+        return parsed;
+    } catch (err) {
+        console.warn(`[Snapshots] Failed to parse ${filename}:`, err);
+        return null;
+    }
+}
+
+function listSnapshotFiles(): string[] {
+    const dir = getSnapshotsDir();
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir).filter((f) => f.endsWith('.json'));
+}
+
+/** Capture the current installed mod set as a recovery snapshot.
+ *  Builds a portable profile from the live install state (not a stored
+ *  profile), wraps it with trigger metadata, and writes atomically.
+ *  Returns the snapshot for callers that want to log it.
+ *
+ *  Each file is tiny (a JSON manifest of GameBanana IDs per mod, no VPK
+ *  bytes), so we don't auto-prune — the user deletes what they want from
+ *  the Snapshots UI.
+ *
+ *  Failure is intentionally not silent here — the caller decides whether to
+ *  swallow (e.g., the update path treats snapshot failure as non-fatal). */
+export async function writeSnapshot(
+    deadlockPath: string,
+    trigger: SnapshotTrigger
+): Promise<Snapshot> {
+    const createdAt = new Date().toISOString();
+    const friendlyTimestamp = createdAt.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+    const profileName =
+        trigger === 'pre-update'
+            ? `Auto-snapshot (before update) ${friendlyTimestamp}`
+            : `Snapshot ${friendlyTimestamp}`;
+
+    const { profile, warnings } = await buildPortableProfileFromInstalled(
+        deadlockPath,
+        profileName
+    );
+    if (warnings.length > 0) {
+        console.log(`[Snapshots] ${warnings.length} local mods skipped:`, warnings);
+    }
+
+    const snapshot: Snapshot = {
+        snapshotId: generateSnapshotId(),
+        createdAt,
+        trigger,
+        modCount: profile.mods.length,
+        profile,
+    };
+
+    writeSnapshotFile(snapshot);
+    return snapshot;
+}
+
+/** Newest-first list of snapshot summaries. Files with unparseable JSON are
+ *  skipped rather than thrown — a broken snapshot file shouldn't block the
+ *  Profiles page from rendering. */
+export function listSnapshots(): SnapshotSummary[] {
+    const summaries: SnapshotSummary[] = [];
+    for (const filename of listSnapshotFiles()) {
+        const snap = readSnapshotFile(filename);
+        if (!snap) continue;
+        summaries.push({
+            snapshotId: snap.snapshotId,
+            createdAt: snap.createdAt,
+            trigger: snap.trigger,
+            modCount: snap.modCount,
+            profileName: snap.profile.profile.name,
+        });
+    }
+    summaries.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+    return summaries;
+}
+
+/** Return the embedded PortableProfile JSON string so the renderer can hand
+ *  it straight to parsePortableProfile + the existing import dialog. */
+export function loadSnapshot(snapshotId: string): string {
+    for (const filename of listSnapshotFiles()) {
+        const snap = readSnapshotFile(filename);
+        if (snap?.snapshotId === snapshotId) {
+            return JSON.stringify(snap.profile, null, 2);
+        }
+    }
+    throw new Error(`Snapshot not found: ${snapshotId}`);
+}
+
+export function deleteSnapshot(snapshotId: string): void {
+    for (const filename of listSnapshotFiles()) {
+        const snap = readSnapshotFile(filename);
+        if (snap?.snapshotId === snapshotId) {
+            try {
+                unlinkSync(snapshotPath(filename));
+            } catch (err) {
+                throw new Error(`Failed to delete snapshot: ${String(err)}`);
+            }
+            return;
+        }
+    }
+    throw new Error(`Snapshot not found: ${snapshotId}`);
+}
+

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -5,6 +5,7 @@ import type {
     PortableResolutionReport,
     PortableResolvedMod,
 } from '../../src/types/portableProfile';
+import type { SnapshotSummary, SnapshotTrigger } from '../../src/types/snapshot';
 import type { SocialSessionStatus } from '../../src/types/social';
 import type {
     LikeResponse,
@@ -130,6 +131,15 @@ export interface ElectronAPI {
     parsePortableProfile: (input: string) => Promise<PortableProfile>;
     resolvePortableProfile: (profile: PortableProfile) => Promise<PortableResolutionReport>;
     finalizePortableImport: (args: { profile: PortableProfile; resolved: PortableResolvedMod[] }) => Promise<Profile>;
+
+    // Snapshots — automatic recovery points captured before risky operations
+    // (currently just mod updates). Restore re-uses the portable-import flow.
+    snapshots: {
+        create: (trigger: SnapshotTrigger) => Promise<SnapshotSummary>;
+        list: () => Promise<SnapshotSummary[]>;
+        load: (snapshotId: string) => Promise<string>;
+        delete: (snapshotId: string) => Promise<void>;
+    };
 
     // Mod Database (Local Cache)
     syncAllMods: () => Promise<{ success: boolean }>;
@@ -920,6 +930,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     resolvePortableProfile: (profile: PortableProfile) => ipcRenderer.invoke('resolve-portable-profile', profile),
     finalizePortableImport: (args: { profile: PortableProfile; resolved: PortableResolvedMod[] }) =>
         ipcRenderer.invoke('finalize-portable-import', args),
+
+    // Snapshots
+    snapshots: {
+        create: (trigger: SnapshotTrigger) => ipcRenderer.invoke('snapshot-create', trigger),
+        list: () => ipcRenderer.invoke('snapshot-list'),
+        load: (snapshotId: string) => ipcRenderer.invoke('snapshot-load', snapshotId),
+        delete: (snapshotId: string) => ipcRenderer.invoke('snapshot-delete', snapshotId),
+    },
 
     // Mod Database (Local Cache)
     syncAllMods: () => ipcRenderer.invoke('sync-all-mods'),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -414,6 +414,28 @@ export async function finalizePortableImport(args: {
 }
 
 // =====================
+// Snapshots API
+// =====================
+
+import type { SnapshotSummary, SnapshotTrigger } from '../types/snapshot';
+
+export async function createSnapshot(trigger: SnapshotTrigger): Promise<SnapshotSummary> {
+  return window.electronAPI.snapshots.create(trigger);
+}
+
+export async function listSnapshots(): Promise<SnapshotSummary[]> {
+  return window.electronAPI.snapshots.list();
+}
+
+export async function loadSnapshot(snapshotId: string): Promise<string> {
+  return window.electronAPI.snapshots.load(snapshotId);
+}
+
+export async function deleteSnapshot(snapshotId: string): Promise<void> {
+  return window.electronAPI.snapshots.delete(snapshotId);
+}
+
+// =====================
 // Grimoire Social API
 // =====================
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -23,7 +23,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import type { GameBananaModDetails } from '../types/gamebanana';
@@ -373,6 +373,9 @@ export default function Installed() {
     // still find the new install even when we redirected a stale snapshot.
     const completed: { gameBananaId: number; gameBananaFileId: number; wasEnabled: boolean; fileName: string }[] = [];
     let progress = 0;
+    // Guard so a multi-group update writes exactly one recovery snapshot, not
+    // one per group.
+    let snapshotTaken = false;
 
     for (const [, group] of groups) {
       let details: GameBananaModDetails;
@@ -421,6 +424,20 @@ export default function Installed() {
             snapshot: s,
             reason: 'file no longer on GameBanana; mod files changed. Reinstall from Browse.',
           });
+        }
+      }
+
+      // Capture a recovery snapshot before any delete runs in this group.
+      // We only snapshot once per runUpdate invocation (guarded by the
+      // `snapshotTaken` flag below), so a 50-mod update writes one file, not
+      // one per mod. Failure is non-fatal: a missing snapshot must not block
+      // the update the user just clicked.
+      if (!snapshotTaken && resolutions.some((r) => r.ok)) {
+        snapshotTaken = true;
+        try {
+          await createSnapshot('pre-update');
+        } catch (err) {
+          console.warn('[Update] failed to capture pre-update snapshot:', err);
         }
       }
 

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X, Upload, Share2, Globe } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X, Upload, Share2, Globe, History, RotateCcw, Camera } from 'lucide-react';
 import {
   getProfiles,
   createProfile,
@@ -8,8 +8,14 @@ import {
   deleteProfile,
   renameProfile,
   getSettings,
+  createSnapshot,
+  listSnapshots,
+  loadSnapshot,
+  deleteSnapshot,
 } from '../lib/api';
 import type { Profile, ProfileCrosshairSettings } from '../lib/api';
+import type { SnapshotSummary } from '../types/snapshot';
+import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import type { AppSettings } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import { useCrosshairStore } from '../stores/crosshairStore';
@@ -102,6 +108,14 @@ export default function Profiles() {
   const [exportingProfileId, setExportingProfileId] = useState<string | null>(null);
   const [publishingProfileId, setPublishingProfileId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
+  // When set, the ImportProfileDialog renders with this JSON pre-seeded (via
+  // initialInput) and auto-resolves it — the snapshot restore flow.
+  const [restoringSnapshotJson, setRestoringSnapshotJson] = useState<string | null>(null);
+  const [snapshots, setSnapshots] = useState<SnapshotSummary[]>([]);
+  const [snapshotsExpanded, setSnapshotsExpanded] = useState(false);
+  const [restoringSnapshotId, setRestoringSnapshotId] = useState<string | null>(null);
+  const [deleteSnapshotConfirmId, setDeleteSnapshotConfirmId] = useState<string | null>(null);
+  const [creatingSnapshot, setCreatingSnapshot] = useState(false);
 
   const { mods, loadMods } = useAppStore();
   const { getSettings: getCrosshairSettings, loadSettingsFromPreset } = useCrosshairStore();
@@ -131,9 +145,55 @@ export default function Profiles() {
     }
   };
 
+  const loadSnapshotList = useCallback(async () => {
+    try {
+      setSnapshots(await listSnapshots());
+    } catch (err) {
+      // Snapshot listing failures shouldn't gate the rest of the page.
+      console.warn('[Profiles] failed to load snapshots:', err);
+    }
+  }, []);
+
   useEffect(() => {
     loadProfileList();
+    void loadSnapshotList();
+  }, [loadSnapshotList]);
+
+  const handleRestoreSnapshot = useCallback(async (snapshotId: string) => {
+    setRestoringSnapshotId(snapshotId);
+    try {
+      const json = await loadSnapshot(snapshotId);
+      setRestoringSnapshotJson(json);
+    } catch (err) {
+      setError(`Failed to load snapshot: ${String(err)}`);
+    } finally {
+      setRestoringSnapshotId(null);
+    }
   }, []);
+
+  const handleCreateManualSnapshot = useCallback(async () => {
+    setCreatingSnapshot(true);
+    try {
+      await createSnapshot('manual');
+      await loadSnapshotList();
+      setSnapshotsExpanded(true);
+    } catch (err) {
+      setError(`Failed to capture snapshot: ${String(err)}`);
+    } finally {
+      setCreatingSnapshot(false);
+    }
+  }, [loadSnapshotList]);
+
+  const handleDeleteSnapshot = useCallback(async (snapshotId: string) => {
+    try {
+      await deleteSnapshot(snapshotId);
+      await loadSnapshotList();
+    } catch (err) {
+      setError(`Failed to delete snapshot: ${String(err)}`);
+    } finally {
+      setDeleteSnapshotConfirmId(null);
+    }
+  }, [loadSnapshotList]);
 
   const toggleExpand = (id: string) => {
     const next = new Set(expandedProfiles);
@@ -295,6 +355,117 @@ export default function Profiles() {
                 Import
               </Button>
             </div>
+          </Card>
+
+          {/* Snapshots — automatic recovery points captured before
+              destructive operations (mod updates, profile apply). Also
+              supports manual capture. Restore re-uses the portable-import
+              dialog so the user sees exactly what will re-download. */}
+          <Card
+            title={`Snapshots${snapshots.length > 0 ? ` (${snapshots.length})` : ''}`}
+            icon={History}
+            action={
+              <div className="flex items-center gap-1">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  icon={Camera}
+                  onClick={handleCreateManualSnapshot}
+                  isLoading={creatingSnapshot}
+                  disabled={creatingSnapshot}
+                  title="Capture your current installed mods now. Use this before experimenting (mass-installing variants, testing a collection, etc.) so you can roll back to this exact state."
+                  aria-label="Snapshot now"
+                >
+                  Snapshot now
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setSnapshotsExpanded((v) => !v)}
+                  icon={snapshotsExpanded ? ChevronUp : ChevronDown}
+                  aria-label={snapshotsExpanded ? 'Collapse snapshots' : 'Expand snapshots'}
+                  title={snapshotsExpanded ? 'Collapse list' : 'Show all snapshots'}
+                  className="px-1.5"
+                />
+              </div>
+            }
+          >
+            {!snapshotsExpanded ? (
+              <p
+                className="text-xs text-text-secondary"
+                title="Snapshots are automatic recovery points taken before mod updates and profile applies. They store the list of installed mods (not the VPK files), and restore by re-downloading from GameBanana. Snapshots accumulate until you delete them."
+              >
+                {snapshots.length === 0
+                  ? 'Automatic recovery points captured before updates or profile applies. None yet — one will appear here the next time you run either.'
+                  : `Most recent: ${formatRelativeDate(snapshots[0].createdAt)} · ${snapshots[0].modCount} mods.`}
+              </p>
+            ) : snapshots.length === 0 ? (
+              <p className="text-xs text-text-secondary">
+                Grimoire takes a snapshot of your installed mod set automatically before each mod update and before applying a profile. Restore re-downloads those mods from GameBanana, so a bad update or wrong-profile-applied can be rolled back. Snapshots store only the list of mods (their GameBanana IDs), never the VPK files, so disk cost stays tiny — they accumulate until you delete them. You can also capture one manually with the button above before experimenting.
+              </p>
+            ) : (
+              <ul className="divide-y divide-white/5">
+                {snapshots.map((snap) => {
+                  const isRestoring = restoringSnapshotId === snap.snapshotId;
+                  const triggerLabel =
+                    snap.trigger === 'pre-update'
+                      ? 'Before update'
+                      : snap.trigger === 'pre-apply-profile'
+                      ? 'Before applying profile'
+                      : 'Manual';
+                  const triggerExplanation =
+                    snap.trigger === 'pre-update'
+                      ? 'Captured automatically right before mod files were replaced by an update.'
+                      : snap.trigger === 'pre-apply-profile'
+                      ? 'Captured automatically right before a saved profile was applied (enable/disable layout rewritten).'
+                      : 'You captured this manually from the Snapshot now button.';
+                  return (
+                    <li
+                      key={snap.snapshotId}
+                      className="flex flex-wrap items-center gap-3 py-2.5"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div
+                          className="text-sm text-text-primary truncate"
+                          title={triggerExplanation}
+                        >
+                          {triggerLabel}
+                          <span className="text-text-secondary"> · {snap.modCount} mods</span>
+                        </div>
+                        <div
+                          className="text-xs text-text-secondary"
+                          title={formatAbsoluteDate(snap.createdAt)}
+                        >
+                          {formatRelativeDate(snap.createdAt)}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          icon={RotateCcw}
+                          onClick={() => handleRestoreSnapshot(snap.snapshotId)}
+                          isLoading={isRestoring}
+                          disabled={isRestoring}
+                          title="Opens the import dialog with this snapshot's mod list pre-resolved. Mods already on disk stay as-is; anything missing or different re-downloads from GameBanana. Confirming creates a new profile you can apply to swap your install set back to this state."
+                        >
+                          Restore
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          icon={Trash2}
+                          onClick={() => setDeleteSnapshotConfirmId(snap.snapshotId)}
+                          title="Delete this snapshot file. Other snapshots are unaffected; your installed mods are unaffected."
+                          aria-label="Delete snapshot"
+                          className="px-1.5"
+                        />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </Card>
 
           {/* Profile List */}
@@ -593,6 +764,28 @@ export default function Profiles() {
           onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}
         />
       )}
+
+      {/* Snapshot restore: same dialog, JSON pre-seeded so the user sees
+          exactly which mods will re-download before committing. */}
+      {restoringSnapshotJson !== null && (
+        <ImportProfileDialog
+          activeDeadlockPath={getActiveDeadlockPath(settings)}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          initialInput={restoringSnapshotJson}
+          onClose={() => setRestoringSnapshotJson(null)}
+          onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}
+        />
+      )}
+
+      <ConfirmModal
+        isOpen={deleteSnapshotConfirmId !== null}
+        onCancel={() => setDeleteSnapshotConfirmId(null)}
+        onConfirm={() => deleteSnapshotConfirmId && handleDeleteSnapshot(deleteSnapshotConfirmId)}
+        title="Delete Snapshot"
+        message="Delete this recovery snapshot? You won't be able to restore from it later."
+        confirmLabel="Delete"
+        variant="danger"
+      />
     </div>
   );
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -379,6 +379,17 @@ export interface ElectronAPI {
         resolved: import('./portableProfile').PortableResolvedMod[];
     }) => Promise<Profile>;
 
+    // Snapshots — automatic recovery points captured before risky operations
+    // (currently just mod updates). Restore re-uses the portable-import flow.
+    snapshots: {
+        create: (
+            trigger: import('./snapshot').SnapshotTrigger
+        ) => Promise<import('./snapshot').SnapshotSummary>;
+        list: () => Promise<import('./snapshot').SnapshotSummary[]>;
+        load: (snapshotId: string) => Promise<string>;
+        delete: (snapshotId: string) => Promise<void>;
+    };
+
     // Mod Database (Local Cache)
     syncAllMods: () => Promise<{ success: boolean }>;
     syncSection: (section: string) => Promise<{ success: boolean }>;

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -1,0 +1,15 @@
+/** Reason a snapshot was taken. Automatic triggers fire before destructive
+ *  operations that overwrite installed mods (update from Browse,
+ *  apply-profile swap). `manual` is the "Snapshot now" button. */
+export type SnapshotTrigger = 'pre-update' | 'pre-apply-profile' | 'manual';
+
+/** Summary used by the list view. Keeps the wire small when the user has
+ *  accumulated many snapshots — the full PortableProfile only crosses the
+ *  IPC boundary on restore, not on list. */
+export interface SnapshotSummary {
+    snapshotId: string;
+    createdAt: string;
+    trigger: SnapshotTrigger;
+    modCount: number;
+    profileName: string;
+}


### PR DESCRIPTION
## Summary

- **Captures a JSON manifest of the installed mod set** (GameBanana submission + file IDs, enabled, priority) before each mod update and before applying a saved profile. Also supports a manual **Snapshot now** button on the Profiles page.
- **Restore re-uses the existing portable-import dialog** end to end: parse, resolve against GameBanana, queue downloads for anything not already on disk, build a "Restored: …" profile the user then applies.
- **No new wire format, no VPK byte duplication.** Files land at `<userData>/snapshots/*.json` in the existing v1.1 portable-profile schema, so a savvy user could also import a snapshot via the standard paste UI.

## Motivation

v1.10.3 shipped a fake-updates trigger that corrupted every mod it touched; v1.10.4 (#42) fixed detection. But the update path is still an irreversible delete+download per mod with no rollback if a future download lands bad files. This change turns "I have to reinstall every mod by hand" into a one-click recovery.

A community report (CARCASS in Discord) prompted the request: an "automatic backup for recovery" was preferred over a literal "Reinstall All" button because it covers more scenarios (apply-wrong-profile, exploration mistakes) at near-zero disk cost.

## How recovery works

1. User clicks Update / Update All on Installed. `runUpdate` fires one `createSnapshot('pre-update')` IPC before the first `deleteMod`.
2. If downloads land corrupt, user opens Profiles → Snapshots → Restore.
3. The portable-import dialog opens with the snapshot's JSON pre-resolved. Mods already on disk stay; missing/different ones queue for download.
4. Confirm creates a "Restored: …" profile.
5. Apply the restored profile from the Profiles page. `applyProfile` enables the snapshot's mods and disables every installed mod not in the profile (i.e., the corrupted update VPKs). Priority order restored.

## What gets stored vs not

- **Stored**: per-mod GameBanana submission ID + file ID + enabled + priority + display hints (name, category, thumbnail). Crosshair/autoexec are not currently captured by the install-state builder (callers can pass an active profile in if needed later).
- **Not stored**: VPK file bytes. Each snapshot is a few hundred bytes per mod; a 200-mod locker is ~50 KB per snapshot.

## Triggers

| Trigger | Where it fires |
|---|---|
| `pre-update` | `src/pages/Installed.tsx` `runUpdate`, once per batch, just before the first `deleteMod` |
| `pre-apply-profile` | `electron/main/ipc/profiles.ts` `apply-profile` handler, before `applyProfile()` runs |
| `manual` | "Snapshot now" button on the Snapshots card |

Failure to capture a snapshot is intentionally non-fatal (logged + swallowed) so a snapshot bug can't block the operation the user just clicked.

## Retention

No auto-prune. Manifests are tiny and the user deletes from the Snapshots UI when they want to.

## Files

- `electron/main/services/portableProfile.ts` — new `buildPortableProfileFromInstalled` (no stored-profile required)
- `electron/main/services/snapshots.ts` — write/list/load/delete, atomic writes
- `electron/main/ipc/snapshots.ts` — IPC handlers (`snapshot-create/list/load/delete`)
- `electron/main/ipc/profiles.ts` — hook into `apply-profile`
- `electron/main/index.ts`, `electron/preload/index.ts` — register + bridge
- `src/lib/api.ts`, `src/types/electron.d.ts`, `src/types/snapshot.ts` — renderer surface
- `src/pages/Installed.tsx` — hook into `runUpdate`
- `src/pages/Profiles.tsx` — Snapshots card with manual capture, restore, delete, plus hover tooltips on every control

## Test plan

- [ ] Trigger a real mod update; confirm one snapshot appears in `~/.config/grimoire/snapshots/` and on the Profiles page Snapshots card
- [ ] Apply a saved profile; confirm a "Before applying profile" snapshot appears
- [ ] Click "Snapshot now"; confirm a "Manual" snapshot appears
- [ ] Restore a snapshot: walk through the import dialog, apply the resulting "Restored: …" profile, verify the captured mod set is restored
- [ ] Delete a snapshot from the UI; verify the JSON file is gone
- [ ] Open a snapshot JSON in an editor and verify it parses as a valid PortableProfile (savvy users can import via the standard paste UI)
- [ ] `pnpm lint` clean (no new warnings beyond the 3 pre-existing)
- [ ] `pnpm build` clean