### PR TITLE
fix(locker): let multiple sound mods run on the same hero

### DIFF
--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -25,7 +25,6 @@ import {
   countLockerSkins,
   detectMinaTextures,
   findMinaVariant,
-  getLockerSkinKey,
   getHeroFacePosition,
   getHeroNamePath,
   getHeroRenderPath,
@@ -205,75 +204,22 @@ export default function Locker() {
     [minaVariants, minaSelection]
   );
 
+  // Both skins and sounds toggle independently. Users layering multiple VPKs
+  // on the same hero (textures + weapons + voice) is a valid workflow; the
+  // Locker reflects what's enabled rather than enforcing one-at-a-time. Real
+  // conflicts surface on the Conflicts page.
   const setActiveSkin = async (heroId: number, modId: string) => {
-    // Pick the section list (skins vs sounds) that actually contains the
-    // clicked mod. Keeps cross-section toggles independent: picking a Geist
-    // skin must not silently kill an enabled Geist voice pack.
     const skins = heroMods.map.get(heroId) ?? [];
     const sounds = heroSounds.map.get(heroId) ?? [];
-    const isSound = sounds.some((m) => m.id === modId);
-    const list = isSound ? sounds : skins;
-    const selected = list.find((mod) => mod.id === modId);
-    if (!selected) return;
-
-    // Sounds: just flip the one mod. A player can reasonably want a voice
-    // pack from one upload running alongside ability sounds from another,
-    // so the Sounds section doesn't enforce single-active semantics.
-    if (isSound) {
-      await toggleMod(modId);
-      return;
-    }
-
-    const selectedSkinKey = getLockerSkinKey(selected);
-    const selectedSkinFiles = list.filter((mod) => getLockerSkinKey(mod) === selectedSkinKey);
-    const selectedEnabledFiles = selectedSkinFiles.filter((mod) => mod.enabled);
-    const otherEnabledFiles = list.filter(
-      (mod) => getLockerSkinKey(mod) !== selectedSkinKey && mod.enabled
-    );
-    const actions: Promise<void>[] = [];
-    if (selectedEnabledFiles.length > 0 && otherEnabledFiles.length === 0) {
-      for (const mod of selectedEnabledFiles) {
-        actions.push(toggleMod(mod.id));
-      }
-    } else {
-      for (const mod of otherEnabledFiles) {
-        actions.push(toggleMod(mod.id));
-      }
-      if (selectedEnabledFiles.length === 0 && !selected.enabled) {
-        actions.push(toggleMod(selected.id));
-      }
-    }
-    await Promise.all(actions);
+    if (!skins.some((m) => m.id === modId) && !sounds.some((m) => m.id === modId)) return;
+    await toggleMod(modId);
   };
 
-  // Toggle one variant within a group. For skins, disables enabled mods from
-  // other groups for the hero (so switching groups still feels exclusive),
-  // but leaves the target's siblings alone so users can co-enable e.g. a
-  // model + voice VPK. For sounds, just toggles the clicked mod so several
-  // sound mods can run simultaneously on the same hero.
   const toggleHeroVariant = async (heroId: number, modId: string) => {
     const skins = heroMods.map.get(heroId) ?? [];
     const sounds = heroSounds.map.get(heroId) ?? [];
-    const isSound = sounds.some((m) => m.id === modId);
-    const list = isSound ? sounds : skins;
-    const target = list.find((m) => m.id === modId);
-    if (!target) return;
-
-    if (isSound) {
-      await toggleMod(modId);
-      return;
-    }
-
-    const groupKey = getLockerSkinKey(target);
-    const actions: Promise<void>[] = [];
-    for (const mod of list) {
-      if (mod.id === modId) continue;
-      if (!mod.enabled) continue;
-      const otherKey = getLockerSkinKey(mod);
-      if (otherKey !== groupKey) actions.push(toggleMod(mod.id));
-    }
-    actions.push(toggleMod(modId));
-    await Promise.all(actions);
+    if (!skins.some((m) => m.id === modId) && !sounds.some((m) => m.id === modId)) return;
+    await toggleMod(modId);
   };
 
   // Sorted hero name list for the "tag as hero" dropdown on Unassigned cards.

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -211,9 +211,18 @@ export default function Locker() {
     // skin must not silently kill an enabled Geist voice pack.
     const skins = heroMods.map.get(heroId) ?? [];
     const sounds = heroSounds.map.get(heroId) ?? [];
-    const list = skins.some((m) => m.id === modId) ? skins : sounds;
+    const isSound = sounds.some((m) => m.id === modId);
+    const list = isSound ? sounds : skins;
     const selected = list.find((mod) => mod.id === modId);
     if (!selected) return;
+
+    // Sounds: just flip the one mod. A player can reasonably want a voice
+    // pack from one upload running alongside ability sounds from another,
+    // so the Sounds section doesn't enforce single-active semantics.
+    if (isSound) {
+      await toggleMod(modId);
+      return;
+    }
 
     const selectedSkinKey = getLockerSkinKey(selected);
     const selectedSkinFiles = list.filter((mod) => getLockerSkinKey(mod) === selectedSkinKey);
@@ -237,15 +246,24 @@ export default function Locker() {
     await Promise.all(actions);
   };
 
-  // Toggle one variant within a group. Disables enabled mods from other groups
-  // for the hero (so switching groups still feels exclusive), but leaves the
-  // target's siblings alone so users can co-enable e.g. a model + voice VPK.
+  // Toggle one variant within a group. For skins, disables enabled mods from
+  // other groups for the hero (so switching groups still feels exclusive),
+  // but leaves the target's siblings alone so users can co-enable e.g. a
+  // model + voice VPK. For sounds, just toggles the clicked mod so several
+  // sound mods can run simultaneously on the same hero.
   const toggleHeroVariant = async (heroId: number, modId: string) => {
     const skins = heroMods.map.get(heroId) ?? [];
     const sounds = heroSounds.map.get(heroId) ?? [];
-    const list = skins.some((m) => m.id === modId) ? skins : sounds;
+    const isSound = sounds.some((m) => m.id === modId);
+    const list = isSound ? sounds : skins;
     const target = list.find((m) => m.id === modId);
     if (!target) return;
+
+    if (isSound) {
+      await toggleMod(modId);
+      return;
+    }
+
     const groupKey = getLockerSkinKey(target);
     const actions: Promise<void>[] = [];
     for (const mod of list) {

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -184,12 +184,25 @@ export default function LockerHero() {
     return null;
   };
 
+  // Sounds don't need to be mutually exclusive within a hero: a player can
+  // reasonably want a voice-pack from one sound mod and ability sounds from
+  // another running together. Only the Skins section enforces single-active
+  // semantics (a hero can only wear one model at a time).
+  const isSoundMod = (modId: string) => soundList.some((m) => m.id === modId);
+
   const setActiveSkin = async (modId: string) => {
     if (!hero) return;
     const heroModList = listForMod(modId);
     if (!heroModList) return;
     const clicked = heroModList.find((m) => m.id === modId);
     if (!clicked) return;
+
+    // Sounds: just flip the one mod, leave every other enabled sound alone.
+    if (isSoundMod(modId)) {
+      await toggleMod(modId);
+      return;
+    }
+
     const actions: Promise<void>[] = [];
     if (clicked.enabled) {
       // Click again on the active skin disables it (and any sibling variants
@@ -209,15 +222,22 @@ export default function LockerHero() {
     await Promise.all(actions);
   };
 
-  // Toggle one variant within a group. Disables enabled mods from other groups
-  // for the hero, but leaves sibling variants in the same group alone so a
-  // model + voice-lines pair can stay co-enabled.
+  // Toggle one variant within a group. For skins, disables enabled mods from
+  // other groups for the hero (leaving sibling variants in the same group
+  // alone so a model + voice-lines pair stays co-enabled). For sounds, just
+  // toggles the clicked mod so several sound mods can run simultaneously.
   const toggleHeroVariant = async (modId: string) => {
     if (!hero) return;
     const heroModList = listForMod(modId);
     if (!heroModList) return;
     const target = heroModList.find((m) => m.id === modId);
     if (!target) return;
+
+    if (isSoundMod(modId)) {
+      await toggleMod(modId);
+      return;
+    }
+
     const groupKey = getLockerSkinKey(target);
     const actions: Promise<void>[] = [];
     for (const mod of heroModList) {

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -21,7 +21,6 @@ import {
   countLockerSkins,
   detectMinaTextures,
   findMinaVariant,
-  getLockerSkinKey,
   getHeroNamePath,
   getHeroRenderPath,
   getHeroWikiUrl,
@@ -184,70 +183,23 @@ export default function LockerHero() {
     return null;
   };
 
-  // Sounds don't need to be mutually exclusive within a hero: a player can
-  // reasonably want a voice-pack from one sound mod and ability sounds from
-  // another running together. Only the Skins section enforces single-active
-  // semantics (a hero can only wear one model at a time).
-  const isSoundMod = (modId: string) => soundList.some((m) => m.id === modId);
-
+  // Both skins and sounds toggle independently in the Locker now. Users have
+  // valid reasons to layer multiple VPKs on the same hero (e.g. one mod
+  // touches textures, another touches weapons, another the voice). The Locker
+  // surfaces what's enabled; it doesn't enforce exclusivity. If two enabled
+  // mods truly conflict, that's the Conflicts page's job to flag.
   const setActiveSkin = async (modId: string) => {
     if (!hero) return;
     const heroModList = listForMod(modId);
-    if (!heroModList) return;
-    const clicked = heroModList.find((m) => m.id === modId);
-    if (!clicked) return;
-
-    // Sounds: just flip the one mod, leave every other enabled sound alone.
-    if (isSoundMod(modId)) {
-      await toggleMod(modId);
-      return;
-    }
-
-    const actions: Promise<void>[] = [];
-    if (clicked.enabled) {
-      // Click again on the active skin disables it (and any sibling variants
-      // currently enabled), returning the hero to the default in-game skin.
-      for (const mod of heroModList) {
-        if (mod.enabled) actions.push(toggleMod(mod.id));
-      }
-    } else {
-      for (const mod of heroModList) {
-        if (mod.id === modId) {
-          if (!mod.enabled) actions.push(toggleMod(mod.id));
-        } else if (mod.enabled) {
-          actions.push(toggleMod(mod.id));
-        }
-      }
-    }
-    await Promise.all(actions);
+    if (!heroModList?.some((m) => m.id === modId)) return;
+    await toggleMod(modId);
   };
 
-  // Toggle one variant within a group. For skins, disables enabled mods from
-  // other groups for the hero (leaving sibling variants in the same group
-  // alone so a model + voice-lines pair stays co-enabled). For sounds, just
-  // toggles the clicked mod so several sound mods can run simultaneously.
   const toggleHeroVariant = async (modId: string) => {
     if (!hero) return;
     const heroModList = listForMod(modId);
-    if (!heroModList) return;
-    const target = heroModList.find((m) => m.id === modId);
-    if (!target) return;
-
-    if (isSoundMod(modId)) {
-      await toggleMod(modId);
-      return;
-    }
-
-    const groupKey = getLockerSkinKey(target);
-    const actions: Promise<void>[] = [];
-    for (const mod of heroModList) {
-      if (mod.id === modId) continue;
-      if (!mod.enabled) continue;
-      const otherKey = getLockerSkinKey(mod);
-      if (otherKey !== groupKey) actions.push(toggleMod(mod.id));
-    }
-    actions.push(toggleMod(modId));
-    await Promise.all(actions);
+    if (!heroModList?.some((m) => m.id === modId)) return;
+    await toggleMod(modId);
   };
 
   const applyMinaPreset = async (presetFileName: string) => {


### PR DESCRIPTION
## Summary

Followup that didn't make the v1.11.0 release PR cutoff. Hero-aware sounds inherited the skin section's mutual-exclusion logic: clicking a sound for a hero disabled every other sound tagged to that hero. That makes sense for skins (one model at a time) but breaks the natural case of running a voice pack from one upload with ability sounds from another.

The two click handlers in `LockerHero.tsx` (`setActiveSkin` for card-click, `toggleHeroVariant` for variant pills) now short-circuit for sound mods and just flip the clicked mod. Skins keep the existing one-at-a-time behavior. Section is detected via the existing `soundList` membership check; no new state.

## Test plan

- [x] `pnpm lint` clean (3 pre-existing warnings unchanged).
- [x] `pnpm build` clean.
- [x] Open the Locker for a hero with multiple sound mods, switch to *Sounds*, enable two of them, confirm both stay enabled and audible in-game.
- [x] Verify skin section still enforces one-at-a-time on the same hero.

Targets release: bundled into v1.11.0 release notes; we'll tag after this lands.