### PR TITLE
fix: large-profile import + clearer revoked-mod install errors

### DIFF
--- a/docs/profile-spec.md
+++ b/docs/profile-spec.md
@@ -163,6 +163,7 @@ mp1:<base64url(gzip(json))>
 * Body is base64url (RFC 4648 §5, no padding) of `gzip(UTF-8 JSON)`.
 * Typical profile compresses to 1 to 2 KB. Stay under 4 KB to fit comfortably in a Discord message.
 * Decoder MUST validate the prefix, decode, decompress, and then validate the JSON against this spec.
+* Decoder MUST cap the inflated payload to bound gzip-bomb risk. Profiles that exceed this cap can still be shared as a `.modprofile.json` file (the file path skips the gzip cap, but importers are still free to cap raw JSON size). Grimoire's current limit is 256 KB inflated for share codes, sized to fit a 100-mod Deadlock profile with every optional hint field populated.
 
 A share code is informationally equivalent to a `.modprofile.json` file; one can be converted to the other losslessly.
 

--- a/docs/social-architecture-decisions.md
+++ b/docs/social-architecture-decisions.md
@@ -125,7 +125,7 @@ A log of the load-bearing decisions made while planning Grimoire Social. Each en
 - (-) Migrating to R2 later (e.g. if we add user-uploaded preview images) requires a copy
 - (-) Each row is ~1 KB heavier; row-count storage limits hit slightly sooner
 
-**Alternatives considered.** R2 + metadata in D1 (rejected: extra latency + consistency complexity for no benefit at 1 KB blobs). Hybrid (small inline, large in R2) (rejected: premature; profiles are bounded ~16 KB by validation cap).
+**Alternatives considered.** R2 + metadata in D1 (rejected: extra latency + consistency complexity for no benefit at 1 KB blobs). Hybrid (small inline, large in R2) (rejected: premature; profiles are bounded ~256 KB by validation cap).
 
 **Revisit when.** We add user-uploaded preview images, or median profile size exceeds ~10 KB.
 

--- a/docs/social-architecture.md
+++ b/docs/social-architecture.md
@@ -165,7 +165,7 @@ All routes JSON, all responses include `{ error: string }` on failure. Auth via 
 
 **Validation done server-side at publish**:
 - Decode share code with the same parser the client uses (port `parsePortableProfile` to Workers; pure JS, no Node deps)
-- Reject if format/version unknown, mod count > 100, blob > 16 KB inflated
+- Reject if format/version unknown, mod count > 100, blob > 256 KB inflated
 - Recompute `has_nsfw`, `mod_count`, `primary_hero` from the blob (don't trust client-supplied values)
 - Title/description trimmed, length-capped, stripped of control chars
 

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -503,12 +503,20 @@ async function executeDownload(
     const details: GameBananaModDetails = await fetchModDetails(modId, section);
 
     if (!details.files || details.files.length === 0) {
-        throw new Error('No files available for this mod');
+        throw new Error(
+            'This mod has no downloadable files on GameBanana. It may have been ' +
+            'revoked (copyright, moderation) or the author removed the file. ' +
+            'The catalog entry will clear on the next sync.'
+        );
     }
 
     const file = details.files.find((f) => f.id === fileId);
     if (!file) {
-        throw new Error(`File ${fileId} not found in mod ${modId}`);
+        throw new Error(
+            'The specific file Grimoire had cached for this mod is no longer on ' +
+            'GameBanana (likely revoked or replaced). Open the mod page in Browse ' +
+            'and pick a current file, or refresh the catalog.'
+        );
     }
 
     // Validate download URL before proceeding (P0 security fix)

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -40,10 +40,12 @@ export function encodeShareCode(json: string): string {
 }
 
 // Mirror the server-side cap so a malicious / corrupted share code can't
-// inflate into a multi-MB allocation in the Electron main process. The
-// previous implementation called gunzipSync with no maxOutputLength, which
-// let a 16 KB compressed payload expand up to ~16 MB before failing.
-const MAX_INFLATED_SHARE_CODE_BYTES = 16 * 1024;
+// inflate into a multi-MB allocation in the Electron main process. 256 KB
+// fits the worst realistic case (Deadlock's ~100-mod ceiling with every
+// optional hint filled measures ~70 KB pretty-printed; 150 mods ~106 KB)
+// with comfortable headroom for future schema growth, while still bounding
+// gzip-bomb risk to a trivial allocation.
+export const MAX_INFLATED_SHARE_CODE_BYTES = 256 * 1024;
 
 export function decodeShareCode(code: string): string {
     if (!code.startsWith(PORTABLE_PROFILE_SHARE_PREFIX)) {
@@ -62,6 +64,14 @@ export function decodeShareCode(code: string): string {
         });
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        const tooLarge = /buffer/i.test(msg) && /larger|too large|exceed/i.test(msg);
+        if (tooLarge) {
+            const kb = Math.round(MAX_INFLATED_SHARE_CODE_BYTES / 1024);
+            throw new Error(
+                `Share code is too large to import (exceeds ${kb} KB after decompression). ` +
+                `Export the profile to a .modprofile.json file and load it from disk instead.`
+            );
+        }
         throw new Error(
             `Invalid share code (gzip payload rejected: ${msg.slice(0, 120)})`
         );


### PR DESCRIPTION
## Summary

Two fixes driven by `#bugs` threads in the Grimoire Discord (2026-05-18).

- **Raise share-code inflate cap from 16 KB to 256 KB.** The previous cap rejected legitimate large profiles. A verbose 100-mod profile (Deadlock's effective limit) inflates to ~70 KB pretty-printed. 256 KB gives ~4x headroom while keeping gzip-bomb risk bounded to a trivial allocation. Cap-exceeded error now points users at the `.modprofile.json` file-import workaround instead of surfacing a raw Node "Cannot create a Buffer larger than N bytes". Mirrored on the server in `grimoire-social` (see companion PR).
- **Explain revoked / missing GameBanana files in install errors.** When a cached catalog entry points at a submission whose file has been revoked (copyright, moderation) or replaced, the install previously failed with `No files available for this mod` or `File N not found in mod M`. Now surfaces concrete error text that names the likely cause and points the user at refreshing the catalog or picking a current file. Followup to carcass's "Mods won't install" thread (Tailed Infernus).

## Test plan

Cap bump verified by round-trip through the exact zlib codepath:

| n mods (verbose hints) | inflated JSON | share code | round-trip |
|---|---|---|---|
| 50 | 34 KB | 2.2 KB | ✅ |
| 100 | 68 KB | 3.7 KB | ✅ |
| 150 | 102 KB | 5.2 KB | ✅ |
| 200 | 136 KB | 6.7 KB | ✅ |
| 300 | 204 KB | 9.5 KB | ✅ |
| 2 MB gzip-bomb | — | 2.7 KB compressed | ✅ rejected at cap |

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` clean
- [x] Smoke test: import a previously-rejected large share code in the running client
- [x] Smoke test: trigger the "no files available" path against a revoked GB submission and confirm the new error surfaces