### PR TITLE
Update-all UI polish + fix unknown-mod CRC matcher + focus-refresh

### DIFF
--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -464,14 +464,19 @@ async function fetchBucketCandidates(
     return [...byId.values()];
 }
 
+// Accept any .vpk inside the archive, not just *_dir.vpk. Mod authors often
+// ship a single non-chunked VPK (e.g. demomanbebop.vpk) and Grimoire renames
+// it to pakNN_dir.vpk on install. The bytes are preserved, so CRC still
+// matches: but the old `_dir.vpk`-only filter skipped these archives before
+// any CRC check could happen. See GB 678174 for a repro case.
 function rawVpkPathsCouldMatch(rawPaths: string[]): boolean {
     if (rawPaths.length === 0) return false;
-    return rawPaths.some((rawPath) => rawPath.toLowerCase().endsWith('_dir.vpk'));
+    return rawPaths.some((rawPath) => rawPath.toLowerCase().endsWith('.vpk'));
 }
 
 function archiveMatchesLocalVpk(localFile: LocalVpkFingerprint, archiveEntries: ArchiveVpkCrcEntry[]): boolean {
     return archiveEntries.some((entry) => (
-        entry.name.toLowerCase().endsWith('_dir.vpk') &&
+        entry.name.toLowerCase().endsWith('.vpk') &&
         entry.uncompressedSize === localFile.size &&
         entry.crc32.toLowerCase() === localFile.crc32
     ));

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -89,6 +89,26 @@ export default function Layout() {
     checkFirstRun();
   }, []);
 
+  // Silent mod refresh when the window regains focus. Covers the case where
+  // the user drops a VPK into addons/ from a file manager while Grimoire is
+  // in the background — alt-tabbing back triggers a re-scan so the new file
+  // shows up without forcing a navigation. Throttled so rapid focus/blur
+  // (some WMs flicker on tooltip hover) doesn't spam the backend.
+  useEffect(() => {
+    let lastRun = 0;
+    const onFocus = () => {
+      const state = useAppStore.getState();
+      if (!getActiveDeadlockPath(state.settings)) return;
+      if (state.modsLoading) return;
+      const now = Date.now();
+      if (now - lastRun < 1500) return;
+      lastRun = now;
+      state.loadMods({ silent: true });
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
+
   useEffect(() => {
     const unsubscribe = window.electronAPI.onOneClickInstall((data) => {
       if (data.error) {

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -207,28 +207,22 @@ export default function VariantPickerModal({
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
                         {onUpdateGroup && variantsWithUpdate && variantsWithUpdate.size > 0 && (
-                            <button
+                            <Button
+                                variant="primary"
+                                size="sm"
+                                icon={Download}
+                                isLoading={isUpdating}
                                 onClick={() => void onUpdateGroup()}
-                                disabled={isUpdating}
-                                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-text-primary bg-white/10 border border-white/30 hover:bg-white/15 hover:border-white/50 rounded cursor-pointer transition-colors disabled:cursor-default disabled:opacity-60"
                                 title={
                                     isUpdating
                                         ? 'Update already in progress'
                                         : `Re-download ${variantsWithUpdate.size} file${variantsWithUpdate.size === 1 ? '' : 's'} and restore their enabled state`
                                 }
                             >
-                                {isUpdating && updateProgress ? (
-                                    <>
-                                        <span className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                                        Updating {updateProgress.done}/{updateProgress.total}
-                                    </>
-                                ) : (
-                                    <>
-                                        <Download className="w-3.5 h-3.5" />
-                                        Update {variantsWithUpdate.size}
-                                    </>
-                                )}
-                            </button>
+                                {isUpdating && updateProgress
+                                    ? `Updating ${updateProgress.done}/${updateProgress.total}`
+                                    : `Update ${variantsWithUpdate.size}`}
+                            </Button>
                         )}
                         {onOpenModDetails && (
                             <button
@@ -407,13 +401,14 @@ export default function VariantPickerModal({
                                                     </span>
                                                     {v.isArchived && <ArchivedTag />}
                                                     {hasUpdate && (
-                                                        <span
+                                                        <Tag
+                                                            tone="accent"
+                                                            icon={Download}
                                                             title="A newer version is available on GameBanana"
-                                                            className="flex-shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-white/10 border border-white/30 text-text-primary uppercase tracking-wide"
+                                                            className="flex-shrink-0 uppercase tracking-wide"
                                                         >
-                                                            <Download className="w-3 h-3" />
                                                             Update
-                                                        </span>
+                                                        </Tag>
                                                     )}
                                                     {conflictDetails.length > 0 && (
                                                         <Tag

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1380,7 +1380,12 @@ export default function Installed() {
           onClick={() => setUpdateAllConfirmOpen(true)}
           icon={Download}
           isLoading={!!updateAllProgress}
-          title="Re-download every mod with a newer version on GameBanana and restore each one's enabled state"
+          aria-live="polite"
+          title={
+            updateAllProgress
+              ? 'Update in progress. Please wait until all mods finish before starting another.'
+              : "Re-download every mod with a newer version on GameBanana and restore each one's enabled state"
+          }
         >
           {updateAllProgress
             ? `Updating ${updateAllProgress.done}/${updateAllProgress.total}…`
@@ -1547,14 +1552,14 @@ export default function Installed() {
               const pending = mods.filter((m) => updatesAvailable.has(m.id));
               if (pending.length === 0) return null;
               return (
-                <div className="update-stripes border border-border bg-bg-tertiary/40 rounded-md px-3 py-2 max-h-48 overflow-y-auto">
-                  <div className="text-[11px] uppercase tracking-wider text-text-secondary mb-1.5 font-semibold">
-                    Mods receiving updates
+                <div className="update-stripes border border-accent/20 bg-bg-tertiary/40 rounded-md px-3 py-2 max-h-48 overflow-y-auto">
+                  <div className="text-[10px] uppercase tracking-wider text-accent mb-1.5 font-semibold">
+                    Mods receiving updates ({pending.length})
                   </div>
                   <ul className="space-y-1 text-sm text-text-primary">
                     {pending.map((m) => (
                       <li key={m.id} className="flex items-center gap-2 min-w-0">
-                        <Download className="w-3.5 h-3.5 text-text-secondary flex-shrink-0" />
+                        <Download className="w-3.5 h-3.5 text-accent flex-shrink-0" />
                         <span className="truncate" title={m.name}>{m.name}</span>
                       </li>
                     ))}
@@ -1571,14 +1576,18 @@ export default function Installed() {
       />
 
       {updateAllError && (
-        <div className="fixed bottom-4 right-4 z-50 max-w-md bg-red-500/10 border border-red-500/30 text-red-300 rounded-lg px-4 py-3 shadow-lg flex items-start gap-3">
+        <div
+          role="alert"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-50 max-w-md bg-state-danger/10 border border-state-danger/40 text-state-danger rounded-sm px-4 py-3 shadow-lg flex items-start gap-3 animate-fade-in"
+        >
           <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-          <div className="flex-1 text-sm">{updateAllError}</div>
+          <div className="flex-1 text-sm text-text-primary">{updateAllError}</div>
           <button
             type="button"
             onClick={() => setUpdateAllError(null)}
-            className="text-red-300 hover:text-red-100 p-1 -m-1 cursor-pointer"
-            aria-label="Dismiss"
+            className="text-state-danger hover:text-text-primary p-1 -m-1 cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-state-danger"
+            aria-label="Dismiss update error"
           >
             <X className="w-4 h-4" />
           </button>
@@ -2687,13 +2696,15 @@ function ModCard({
                 </Tag>
               )}
               {updateAvailable && (
-                <span
+                <Tag
+                  tone="accent"
+                  variant="overlay"
+                  icon={Download}
                   title="A newer version is available on GameBanana"
-                  className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold leading-none bg-black/75 backdrop-blur-sm border border-white/40 text-white shadow-[0_1px_2px_rgba(0,0,0,0.45)] uppercase tracking-wide"
+                  className="uppercase tracking-wide"
                 >
-                  <Download className="w-3 h-3" />
                   Update
-                </span>
+                </Tag>
               )}
             </div>
           </>
@@ -2909,13 +2920,14 @@ function ModCard({
                 <Tag tone="danger" className="flex-shrink-0">18+</Tag>
               )}
               {updateAvailable && (
-                <span
+                <Tag
+                  tone="accent"
+                  icon={Download}
                   title="A newer version is available on GameBanana"
-                  className="flex-shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold leading-none bg-white/10 border border-white/30 text-text-primary uppercase tracking-wide"
+                  className="flex-shrink-0 uppercase tracking-wide"
                 >
-                  <Download className="w-3 h-3" />
                   Update
-                </span>
+                </Tag>
               )}
               {mod.enabled && (
                 <Tag

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -116,7 +116,11 @@ interface AppState {
   loadSettings: () => Promise<void>;
   saveSettings: (settings: AppSettings) => Promise<void>;
   detectDeadlock: () => Promise<string | null>;
-  loadMods: () => Promise<void>;
+  /** Reload the installed-mods list from the main process.
+   *  Pass `{ silent: true }` to refresh without toggling `modsLoading`,
+   *  so background refreshes (e.g. on window focus) don't replace the
+   *  page with the loading skeleton. */
+  loadMods: (opts?: { silent?: boolean }) => Promise<void>;
   toggleMod: (modId: string) => Promise<void>;
   deleteMod: (modId: string) => Promise<void>;
   setModPriority: (modId: string, priority: number) => Promise<void>;
@@ -189,14 +193,17 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  // Load mods from backend
-  loadMods: async () => {
-    set({ modsLoading: true, modsError: null });
+  // Load mods from backend.
+  // Silent refreshes (window focus, etc.) skip the loading flag so the UI
+  // doesn't flash the skeleton over already-rendered content.
+  loadMods: async (opts) => {
+    const silent = !!opts?.silent;
+    if (!silent) set({ modsLoading: true, modsError: null });
     try {
       const mods = await api.getMods();
-      set({ mods, modsLoading: false });
+      set(silent ? { mods, modsError: null } : { mods, modsLoading: false });
     } catch (err) {
-      set({ modsError: String(err), modsLoading: false });
+      set(silent ? { modsError: String(err) } : { modsError: String(err), modsLoading: false });
     }
   },
 


### PR DESCRIPTION
## Summary

Three small, independent changes bundled for the upcoming patch release:

- **fix(unknown-mods): match CRC on any .vpk archive entry** (`5fa7b22`)
  The Unknown-mod auto-identifier filtered archive entries to those ending in `_dir.vpk`, so mods that ship a single non-chunked VPK (e.g. [GB 678174](https://gamebanana.com/mods/678174) ships `demomanbebop.vpk`) were skipped before any CRC check ran. Grimoire's installer renames such files to `pakNN_dir.vpk` while preserving bytes, so the CRC match still works once we stop pre-filtering them out. Relaxed both `rawVpkPathsCouldMatch` and `archiveMatchesLocalVpk` to accept any `.vpk` entry; size + CRC-32 keeps collisions vanishingly unlikely.

- **style(update-all): unify Update affordances on the design system** (`ee46858`)
  Three hand-rolled "Update" tag variants (grid overlay, list inline, variant-picker row) and a hand-rolled "Update N" button all rendered as neutral white chips. Replaced with `Tag tone="accent"` and the `Button` component so Update reads as the action CTA it actually is, matching the page-level Update all button. Confirm modal gets accent reinforcement on the per-row Download icons + section label. Error toast moved off raw `red-500/*` to `state-danger` tokens with `role="alert"` + `aria-live="polite"`; progress button got `aria-live` so the "Updating X/Y" count is announced.

- **feat(installed): refresh mod list when window regains focus** (`a0b01e2`)
  Dropping a VPK into `addons/` from a file manager while Grimoire was in the background used to require a navigation away and back before the new mod appeared. A window `focus` listener now triggers a silent `loadMods`. Throttled to once per 1.5s, gated on `activeDeadlockPath`, skipped while a load is in flight. Adds an `opts.silent` flag to `loadMods` so the refresh doesn't flash the `InstalledSkeleton` over already-rendered content.

## Test plan

- [x] Auto-identify the repro mod: install [GB 678174](https://gamebanana.com/mods/678174) outside Grimoire (or drop its VPK into `addons/`), click "Fix unknown" on the resulting card, confirm the matcher proposes Bebop Demoman TF2 via CRC.
- [x] Visual smoke on Installed page: cards with an available update show the orange-accented Update tag (grid overlay + list inline). VariantPicker shows accent Tag + accent Update N button.
- [x] Run Update all on at least 2 flagged mods: confirm modal lists them with accent download icons, progress button reads "Updating X/Y…", on completion the mods re-enable in their previous state.
- [x] Trigger an error: kill network mid-update, confirm the toast renders in `state-danger` tone and dismisses cleanly.
- [x] Live refresh: while on the Installed tab, drag a VPK into `addons/` from a file manager, alt-tab back to Grimoire, confirm the new file appears within ~1s with no skeleton flash.
- [x] Type check + lint clean: `pnpm exec tsc --noEmit`, `pnpm lint` (3 pre-existing warnings in AudioPreviewPlayer and Stats are unrelated).