### PR TITLE
Release v1.11.0: hero-aware sounds, profile correctness, experimental VPK merger

### DIFF
--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -22,6 +22,14 @@ export interface AppSettings {
      *  but the search/find buttons and bulk auto-find are hidden, leaving
      *  only the manual "Make Custom Mod" path. */
     experimentalUnknownModMatching: boolean;
+    /** Combine multiple installed mods into one VPK via the bundled vpkmerge
+     *  CLI. Off by default while the workflow gathers field signal. When off,
+     *  the Merge button is hidden from the Installed bulk-select toolbar, but
+     *  any merged mods that already exist remain fully interactive: their
+     *  MergedContentsModal opens, Unmerge still runs, absorbed sources stay
+     *  hidden from the list until unmerged. This avoids stranding sources
+     *  when a user creates a merge and later toggles the flag off. */
+    experimentalVpkMerger: boolean;
     hasCompletedSetup: boolean;      // First-run setup completed
     /** Mod pairs the user has dismissed in the Conflicts page. New entries use
      *  stable per-mod identities (GameBanana mod/file ids when available)
@@ -50,6 +58,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     experimentalCrosshair: false,
     experimentalSocial: false,
     experimentalUnknownModMatching: false,
+    experimentalVpkMerger: false,
     hasCompletedSetup: false,
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.10.5",
+  "version": "1.11.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/smoke-merger.mjs
+++ b/scripts/smoke-merger.mjs
@@ -15,7 +15,7 @@
 import { spawn } from 'node:child_process';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
-import { promises as fs, existsSync, openSync, readSync, closeSync } from 'node:fs';
+import { promises as fs, existsSync, openSync, readSync, closeSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -26,13 +26,65 @@ const SMOKE_DIR = '/tmp/grimoire-smoke';
 const ADDONS = join(SMOKE_DIR, 'addons');
 const VPKMERGE = join(REPO, 'resources', 'vpkmerge', 'vpkmerge-linux-x86_64');
 
-const DEADLOCK_ADDONS = '/home/esoc/.steam/steam/steamapps/common/Deadlock/game/citadel/addons';
-// Smallest two real mods on disk. Smoke-test stays fast and never touches
-// the real install (we copy out to /tmp).
-const SOURCE_MODS = [
-    `${DEADLOCK_ADDONS}/.disabled/pak12_dir.vpk`,
-    `${DEADLOCK_ADDONS}/.disabled/pak02_dir.vpk`,
-];
+// Where to look for real VPKs. Override with GRIMOIRE_DEADLOCK_ADDONS for
+// non-standard installs (or to point at a fixture directory in CI).
+const DEADLOCK_ADDONS = process.env.GRIMOIRE_DEADLOCK_ADDONS
+    || '/home/esoc/.steam/steam/steamapps/common/Deadlock/game/citadel/addons';
+
+/** Pick the two smallest pak##_dir.vpk files from addons/ and addons/.disabled/.
+ *  Smallest-first keeps the smoke test fast: a couple of single-asset mods is
+ *  enough to validate vpkmerge spawn shape. Override the whole pair with
+ *  GRIMOIRE_SMOKE_SOURCE_MODS=path1,path2 if you want specific files.
+ *  Never touches the real install: caller copies these out to /tmp. */
+function discoverSourceMods() {
+    const override = process.env.GRIMOIRE_SMOKE_SOURCE_MODS;
+    if (override) {
+        const paths = override.split(',').map((p) => p.trim()).filter(Boolean);
+        if (paths.length < 2) {
+            throw new Error('GRIMOIRE_SMOKE_SOURCE_MODS must list at least 2 comma-separated paths');
+        }
+        return paths.slice(0, 2);
+    }
+
+    const candidates = [];
+    for (const root of [DEADLOCK_ADDONS, join(DEADLOCK_ADDONS, '.disabled')]) {
+        if (!existsSync(root)) continue;
+        for (const name of readdirSync(root)) {
+            if (!/^pak\d+_dir\.vpk$/.test(name)) continue;
+            const p = join(root, name);
+            try { candidates.push({ path: p, size: statSync(p).size }); } catch { /* ignore */ }
+        }
+    }
+    if (candidates.length < 2) {
+        throw new Error(
+            `Need at least 2 pak##_dir.vpk files in ${DEADLOCK_ADDONS} (or its .disabled/), ` +
+            `found ${candidates.length}. Set GRIMOIRE_DEADLOCK_ADDONS or GRIMOIRE_SMOKE_SOURCE_MODS.`
+        );
+    }
+    candidates.sort((a, b) => a.size - b.size);
+    return [candidates[0].path, candidates[1].path];
+}
+
+let SOURCE_MODS = [];
+
+/** Read the prod inflate cap straight out of portableProfile.ts so this script
+ *  can't silently lie about which cap it's verifying. Single source of truth
+ *  for the value; the assertion message and the local decoder's
+ *  maxOutputLength both derive from this. */
+async function readProdShareCodeCap() {
+    const path = join(REPO, 'electron', 'main', 'services', 'portableProfile.ts');
+    const src = await fs.readFile(path, 'utf8');
+    const m = src.match(/MAX_INFLATED_SHARE_CODE_BYTES\s*=\s*(\d+)\s*\*\s*(\d+)\s*;/);
+    if (!m) {
+        throw new Error(
+            `Could not parse MAX_INFLATED_SHARE_CODE_BYTES from ${path}. ` +
+            `If the literal form changed, update readProdShareCodeCap().`
+        );
+    }
+    return parseInt(m[1], 10) * parseInt(m[2], 10);
+}
+
+let PROD_SHARE_CODE_CAP = 0;
 
 function ok(msg)   { console.log(`  \x1b[32m✓\x1b[0m ${msg}`); }
 function fail(msg) { console.log(`  \x1b[31m✗\x1b[0m ${msg}`); process.exitCode = 1; }
@@ -51,7 +103,7 @@ function encodeShareCode(json) {
 }
 function decodeShareCode(code) {
     if (!code.startsWith('mp1:')) throw new Error('missing mp1: prefix');
-    return gunzipSync(base64UrlDecode(code.slice(4)), { maxOutputLength: 16 * 1024 }).toString('utf8');
+    return gunzipSync(base64UrlDecode(code.slice(4)), { maxOutputLength: PROD_SHARE_CODE_CAP }).toString('utf8');
 }
 
 function runVpkmerge(args) {
@@ -208,7 +260,7 @@ function testShareCodeRoundtrip() {
         fail('bomb payload was accepted (size cap not enforced)');
     } catch (err) {
         if (err.message.toLowerCase().includes('output') || err.message.toLowerCase().includes('size') || err.message.toLowerCase().includes('large')) {
-            ok('oversized payload rejected by 16KB output cap');
+            ok(`oversized payload rejected by ${Math.round(PROD_SHARE_CODE_CAP / 1024)}KB output cap`);
         } else {
             fail(`bomb test failed with unexpected error: ${err.message}`);
         }
@@ -222,12 +274,11 @@ async function main() {
         fail(`vpkmerge binary not at ${VPKMERGE}. Run \`pnpm fetch-vpkmerge\` first.`);
         return;
     }
-    for (const src of SOURCE_MODS) {
-        if (!existsSync(src)) {
-            fail(`Source mod missing: ${src}`);
-            return;
-        }
-    }
+
+    PROD_SHARE_CODE_CAP = await readProdShareCodeCap();
+    SOURCE_MODS = discoverSourceMods();
+    ok(`prod inflate cap: ${PROD_SHARE_CODE_CAP / 1024} KB (parsed from portableProfile.ts)`);
+    ok(`source mods: ${SOURCE_MODS.map((p) => p.split('/').slice(-2).join('/')).join(', ')}`);
 
     await setup();
     try {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1261,6 +1261,10 @@ export default function Installed() {
   // limited path. Gated behind an experimental toggle while it's being
   // reworked; when off, only the manual "Make Custom Mod" path is offered.
   const autoMatchEnabled = settings?.experimentalUnknownModMatching ?? false;
+  // VPK merger (bulk Merge action). Hidden by default while the feature
+  // gathers field signal. Existing merged mods stay interactive regardless
+  // of the flag so unmerge always works.
+  const vpkMergerEnabled = settings?.experimentalVpkMerger ?? false;
   const selectedUnknownState = unknownFilterGuess
     ? {
         mod: unknownFilterGuess.mod,
@@ -2216,25 +2220,27 @@ export default function Installed() {
               >
                 Disable{selectedEnabledCount > 0 ? ` (${selectedEnabledCount})` : ''}
               </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={
-                  selectedMods.length < 2 ||
-                  selectedMods.some((m) => !!m.merged)
-                }
-                icon={Layers}
-                onClick={openBulkMerge}
-                title={
-                  selectedMods.length < 2
-                    ? 'Select 2+ mods to merge'
-                    : selectedMods.some((m) => !!m.merged)
-                      ? 'Cannot merge an already-merged mod. Unmerge it first.'
-                      : `Combine ${selectedMods.length} mods into one VPK`
-                }
-              >
-                Merge{selectedMods.length >= 2 ? ` (${selectedMods.length})` : ''}
-              </Button>
+              {vpkMergerEnabled && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={
+                    selectedMods.length < 2 ||
+                    selectedMods.some((m) => !!m.merged)
+                  }
+                  icon={Layers}
+                  onClick={openBulkMerge}
+                  title={
+                    selectedMods.length < 2
+                      ? 'Select 2+ mods to merge'
+                      : selectedMods.some((m) => !!m.merged)
+                        ? 'Cannot merge an already-merged mod. Unmerge it first.'
+                        : `Combine ${selectedMods.length} mods into one VPK`
+                  }
+                >
+                  Merge{selectedMods.length >= 2 ? ` (${selectedMods.length})` : ''}
+                </Button>
+              )}
               <Button
                 variant="danger"
                 size="sm"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -904,6 +904,15 @@ export default function Settings() {
               label="Fix Unknown Mods"
               description="Auto-match unknown local VPKs against GameBanana to recover their names and thumbnails. Currently hits rate limits on larger libraries while we rework it. The manual Custom Mod path stays available either way."
             />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.experimentalVpkMerger ?? false}
+              onChange={(checked) => settings && saveSettings({ ...settings, experimentalVpkMerger: checked })}
+              label="VPK Merger"
+              description="Combine 2+ installed mods into one VPK from the Installed page bulk-select toolbar. Includes Unmerge recovery via the merged mod's contents view. Any merges you create remain interactive even if you turn this off later."
+            />
           </div>
         </Card>
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -184,6 +184,7 @@ export interface AppSettings {
   experimentalCrosshair: boolean;
   experimentalSocial: boolean;
   experimentalUnknownModMatching: boolean;
+  experimentalVpkMerger: boolean;
   hasCompletedSetup: boolean;
   ignoredConflicts: string[];
   ignoreConflictsByDefault: boolean;


### PR DESCRIPTION
## Summary

Release prep for **v1.11.0**. Three commits on this branch:

- `chore(test): self-healing source discovery + parsed prod cap in smoke-merger` — replaces hardcoded VPK paths in `scripts/smoke-merger.mjs` with smallest-two discovery (env-overridable) and reads `MAX_INFLATED_SHARE_CODE_BYTES` straight from `portableProfile.ts` so the bomb-test assertion can't drift.
- `feat(merger): gate behind experimentalVpkMerger flag (off by default)` — Merge button hidden in the Installed bulk-select toolbar until the user opts in from Settings. `MergedContentsModal` + Unmerge stay reachable regardless so existing merges never get stranded.
- `chore(release): v1.11.0` — version bump in `package.json`.

The wider release rolls up PRs #47, #48, #49, #51, #52, #53, #54 already on `main`.

### What ships visible by default
- Locker: hero-aware sound mods (auto-grouped via VPK content inference + 35-entry hero codename map; manual `lockerHero` override from Unassigned).
- Snapshots: bulk-select + bulk delete.
- Profiles: stable-id resolution (no more silent disables after reorders), share-export resolves by GameBanana id, large-profile import (up to 256 KB inflated), `Re-apply` button on the active profile.
- Browse: NSFW/Installed/Outdated chips inline above sound-card titles (no more overlap on audio cards).
- Installed: collision-tolerant priority retype, Ctrl/Cmd+A in select mode, inline `PriorityEditor`, update-check fan-out capped at 5 concurrent.
- Downloads: chevron collapse on the expanded panel, in-toast cancel, multi-variant profile import.
- Errors: dev-mode no longer prunes real metadata; revoked GameBanana files surface a useful install error.

### What ships behind a Settings toggle
- VPK merger (combine 2+ mods into one VPK via bundled vpkmerge CLI). Off by default; toggle in Settings → Experimental. Existing merges remain unmergeable even if the flag flips off (recovery path is intentionally always-on).
- Unknown-mod auto-matching (unchanged from v1.10.5).

### Audit summary
All schema changes since v1.10.5 are additive: optional fields on `Mod` / `ModMetadata` / `ProfileMod` / `AppSettings`, additive download error code, additive IPC channels. Old configs and old profiles load fine; new fields are ignored if a user downgrades.

## Test plan

- [x] `pnpm lint` clean (3 pre-existing warnings unchanged).
- [x] `pnpm build` clean with `GRIMOIRE_SOCIAL_BASE_URL` set per CI.
- [x] `node scripts/smoke-merger.mjs` passes against discovered VPKs; bomb assertion reports the real prod cap (256 KB).
- [x] Manual smoke after merge: open the app with flag off → no Merge button in bulk-select; flag on → Merge button visible; turn off again → existing merges still openable + unmergeable.
- [ ] After tag `v1.11.0` is pushed: confirm CI builds Windows + Linux artifacts and that the GitHub Release body gets replaced with the structured notes template.