### PR TITLE
fix(installed): profile reorder, priority retype collisions, experimental unknown-mod gate

### DIFF
--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -590,6 +590,23 @@ export async function reorderMods(
 }
 
 /**
+ * Dense-pack enabled mods to consecutive pak## slots in their current priority
+ * order, skipping any slot reserved by a disabled mod. Wraps reorderMods so
+ * callers (applyProfile, post-install, post-enable/disable) get a single
+ * two-phase rename instead of per-mod setModPriority cascades that fail on
+ * mid-operation slot collisions.
+ */
+export async function compactEnabledMods(deadlockPath: string): Promise<void> {
+    const mods = await scanMods(deadlockPath);
+    const orderedFileNames = mods
+        .filter((m) => m.enabled)
+        .sort((a, b) => a.priority - b.priority)
+        .map((m) => m.fileName);
+    if (orderedFileNames.length === 0) return;
+    await reorderMods(deadlockPath, orderedFileNames);
+}
+
+/**
  * Swap the priorities of two mods (async).
  */
 export async function swapModPriority(

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
-import { scanMods, enableMod, disableMod, setModPriority } from './mods';
+import { scanMods, enableMod, disableMod, reorderMods } from './mods';
 import { getModMetadata } from './metadata';
 import { readAutoexec, writeAutoexec } from './autoexec';
 
@@ -275,19 +275,22 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
         }
     }
 
-    // 1b. Apply priority order - rescan so we have up-to-date IDs/paths after enable/disable
+    // 1b. Apply priority order in a single two-phase pass via reorderMods.
+    // The previous implementation called setModPriority per mod and swallowed
+    // "Priority X is already in use" errors — common when switching between
+    // profiles, since the OTHER profile's mods still occupy the target slots
+    // until later iterations move them. reorderMods stages every rename via
+    // a tmp prefix first, so transient mid-loop collisions can't happen.
     const refreshedMods = await scanMods(deadlockPath);
-    const byFileName = new Map(refreshedMods.map((m) => [m.fileName, m]));
-    const orderedProfileMods = [...profile.mods].sort((a, b) => a.priority - b.priority);
-    for (const profileMod of orderedProfileMods) {
-        const current = byFileName.get(profileMod.fileName);
-        if (current && current.priority !== profileMod.priority) {
-            try {
-                await setModPriority(deadlockPath, current.id, profileMod.priority);
-            } catch (err) {
-                console.warn(`[applyProfile] Could not restore priority for ${profileMod.fileName}:`, err);
-            }
-        }
+    const enabledFileNames = new Set(
+        refreshedMods.filter((m) => m.enabled).map((m) => m.fileName)
+    );
+    const orderedFileNames = [...profile.mods]
+        .filter((pm) => pm.enabled && enabledFileNames.has(pm.fileName))
+        .sort((a, b) => a.priority - b.priority)
+        .map((pm) => pm.fileName);
+    if (orderedFileNames.length > 0) {
+        await reorderMods(deadlockPath, orderedFileNames);
     }
 
     // 2. Apply Autoexec & Crosshair

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -15,6 +15,13 @@ export interface AppSettings {
     experimentalStats: boolean;
     experimentalCrosshair: boolean;
     experimentalSocial: boolean;     // Grimoire Social: Discover page + publish/account UI
+    /** Auto-match unknown local VPKs against GameBanana (CRC-32 + filter
+     *  search). Off by default while the matching path is reworked: the
+     *  current implementation hits GameBanana rate limits hard on libraries
+     *  with many unknown files. When off, the "Fix unknown" UI still opens
+     *  but the search/find buttons and bulk auto-find are hidden, leaving
+     *  only the manual "Make Custom Mod" path. */
+    experimentalUnknownModMatching: boolean;
     hasCompletedSetup: boolean;      // First-run setup completed
     /** Mod pairs the user has dismissed in the Conflicts page. New entries use
      *  stable per-mod identities (GameBanana mod/file ids when available)
@@ -42,6 +49,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     experimentalStats: false,
     experimentalCrosshair: false,
     experimentalSocial: false,
+    experimentalUnknownModMatching: false,
     hasCompletedSetup: false,
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -8,6 +8,10 @@ interface Props {
   modName: string;
   priority: number;
   variant?: 'overlay' | 'inline';
+  /** Override the default single-rename commit path. Provided by Installed.tsx
+   *  so collisions with same-section mods rebuild the order via reorderMods
+   *  (insert-and-shift) instead of throwing "already in use". */
+  onCommit?: (newPriority: number) => Promise<void>;
 }
 
 /**
@@ -25,6 +29,7 @@ export default function PriorityEditor({
   modName,
   priority,
   variant = 'inline',
+  onCommit,
 }: Props) {
   const loadMods = useAppStore((s) => s.loadMods);
   const [editing, setEditing] = useState(false);
@@ -61,8 +66,12 @@ export default function PriorityEditor({
     if (n === priority) return cancel();
     setBusy(true);
     try {
-      await setModPriority(modId, n);
-      await loadMods();
+      if (onCommit) {
+        await onCommit(n);
+      } else {
+        await setModPriority(modId, n);
+        await loadMods();
+      }
       setEditing(false);
       setError(null);
     } catch (err) {
@@ -123,18 +132,27 @@ export default function PriorityEditor({
     );
   }
 
+  // Rendered as a span+role=button rather than a <button> because this widget
+  // sits inside the ModCard's outer "view details" <button>; nesting buttons
+  // is invalid HTML and React 19 surfaces it as a hydration warning.
   return (
-    <button
-      type="button"
+    <span
+      role="button"
+      tabIndex={0}
       onClick={startEdit}
       onContextMenu={startEdit}
-      className="cursor-text appearance-none bg-transparent border-0 p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          startEdit(e);
+        }
+      }}
+      className="inline-flex cursor-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
       title={`Load #${priority}. Click (or right-click) to retype. Lower numbers load first.`}
       aria-label={`Load order ${priority}. Click to change.`}
     >
       <Tag tone="accent" variant={variant} className="tabular-nums">
         Load #{priority}
       </Tag>
-    </button>
+    </span>
   );
 }

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -25,11 +25,12 @@ import {
   Layers,
   Scissors,
   Share2,
+  Beaker,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, UnknownModFilterGuess } from '../types/mod';
@@ -437,8 +438,13 @@ export default function Installed() {
     // Auto-kick the search when there's no cached result and nothing in
     // flight. Otherwise the user has to click Find inside the modal after
     // already clicking Fix outside — one click too many, and confusing
-    // because the modal just sits idle.
-    if (!unknownFilterCache[mod.id] && !unknownFilterPendingIds.has(mod.id)) {
+    // because the modal just sits idle. Suppressed when the experimental
+    // matcher is disabled (the modal opens straight to the custom-mod path).
+    if (
+      autoMatchEnabled &&
+      !unknownFilterCache[mod.id] &&
+      !unknownFilterPendingIds.has(mod.id)
+    ) {
       void inspectUnknownModFilters(mod, false, mode);
     }
   };
@@ -515,8 +521,13 @@ export default function Installed() {
     openUnknownModFix(first, 'bulk');
     // Kick searches for the rest in parallel so every row progresses while
     // the user reviews the first one. The queue dedupes against pending/
-    // cached, so re-kicking the first mod here is a no-op.
-    findAllUnknownMods(unknowns);
+    // cached, so re-kicking the first mod here is a no-op. Gated behind the
+    // experimental flag while the matcher is being reworked. Without it the
+    // bulk modal just lists the unknowns so the user can route each one to
+    // the manual custom-mod path.
+    if (autoMatchEnabled) {
+      findAllUnknownMods(unknowns);
+    }
   };
 
   const findAllUnknownMods = (unknowns: Mod[]) => {
@@ -1236,6 +1247,10 @@ export default function Installed() {
   const unknownMods = mods
     .filter((mod) => mod.isUnknown)
     .sort((a, b) => a.priority - b.priority);
+  // Auto-matching against GameBanana (CRC + filter search) is the rate-
+  // limited path. Gated behind an experimental toggle while it's being
+  // reworked; when off, only the manual "Make Custom Mod" path is offered.
+  const autoMatchEnabled = settings?.experimentalUnknownModMatching ?? false;
   const selectedUnknownState = unknownFilterGuess
     ? {
         mod: unknownFilterGuess.mod,
@@ -1328,6 +1343,55 @@ export default function Installed() {
   };
 
   /**
+   * Commit a typed priority from the right-click Load editor. When the target
+   * slot is held by another enabled mod we can't just rename (the file would
+   * collide), so we rebuild the enabled-section order with this mod inserted
+   * before the collider and hand it to reorderMods. That mirrors drag-and-drop
+   * semantics: typing `N` is "drop me onto whoever owns N". When the slot is
+   * free we fall back to a single rename so the user gets the exact number
+   * they typed, even if disabled mods occupy nearby slots.
+   *
+   * Calls the API directly (not the store wrappers) so errors propagate back
+   * to PriorityEditor for inline display instead of being swallowed into
+   * modsError.
+   */
+  const commitPriorityForMod = async (modId: string, newPriority: number): Promise<void> => {
+    const mod = mods.find((m) => m.id === modId);
+    if (!mod) throw new Error('Mod not found');
+    if (mod.priority === newPriority) return;
+
+    const collider = mods.find(
+      (m) => m.id !== modId && m.enabled && m.priority === newPriority
+    );
+
+    if (!collider) {
+      await apiSetModPriority(modId, newPriority);
+      await loadMods();
+      return;
+    }
+
+    const enabled = mods
+      .filter((m) => m.enabled)
+      .sort((a, b) => a.priority - b.priority);
+    const withoutMoved = enabled.filter((m) => m.id !== modId);
+    const insertIdx = withoutMoved.findIndex((m) => m.id === collider.id);
+    if (insertIdx === -1) {
+      // Defensive: collider must be enabled, so this shouldn't trigger.
+      // Fall back to the single rename so the user still gets feedback.
+      await apiSetModPriority(modId, newPriority);
+      await loadMods();
+      return;
+    }
+    const reordered = [
+      ...withoutMoved.slice(0, insertIdx),
+      mod,
+      ...withoutMoved.slice(insertIdx),
+    ];
+    await apiReorderMods(reordered.map((m) => m.fileName));
+    await loadMods();
+  };
+
+  /**
    * Render a single entry as a ModCard. Centralizes both the "single mod"
    * and "grouped variants" paths so the enabled/disabled sections don't
    * each carry a 40-line inline JSX block.
@@ -1368,6 +1432,7 @@ export default function Installed() {
           onDelete={() => setModToDelete({ ids: [mod.id], name: mod.name, isGroup: false })}
           onFixUnknown={mod.isUnknown ? () => openUnknownModFix(mod, 'single') : undefined}
           fixingUnknown={unknownFilterPendingIds.has(mod.id)}
+          onCommitPriority={(p) => commitPriorityForMod(mod.id, p)}
           onUnmerge={mod.merged ? () => setUnmergeTarget(mod) : undefined}
           onCopyShareCode={mod.merged ? () => void handleCopyShareCode(mod) : undefined}
           selectMode={selectMode}
@@ -1447,6 +1512,7 @@ export default function Installed() {
             isGroup: true,
           })
         }
+        onCommitPriority={(p) => commitPriorityForMod(entry.primary.id, p)}
         selectMode={selectMode}
         selected={entrySelected}
         onSelectToggle={() => toggleEntrySelection(entry)}
@@ -1937,6 +2003,7 @@ export default function Installed() {
         <UnknownFilterGuessModal
           state={selectedUnknownState}
           hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          autoMatchEnabled={autoMatchEnabled}
           onApplyMatch={applyUnknownMatch}
           onViewMatch={viewUnknownMatch}
           onMakeCustom={makeUnknownCustomMod}
@@ -1952,6 +2019,7 @@ export default function Installed() {
           unknownMods={unknownMods}
           state={selectedUnknownState}
           hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          autoMatchEnabled={autoMatchEnabled}
           cache={unknownFilterCache}
           pendingIds={unknownFilterPendingIds}
           errors={unknownFilterErrors}
@@ -2240,6 +2308,7 @@ function InstalledSkeleton({ viewMode }: { viewMode: ViewMode }) {
 function UnknownFilterGuessModal({
   state,
   hideNsfwPreviews,
+  autoMatchEnabled,
   onApplyMatch,
   onViewMatch,
   onMakeCustom,
@@ -2256,6 +2325,7 @@ function UnknownFilterGuessModal({
     cancelled?: boolean;
   };
   hideNsfwPreviews: boolean;
+  autoMatchEnabled: boolean;
   onApplyMatch: (mod: Mod, match: FoundUnknownMatch) => Promise<void>;
   onViewMatch: (mod: Mod, match: FoundUnknownMatch) => void;
   onMakeCustom: (mod: Mod) => void;
@@ -2302,6 +2372,7 @@ function UnknownFilterGuessModal({
           key={mod.id}
           state={state}
           hideNsfwPreviews={hideNsfwPreviews}
+          autoMatchEnabled={autoMatchEnabled}
           onApplyMatch={onApplyMatch}
           onViewMatch={onViewMatch}
           onMakeCustom={onMakeCustom}
@@ -2319,6 +2390,7 @@ function BulkUnknownFixModal({
   unknownMods,
   state,
   hideNsfwPreviews,
+  autoMatchEnabled,
   cache,
   pendingIds,
   errors,
@@ -2341,6 +2413,7 @@ function BulkUnknownFixModal({
     cancelled?: boolean;
   };
   hideNsfwPreviews: boolean;
+  autoMatchEnabled: boolean;
   cache: Record<string, UnknownModFilterGuess>;
   pendingIds: Set<string>;
   errors: Record<string, string>;
@@ -2379,16 +2452,18 @@ function BulkUnknownFixModal({
             </p>
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <Button
-              variant="primary"
-              size="sm"
-              icon={Search}
-              disabled={findableCount === 0}
-              onClick={() => onFindAll(unknownMods)}
-              title="Search every unknown mod that has not already been checked"
-            >
-              Find all
-            </Button>
+            {autoMatchEnabled && (
+              <Button
+                variant="primary"
+                size="sm"
+                icon={Search}
+                disabled={findableCount === 0}
+                onClick={() => onFindAll(unknownMods)}
+                title="Search every unknown mod that has not already been checked"
+              >
+                Find all
+              </Button>
+            )}
             <button
               type="button"
               onClick={onClose}
@@ -2453,6 +2528,7 @@ function BulkUnknownFixModal({
             key={state.mod.id}
             state={state}
             hideNsfwPreviews={hideNsfwPreviews}
+            autoMatchEnabled={autoMatchEnabled}
             onApplyMatch={onApplyMatch}
             onViewMatch={onViewMatch}
             onMakeCustom={onMakeCustom}
@@ -2469,6 +2545,7 @@ function BulkUnknownFixModal({
 function UnknownMatchPanel({
   state,
   hideNsfwPreviews,
+  autoMatchEnabled,
   onApplyMatch,
   onViewMatch,
   onMakeCustom,
@@ -2484,6 +2561,7 @@ function UnknownMatchPanel({
     cancelled?: boolean;
   };
   hideNsfwPreviews: boolean;
+  autoMatchEnabled: boolean;
   onApplyMatch: (mod: Mod, match: FoundUnknownMatch) => Promise<void>;
   onViewMatch: (mod: Mod, match: FoundUnknownMatch) => void;
   onMakeCustom: (mod: Mod) => void;
@@ -2561,7 +2639,7 @@ function UnknownMatchPanel({
           applying={applying}
           onApply={() => void handleApply(foundMatch)}
           onView={() => onViewMatch(mod, foundMatch)}
-          onRetry={handleRetry}
+          onRetry={autoMatchEnabled ? handleRetry : undefined}
         />
       )}
 
@@ -2593,14 +2671,16 @@ function UnknownMatchPanel({
             </div>
           </div>
           <div className="border-t border-white/5 px-4 py-3 bg-black/10 flex flex-wrap justify-end gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={RotateCcw}
-              onClick={handleRetry}
-            >
-              Retry
-            </Button>
+            {autoMatchEnabled && (
+              <Button
+                variant="secondary"
+                size="sm"
+                icon={RotateCcw}
+                onClick={handleRetry}
+              >
+                Retry
+              </Button>
+            )}
             {match.status !== 'error' && (
               <Button
                 variant="secondary"
@@ -2615,7 +2695,7 @@ function UnknownMatchPanel({
         </div>
       )}
 
-      {!loading && !error && !result && (
+      {!loading && !error && !result && autoMatchEnabled && (
         <div className="rounded-md bg-bg-tertiary/50 border border-white/5 px-4 py-4 text-sm text-text-secondary flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             {cancelled ? (
@@ -2633,6 +2713,29 @@ function UnknownMatchPanel({
           >
             Search
           </Button>
+        </div>
+      )}
+
+      {!loading && !error && !result && !autoMatchEnabled && (
+        <div className="rounded-md bg-bg-tertiary/50 border border-white/5 px-4 py-4 space-y-3">
+          <div className="flex items-start gap-3 text-sm text-text-secondary">
+            <Beaker className="w-4 h-4 text-accent flex-shrink-0 mt-0.5" />
+            <span>
+              Automatic GameBanana matching is off. It hits rate limits on larger
+              libraries; we're reworking it. Enable it under Settings (Experimental
+              Features) once you're ready to retry, or add custom metadata below.
+            </span>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              size="sm"
+              icon={FilePlus}
+              onClick={() => onMakeCustom(mod)}
+            >
+              Make Custom Mod
+            </Button>
+          </div>
         </div>
       )}
     </div>
@@ -2658,7 +2761,9 @@ function UnknownMatchCard({
   applying: boolean;
   onApply: () => void;
   onView: () => void;
-  onRetry: () => void;
+  /** Omitted when the experimental matcher is disabled (nothing to retry
+   *  against), so the card hides the Retry button entirely. */
+  onRetry?: () => void;
 }) {
   return (
     <div className="rounded-md border border-state-success/35 bg-state-success/10 overflow-hidden">
@@ -2716,15 +2821,17 @@ function UnknownMatchCard({
         >
           View Mod
         </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          icon={RotateCcw}
-          disabled={applying}
-          onClick={onRetry}
-        >
-          Retry
-        </Button>
+        {onRetry && (
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={RotateCcw}
+            disabled={applying}
+            onClick={onRetry}
+          >
+            Retry
+          </Button>
+        )}
         <Button
           variant="success"
           size="sm"
@@ -2767,6 +2874,9 @@ interface ModCardProps {
   onDelete: () => void;
   onFixUnknown?: () => void;
   fixingUnknown?: boolean;
+  /** Collision-tolerant priority commit. Passed through to PriorityEditor so
+   *  retyping an already-used slot insert-shifts instead of throwing. */
+  onCommitPriority?: (newPriority: number) => Promise<void>;
   /** Open the unmerge confirm flow. Only meaningful when `mod.merged` is set. */
   onUnmerge?: () => void;
   /** Copy the merged mod's share code to the clipboard. */
@@ -2810,6 +2920,7 @@ function ModCard({
   onDelete,
   onFixUnknown,
   fixingUnknown,
+  onCommitPriority,
   onUnmerge,
   onCopyShareCode,
   selectMode,
@@ -2961,6 +3072,7 @@ function ModCard({
                   modName={mod.name}
                   priority={mod.priority}
                   variant="overlay"
+                  onCommit={onCommitPriority}
                 />
               </div>
             )}
@@ -3238,6 +3350,7 @@ function ModCard({
                     modName={mod.name}
                     priority={mod.priority}
                     variant="inline"
+                    onCommit={onCommitPriority}
                   />
                 </span>
               )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -895,6 +895,15 @@ export default function Settings() {
               label="Grimoire Social"
               description="Sign in with Steam to publish profiles and browse uploads from other players in Discover."
             />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.experimentalUnknownModMatching ?? false}
+              onChange={(checked) => settings && saveSettings({ ...settings, experimentalUnknownModMatching: checked })}
+              label="Fix Unknown Mods"
+              description="Auto-match unknown local VPKs against GameBanana to recover their names and thumbnails. Currently hits rate limits on larger libraries while we rework it. The manual Custom Mod path stays available either way."
+            />
           </div>
         </Card>
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -178,6 +178,7 @@ export interface AppSettings {
   experimentalStats: boolean;
   experimentalCrosshair: boolean;
   experimentalSocial: boolean;
+  experimentalUnknownModMatching: boolean;
   hasCompletedSetup: boolean;
   ignoredConflicts: string[];
   ignoreConflictsByDefault: boolean;


### PR DESCRIPTION
## Summary

Three Installed-page fixes shipped together. The profile reorder is the original driver; the other two landed in the same branch because they touch adjacent code paths.

### 1. Profile apply: two-phase reorder (original driver)

Driven by carcass's "Profiles do not enable/disable properly" thread in `#bugs` (2026-05-20). Their attached diagnostic log shows `applyProfile` warning **"Could not restore priority"** for ten different mods in a single profile switch (priorities 7, 15, 18, 19, 25, 31, 36, 52, 59, 69). Every one of those mods was left at its OLD priority. Visible symptom: switching profiles "just turns everything on" or leaves mods stuck in the wrong order.

**Root cause.** `applyProfile` looped `setModPriority` per mod. When the target slot was held by another mod that *also* needed to move (the standard case when swapping profiles whose mod sets overlap), `setModPriority` threw `Priority X is already in use` and the catch silently warned. The mod never moved.

**Fix.** Route the priority pass through `reorderMods`, which already stages every rename via a `tmp_<uuid>_*` prefix (phase 1) before placing anything at its final `pak##` name (phase 2). No mid-loop slot can be both occupied and the target of an incoming rename. The collision class is gone.

Also exposes a small `compactEnabledMods(deadlockPath)` helper that wraps `reorderMods` with "scan, sort by current priority, dense-pack". Future callers (post-install, post-enable/disable) can use this to close gaps without owning the two-phase plumbing.

### 2. Right-click load-order: collision-tolerant retype

Right-click on a mod's Load badge let users retype the slot number, but `PriorityEditor` called `setModPriority` directly and threw "Priority N is already in use" the moment N was held by another mod. Drag-and-drop never hit this because it goes through `reorderMods`.

Fix: route typed priorities through Installed.tsx, which finds the same-section collider and rebuilds the order with the moved mod inserted before it, then calls `reorderMods`. Matches drag-drop semantics: typing N is "drop me onto whoever owns N". Free slots still take the single-rename path so the user keeps the exact number they typed. Slots reserved by *disabled* mods still error (reorderMods doesn't move across sections).

### 3. Unknown-mod auto-matching: now experimental

The CRC + GameBanana filter-search path used by "Fix unknown" hits rate limits hard on libraries with many unknown files. Gated behind a new `experimentalUnknownModMatching` setting (off by default) while it gets reworked.

When off:
- "Fix unknown" top-bar button and per-row wrench stay visible.
- Opening the modal goes straight to a notice + "Make Custom Mod" primary action.
- The bulk modal's "Find all" button, the panel's "Search", and the Retry buttons on result cards are all hidden.
- No automatic GameBanana lookups happen on modal open.

Toggle lives in Settings > Experimental Features alongside Stats / Crosshair / Social.

## What this does NOT do

- Does not raise the 99-pak ceiling. Users with 99+ total (enabled + disabled) still hit the cap; tracked separately.
- Does not address EBUSY errors from running Deadlock during apply (separate task: game-running detection).
- Does not auto-compact gaps after enable/disable/install. The helper is wired up, but only `applyProfile` calls into the two-phase path in this PR.
- Does not rework the unknown-mod matcher itself; just gates the existing implementation.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean on both renderer and main tsconfigs.
- [x] `pnpm lint` clean (only pre-existing warnings).
- [ ] Profile apply: build two profiles with overlapping mod sets but different priorities. Apply A, confirm order. Apply B, confirm every mod lands at its B-priority. Apply A again, confirm round-trip.
- [ ] Profile apply: profile with a mod that is disabled in A and enabled in B. Apply A, apply B, confirm the mod ends up enabled at the right priority.
- [ ] Profile apply: profile referencing a mod the user no longer has installed. Confirm no crash, other mods land at correct priorities.
- [ ] Right-click retype: type a slot held by another enabled mod. Confirm insert-shift (no error, target reaches typed slot, collider shifts).
- [ ] Right-click retype: type a free slot. Confirm exact-slot rename (user gets the number they typed).
- [ ] Right-click retype: type a slot held by a disabled mod. Confirm inline error (matches prior behavior).
- [ ] Unknown-mod gate OFF (default): open Fix unknown on any unknown mod. Confirm modal shows the experimental notice + "Make Custom Mod" button, no API call fires. Confirm bulk modal hides "Find all".
- [ ] Unknown-mod gate ON: confirm matcher behaves as before (Search button, Find all, auto-kick on open).