### PR TITLE
ci: drop WORKSPACE_PAT from social-types checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,10 @@ jobs:
       # ../grimoire-social/packages/*. Local dev works because both repos sit
       # side-by-side; CI has to mirror that or every social import becomes an
       # implicit-any and the build fails on the workspace dep.
-      #
-      # grimoire-social is private, so the default GITHUB_TOKEN can't read it.
-      # WORKSPACE_PAT is a fine-grained PAT scoped to Slush97/grimoire-social
-      # with Contents:Read. Set it under
-      # https://github.com/Slush97/grimoire/settings/secrets/actions
       - name: Checkout grimoire-social (sibling for shared types)
         uses: actions/checkout@v4
         with:
           repository: Slush97/grimoire-social
-          token: ${{ secrets.WORKSPACE_PAT }}
           path: grimoire-social
           ref: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,10 @@ jobs:
       # pnpm-workspace.yaml resolves @grimoire/social-types from
       # ../grimoire-social/packages/*. Without this sibling checkout the
       # workspace dep fails to resolve and pnpm install bails out.
-      # WORKSPACE_PAT is a fine-grained PAT scoped to Slush97/grimoire-social
-      # with Contents:Read (private repo, default GITHUB_TOKEN can't read it).
       - name: Checkout grimoire-social (sibling for shared types)
         uses: actions/checkout@v4
         with:
           repository: Slush97/grimoire-social
-          token: ${{ secrets.WORKSPACE_PAT }}
           path: grimoire-social
           ref: main
 


### PR DESCRIPTION
## Summary

- `grimoire-social` is now public, so the default `GITHUB_TOKEN` can read it. The explicit `secrets.WORKSPACE_PAT` is no longer needed in either `ci.yml` or `release.yml`.
- This also fixes CI for fork PRs. GitHub deliberately does not expose repo secrets to workflows triggered by pull requests from forks, which was previously failing the social-types checkout step for any external contributor (observed yesterday by @TinyDerp).
- Comment blocks explaining the PAT setup are removed since they no longer apply.

## Test plan

- [x] Confirm `grimoire-social` is public (`gh repo view Slush97/grimoire-social --json visibility`)
- [ ] CI on this PR passes end to end (the PR itself exercises the new tokenless checkout path)
- [ ] After merge, kick a `workflow_dispatch` run of `release.yml` in draft mode to validate the release-path checkout
- [ ] After a clean release build, delete the `WORKSPACE_PAT` secret in repo Actions settings and revoke the PAT at github.com/settings/tokens