### PR TITLE
feat: hero-aware sounds, manual tagging, profile-share fixes

### DIFF
--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -5,6 +5,7 @@ import {
     fetchCategoryTree,
     fetchSubmissions,
     fetchModDetails,
+    fetchModFileList,
     fetchModComments,
     fetchCollection,
     fetchCollectionItems,
@@ -12,6 +13,7 @@ import {
     GameBananaCategoryNode,
     GameBananaModsResponse,
     GameBananaModDetails,
+    GameBananaModFileList,
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
 } from '../services/gamebanana';
@@ -79,6 +81,15 @@ ipcMain.handle(
         }
 
         return details;
+    }
+);
+
+// get-mod-file-list (slim variant used by the Installed-page update check)
+ipcMain.handle(
+    'get-mod-file-list',
+    async (_, args: GetModDetailsArgs): Promise<GameBananaModFileList> => {
+        const { modId, section = 'Mod' } = args;
+        return fetchModFileList(modId, section);
     }
 );
 

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -17,7 +17,7 @@ import {
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
 } from '../services/gamebanana';
-import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, resolveSuspiciousFileDecision, resolveMultiVpkPick, DownloadModArgs } from '../services/download';
+import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, cancelActiveDownload, resolveSuspiciousFileDecision, resolveMultiVpkPick, DownloadModArgs } from '../services/download';
 import { getMainWindow } from '../index';
 import { updateModNsfw } from '../services/modDatabase';
 
@@ -116,6 +116,11 @@ ipcMain.handle('get-current-download', () => {
 // remove-from-queue (cancel a queued download)
 ipcMain.handle('remove-from-queue', (_, modId: number): boolean => {
     return removeFromQueue(modId);
+});
+
+// cancel-active-download (abort the currently-running download)
+ipcMain.handle('cancel-active-download', (): boolean => {
+    return cancelActiveDownload();
 });
 
 // one-click-suspicious-response (renderer relays user's modal decision)

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -15,6 +15,8 @@ import {
 } from '../services/mods';
 import { getAddonsPath } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
+import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
+import { inferHeroFromVpk } from '../services/vpk';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 import { detectUnknownModFilters, type UnknownModFilterGuess } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
@@ -36,7 +38,12 @@ function getActiveDeadlockPath(): string | null {
 }
 
 /**
- * Enrich mod with metadata
+ * Enrich mod with metadata.
+ *
+ * For Sound mods without a stored lockerHero, lazily infer one from the mod
+ * name and persist it. The infer call is cheap (substring + a few regexes per
+ * hero) but writing back means follow-up scans skip the work and the manual
+ * override path has a stable field to overwrite.
  */
 function enrichMod(mod: Mod): Mod {
     const metadata = getModMetadata(mod.fileName);
@@ -44,6 +51,25 @@ function enrichMod(mod: Mod): Mod {
         !metadata?.gameBananaId &&
         !(typeof metadata?.modName === 'string' && metadata.modName.trim().length > 0);
     if (metadata) {
+        let lockerHero = metadata.lockerHero;
+        if (!lockerHero && metadata.sourceSection === 'Sound') {
+            // Title match first because it's O(1) regex; only crack open the
+            // VPK if the title gave us nothing. The VPK path is authoritative
+            // (parses real Source 2 codenames like `ghost` → Lady Geist) but
+            // costs a disk read + directory tree parse per call.
+            let inferred = inferHeroFromTitle(metadata.modName || mod.name);
+            if (!inferred) {
+                try {
+                    inferred = inferHeroFromVpk(mod.path);
+                } catch (err) {
+                    console.warn(`[enrichMod] VPK hero inference failed for ${mod.fileName}:`, err);
+                }
+            }
+            if (inferred) {
+                setModMetadata(mod.fileName, { lockerHero: inferred });
+                lockerHero = inferred;
+            }
+        }
         return {
             ...mod,
             // Use the stored mod name from GameBanana if available
@@ -62,6 +88,7 @@ function enrichMod(mod: Mod): Mod {
             variantLabel: metadata.variantLabel,
             fileDescription: metadata.fileDescription,
             sourceFileName: metadata.sourceFileName,
+            lockerHero,
             merged: metadata.merged,
         };
     }
@@ -275,6 +302,30 @@ ipcMain.handle(
         const trimmed = label.trim();
         setModMetadata(target.fileName, {
             variantLabel: trimmed.length > 0 ? trimmed : undefined,
+        });
+        return enrichMod(target);
+    }
+);
+
+// set-mod-locker-hero — manual hero tag for the Locker. Pass null to clear
+// the override and fall back to categoryId / inferHeroFromTitle. Used from
+// the Locker's "unassigned" section when GameBanana left a mod under the
+// generic "Skins" parent (or when an author misspelled the hero name).
+ipcMain.handle(
+    'set-mod-locker-hero',
+    async (_, modId: string, heroName: string | null): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const all = await scanMods(deadlockPath);
+        const target = all.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+        const trimmed = heroName?.trim() ?? '';
+        setModMetadata(target.fileName, {
+            lockerHero: trimmed.length > 0 ? trimmed : undefined,
         });
         return enrichMod(target);
     }

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -7,11 +7,12 @@ import { getDisabledPath } from './deadlock';
 import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles } from './extract';
 import { randomUUID } from 'crypto';
 import { setModMetadataWithHash, getModMetadata } from './metadata';
+import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
 import { getUsedPriorities, scanMods, disableMod, enableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
 import { loadSettings } from './settings';
-import { getVpkLabels } from './vpk';
+import { getVpkLabels, inferHeroFromVpk } from './vpk';
 import https from 'https';
 import http from 'http';
 
@@ -103,6 +104,30 @@ async function cleanupDownloadWorkDir(workDir: string): Promise<void> {
 function normalizePathForCompare(filePath: string): string {
     const normalized = resolve(filePath);
     return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * Per-VPK lockerHero stamp. Skin downloads ride on their GameBanana
+ * categoryId so this is a no-op for them. For Sound mods we prefer the
+ * caller's title-inferred lockerHero (cheap, already computed), and only
+ * fall back to cracking the VPK open when title inference missed.
+ * Sound mods with creative titles ("King Vondicta", "Low Honor kills...")
+ * still tag correctly because the underlying paths reference Source 2
+ * codenames like `hornet` / `inferno` / `synth`.
+ */
+function stampVpkLockerHero<T extends { lockerHero?: string }>(
+    base: T,
+    section: string | undefined,
+    vpkPath: string
+): T {
+    if (base.lockerHero || section !== 'Sound') return base;
+    try {
+        const vpkHero = inferHeroFromVpk(vpkPath);
+        if (vpkHero) return { ...base, lockerHero: vpkHero };
+    } catch (err) {
+        console.warn(`[download] VPK hero inference failed for ${vpkPath}:`, err);
+    }
+    return base;
 }
 
 async function moveFileWithoutOverwrite(sourcePath: string, destinationPath: string): Promise<void> {
@@ -574,6 +599,13 @@ async function executeDownload(
     // meaningful label even when the description is empty.
     const sourceFileNameStem = stripArchiveExtension(fileName);
 
+    // Auto-tag Sound mods with their hero so they show up in the per-hero
+    // Locker view. Sound mods don't have hero categoryIds on GameBanana, so the
+    // mod title is the only signal we have. Skin downloads keep their explicit
+    // categoryId and don't need this fallback.
+    const lockerHero =
+        section === 'Sound' ? inferHeroFromTitle(details.name) ?? undefined : undefined;
+
     const metadata = {
         modName: details.name,  // Store the actual mod name from GameBanana
         gameBananaId: modId,
@@ -587,6 +619,7 @@ async function executeDownload(
         isArchived: selectedFile?.isArchived ?? false,
         fileDescription: fileDescription && fileDescription.length > 0 ? fileDescription : undefined,
         sourceFileName: sourceFileNameStem.length > 0 ? sourceFileNameStem : undefined,
+        lockerHero,
     };
 
     let installedVpks: string[] = [];
@@ -738,7 +771,9 @@ async function executeDownload(
     console.log(`[downloadMod] Saving metadata for ${installedVpks.length} VPKs`);
     for (const vpkFileName of installedVpks) {
         console.log(`[downloadMod] Saving metadata for: ${vpkFileName}`);
-        await setModMetadataWithHash(vpkFileName, metadata, join(targetPath, vpkFileName));
+        const vpkPath = join(targetPath, vpkFileName);
+        const perVpkMetadata = stampVpkLockerHero(metadata, section, vpkPath);
+        await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
     }
 
     // Auto-disable previously installed variants of the same GameBanana mod so
@@ -1081,8 +1116,11 @@ async function executeOneClickDownload(
     const oneClickSourceFileName = stripArchiveExtension(
         matchedFile?.fileName ?? responseFilename ?? fileName
     );
+    const oneClickModName = enriched?.name ?? fileName.replace(/\.(zip|7z|rar|vpk)$/i, '');
+    const oneClickLockerHero =
+        section === 'Sound' ? inferHeroFromTitle(oneClickModName) ?? undefined : undefined;
     const metadata = {
-        modName: enriched?.name ?? fileName.replace(/\.(zip|7z|rar|vpk)$/i, ''),
+        modName: oneClickModName,
         gameBananaId: realModId,
         gameBananaFileId: resolvedFileId,
         categoryId: enriched?.category?.id,
@@ -1097,6 +1135,7 @@ async function executeOneClickDownload(
                 ? oneClickFileDescription
                 : undefined,
         sourceFileName: oneClickSourceFileName.length > 0 ? oneClickSourceFileName : undefined,
+        lockerHero: oneClickLockerHero,
     };
 
     let installedVpks: string[] = [];
@@ -1190,7 +1229,9 @@ async function executeOneClickDownload(
     }
 
     for (const vpkFileName of installedVpks) {
-        await setModMetadataWithHash(vpkFileName, metadata, join(targetPath, vpkFileName));
+        const vpkPath = join(targetPath, vpkFileName);
+        const perVpkMetadata = stampVpkLockerHero(metadata, section, vpkPath);
+        await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
     }
 
     mainWindow?.webContents.send('download-complete', { modId, fileId });

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -166,6 +166,12 @@ const downloadQueue: QueuedDownload[] = [];
 let isProcessingQueue = false;
 let currentDownloadInfo: { modId: number; fileId: number; fileName: string } | null = null;
 
+// Cancellation handle for the in-flight phase of the current download. The
+// active phase (HTTP fetch, multi-VPK picker prompt) installs a teardown
+// function here; cancelActiveDownload() invokes it. Only one phase is active
+// at a time, so a single slot is enough.
+let currentCancelHandler: (() => void) | null = null;
+
 /**
  * Get the current download queue state for UI display
  */
@@ -222,10 +228,22 @@ export function downloadMod(
     args: DownloadModArgs,
     mainWindow: BrowserWindow | null
 ): Promise<DownloadInstallResult> {
-    // Check if this mod is already in the queue (prevent duplicates)
-    const alreadyQueued = downloadQueue.some(q => q.args.modId === args.modId);
-    if (alreadyQueued) {
-        console.log(`[downloadMod] Mod ${args.modId} already in queue, skipping`);
+    // Dedup at (modId, fileId), not modId alone: a single submission can have
+    // multiple files (Gold/Silver variants, lite/HD versions) and profile
+    // imports legitimately queue several of them back-to-back. Also check the
+    // in-progress download — handleConfirm fires its calls in one tick, so
+    // call N+1 races against processQueue having already shifted call N out.
+    const sameTarget = (q: QueuedDownload) =>
+        q.args.modId === args.modId && q.args.fileId === args.fileId;
+    if (downloadQueue.some(sameTarget)) {
+        console.log(`[downloadMod] Mod ${args.modId} file ${args.fileId} already queued, skipping`);
+        return Promise.resolve({ installedVpks: [] });
+    }
+    if (
+        currentDownloadInfo?.modId === args.modId &&
+        currentDownloadInfo?.fileId === args.fileId
+    ) {
+        console.log(`[downloadMod] Mod ${args.modId} file ${args.fileId} already downloading, skipping`);
         return Promise.resolve({ installedVpks: [] });
     }
 
@@ -330,8 +348,21 @@ async function processQueue(): Promise<void> {
                 : await executeDownload(item.deadlockPath, item.args, item.mainWindow);
             item.resolve(result);
         } catch (error) {
-            item.reject(error instanceof Error ? error : new Error(String(error)));
+            const err = error instanceof Error ? error : new Error(String(error));
+            // Surface user-cancellation so the renderer can clear the row.
+            // The multi-VPK-picker cancel path already emits download-error
+            // itself; this only covers HTTP-phase cancels which don't.
+            if (err.message === 'CANCELLED_BY_USER') {
+                item.mainWindow?.webContents.send('download-error', {
+                    modId: item.args.modId,
+                    fileId: item.args.fileId,
+                    errorCode: 'CANCELLED_BY_USER',
+                    message: 'Download cancelled.',
+                });
+            }
+            item.reject(err);
         }
+        currentCancelHandler = null;
         currentDownloadInfo = null;
     }
 
@@ -355,6 +386,18 @@ async function downloadFile(
         const protocol = url.startsWith('https') ? https : http;
         let connectionTimedOut = false;
         let responseTimedOut = false;
+        let userCancelled = false;
+        let settled = false;
+        let fileStream: ReturnType<typeof createWriteStream> | null = null;
+
+        // Wrap resolve/reject so a duplicate completion (e.g. cancel races
+        // against a normal finish event) only fires the outer promise once.
+        const finalize = (err: Error | null) => {
+            if (settled) return;
+            settled = true;
+            if (err) reject(err);
+            else resolve();
+        };
 
         const request = protocol.get(url, (response) => {
             // Clear connection timeout once we get a response
@@ -383,7 +426,7 @@ async function downloadFile(
             }
 
             if (response.statusCode !== 200) {
-                reject(new Error(`Download failed with status ${response.statusCode}`));
+                finalize(new Error(`Download failed with status ${response.statusCode}`));
                 return;
             }
 
@@ -401,16 +444,17 @@ async function downloadFile(
             let downloadedSize = 0;
             let lastProgressTime = Date.now();
 
-            const fileStream = createWriteStream(destPath);
+            fileStream = createWriteStream(destPath);
+            const stream = fileStream;
 
             // Set up response timeout - reset on each data chunk
             const checkStall = setInterval(() => {
                 if (Date.now() - lastProgressTime > 60000) { // 1 minute without data
                     responseTimedOut = true;
                     request.destroy();
-                    fileStream.close();
+                    stream.close();
                     clearInterval(checkStall);
-                    reject(new Error('Download stalled - no data received for 60 seconds'));
+                    finalize(new Error('Download stalled - no data received for 60 seconds'));
                 }
             }, 10000);
 
@@ -420,21 +464,27 @@ async function downloadFile(
                 onProgress(downloadedSize, totalSize);
             });
 
-            response.pipe(fileStream);
+            response.pipe(stream);
 
-            fileStream.on('finish', () => {
+            stream.on('finish', () => {
                 clearInterval(checkStall);
-                fileStream.close();
-                resolve();
+                stream.close();
+                currentCancelHandler = null;
+                finalize(null);
             });
 
-            fileStream.on('error', async (err) => {
+            stream.on('error', async (err) => {
                 clearInterval(checkStall);
-                fileStream.close();
+                stream.close();
+                currentCancelHandler = null;
                 if (existsSync(destPath)) {
                     await fs.unlink(destPath).catch(() => { });
                 }
-                reject(err);
+                if (userCancelled) {
+                    finalize(new Error('CANCELLED_BY_USER'));
+                    return;
+                }
+                finalize(err);
             });
         });
 
@@ -442,14 +492,41 @@ async function downloadFile(
         const connectionTimeoutId = setTimeout(() => {
             connectionTimedOut = true;
             request.destroy();
-            reject(new Error(`Download connection timed out after ${connectionTimeoutMs / 1000} seconds`));
+            finalize(new Error(`Download connection timed out after ${connectionTimeoutMs / 1000} seconds`));
         }, connectionTimeoutMs);
 
         request.on('error', (err) => {
             clearTimeout(connectionTimeoutId);
+            currentCancelHandler = null;
             if (connectionTimedOut || responseTimedOut) return;
-            reject(err);
+            if (userCancelled) {
+                finalize(new Error('CANCELLED_BY_USER'));
+                return;
+            }
+            finalize(err);
         });
+
+        // Register the cancel handler. request.destroy() alone is not enough:
+        // when the response is mid-pipe to fileStream, destroying the request
+        // may leave the write stream in a state where neither 'finish' nor
+        // 'error' fires, so the outer promise stays pending. Tear both down
+        // and reject explicitly.
+        currentCancelHandler = () => {
+            if (userCancelled) return;
+            userCancelled = true;
+            clearTimeout(connectionTimeoutId);
+            try { request.destroy(); } catch { /* already gone */ }
+            if (fileStream) {
+                try { fileStream.destroy(); } catch { /* already gone */ }
+            }
+            // Best-effort cleanup of the partial file. The stream 'error'
+            // handler also tries, but if the stream never fires we'd leak
+            // the partial.
+            if (existsSync(destPath)) {
+                fs.unlink(destPath).catch(() => { });
+            }
+            finalize(new Error('CANCELLED_BY_USER'));
+        };
     });
 }
 
@@ -891,7 +968,17 @@ function awaitMultiVpkPick(
     mainWindow: BrowserWindow | null
 ): Promise<{ selected: string[] } | null> {
     return new Promise((resolve) => {
-        pendingVpkPicks.set(requestId, resolve);
+        const wrappedResolve = (decision: { selected: string[] } | null) => {
+            currentCancelHandler = null;
+            resolve(decision);
+        };
+        pendingVpkPicks.set(requestId, wrappedResolve);
+        // Toast cancel mid-picker resolves the same null-decision path the
+        // picker modal's Cancel button uses, so the existing cleanup runs.
+        currentCancelHandler = () => {
+            pendingVpkPicks.delete(requestId);
+            wrappedResolve(null);
+        };
         mainWindow?.webContents.send('multi-vpk-pick', {
             requestId,
             modName,
@@ -899,6 +986,20 @@ function awaitMultiVpkPick(
             vpkLabels,
         });
     });
+}
+
+/**
+ * Cancel the in-flight download phase (HTTP fetch or multi-VPK picker prompt)
+ * for the currently-processing queue item. Returns true when a handler was
+ * available and invoked. Safe no-op when nothing is in flight or the active
+ * phase is non-cancellable (e.g. extracting, writing metadata).
+ */
+export function cancelActiveDownload(): boolean {
+    if (!currentCancelHandler) return false;
+    const handler = currentCancelHandler;
+    currentCancelHandler = null;
+    handler();
+    return true;
 }
 
 function awaitSuspiciousDecision(

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -679,6 +679,42 @@ export async function fetchModDetails(
     };
 }
 
+export interface GameBananaModFileListEntry {
+    id: number;
+    isArchived: boolean;
+}
+
+export interface GameBananaModFileList {
+    id: number;
+    files: GameBananaModFileListEntry[];
+}
+
+interface ModFileListRaw {
+    _idRow: number;
+    _aFiles?: Array<{ _idRow: number; _bIsArchived?: boolean }>;
+}
+
+/**
+ * Slim variant of fetchModDetails that asks GameBanana for only the file list.
+ * The Installed page's update check uses this to scan every installed mod
+ * cheaply on mount - the full details payload (description, preview media,
+ * category) is wasteful when we only compare file ids.
+ */
+export async function fetchModFileList(
+    modId: number,
+    section = 'Mod'
+): Promise<GameBananaModFileList> {
+    const url = `${GAMEBANANA_API_BASE}/${section}/${modId}?_csvProperties=_idRow,_aFiles`;
+    const raw = await fetchJson<ModFileListRaw>(url);
+    return {
+        id: raw._idRow,
+        files: (raw._aFiles ?? []).map((f) => ({
+            id: f._idRow,
+            isArchived: f._bIsArchived ?? false,
+        })),
+    };
+}
+
 function isVpkPath(path: string): boolean {
     const normalized = path.replace(/\\/g, '/').trim().toLowerCase();
     return normalized.endsWith('.vpk') && !normalized.endsWith('/');

--- a/electron/main/services/heroSoundCodenames.ts
+++ b/electron/main/services/heroSoundCodenames.ts
@@ -1,0 +1,59 @@
+/**
+ * Deadlock hero "sound-path" codename → display name dictionary.
+ *
+ * Source of truth: docs/hero-sound-codenames.md. Sound mods organize their
+ * payloads under `sounds/abilities/<sound_codename>/aN_*` (and a handful
+ * under `sounds/heroes/<sound_codename>/`). Codenames sometimes diverge
+ * from the API `class_name` (e.g. Abrams' `class_name` is `hero_atlas`),
+ * so we key off the sound-path namespace here, not the script namespace.
+ *
+ * Heroes flagged as in-development or disabled in deadlock-api are
+ * intentionally kept in the table: their VPK assets ship today, and a
+ * sound mod targeting them should still get tagged. UI filtering (hiding
+ * disabled heroes from the Locker list) happens elsewhere.
+ */
+export const HERO_SOUND_CODENAMES: Readonly<Record<string, string>> = {
+    abrams: 'Abrams',
+    astro: 'Holliday',
+    bebop: 'Bebop',
+    bookworm: 'Paige',
+    chrono: 'Paradox',
+    drifter: 'Drifter',
+    dynamo: 'Dynamo',
+    fathom: 'Fathom',
+    fencer: 'Apollo',
+    forge: 'McGinnis',
+    ghost: 'Lady Geist',
+    gigawatt: 'Seven',
+    haze: 'Haze',
+    hornet: 'Vindicta',
+    inferno: 'Infernus',
+    kali: 'Kali',
+    kelvin: 'Kelvin',
+    lash: 'Lash',
+    mirage: 'Mirage',
+    mokrill: 'Mo & Krill',
+    nano: 'Calico',
+    orion: 'Grey Talon',
+    punkgoat: 'Billy',
+    shiv: 'Shiv',
+    synth: 'Pocket',
+    tengu: 'Ivy',
+    tokamak: 'Tokamak',
+    trapper: 'Trapper',
+    unicorn: 'Celeste',
+    vampirebat: 'Mina',
+    viper: 'Vyper',
+    viscous: 'Viscous',
+    werewolf: 'Silver',
+    wrecker: 'Wrecker',
+    yamato: 'Yamato',
+};
+
+/**
+ * Resolve a sound-path codename to a display name. Case-insensitive.
+ * Returns null when the codename isn't a known Deadlock hero.
+ */
+export function heroForSoundCodename(codename: string): string | null {
+    return HERO_SOUND_CODENAMES[codename.toLowerCase()] ?? null;
+}

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -21,6 +21,14 @@ export interface ModMetadata {
     variantLabel?: string;  // User-provided label to disambiguate variants of the same mod
     fileDescription?: string;  // GameBanana file "header" (_sDescription) — author's per-file label, used as fallback when the user hasn't named the variant
     sourceFileName?: string;   // Original GameBanana filename stem (e.g. "galaxy_rem_gold") — used as a label fallback when the author didn't set a file header
+    /** Hero this mod belongs to in the Locker, by canonical hero name (e.g. "Lady Geist").
+     *  Two reasons to store it: (1) GameBanana sometimes leaves a Skin under the
+     *  generic "Skins" parent so categoryId never names a hero; (2) Sound mods
+     *  live under their own category tree entirely. Set automatically at download
+     *  time for Sound mods via inferHeroFromTitle, or manually by the user from
+     *  the Locker's unassigned section. Takes precedence over categoryId when
+     *  the locker maps mods to heroes. */
+    lockerHero?: string;
     /** Set when this VPK was produced by mergeMods. The share code +
      *  source list are the unroll payload. */
     merged?: import('../../../src/types/mod').MergedModInfo;

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -48,6 +48,10 @@ export interface Mod {
      *  a meaningful label - falls between fileDescription and the local
      *  pakNN_dir.vpk filename in the picker's display chain. */
     sourceFileName?: string;
+    /** Hero this mod belongs to in the Locker (canonical name). Either
+     *  auto-inferred at download time for Sound mods or manually set by the
+     *  user; takes precedence over categoryId in the locker grouping. */
+    lockerHero?: string;
     /** Populated when this VPK was produced by mergeMods. The metadata
      *  enricher reads this from the mod metadata sidecar. */
     merged?: import('../../../src/types/mod').MergedModInfo;

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -529,10 +529,17 @@ export async function createProfileFromPortable(
         if (claimedVariants.has(fileName)) continue;
         claimedVariants.add(fileName);
 
+        // Persist the stable GameBanana ids alongside the fileName so
+        // applyProfile / buildPortableProfile can find this mod after a
+        // later reorder rotates its pakNN_ prefix. Without these, imported
+        // and snapshot-restored profiles regress to fileName-only lookups
+        // and re-export warns "Skipped local mod" the moment files move.
         profileMods.push({
             fileName,
             enabled: r.entry.enabled,
             priority: r.entry.priority,
+            gameBananaId: ref.submissionId,
+            gameBananaFileId: r.resolvedFileId,
         });
     }
 

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -166,15 +166,44 @@ export async function buildPortableProfile(
 
     const installed = await scanMods(deadlockPath);
     const modByFileName = new Map(installed.map((m) => [m.fileName, m]));
+    // Resolve profile mods to live installed mods by stable id first, mirroring
+    // applyProfile's resolver (see profiles.ts buildProfileModResolver). Without
+    // this, a re-share after switching profiles loses every mod whose pakNN_
+    // prefix shifted via reorderMods: the saved profileMod.fileName no longer
+    // matches anything on disk, so both modByFileName and getModMetadata return
+    // undefined and the export warns "Skipped local mod" for known GameBanana
+    // installs.
+    const modByGbFile = new Map<string, typeof installed[number]>();
+    for (const m of installed) {
+        const meta = getModMetadata(m.fileName);
+        if (typeof meta?.gameBananaId === 'number' && typeof meta?.gameBananaFileId === 'number') {
+            const key = `${meta.gameBananaId}:${meta.gameBananaFileId}`;
+            if (!modByGbFile.has(key)) modByGbFile.set(key, m);
+        }
+    }
 
     const mods: PortableModEntry[] = [];
     const warnings: string[] = [];
 
     for (const profileMod of profile.mods) {
-        const installedMod = modByFileName.get(profileMod.fileName);
-        const metadata = getModMetadata(profileMod.fileName);
-        const gbId = metadata?.gameBananaId ?? installedMod?.gameBananaId;
-        const fileId = metadata?.gameBananaFileId ?? installedMod?.gameBananaFileId;
+        const stableKey =
+            typeof profileMod.gameBananaId === 'number' &&
+            typeof profileMod.gameBananaFileId === 'number'
+                ? `${profileMod.gameBananaId}:${profileMod.gameBananaFileId}`
+                : null;
+        const installedMod =
+            (stableKey ? modByGbFile.get(stableKey) : undefined) ??
+            modByFileName.get(profileMod.fileName);
+        const metadataFileName = installedMod?.fileName ?? profileMod.fileName;
+        const metadata = getModMetadata(metadataFileName);
+        const gbId =
+            profileMod.gameBananaId ??
+            metadata?.gameBananaId ??
+            installedMod?.gameBananaId;
+        const fileId =
+            profileMod.gameBananaFileId ??
+            metadata?.gameBananaFileId ??
+            installedMod?.gameBananaFileId;
 
         if (!gbId || !fileId) {
             const label =
@@ -191,7 +220,7 @@ export async function buildPortableProfile(
             metadata?.sourceFileName ||
             undefined;
 
-        const vpkStem = vpkStemOf(profileMod.fileName);
+        const vpkStem = vpkStemOf(installedMod?.fileName ?? profileMod.fileName);
         mods.push({
             source: 'gamebanana',
             ref: {

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -324,9 +324,30 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     // currentMod.id → ProfileMod, when matched. Drives the enable/disable
     // loop and the reorder pass below.
     const profileModByCurrentId = new Map<string, ProfileMod>();
+    // Heal pre-stable-id and pre-fix portable-import profiles: any time we
+    // match a profileMod whose stable ids are missing to a current mod whose
+    // metadata has them, backfill onto the saved entry. Without this, the
+    // entry stays vulnerable to the next reorder rotating its pakNN_ prefix,
+    // at which point both applyProfile and buildPortableProfile lose it.
+    let healedAny = false;
     for (const profileMod of profile.mods) {
         const matched = resolveProfileMod(profileMod);
-        if (matched) profileModByCurrentId.set(matched.id, profileMod);
+        if (!matched) continue;
+        profileModByCurrentId.set(matched.id, profileMod);
+        if (typeof profileMod.gameBananaId === 'number' && typeof profileMod.gameBananaFileId === 'number') continue;
+        const matchedMeta = getModMetadata(matched.fileName);
+        if (typeof matchedMeta?.gameBananaId !== 'number' || typeof matchedMeta?.gameBananaFileId !== 'number') continue;
+        profileMod.gameBananaId = matchedMeta.gameBananaId;
+        profileMod.gameBananaFileId = matchedMeta.gameBananaFileId;
+        healedAny = true;
+    }
+    if (healedAny) {
+        const all = loadProfiles();
+        const idx = all.findIndex((p) => p.id === profileId);
+        if (idx !== -1) {
+            all[idx] = { ...all[idx], mods: profile.mods };
+            saveProfiles(all);
+        }
     }
 
     for (const mod of currentMods) {

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -1,4 +1,5 @@
 import { openSync, readSync, closeSync, existsSync } from 'fs';
+import { heroForSoundCodename } from './heroSoundCodenames';
 
 /**
  * VPK Header Structure (Version 2):
@@ -189,6 +190,63 @@ export function extractHeroFromPath(filePath: string): string | null {
     }
 
     return null;
+}
+
+/**
+ * Sound mod path patterns. Sound mods don't live under `sounds/heroes/`
+ * the way skin VPKs do: they live under `sounds/abilities/<codename>/aN_X/`
+ * or, more rarely, under `sounds/heroes/<codename>/`. The codename is
+ * Deadlock's sound-path namespace (e.g. `ghost` for Lady Geist, `hornet`
+ * for Vindicta), translated via HERO_SOUND_CODENAMES below.
+ *
+ * `soundevents/` files (e.g. `soundevents/citadel/hero_ghost.vsndevts_c`)
+ * are also a strong signal but live outside `sounds/`. We match those too.
+ */
+const SOUND_HERO_PATTERNS: RegExp[] = [
+    /(?:^|\/)sounds\/abilities\/([a-z0-9_]+)\//i,
+    /(?:^|\/)sounds\/heroes\/([a-z0-9_]+)\//i,
+    /(?:^|\/)sounds\/[^/]+\/hero_([a-z0-9_]+)\//i,
+    // `soundevents/citadel/hero_<codename>.vsndevts_c` (hero_ prefix on file).
+    /(?:^|\/)soundevents\/[^/]*\/hero_([a-z0-9_]+)\.vsndevts/i,
+    // `soundevents/hero/<codename>.vsndevts_c` (hero is the folder, file is
+    // just the codename). Observed on pak04 "We don't talk Animal" which
+    // ships soundevents/hero/werewolf.vsndevts_c.
+    /(?:^|\/)soundevents\/hero\/([a-z0-9_]+)\.vsndevts/i,
+];
+
+/**
+ * Inspect a VPK's path list for sound-mod payloads and return the display
+ * name of the hero they target. Returns null when no recognized hero
+ * codename appears, or when the VPK touches more than one hero (we'd
+ * rather leave that case to manual tagging than pick the wrong one).
+ */
+export function inferHeroFromVpkPaths(paths: string[]): string | null {
+    const heroes = new Set<string>();
+    for (const filePath of paths) {
+        for (const pattern of SOUND_HERO_PATTERNS) {
+            const match = filePath.match(pattern);
+            if (!match) continue;
+            const hero = heroForSoundCodename(match[1]);
+            if (hero) {
+                heroes.add(hero);
+                break;
+            }
+        }
+        // Bail early once we've already seen a conflict: no point scanning
+        // the rest of a large VPK if the answer is already "ambiguous."
+        if (heroes.size > 1) return null;
+    }
+    return heroes.size === 1 ? [...heroes][0] : null;
+}
+
+/**
+ * Convenience wrapper: parse the VPK directory and run the path-based
+ * inference. Returns null when the VPK can't be parsed or no hero matches.
+ */
+export function inferHeroFromVpk(vpkPath: string): string | null {
+    const paths = parseVpkDirectory(vpkPath);
+    if (!paths || paths.length === 0) return null;
+    return inferHeroFromVpkPaths(paths);
 }
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -118,6 +118,7 @@ export interface ElectronAPI {
     getDownloadQueue: () => Promise<DownloadQueueItem[]>;
     getCurrentDownload: () => Promise<DownloadQueueItem | null>;
     removeFromQueue: (modId: number) => Promise<boolean>;
+    cancelActiveDownload: () => Promise<boolean>;
     onDownloadQueueUpdated: (callback: (data: DownloadQueueData) => void) => () => void;
 
     // GameBanana 1-Click protocol handler
@@ -494,7 +495,7 @@ interface DownloadEventData {
 interface DownloadErrorData {
     modId: number;
     fileId: number;
-    errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
+    errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'CANCELLED_BY_USER' | 'UNKNOWN';
     message: string;
     helpUrl?: string;
 }
@@ -870,6 +871,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getDownloadQueue: () => ipcRenderer.invoke('get-download-queue'),
     getCurrentDownload: () => ipcRenderer.invoke('get-current-download'),
     removeFromQueue: (modId: number) => ipcRenderer.invoke('remove-from-queue', modId),
+    cancelActiveDownload: () => ipcRenderer.invoke('cancel-active-download'),
     onDownloadQueueUpdated: (callback: (data: DownloadQueueData) => void) => {
         const handler = (_event: Electron.IpcRendererEvent, data: DownloadQueueData) => callback(data);
         ipcRenderer.on('download-queue-updated', handler);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -49,6 +49,7 @@ export interface ElectronAPI {
     applyUnknownModMatch: (modId: string, args: ApplyUnknownModMatchArgs) => Promise<Mod>;
     applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
+    setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
     backfillGameBananaFileId: (
         modId: string,
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
@@ -74,6 +75,7 @@ export interface ElectronAPI {
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
     getModDetails: (args: GetModDetailsArgs) => Promise<GameBananaModDetails>;
+    getModFileList: (args: GetModDetailsArgs) => Promise<GameBananaModFileList>;
     getModComments: (args: GetModCommentsArgs) => Promise<GameBananaCommentsResponse>;
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;
@@ -553,6 +555,11 @@ interface GameBananaModDetails {
     previewMedia?: unknown;
 }
 
+interface GameBananaModFileList {
+    id: number;
+    files: Array<{ id: number; isArchived: boolean }>;
+}
+
 interface GameBananaSection {
     pluralTitle: string;
     modelName: string;
@@ -760,6 +767,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('apply-unknown-custom-mod', modId, args),
     setVariantLabel: (modId: string, label: string) =>
         ipcRenderer.invoke('set-variant-label', modId, label),
+    setModLockerHero: (modId: string, heroName: string | null) =>
+        ipcRenderer.invoke('set-mod-locker-hero', modId, heroName),
     backfillGameBananaFileId: (
         modId: string,
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
@@ -795,6 +804,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // GameBanana
     browseMods: (args: BrowseModsArgs) => ipcRenderer.invoke('browse-mods', args),
     getModDetails: (args: GetModDetailsArgs) => ipcRenderer.invoke('get-mod-details', args),
+    getModFileList: (args: GetModDetailsArgs) => ipcRenderer.invoke('get-mod-file-list', args),
     getModComments: (args: GetModCommentsArgs) => ipcRenderer.invoke('get-mod-comments', args),
     downloadMod: (args: DownloadModArgs) => ipcRenderer.invoke('download-mod', args),
     getGameBananaSections: () => ipcRenderer.invoke('get-gamebanana-sections'),

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -118,6 +118,10 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
         await window.electronAPI.removeFromQueue(modId);
     };
 
+    const handleCancelActive = async () => {
+        await window.electronAPI.cancelActiveDownload();
+    };
+
     const totalItems = queueState.queue.length + (queueState.currentDownload ? 1 : 0);
     const progressPercent =
         queueState.progress && queueState.progress.total > 0
@@ -138,43 +142,62 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
     return (
         <div className={`pointer-events-auto ${className}`}>
             {/* Collapsed pill: compact chip with filename + percent and an
-                inline progress bar across the bottom edge. Clicking pops the
-                expanded panel up above it. */}
+                inline progress bar across the bottom edge. Clicking the body
+                pops the expanded panel; the trailing X (when a download is
+                actually in flight) cancels the active fetch. */}
             {!isExpanded && (
-                <button
-                    type="button"
-                    onClick={() => setIsExpanded(true)}
-                    className="group relative flex w-72 items-center gap-2.5 overflow-hidden rounded-full border border-white/10 bg-bg-secondary/95 px-3 py-2 text-left shadow-lg shadow-black/40 backdrop-blur-md transition-colors hover:border-accent/40 hover:bg-bg-tertiary/90 cursor-pointer"
-                    title="Show download details"
+                <div
+                    className="group relative flex w-72 items-stretch overflow-hidden rounded-full border border-white/10 bg-bg-secondary/95 text-left shadow-lg shadow-black/40 backdrop-blur-md transition-colors hover:border-accent/40 hover:bg-bg-tertiary/90"
                 >
-                    <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-accent/15">
-                        {queueState.currentDownload ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin text-accent" />
-                        ) : (
-                            <Download className="h-3.5 w-3.5 text-accent" />
-                        )}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                        <div className="truncate text-[13px] font-medium leading-tight text-text-primary" title={currentFileName}>
-                            {currentFileName}
-                        </div>
-                        <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary">
-                            <span className="tabular-nums">{progressPercentRounded}%</span>
-                            {speed > 0 && (
-                                <>
-                                    <span className="opacity-50">·</span>
-                                    <span className="tabular-nums">{formatSpeed(speed)}</span>
-                                </>
+                    <button
+                        type="button"
+                        onClick={() => setIsExpanded(true)}
+                        className="flex min-w-0 flex-1 items-center gap-2.5 px-3 py-2 cursor-pointer text-left"
+                        title="Show download details"
+                    >
+                        <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-accent/15">
+                            {queueState.currentDownload ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin text-accent" />
+                            ) : (
+                                <Download className="h-3.5 w-3.5 text-accent" />
                             )}
-                            {totalItems > 1 && (
-                                <>
-                                    <span className="opacity-50">·</span>
-                                    <span>{totalItems - 1} queued</span>
-                                </>
-                            )}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <div className="truncate text-[13px] font-medium leading-tight text-text-primary" title={currentFileName}>
+                                {currentFileName}
+                            </div>
+                            <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary">
+                                <span className="tabular-nums">{progressPercentRounded}%</span>
+                                {speed > 0 && (
+                                    <>
+                                        <span className="opacity-50">·</span>
+                                        <span className="tabular-nums">{formatSpeed(speed)}</span>
+                                    </>
+                                )}
+                                {totalItems > 1 && (
+                                    <>
+                                        <span className="opacity-50">·</span>
+                                        <span>{totalItems - 1} queued</span>
+                                    </>
+                                )}
+                            </div>
                         </div>
-                    </div>
-                    <ChevronUp className="h-4 w-4 flex-shrink-0 text-text-secondary opacity-0 transition-opacity group-hover:opacity-100" />
+                        <ChevronUp className="h-4 w-4 flex-shrink-0 text-text-secondary opacity-0 transition-opacity group-hover:opacity-100" />
+                    </button>
+                    {queueState.currentDownload && (
+                        <button
+                            type="button"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                void handleCancelActive();
+                            }}
+                            className="flex flex-shrink-0 items-center justify-center border-l border-white/5 px-3 text-text-secondary transition-colors hover:bg-red-500/10 hover:text-red-300 cursor-pointer"
+                            aria-label="Cancel download"
+                            title="Cancel download"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                    )}
                     <span
                         aria-hidden
                         className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/5"
@@ -184,7 +207,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                             style={{ width: `${progressPercent}%` }}
                         />
                     </span>
-                </button>
+                </div>
             )}
 
             {/* Expanded panel: opens upward (transform-origin-bottom) so the
@@ -222,6 +245,15 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                 <span className="text-xs tabular-nums text-accent font-semibold">
                                     {progressPercentRounded}%
                                 </span>
+                                <button
+                                    type="button"
+                                    onClick={() => void handleCancelActive()}
+                                    className="rounded-md p-1 text-text-secondary transition-colors hover:bg-red-500/10 hover:text-red-300 cursor-pointer"
+                                    aria-label="Cancel download"
+                                    title="Cancel download"
+                                >
+                                    <X className="h-3.5 w-3.5" />
+                                </button>
                             </div>
                             <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/5">
                                 <div

--- a/src/components/ModThumbnail.tsx
+++ b/src/components/ModThumbnail.tsx
@@ -1,5 +1,6 @@
 import { EyeOff } from 'lucide-react';
 import type { MergedModSource } from '../types/mod';
+import { getHeroRenderPath } from '../lib/lockerUtils';
 
 interface ModThumbnailProps {
   src?: string;
@@ -9,6 +10,11 @@ interface ModThumbnailProps {
   className?: string;
   imageClassName?: string;
   fallback?: React.ReactNode;
+  /** Canonical Deadlock hero name (e.g. "Lady Geist"). When set, the hero's
+   *  render image is used instead of `src`. Sound mods use this so the locker
+   *  reads as "Geist sounds" at a glance rather than showing the uploader's
+   *  generic speaker icon. */
+  heroPortrait?: string;
   /** When present, render an N-up collage of the source thumbnails instead
    *  of the single `src` image. Used by merged mods. The single-image path
    *  is still used when the user uploaded an override thumbnail (we treat
@@ -24,14 +30,19 @@ export default function ModThumbnail({
   className = '',
   imageClassName = '',
   fallback,
+  heroPortrait,
   mergedSources,
 }: ModThumbnailProps) {
   const shouldBlur = nsfw && hideNsfw;
+  // Hero portrait wins over the uploader's thumbnail. NSFW blur is suppressed
+  // here because hero renders are official Valve art, not user uploads.
+  const resolvedSrc = heroPortrait ? getHeroRenderPath(heroPortrait) : src;
+  const resolvedBlur = heroPortrait ? false : shouldBlur;
 
   // Collage path: only when there's no explicit src and we have sources to
   // tile. The user-uploaded thumbnail (when set) always wins so they have a
   // way to override the collage if they don't like it.
-  if (!src && mergedSources && mergedSources.length > 0) {
+  if (!resolvedSrc && mergedSources && mergedSources.length > 0) {
     return (
       <MergedCollage
         sources={mergedSources}
@@ -42,7 +53,7 @@ export default function ModThumbnail({
     );
   }
 
-  if (!src) {
+  if (!resolvedSrc) {
     return (
       fallback ?? (
         <div className={`flex items-center justify-center text-text-secondary text-xs ${className}`}>
@@ -56,14 +67,14 @@ export default function ModThumbnail({
     <div className={`relative overflow-hidden ${className}`}>
       <div className={`w-full h-full ${imageClassName}`}>
         <img
-          src={src}
+          src={resolvedSrc}
           alt={alt}
           className={`block w-full h-full object-cover transition-[filter] duration-200 ${
-            shouldBlur ? 'blur-xl scale-110' : ''
+            resolvedBlur ? 'blur-xl scale-110' : ''
           }`}
         />
       </div>
-      {shouldBlur && (
+      {resolvedBlur && (
         <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/30">
           <EyeOff className="w-4 h-4 text-white/70" />
           <span className="text-[9px] text-white/70 mt-0.5">NSFW</span>

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -54,6 +54,17 @@ interface HeroSkinsPanelProps {
   onToggleVariant?: (modId: string) => void;
   hideNsfwPreviews?: boolean;
   categoryId?: number;
+  /** Render thumbnails as the hero portrait instead of the mod's uploader
+   *  thumbnail. Sound-section view uses this so the panel reads as the right
+   *  hero at a glance even though sound uploads usually carry a generic icon. */
+  useHeroPortraitThumbnails?: boolean;
+  /** Canonical hero name used when useHeroPortraitThumbnails is on. */
+  heroName?: string;
+  /** Show the DownloadableSkinsSection footer. Off for the Sounds tab,
+   *  which would otherwise surface Skin-category GameBanana results. */
+  showDownloadable?: boolean;
+  /** Message rendered when the mod list for this section is empty. */
+  emptyMessage?: string;
   minaPresets?: MinaPreset[];
   activeMinaPreset?: MinaPreset;
   minaTextures?: Mod[];
@@ -76,6 +87,10 @@ export default function HeroSkinsPanel({
   onToggleVariant,
   hideNsfwPreviews = false,
   categoryId,
+  useHeroPortraitThumbnails = false,
+  heroName,
+  showDownloadable = true,
+  emptyMessage = 'Download a skin for this hero to manage it here.',
   minaPresets = [],
   activeMinaPreset,
   minaTextures = [],
@@ -408,6 +423,9 @@ export default function HeroSkinsPanel({
                     alt={primary.name}
                     nsfw={primary.nsfw}
                     hideNsfw={hideNsfwPreviews}
+                    heroPortrait={
+                      useHeroPortraitThumbnails ? heroName : undefined
+                    }
                     className="w-full h-full"
                     fallback={
                       <div className="w-full h-full flex items-center justify-center text-text-secondary text-[10px]">
@@ -484,12 +502,10 @@ export default function HeroSkinsPanel({
           );
         })
       ) : (
-        <div className="text-xs text-text-secondary">
-          Download a skin for this hero to manage it here.
-        </div>
+        <div className="text-xs text-text-secondary">{emptyMessage}</div>
       )}
 
-      {categoryId && <DownloadableSkinsSection categoryId={categoryId} />}
+      {showDownloadable && categoryId && <DownloadableSkinsSection categoryId={categoryId} />}
     </div>
   );
 }

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -70,10 +70,26 @@ interface RowState {
   progress?: { downloaded: number; total: number };
 }
 
-function gbId(mod: PortableResolvedMod): number | null {
+function gbSubmissionId(mod: PortableResolvedMod): number | null {
   if (mod.entry.source !== 'gamebanana') return null;
   const ref = mod.entry.ref as { submissionId?: number };
   return ref.submissionId ?? null;
+}
+
+// Composite tracking key for download events. A submission can appear several
+// times in one import (different file versions, or multi-VPK siblings); keying
+// by submissionId alone would cross-update unrelated rows. Multi-VPK siblings
+// genuinely share (submissionId, fileId) and SHOULD update together, since
+// they all ride on a single archive download.
+function rowKey(mod: PortableResolvedMod): string | null {
+  if (mod.entry.source !== 'gamebanana') return null;
+  const ref = mod.entry.ref as { submissionId?: number; fileId?: number };
+  if (ref.submissionId === undefined || ref.fileId === undefined) return null;
+  return `${ref.submissionId}:${ref.fileId}`;
+}
+
+function eventKey(modId: number, fileId: number): string {
+  return `${modId}:${fileId}`;
 }
 
 export default function ImportProfileDialog({
@@ -116,16 +132,16 @@ export default function ImportProfileDialog({
   const includeAutoexecRef = useRef(true);
   useEffect(() => { includeAutoexecRef.current = includeAutoexec; }, [includeAutoexec]);
 
-  const trackedIds = useMemo(() => {
-    const s = new Set<number>();
+  const trackedKeys = useMemo(() => {
+    const s = new Set<string>();
     for (const r of rows) {
-      const id = gbId(r.mod);
-      if (id !== null) s.add(id);
+      const k = rowKey(r.mod);
+      if (k !== null) s.add(k);
     }
     return s;
   }, [rows]);
-  const trackedIdsRef = useRef(trackedIds);
-  useEffect(() => { trackedIdsRef.current = trackedIds; }, [trackedIds]);
+  const trackedKeysRef = useRef(trackedKeys);
+  useEffect(() => { trackedKeysRef.current = trackedKeys; }, [trackedKeys]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -137,45 +153,50 @@ export default function ImportProfileDialog({
 
   // Listen for download events to drive row status during import.
   useEffect(() => {
-    const updateRowByGb = (id: number, patch: Partial<RowState>) => {
-      setRows((prev) => prev.map((r) => (gbId(r.mod) === id ? { ...r, ...patch } : r)));
+    const updateRowsByKey = (key: string, patch: Partial<RowState>) => {
+      setRows((prev) => prev.map((r) => (rowKey(r.mod) === key ? { ...r, ...patch } : r)));
     };
 
     const unsubQueue = window.electronAPI.onDownloadQueueUpdated((data) => {
-      const queuedSet = new Set(data.queue.map((q) => q.modId));
-      const currentId = data.currentDownload?.modId;
+      const queuedSet = new Set(data.queue.map((q) => eventKey(q.modId, q.fileId)));
+      const currentKey = data.currentDownload
+        ? eventKey(data.currentDownload.modId, data.currentDownload.fileId)
+        : null;
       setRows((prev) =>
         prev.map((r) => {
-          const id = gbId(r.mod);
-          if (id === null || !trackedIdsRef.current.has(id)) return r;
+          const k = rowKey(r.mod);
+          if (k === null || !trackedKeysRef.current.has(k)) return r;
           if (
             r.status === 'installed' ||
             r.status === 'already-installed' ||
             r.status === 'failed' ||
             r.status === 'skipped'
           ) return r;
-          if (currentId === id) return r.status === 'downloading' ? r : { ...r, status: 'downloading' };
-          if (queuedSet.has(id)) return r.status === 'queued' ? r : { ...r, status: 'queued' };
+          if (currentKey === k) return r.status === 'downloading' ? r : { ...r, status: 'downloading' };
+          if (queuedSet.has(k)) return r.status === 'queued' ? r : { ...r, status: 'queued' };
           return r;
         })
       );
     });
 
-    const unsubComplete = window.electronAPI.onDownloadComplete(({ modId }) => {
-      if (!trackedIdsRef.current.has(modId)) return;
-      updateRowByGb(modId, { status: 'installed', statusMessage: undefined });
+    const unsubComplete = window.electronAPI.onDownloadComplete(({ modId, fileId }) => {
+      const k = eventKey(modId, fileId);
+      if (!trackedKeysRef.current.has(k)) return;
+      updateRowsByKey(k, { status: 'installed', statusMessage: undefined });
     });
 
-    const unsubError = window.electronAPI.onDownloadError(({ modId, message }) => {
-      if (!trackedIdsRef.current.has(modId)) return;
-      updateRowByGb(modId, { status: 'failed', statusMessage: message });
+    const unsubError = window.electronAPI.onDownloadError(({ modId, fileId, message }) => {
+      const k = eventKey(modId, fileId);
+      if (!trackedKeysRef.current.has(k)) return;
+      updateRowsByKey(k, { status: 'failed', statusMessage: message });
     });
 
-    const unsubProgress = window.electronAPI.onDownloadProgress(({ modId, downloaded, total }) => {
-      if (!trackedIdsRef.current.has(modId)) return;
+    const unsubProgress = window.electronAPI.onDownloadProgress(({ modId, fileId, downloaded, total }) => {
+      const k = eventKey(modId, fileId);
+      if (!trackedKeysRef.current.has(k)) return;
       setRows((prev) =>
         prev.map((r) =>
-          gbId(r.mod) === modId
+          rowKey(r.mod) === k
             ? { ...r, progress: { downloaded, total } }
             : r
         )
@@ -295,6 +316,7 @@ export default function ImportProfileDialog({
       if (mod.entry.source !== 'gamebanana') continue;
       if (mod.resolvedFileId === undefined || !mod.resolvedFileName) continue;
       const ref = mod.entry.ref as { submissionId: number; section?: string };
+      const failKey = eventKey(ref.submissionId, mod.resolvedFileId);
       void downloadMod(
         ref.submissionId,
         mod.resolvedFileId,
@@ -304,7 +326,7 @@ export default function ImportProfileDialog({
         const message = err instanceof Error ? err.message : String(err);
         setRows((prev) =>
           prev.map((r) =>
-            gbId(r.mod) === ref.submissionId && r.status !== 'installed'
+            rowKey(r.mod) === failKey && r.status !== 'installed'
               ? { ...r, status: 'failed', statusMessage: message }
               : r
           )
@@ -672,7 +694,7 @@ export default function ImportProfileDialog({
                         />
                         <div className="min-w-0 flex-1">
                           <div className="text-sm font-medium text-text-primary truncate">
-                            {hint?.name ?? `Submission #${gbId(mod) ?? '?'}`}
+                            {hint?.name ?? `Submission #${gbSubmissionId(mod) ?? '?'}`}
                           </div>
                           <div className="text-xs text-text-secondary flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
                             {hint?.category && <span className="truncate max-w-[12rem]">{hint.category}</span>}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@ import type { Mod, AppSettings, UnknownModFilterGuess, ApplyUnknownModMatchArgs,
 import type {
   GameBananaModsResponse,
   GameBananaModDetails,
+  GameBananaModFileList,
   GameBananaSection,
   GameBananaCategoryNode,
   GameBananaMod,
@@ -14,6 +15,7 @@ import type {
 export type {
   GameBananaModsResponse,
   GameBananaModDetails,
+  GameBananaModFileList,
   GameBananaSection,
   GameBananaCategoryNode,
   GameBananaMod,
@@ -77,6 +79,13 @@ export async function applyUnknownCustomMod(modId: string, args: ApplyUnknownCus
 
 export async function setVariantLabel(modId: string, label: string): Promise<Mod> {
   return window.electronAPI.setVariantLabel(modId, label);
+}
+
+export async function setModLockerHero(
+  modId: string,
+  heroName: string | null
+): Promise<Mod> {
+  return window.electronAPI.setModLockerHero(modId, heroName);
 }
 
 export async function backfillGameBananaFileId(
@@ -187,6 +196,10 @@ export async function browseMods(
   sort?: string
 ): Promise<GameBananaModsResponse> {
   return window.electronAPI.browseMods({ page, perPage, search, section, categoryId, sort });
+}
+
+export async function getModFileList(modId: number, section?: string): Promise<GameBananaModFileList> {
+  return window.electronAPI.getModFileList({ modId, section });
 }
 
 export async function getModDetails(modId: number, section?: string): Promise<GameBananaModDetails> {

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -238,6 +238,36 @@ export function isLockerManagedMod(mod: Mod): boolean {
   return true;
 }
 
+/**
+ * GameBanana Sound subcategories that aren't per-hero. Killsounds and music
+ * stingers play across the whole match, announcer/UI sounds are global UX.
+ * These belong on Installed but would just sit in the Locker's "Unassigned"
+ * bucket forever (no hero to tag), so we drop them at the eligibility check
+ * instead. Lowercased for case-insensitive compare.
+ */
+const GLOBAL_SOUND_CATEGORIES: ReadonlySet<string> = new Set([
+  'killsounds',
+  'in-game music',
+  'music',
+  'announcer',
+  'ui',
+  'ui sounds',
+  'misc',
+]);
+
+/**
+ * Sound-section equivalent of isLockerManagedMod. Drops Sound mods whose
+ * GameBanana category is one of the global (non-hero) buckets — see
+ * GLOBAL_SOUND_CATEGORIES. Hero-specific subcategories (Abilities, VOs,
+ * etc.) flow through.
+ */
+export function isLockerManagedSound(mod: Mod): boolean {
+  if (mod.sourceSection !== 'Sound') return false;
+  const category = mod.categoryName?.trim().toLowerCase();
+  if (category && GLOBAL_SOUND_CATEGORIES.has(category)) return false;
+  return true;
+}
+
 export function getLockerSkinKey(mod: Mod): string {
   return typeof mod.gameBananaId === 'number' && mod.gameBananaId > 0
     ? `gamebanana:${mod.gameBananaId}`
@@ -385,12 +415,26 @@ export function groupModsByCategory(mods: Mod[], heroList?: { id: number; name: 
   }
 
   for (const mod of mods) {
-    let categoryId = mod.categoryId;
+    let categoryId: number | undefined;
 
-    // If mod has a generic category (like "Skins" parent), try to infer from mod name
-    if (!categoryId || mod.categoryName?.toLowerCase() === 'skins') {
+    // 1. Manual override wins. Users tag a mod when GameBanana left it under
+    //    the generic "Skins" parent or when the title doesn't mention the hero.
+    if (mod.lockerHero) {
+      categoryId = heroNameToId.get(mod.lockerHero.toLowerCase());
+    }
+
+    // 2. Author-supplied categoryId is the next best signal, but skip it when
+    //    the category is "Skins" itself (the generic parent), since that
+    //    points at a virtual node, not a hero.
+    if (!categoryId && mod.categoryId && mod.categoryName?.toLowerCase() !== 'skins') {
+      categoryId = mod.categoryId;
+    }
+
+    // 3. Fall back to fuzzy match on the mod's display name. Same logic the
+    //    "Skins"-parent branch used to do; broadened to also fire when there's
+    //    no categoryId at all (sound mods, custom imports).
+    if (!categoryId) {
       const nameLower = mod.name?.toLowerCase() || '';
-      // Check for hero names in the mod name
       for (const [heroName, heroId] of heroNameToId) {
         if (nameLower.includes(heroName)) {
           categoryId = heroId;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -30,7 +30,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, UnknownModFilterGuess } from '../types/mod';
@@ -1164,22 +1164,32 @@ export default function Installed() {
         }
       }
 
-      await Promise.all(
-        Array.from(uniqueIds.entries()).map(async ([gbId, section]) => {
-          if (updateCheckCache.has(gbId)) return;
+      // Cap concurrency. An unbounded Promise.all here bursts N parallel
+      // requests through the rate limiter and pins ~N JSON payloads in
+      // renderer memory; with 70+ installed mods that visibly stalls the
+      // page on mount. The slim getModFileList only pulls _idRow + _aFiles.
+      const queue = Array.from(uniqueIds.entries()).filter(
+        ([gbId]) => !updateCheckCache.has(gbId),
+      );
+      let cursor = 0;
+      const worker = async () => {
+        while (!cancelled) {
+          const idx = cursor++;
+          if (idx >= queue.length) return;
+          const [gbId, section] = queue[idx];
           try {
-            const details = await getModDetails(gbId, section);
+            const list = await getModFileList(gbId, section);
             const liveIds = new Set(
-              (details.files ?? [])
-                .filter((f) => !f.isArchived)
-                .map((f) => f.id),
+              list.files.filter((f) => !f.isArchived).map((f) => f.id),
             );
             updateCheckCache.set(gbId, liveIds.size > 0 ? liveIds : null);
           } catch {
             // Network or API failure: leave uncached so a later mount retries.
           }
-        }),
-      );
+        }
+      };
+      const concurrency = Math.min(5, queue.length);
+      await Promise.all(Array.from({ length: concurrency }, worker));
 
       if (cancelled) return;
       const available = new Set<string>();

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2872,6 +2872,7 @@ interface ModCardProps {
     nsfw?: boolean;
     gameBananaId?: number;
     isUnknown?: boolean;
+    lockerHero?: string;
     merged?: import('../types/mod').MergedModInfo;
   };
   viewMode: ViewMode;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2955,8 +2955,11 @@ function ModCard({
   const variantStatusTitle = group
     ? `${enabledTitle || 'No files enabled'} - click card to choose files`
     : '';
+  // Prefer the persisted lockerHero (set by VPK content inference at
+  // download/scan time, more accurate than the title) and fall back to
+  // title matching for any Sound mod that hasn't been enriched yet.
   const listHeroName = viewMode === 'list' && mod.sourceSection === 'Sound'
-    ? inferHeroFromTitle(mod.name)
+    ? mod.lockerHero ?? inferHeroFromTitle(mod.name)
     : null;
   const listHeroRenderUrl = listHeroName ? getHeroRenderPath(listHeroName) : null;
   const listHeroFacePos = listHeroName ? getHeroFacePosition(listHeroName) : 50;
@@ -3133,10 +3136,11 @@ function ModCard({
         );
 
         if (isSoundCard) {
-          // Match Browse's Sound section: infer the hero from the mod title
-          // and reuse the locker render so the card carries the same hero
-          // art the user saw when they downloaded it.
-          const inferredHero = inferHeroFromTitle(mod.name);
+          // Prefer mod.lockerHero (persisted from VPK path inference: catches
+          // mods like "We don't talk Animal" whose title doesn't name the
+          // hero but whose VPK ships sounds/abilities/werewolf/*). Fall back
+          // to title matching for not-yet-enriched mods.
+          const inferredHero = mod.lockerHero ?? inferHeroFromTitle(mod.name);
           const heroRenderUrl = inferredHero ? getHeroRenderPath(inferredHero) : null;
           const heroFacePos = inferredHero ? getHeroFacePosition(inferredHero) : 50;
           return (

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -7,6 +7,7 @@ import {
   getGamebananaCategories,
   listMinaVariants,
   setMinaPreset,
+  setModLockerHero,
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
@@ -32,6 +33,7 @@ import {
   groupLockerSkins,
   groupModsByCategory,
   isLockerManagedMod,
+  isLockerManagedSound,
   parseMinaVariant,
   readStoredFavorites,
   type HeroCategory,
@@ -144,13 +146,24 @@ export default function Locker() {
   const baseHeroList = useMemo(() => buildHeroList(categories), [categories]);
 
   const lockerMods = useMemo(() => mods.filter(isLockerManagedMod), [mods]);
+  const lockerSounds = useMemo(() => mods.filter(isLockerManagedSound), [mods]);
 
   // Calculate heroMods, passing heroList for name-based category inference
   const heroMods = useMemo(() => {
     return groupModsByCategory(lockerMods, baseHeroList);
   }, [lockerMods, baseHeroList]);
+  const heroSounds = useMemo(() => {
+    return groupModsByCategory(lockerSounds, baseHeroList);
+  }, [lockerSounds, baseHeroList]);
   const installedSkinCount = useMemo(() => countLockerSkins(lockerMods), [lockerMods]);
   const unassignedSkins = useMemo(() => groupLockerSkins(heroMods.unassigned), [heroMods]);
+  // Sound mods that couldn't be auto-mapped to a hero (e.g. inferHeroFromTitle
+  // didn't catch the hero name in the title). Surfaced in the same Unassigned
+  // section so users can tag them from one place.
+  const unassignedSounds = useMemo(
+    () => groupLockerSkins(heroSounds.unassigned),
+    [heroSounds]
+  );
 
   // Sorted hero list for display
   const heroList = useMemo(() => {
@@ -175,6 +188,10 @@ export default function Locker() {
     () => (selectedHero ? heroMods.map.get(selectedHero.id) ?? [] : []),
     [heroMods, selectedHero]
   );
+  const selectedHeroSoundList = useMemo(
+    () => (selectedHero ? heroSounds.map.get(selectedHero.id) ?? [] : []),
+    [heroSounds, selectedHero]
+  );
   const selectedHeroSkinCount = useMemo(
     () => countLockerSkins(selectedHeroMods),
     [selectedHeroMods]
@@ -189,7 +206,12 @@ export default function Locker() {
   );
 
   const setActiveSkin = async (heroId: number, modId: string) => {
-    const list = heroMods.map.get(heroId) ?? [];
+    // Pick the section list (skins vs sounds) that actually contains the
+    // clicked mod. Keeps cross-section toggles independent: picking a Geist
+    // skin must not silently kill an enabled Geist voice pack.
+    const skins = heroMods.map.get(heroId) ?? [];
+    const sounds = heroSounds.map.get(heroId) ?? [];
+    const list = skins.some((m) => m.id === modId) ? skins : sounds;
     const selected = list.find((mod) => mod.id === modId);
     if (!selected) return;
 
@@ -219,7 +241,9 @@ export default function Locker() {
   // for the hero (so switching groups still feels exclusive), but leaves the
   // target's siblings alone so users can co-enable e.g. a model + voice VPK.
   const toggleHeroVariant = async (heroId: number, modId: string) => {
-    const list = heroMods.map.get(heroId) ?? [];
+    const skins = heroMods.map.get(heroId) ?? [];
+    const sounds = heroSounds.map.get(heroId) ?? [];
+    const list = skins.some((m) => m.id === modId) ? skins : sounds;
     const target = list.find((m) => m.id === modId);
     if (!target) return;
     const groupKey = getLockerSkinKey(target);
@@ -232,6 +256,24 @@ export default function Locker() {
     }
     actions.push(toggleMod(modId));
     await Promise.all(actions);
+  };
+
+  // Sorted hero name list for the "tag as hero" dropdown on Unassigned cards.
+  // We use only heroes that have a GameBanana category, because that's the
+  // pool the locker grouping logic resolves names against; picking a hero
+  // outside this set would silently fail to move the mod.
+  const tagHeroOptions = useMemo(
+    () => [...baseHeroList].sort((a, b) => a.name.localeCompare(b.name)),
+    [baseHeroList]
+  );
+
+  const tagModHero = async (modId: string, heroName: string | null) => {
+    try {
+      await setModLockerHero(modId, heroName);
+      await loadMods();
+    } catch (err) {
+      console.error('[Locker] Failed to set lockerHero override:', err);
+    }
   };
 
   const applyMinaPreset = async (presetFileName: string) => {
@@ -325,16 +367,17 @@ export default function Locker() {
         stats={`${heroList.length} heroes • ${installedSkinCount} installed skins`}
         action={
           <div className="flex items-center gap-3">
-            {viewMode === 'gallery' && unassignedSkins.length > 0 && (
-              <button
-                onClick={() => setViewMode('list')}
-                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-md bg-yellow-500/10 border border-yellow-500/50 text-yellow-400 hover:bg-yellow-500/20 transition-colors"
-                title="Switch to List view to see unassigned mods"
-              >
-                <Layers className="w-3 h-3" />
-                {unassignedSkins.length} unassigned
-              </button>
-            )}
+            {viewMode === 'gallery' &&
+              unassignedSkins.length + unassignedSounds.length > 0 && (
+                <button
+                  onClick={() => setViewMode('list')}
+                  className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-md bg-yellow-500/10 border border-yellow-500/50 text-yellow-400 hover:bg-yellow-500/20 transition-colors"
+                  title="Switch to List view to see unassigned mods"
+                >
+                  <Layers className="w-3 h-3" />
+                  {unassignedSkins.length + unassignedSounds.length} unassigned
+                </button>
+              )}
             <ViewModeToggle
               value={viewMode}
               options={[
@@ -408,20 +451,26 @@ export default function Locker() {
         </div>
       )}
 
-      {viewMode === 'list' && unassignedSkins.length > 0 && (
+      {viewMode === 'list' && (unassignedSkins.length > 0 || unassignedSounds.length > 0) && (
         <div className="space-y-3">
-          <SectionHeader>Unassigned Skins</SectionHeader>
+          <SectionHeader>Unassigned</SectionHeader>
+          <p className="text-xs text-text-secondary -mt-1">
+            These mods couldn't be matched to a hero automatically. Tag one to
+            move it into that hero's locker pile.
+          </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {unassignedSkins.map((skin) => {
+            {[...unassignedSkins, ...unassignedSounds].map((skin) => {
               const mod = skin.primary;
-              const subtitle = skin.variants.length > 1 ? `${skin.variants.length} files` : mod.fileName;
+              const subtitle =
+                skin.variants.length > 1 ? `${skin.variants.length} files` : mod.fileName;
+              const isSound = mod.sourceSection === 'Sound';
 
               return (
                 <div
                   key={skin.key}
                   className="bg-bg-secondary border border-border rounded-lg p-3 flex items-center gap-3 text-left"
                 >
-                  <div className="w-14 h-14 rounded-md overflow-hidden bg-bg-tertiary">
+                  <div className="w-14 h-14 rounded-md overflow-hidden bg-bg-tertiary flex-shrink-0">
                     <ModThumbnail
                       src={mod.thumbnailUrl}
                       alt={mod.name}
@@ -435,9 +484,30 @@ export default function Locker() {
                       }
                     />
                   </div>
-                  <div className="min-w-0">
-                    <div className="font-medium truncate">{mod.name}</div>
-                    <div className="text-xs text-text-secondary truncate">{subtitle}</div>
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <div className="font-medium truncate" title={mod.name}>
+                      {mod.name}
+                    </div>
+                    <div className="text-xs text-text-secondary truncate" title={subtitle}>
+                      {isSound ? 'Sound · ' : ''}
+                      {subtitle}
+                    </div>
+                    <select
+                      aria-label={`Tag ${mod.name} as a hero`}
+                      value={mod.lockerHero ?? ''}
+                      onChange={(event) => {
+                        const next = event.target.value;
+                        void tagModHero(mod.id, next.length > 0 ? next : null);
+                      }}
+                      className="w-full bg-bg-tertiary border border-border rounded-md px-2 py-1 text-xs text-text-primary hover:border-accent/60 cursor-pointer"
+                    >
+                      <option value="">Tag as hero…</option>
+                      {tagHeroOptions.map((hero) => (
+                        <option key={hero.id} value={hero.name}>
+                          {hero.name}
+                        </option>
+                      ))}
+                    </select>
                   </div>
                 </div>
               );
@@ -455,7 +525,8 @@ export default function Locker() {
           <LockerHeroView
             key={selectedHero.id}
             hero={selectedHero}
-            list={selectedHeroMods}
+            skinList={selectedHeroMods}
+            soundList={selectedHeroSoundList}
             skinCount={selectedHeroSkinCount}
             isFavorite={favoriteHeroes.includes(selectedHero.id)}
             onBack={() => navigate('/locker')}

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Layers, Star } from 'lucide-react';
+import { ArrowLeft, Layers, Star, Music, Shirt } from 'lucide-react';
 import { Skeleton } from '../components/common/Skeleton';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -27,6 +27,7 @@ import {
   getHeroWikiUrl,
   groupModsByCategory,
   isLockerManagedMod,
+  isLockerManagedSound,
   parseMinaVariant,
   readStoredFavorites,
   type HeroCategory,
@@ -37,7 +38,11 @@ import {
 
 interface LockerHeroViewProps {
   hero: HeroCategory;
-  list: Mod[];
+  skinList: Mod[];
+  /** Sound-section mods mapped to this hero. Optional because the gallery
+   *  view in `Locker.tsx` keeps the same prop surface and may not split sounds
+   *  out yet. Empty/undefined hides the Sounds toggle entirely. */
+  soundList?: Mod[];
   skinCount: number;
   isFavorite: boolean;
   onBack: () => void;
@@ -142,10 +147,25 @@ export default function LockerHero() {
 
   const heroList = useMemo(() => buildHeroList(categories), [categories]);
   const hero = heroList.find((entry) => entry.id === heroId);
-  const lockerMods = useMemo(() => mods.filter(isLockerManagedMod), [mods]);
-  const heroMods = useMemo(() => groupModsByCategory(lockerMods, heroList), [lockerMods, heroList]);
-  const list = useMemo(() => (hero ? heroMods.map.get(hero.id) ?? [] : []), [hero, heroMods]);
-  const skinCount = useMemo(() => countLockerSkins(list), [list]);
+  const lockerSkins = useMemo(() => mods.filter(isLockerManagedMod), [mods]);
+  const lockerSounds = useMemo(() => mods.filter(isLockerManagedSound), [mods]);
+  const heroSkinsByHero = useMemo(
+    () => groupModsByCategory(lockerSkins, heroList),
+    [lockerSkins, heroList]
+  );
+  const heroSoundsByHero = useMemo(
+    () => groupModsByCategory(lockerSounds, heroList),
+    [lockerSounds, heroList]
+  );
+  const skinList = useMemo(
+    () => (hero ? heroSkinsByHero.map.get(hero.id) ?? [] : []),
+    [hero, heroSkinsByHero]
+  );
+  const soundList = useMemo(
+    () => (hero ? heroSoundsByHero.map.get(hero.id) ?? [] : []),
+    [hero, heroSoundsByHero]
+  );
+  const skinCount = useMemo(() => countLockerSkins(skinList), [skinList]);
 
   const minaPresets = useMemo(() => buildMinaPresets(mods), [mods]);
   const minaTextures = useMemo(() => detectMinaTextures(mods), [mods]);
@@ -155,9 +175,19 @@ export default function LockerHero() {
     [minaVariants, minaSelection]
   );
 
+  // Resolve which section list the clicked mod belongs to. Section exclusivity
+  // is per-section: picking a Geist skin doesn't disable Geist voice lines and
+  // vice versa.
+  const listForMod = (modId: string): Mod[] | null => {
+    if (skinList.some((m) => m.id === modId)) return skinList;
+    if (soundList.some((m) => m.id === modId)) return soundList;
+    return null;
+  };
+
   const setActiveSkin = async (modId: string) => {
     if (!hero) return;
-    const heroModList = heroMods.map.get(hero.id) ?? [];
+    const heroModList = listForMod(modId);
+    if (!heroModList) return;
     const clicked = heroModList.find((m) => m.id === modId);
     if (!clicked) return;
     const actions: Promise<void>[] = [];
@@ -184,7 +214,8 @@ export default function LockerHero() {
   // model + voice-lines pair can stay co-enabled.
   const toggleHeroVariant = async (modId: string) => {
     if (!hero) return;
-    const heroModList = heroMods.map.get(hero.id) ?? [];
+    const heroModList = listForMod(modId);
+    if (!heroModList) return;
     const target = heroModList.find((m) => m.id === modId);
     if (!target) return;
     const groupKey = getLockerSkinKey(target);
@@ -286,7 +317,8 @@ export default function LockerHero() {
     <LockerHeroView
       key={hero.id}
       hero={hero}
-      list={list}
+      skinList={skinList}
+      soundList={soundList}
       skinCount={skinCount}
       isFavorite={favoriteHeroes.includes(hero.id)}
       onBack={() => navigate('/locker')}
@@ -318,7 +350,8 @@ export default function LockerHero() {
 
 export function LockerHeroView({
   hero,
-  list,
+  skinList,
+  soundList = [],
   skinCount,
   isFavorite,
   onBack,
@@ -343,6 +376,13 @@ export function LockerHeroView({
 }: LockerHeroViewProps) {
   const [renderFallbackStep, setRenderFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
+  const [section, setSection] = useState<'skins' | 'sounds'>('skins');
+  const hasSounds = soundList.length > 0;
+  // If the active section runs out of mods (e.g. user deleted their last
+  // sound for this hero) drop back to skins so the panel isn't stuck empty.
+  const activeSection = section === 'sounds' && !hasSounds ? 'skins' : section;
+  const activeList = activeSection === 'sounds' ? soundList : skinList;
+  const soundCount = soundList.length;
 
   const renderSrc =
     renderFallbackStep === 0
@@ -481,32 +521,93 @@ export function LockerHeroView({
               />
             )}
             <span className="text-sm text-text-secondary">
-              {skinCount > 0 ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}` : 'No skins'}
+              {activeSection === 'sounds'
+                ? soundCount > 0
+                  ? `${soundCount} sound${soundCount !== 1 ? 's' : ''}`
+                  : 'No sounds'
+                : skinCount > 0
+                  ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}`
+                  : 'No skins'}
             </span>
           </div>
 
-          {/* Skin Selection */}
+          {/* Section toggle: only when this hero has at least one Sound mod;
+              the toggle would be empty noise for heroes with skins-only piles. */}
+          {hasSounds && (
+            <div
+              role="tablist"
+              aria-label="Section"
+              className="inline-flex items-center rounded-full border border-border bg-bg-tertiary p-0.5 text-xs"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSection === 'skins'}
+                onClick={() => setSection('skins')}
+                className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
+                  activeSection === 'skins'
+                    ? 'bg-accent/15 text-text-primary border border-accent/40'
+                    : 'text-text-secondary hover:text-text-primary border border-transparent'
+                }`}
+              >
+                <Shirt className="w-3.5 h-3.5" />
+                Skins
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSection === 'sounds'}
+                onClick={() => setSection('sounds')}
+                className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
+                  activeSection === 'sounds'
+                    ? 'bg-accent/15 text-text-primary border border-accent/40'
+                    : 'text-text-secondary hover:text-text-primary border border-transparent'
+                }`}
+              >
+                <Music className="w-3.5 h-3.5" />
+                Sounds
+              </button>
+            </div>
+          )}
+
+          {/* Skin / Sound Selection */}
           <div className="space-y-4">
             <HeroSkinsPanel
-              mods={list}
+              mods={activeList}
               onSelect={onSelect}
               onToggleVariant={onToggleVariant}
               hideNsfwPreviews={hideNsfwPreviews}
               categoryId={hero.id}
-              minaPresets={minaPresets}
-              activeMinaPreset={activeMinaPreset}
-              minaTextures={minaTextures}
-              onApplyMinaPreset={onApplyMinaPreset}
-              minaArchivePath={minaArchivePath}
-              onMinaArchivePathChange={onMinaArchivePathChange}
-              minaVariants={minaVariants}
-              minaVariantsLoading={minaVariantsLoading}
-              minaVariantsError={minaVariantsError}
-              onLoadMinaVariants={onLoadMinaVariants}
-              minaSelection={minaSelection}
-              onMinaSelectionChange={onMinaSelectionChange}
-              selectedMinaVariant={selectedMinaVariant}
-              onApplyMinaVariant={onApplyMinaVariant}
+              showDownloadable={activeSection === 'skins'}
+              useHeroPortraitThumbnails={activeSection === 'sounds'}
+              heroName={hero.name}
+              emptyMessage={
+                activeSection === 'sounds'
+                  ? 'No sound mods tagged for this hero yet. Tag one from the Locker.'
+                  : 'Download a skin for this hero to manage it here.'
+              }
+              minaPresets={activeSection === 'skins' ? minaPresets : []}
+              activeMinaPreset={activeSection === 'skins' ? activeMinaPreset : undefined}
+              minaTextures={activeSection === 'skins' ? minaTextures : []}
+              onApplyMinaPreset={activeSection === 'skins' ? onApplyMinaPreset : undefined}
+              minaArchivePath={activeSection === 'skins' ? minaArchivePath : undefined}
+              onMinaArchivePathChange={
+                activeSection === 'skins' ? onMinaArchivePathChange : undefined
+              }
+              minaVariants={activeSection === 'skins' ? minaVariants : []}
+              minaVariantsLoading={
+                activeSection === 'skins' ? minaVariantsLoading : false
+              }
+              minaVariantsError={activeSection === 'skins' ? minaVariantsError : null}
+              onLoadMinaVariants={activeSection === 'skins' ? onLoadMinaVariants : undefined}
+              minaSelection={activeSection === 'skins' ? minaSelection : undefined}
+              onMinaSelectionChange={
+                activeSection === 'skins' ? onMinaSelectionChange : undefined
+              }
+              selectedMinaVariant={
+                activeSection === 'skins' ? selectedMinaVariant : undefined
+              }
+              onApplyMinaVariant={activeSection === 'skins' ? onApplyMinaVariant : undefined}
             />
           </div>
 

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -70,7 +70,12 @@ function getProfileModGroups(
 
   for (const profileMod of profileMods) {
     const mod = modByFileName.get(profileMod.fileName);
-    const key = mod?.gameBananaId ? `gamebanana:${mod.gameBananaId}` : `file:${profileMod.fileName}`;
+    // Prefer the saved stable id over the live scan: a multi-VPK pair whose
+    // pakNN_ prefix shifted since save would otherwise miss in modByFileName
+    // and split into two file:<fileName> groups, inflating the displayed
+    // count by one per stranded sibling.
+    const gbId = profileMod.gameBananaId ?? mod?.gameBananaId;
+    const key = gbId ? `gamebanana:${gbId}` : `file:${profileMod.fileName}`;
     const group = groups.get(key) ?? {
       key,
       name: mod?.name || fallbackFileLabel(profileMod.fileName),

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -116,6 +116,9 @@ export default function Profiles() {
   const [restoringSnapshotId, setRestoringSnapshotId] = useState<string | null>(null);
   const [deleteSnapshotConfirmId, setDeleteSnapshotConfirmId] = useState<string | null>(null);
   const [creatingSnapshot, setCreatingSnapshot] = useState(false);
+  const [selectedSnapshotIds, setSelectedSnapshotIds] = useState<Set<string>>(new Set());
+  const [bulkDeleteSnapshotsOpen, setBulkDeleteSnapshotsOpen] = useState(false);
+  const [bulkDeletingSnapshots, setBulkDeletingSnapshots] = useState(false);
 
   const { mods, loadMods } = useAppStore();
   const { getSettings: getCrosshairSettings, loadSettingsFromPreset } = useCrosshairStore();
@@ -188,12 +191,70 @@ export default function Profiles() {
     try {
       await deleteSnapshot(snapshotId);
       await loadSnapshotList();
+      setSelectedSnapshotIds((prev) => {
+        if (!prev.has(snapshotId)) return prev;
+        const next = new Set(prev);
+        next.delete(snapshotId);
+        return next;
+      });
     } catch (err) {
       setError(`Failed to delete snapshot: ${String(err)}`);
     } finally {
       setDeleteSnapshotConfirmId(null);
     }
   }, [loadSnapshotList]);
+
+  const toggleSnapshotSelected = useCallback((snapshotId: string) => {
+    setSelectedSnapshotIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(snapshotId)) next.delete(snapshotId);
+      else next.add(snapshotId);
+      return next;
+    });
+  }, []);
+
+  const handleBulkDeleteSnapshots = useCallback(async () => {
+    const ids = Array.from(selectedSnapshotIds);
+    if (ids.length === 0) {
+      setBulkDeleteSnapshotsOpen(false);
+      return;
+    }
+    setBulkDeletingSnapshots(true);
+    // Sequential, not Promise.all: deleteSnapshot rewrites the snapshots/
+    // directory listing on each call, and concurrent unlinks against the
+    // shared list scan have raced into "Snapshot not found" before.
+    const failures: string[] = [];
+    for (const id of ids) {
+      try {
+        await deleteSnapshot(id);
+      } catch (err) {
+        failures.push(String(err));
+      }
+    }
+    await loadSnapshotList();
+    setSelectedSnapshotIds(new Set());
+    setBulkDeleteSnapshotsOpen(false);
+    setBulkDeletingSnapshots(false);
+    if (failures.length > 0) {
+      setError(`Failed to delete ${failures.length} of ${ids.length} snapshots: ${failures[0]}`);
+    }
+  }, [selectedSnapshotIds, loadSnapshotList]);
+
+  // Drop selections that refer to snapshots no longer in the list (deleted
+  // elsewhere, refresh dropped them). Keeps the bulk-delete count honest.
+  useEffect(() => {
+    setSelectedSnapshotIds((prev) => {
+      if (prev.size === 0) return prev;
+      const validIds = new Set(snapshots.map((s) => s.snapshotId));
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (validIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [snapshots]);
 
   const toggleExpand = (id: string) => {
     const next = new Set(expandedProfiles);
@@ -404,9 +465,53 @@ export default function Profiles() {
                 Grimoire takes a snapshot of your installed mod set automatically before each mod update and before applying a profile. Restore re-downloads those mods from GameBanana, so a bad update or wrong-profile-applied can be rolled back. Snapshots store only the list of mods (their GameBanana IDs), never the VPK files, so disk cost stays tiny — they accumulate until you delete them. You can also capture one manually with the button above before experimenting.
               </p>
             ) : (
-              <ul className="divide-y divide-white/5">
+              <>
+                {(() => {
+                  const allSelected = snapshots.length > 0 && selectedSnapshotIds.size === snapshots.length;
+                  const someSelected = selectedSnapshotIds.size > 0 && !allSelected;
+                  const toggleAll = () => {
+                    if (allSelected) {
+                      setSelectedSnapshotIds(new Set());
+                    } else {
+                      setSelectedSnapshotIds(new Set(snapshots.map((s) => s.snapshotId)));
+                    }
+                  };
+                  return (
+                    <div className="flex items-center gap-3 pb-2 mb-1 border-b border-white/5 text-xs text-text-secondary">
+                      <label className="flex items-center gap-2 cursor-pointer select-none">
+                        <input
+                          type="checkbox"
+                          checked={allSelected}
+                          ref={(el) => { if (el) el.indeterminate = someSelected; }}
+                          onChange={toggleAll}
+                          aria-label={allSelected ? 'Clear selection' : 'Select all snapshots'}
+                          className="h-3.5 w-3.5 accent-orange-500"
+                        />
+                        <span>
+                          {selectedSnapshotIds.size === 0
+                            ? `Select to bulk delete (${snapshots.length})`
+                            : `${selectedSnapshotIds.size} selected`}
+                        </span>
+                      </label>
+                      {selectedSnapshotIds.size > 0 && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          icon={Trash2}
+                          onClick={() => setBulkDeleteSnapshotsOpen(true)}
+                          className="ml-auto text-red-400 hover:text-red-300"
+                          title={`Delete the ${selectedSnapshotIds.size} selected snapshot${selectedSnapshotIds.size === 1 ? '' : 's'}.`}
+                        >
+                          Delete {selectedSnapshotIds.size}
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })()}
+                <ul className="divide-y divide-white/5">
                 {snapshots.map((snap) => {
                   const isRestoring = restoringSnapshotId === snap.snapshotId;
+                  const isSelected = selectedSnapshotIds.has(snap.snapshotId);
                   const triggerLabel =
                     snap.trigger === 'pre-update'
                       ? 'Before update'
@@ -424,6 +529,13 @@ export default function Profiles() {
                       key={snap.snapshotId}
                       className="flex flex-wrap items-center gap-3 py-2.5"
                     >
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleSnapshotSelected(snap.snapshotId)}
+                        aria-label={isSelected ? 'Unselect snapshot' : 'Select snapshot'}
+                        className="h-3.5 w-3.5 accent-orange-500 shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div
                           className="text-sm text-text-primary truncate"
@@ -464,7 +576,8 @@ export default function Profiles() {
                     </li>
                   );
                 })}
-              </ul>
+                </ul>
+              </>
             )}
           </Card>
 
@@ -788,6 +901,16 @@ export default function Profiles() {
         title="Delete Snapshot"
         message="Delete this recovery snapshot? You won't be able to restore from it later."
         confirmLabel="Delete"
+        variant="danger"
+      />
+
+      <ConfirmModal
+        isOpen={bulkDeleteSnapshotsOpen}
+        onCancel={() => !bulkDeletingSnapshots && setBulkDeleteSnapshotsOpen(false)}
+        onConfirm={handleBulkDeleteSnapshots}
+        title="Delete Selected Snapshots"
+        message={`Delete ${selectedSnapshotIds.size} snapshot${selectedSnapshotIds.size === 1 ? '' : 's'}? Your installed mods are unaffected. You won't be able to restore from the deleted snapshots later.`}
+        confirmLabel={bulkDeletingSnapshots ? 'Deleting…' : `Delete ${selectedSnapshotIds.size}`}
         variant="danger"
       />
     </div>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -132,7 +132,7 @@ export interface DownloadEventData {
 export interface DownloadErrorData {
     modId: number;
     fileId: number;
-    errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'UNKNOWN';
+    errorCode: 'MISSING_7ZIP' | 'EXTRACTION_FAILED' | 'CANCELLED_BY_USER' | 'UNKNOWN';
     message: string;
     helpUrl?: string;
 }
@@ -356,6 +356,7 @@ export interface ElectronAPI {
     getDownloadQueue: () => Promise<DownloadQueueItem[]>;
     getCurrentDownload: () => Promise<DownloadQueueItem | null>;
     removeFromQueue: (modId: number) => Promise<boolean>;
+    cancelActiveDownload: () => Promise<boolean>;
     onDownloadQueueUpdated: (callback: (data: DownloadQueueData) => void) => () => void;
 
     // GameBanana 1-Click protocol handler

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -11,6 +11,7 @@ import type {
 import type {
     GameBananaModsResponse,
     GameBananaModDetails,
+    GameBananaModFileList,
     GameBananaSection,
     GameBananaCategoryNode,
     GameBananaCollection,
@@ -287,6 +288,7 @@ export interface ElectronAPI {
     applyUnknownModMatch: (modId: string, args: ApplyUnknownModMatchArgs) => Promise<Mod>;
     applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
+    setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
     backfillGameBananaFileId: (
       modId: string,
       payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
@@ -312,6 +314,7 @@ export interface ElectronAPI {
     // GameBanana
     browseMods: (args: BrowseModsArgs) => Promise<GameBananaModsResponse>;
     getModDetails: (args: GetModDetailsArgs) => Promise<GameBananaModDetails>;
+    getModFileList: (args: GetModDetailsArgs) => Promise<GameBananaModFileList>;
     getModComments: (args: { modId: number; section?: string; page?: number }) => Promise<{ comments: Array<{ id: number; text: string; dateAdded: number; poster: { id: number; name: string; avatarUrl?: string } }>; totalCount: number }>;
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;

--- a/src/types/gamebanana.ts
+++ b/src/types/gamebanana.ts
@@ -87,6 +87,11 @@ export interface GameBananaModDetails {
   previewMedia?: GameBananaPreviewMedia;
 }
 
+export interface GameBananaModFileList {
+  id: number;
+  files: Array<{ id: number; isArchived: boolean }>;
+}
+
 export interface GameBananaComment {
   id: number;
   text: string;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -60,6 +60,11 @@ export interface Mod {
   variantLabel?: string;
   fileDescription?: string;
   sourceFileName?: string;
+  /** Hero this mod belongs to in the Locker, by canonical hero name. Set
+   *  automatically at download time for Sound mods (inferHeroFromTitle) or
+   *  manually via the Locker's "Tag hero" affordance. Takes precedence over
+   *  categoryId when grouping mods into hero piles. */
+  lockerHero?: string;
   /** Set when this mod was produced by mergeMods. Carries the unroll payload
    *  (share code + source list). */
   merged?: MergedModInfo;


### PR DESCRIPTION
## Summary

Started as a Locker UX pass (hero-aware Sound mods + manual tagging) and grew to cover a cluster of profile sharing/import bugs surfaced along the way.

### Locker
- **Hero-aware Sound mods** — Sound submissions get a `lockerHero` inferred from the title at download time, with a VPK-path fallback for cases the title misses. The Locker groups them next to skins for the same hero instead of dumping them into a generic Sound bucket.
- **Manual hero tagging** — `set-mod-locker-hero` IPC + UI on the Locker's Unassigned row, so a user can fix mods GameBanana left under the generic "Skins" parent or misspelled.
- **Sound-card tag stack** + minor sidebar/tile cleanup in the locker grid.

### Profiles
- **Share-export resolves by GameBanana id**, not stale `ProfileMod.fileName`. Switching profiles rotates pakNN_ prefixes, so the old fileName lookup warned "Skipped local mod" on every shifted entry.
- **Portable imports persist stable ids**. `createProfileFromPortable` was writing only `fileName`, so imported / snapshot-restored profiles regressed to the same brittle lookup.
- **`applyProfile` heals legacy entries** by backfilling `gameBananaId` / `gameBananaFileId` onto matched `ProfileMod` rows from live metadata. One apply rehabs any pre-fix profile already on disk.
- **Variant grouping uses persisted GameBanana id** so multi-VPK siblings don't split into separate file:* keys after a reorder.

### Downloads
- **Multi-variant profile imports actually queue every file**. Dedup now keys `(modId, fileId)` instead of `modId`, since a submission legitimately ships several files in one import. Also handles the race where consecutive `downloadMod` calls fire before `processQueue` shifts the prior one out.
- **Update-check fan-out is capped** and the per-mod payload is slimmed, fixing the spinner stall on large libraries.

### Snapshots
- **Bulk delete** — per-row checkboxes + a select-all toolbar in the expanded list with one confirm modal for the whole batch. Single-row trash flow is unchanged.

## Test plan
- [x] Sound mod from GameBanana lands under its hero in the Locker without manual tagging.
- [x] Re-tagging a Skin from "Unassigned" persists across an app restart.
- [x] Save Profile A → apply Profile B → re-share Profile A and confirm no "Skipped local mod" warning.
- [x] Import a portable profile that has 2+ VPKs in one submission, confirm both rows progress through download → installed.
- [x] Re-apply a pre-existing profile (created before this PR) and verify `profiles.json` now carries `gameBananaId` / `gameBananaFileId` on each mod.
- [x] Expand Snapshots, select 3 rows, click "Delete 3", confirm — list refreshes with those gone and others untouched.