### PR TITLE
feat(ux): download chevron, sound-card tag stack, re-apply active profile

### DIFF
--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Download, Loader2, X, ChevronUp } from 'lucide-react';
+import { Download, Loader2, X, ChevronUp, ChevronDown } from 'lucide-react';
 import type { DownloadQueueItem, DownloadProgressData } from '../types/electron';
 
 interface DownloadQueueIndicatorProps {
@@ -205,7 +205,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                             aria-label="Collapse"
                             title="Collapse"
                         >
-                            <X className="h-3.5 w-3.5" />
+                            <ChevronDown className="h-4 w-4" />
                         </button>
                     </div>
 

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1866,9 +1866,33 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
         }
       />
 
-      {/* Info — moved to TOP for audio-preview sound cards so it stops covering the player */}
+      {/* Info: moved to TOP for audio-preview sound cards so it stops covering the player.
+          State tags (NSFW/Installed/Outdated) live inside this block too, on a row
+          ABOVE the title. The default top-left overlay covers the title text on this
+          variant because the title is anchored at top:0 instead of bottom:0. */}
       {isSoundSection && hasAudioPreview ? (
         <div className={`absolute top-0 left-0 right-0 pointer-events-none ${isCompact ? 'p-2.5 pr-10' : 'p-3 pr-12'}`}>
+          {(mod.nsfw || installed || isOutdated) && (
+            <div className="flex flex-wrap items-center gap-1 mb-1.5">
+              {mod.nsfw && <Tag tone="danger" variant="overlay">18+</Tag>}
+              {installed && (
+                <Tag tone="success" variant="overlay">
+                  <span aria-hidden>✓</span>
+                  Installed
+                </Tag>
+              )}
+              {!installed && isOutdated && (
+                <Tag
+                  tone="warning"
+                  variant="overlay"
+                  icon={AlertTriangle}
+                  title={`Last updated ${formatDate(mod.dateModified)}`}
+                >
+                  Outdated
+                </Tag>
+              )}
+            </div>
+          )}
           <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
           <div className={`flex items-center gap-3 text-white/90 mt-1 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] flex-wrap ${isCompact ? 'text-[11px]' : 'text-xs'}`}>
             <span className="flex items-center gap-1"><ThumbsUp className="w-3 h-3" />{formatCount(mod.likeCount)}</span>
@@ -1902,26 +1926,31 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
       )}
 
       {/* State tag stack — top-left. Stacks NSFW / INSTALLED / OUTDATED so the
-          card is decodable without relying on icon color alone. */}
-      <div className="absolute top-2 left-2 z-10 flex flex-col gap-1 items-start">
-        {mod.nsfw && <Tag tone="danger" variant="overlay">18+</Tag>}
-        {installed && (
-          <Tag tone="success" variant="overlay">
-            <span aria-hidden>✓</span>
-            Installed
-          </Tag>
-        )}
-        {!installed && isOutdated && (
-          <Tag
-            tone="warning"
-            variant="overlay"
-            icon={AlertTriangle}
-            title={`Last updated ${formatDate(mod.dateModified)}`}
-          >
-            Outdated
-          </Tag>
-        )}
-      </div>
+          card is decodable without relying on icon color alone. Skipped for
+          sound+audio cards because those render the same tags inline above the
+          title (the title moves to top:0 on that variant and the absolute
+          overlay would cover it). */}
+      {!(isSoundSection && hasAudioPreview) && (
+        <div className="absolute top-2 left-2 z-10 flex flex-col gap-1 items-start">
+          {mod.nsfw && <Tag tone="danger" variant="overlay">18+</Tag>}
+          {installed && (
+            <Tag tone="success" variant="overlay">
+              <span aria-hidden>✓</span>
+              Installed
+            </Tag>
+          )}
+          {!installed && isOutdated && (
+            <Tag
+              tone="warning"
+              variant="overlay"
+              icon={AlertTriangle}
+              title={`Last updated ${formatDate(mod.dateModified)}`}
+            >
+              Outdated
+            </Tag>
+          )}
+        </div>
+      )}
 
       {/* Audio preview + volume, pinned to bottom with its own pointer-events layer.
           z-20 keeps it above the gradient + any overlays so clicks always land.

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -574,18 +574,22 @@ export default function Profiles() {
 
                       <div className="flex flex-wrap items-center gap-2 pt-3 border-t border-white/5">
                         <div className="flex items-center gap-2 flex-1 min-w-0 basis-full @sm/profile-card:basis-auto">
-                          {!isActive && (
-                            <Button
-                              size="sm"
-                              className="flex-1 min-w-0"
-                              onClick={() => handleApplyProfile(profile.id)}
-                              disabled={isApplying || isUpdating}
-                              isLoading={isApplying}
-                              icon={Play}
-                            >
-                              Apply
-                            </Button>
-                          )}
+                          <Button
+                            size="sm"
+                            className="flex-1 min-w-0"
+                            onClick={() => handleApplyProfile(profile.id)}
+                            disabled={isApplying || isUpdating}
+                            isLoading={isApplying}
+                            icon={isActive ? RotateCcw : Play}
+                            variant={isActive ? 'secondary' : 'primary'}
+                            title={
+                              isActive
+                                ? 'Re-apply: snap mods back to this profile if they have drifted'
+                                : undefined
+                            }
+                          >
+                            {isActive ? 'Re-apply' : 'Apply'}
+                          </Button>
                           <Button
                             size="sm"
                             className="flex-1 min-w-0"


### PR DESCRIPTION
## Summary

Three small UX fixes batched together. None touch backend logic.

### 1. Download menu collapse icon

The expanded download panel had an `X` for collapse, which read as cancel and made users hesitate. Swapped for `ChevronDown` (panel collapses downward into the pill). The per-queue-item `X` that actually cancels a queued download is unchanged.

### 2. Outdated badge no longer covers the title on sound cards

On sound mods with an audio preview the title is anchored at `top:0` so the audio player can pin to `bottom:0`. The state-tag stack (NSFW / Installed / Outdated) was absolutely positioned at `top-2 left-2` and covered the title text. For that variant only, the tags now render as a chip row inline above the title; all other card variants keep the existing top-left overlay.

### 3. Re-apply for the currently-active profile

The Apply button was hidden when a profile was already marked active, so users who had manually toggled mods couldn't snap state back. Always render the button; relabel to "Re-apply" with `RotateCcw` + a secondary tone + a tooltip when `isActive`. Handler is unchanged.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean on both renderer and main tsconfigs.
- [x] `pnpm lint` clean (only pre-existing warnings).
- [x] Start a download. Open the expanded panel, hit the new chevron, confirm it collapses to the pill. Hit the per-item X, confirm it cancels just that queued item.
- [x] Browse > a sound section. Confirm Outdated / Installed / NSFW tags now sit above the title in a chip row and the title is readable. Check both grid and compact modes.
- [x] Browse > a non-sound section. Confirm tags still sit at top-left as before.
- [x] Profiles: with an active profile, confirm a "Re-apply" button now appears (RotateCcw icon, secondary tone). Click it, confirm it runs through the two-phase reorder without errors.