### PR TITLE
fix(mods): don't prune metadata while dev mode is active

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -91,9 +91,13 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     }
     const mods = await scanMods(deadlockPath);
     // Self-heal users whose metadata.json still carries orphan entries from
-    // pre-fix deletes (issue #26). pruneOrphanMetadata is a no-op when there
-    // are none, so the steady-state cost is one JSON parse.
-    pruneOrphanMetadata(new Set(mods.map((m) => m.fileName)));
+    // pre-fix deletes (issue #26). Skip while dev mode is active: the dev
+    // sandbox starts empty, and pruning against it would wipe every real
+    // install's name/thumbnail/gameBananaId from the global metadata sidecar.
+    const settings = loadSettings();
+    if (!settings.devMode) {
+        pruneOrphanMetadata(new Set(mods.map((m) => m.fileName)));
+    }
     return mods.map(enrichMod);
 });
 


### PR DESCRIPTION
## Summary

- `get-mods` ran `pruneOrphanMetadata` on every refresh against the **active** addons folder. When dev mode is on the active path is the empty `<userData>/dev-deadlock` sandbox, so the prune wiped every real install's `modName` / `thumbnailUrl` / `gameBananaId` / etc. from the global `mod-metadata.json` sidecar.
- After toggling dev mode off, users' VPKs were still on disk but every mod rendered as "unknown" with no cheap recovery: GameBanana rematching is rate-limited and per-mod expensive.
- Fix: skip the prune while `devMode` is true. The self-heal only catches real-install orphans, and those can't be observed from the dev sandbox anyway.

Reported in the Discord #help forum (\"Am I able to restore mods after toggling dev mode?\" by stardustslime, on 1.10.5).

## Test plan

- [ ] Install ≥ 1 GameBanana mod with real install path configured. Confirm names + thumbnails render on Installed page.
- [ ] Toggle dev mode on (Settings). Confirm Installed page shows the dev sandbox (likely empty).
- [ ] Toggle dev mode off. Confirm the real-install mods come back with names + thumbnails intact.
- [ ] Sanity: delete a mod with dev mode off and confirm its metadata is still cleaned up (covered by `deleteMod`'s explicit `removeModMetadata` at `mods.ts:429`, independent of this prune).

## Follow-ups (out of scope)

- Atomic write at `metadata.ts:54` overwrites the previous file on rename. A rolling `.bak` would give the next "metadata went sideways" report a one-click restore.
- `pruneOrphanMetadata` on every `get-mods` is overkill for what is fundamentally a one-shot post-upgrade migration. Could move to startup-only.