### PR TITLE
ci: bump actions to Node 24 cohort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout grimoire
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: grimoire
 
@@ -20,19 +20,19 @@ jobs:
       # side-by-side; CI has to mirror that or every social import becomes an
       # implicit-any and the build fails on the workspace dep.
       - name: Checkout grimoire-social (sibling for shared types)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Slush97/grimoire-social
           path: grimoire-social
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout grimoire
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: grimoire
 
@@ -40,19 +40,19 @@ jobs:
       # ../grimoire-social/packages/*. Without this sibling checkout the
       # workspace dep fails to resolve and pnpm install bails out.
       - name: Checkout grimoire-social (sibling for shared types)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Slush97/grimoire-social
           path: grimoire-social
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -124,7 +124,7 @@ jobs:
           cat "SHA256SUMS-${{ matrix.platform }}.txt"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             grimoire/release/*.exe
@@ -132,7 +132,7 @@ jobs:
             grimoire/release/*.deb
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.platform }}-build
           path: grimoire/release/*
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -186,10 +186,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-build
           path: artifacts


### PR DESCRIPTION
## Summary

GitHub Actions warned that all Node 20 actions used in `ci.yml` and `release.yml` will be forced to Node 24 on **2026-06-02** and Node 20 will be removed from the runner on **2026-09-16**. This PR lands the bump now so the cutover is a no-op.

Bumps:

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | Node 24 runtime, no behavior changes |
| `actions/setup-node` | v4 | v6 | v6 walked back v5's intrusive auto package-manager-cache feature; our explicit `cache: pnpm` keeps working |
| `actions/upload-artifact` | v4 | v7 | ESM upgrade; optional `archive: false` param we don't use |
| `actions/download-artifact` | v4 | v8 | Tracks upload, same Node 24 transition |
| `pnpm/action-setup` | v4 | v6 | Node 24 + pnpm v11 support; we still pin `version: 9` so unaffected |
| `actions/attest-build-provenance` | v2 | v4 | Pulls in newer pinned inner `actions/attest` SHAs |

`softprops/action-gh-release` stays at `v2` (third-party action, was not in the deprecation warning).

The project's own `node-version: 20` in `setup-node` is intentionally **not** changed here. Bumping the project's Node version would re-trigger the better-sqlite3 / electron-builder validation surface and belongs in its own PR.

## Test plan

- [ ] CI on this PR passes end to end
- [ ] After merge, `workflow_dispatch` run of `release.yml` in draft mode succeeds on both Linux + Windows matrix legs
- [ ] Build provenance attestation step still produces a valid attestation under `attest-build-provenance@v4`