### PR TITLE
Release v1.11.1: variant picker on import flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -154,6 +154,19 @@ export default function ImportCollectionModal({
   // stays interactive (cancel buttons, variant pickers for not-yet-queued
   // rows, etc.).
   const [submitting, setSubmitting] = useState(false);
+  // Selected mods that have multiple downloadable files and no manual pick.
+  // Populated when the user clicks Queue; submission is blocked while this
+  // set is non-empty so the user is forced to choose instead of silently
+  // getting the most-downloaded variant.
+  const [needsVariantPicks, setNeedsVariantPicks] = useState<Set<number>>(new Set());
+  // Whether the user has opted into seeing every variant up-front. Off by
+  // default to avoid the API-spam cost on large collections. When on, we
+  // fetch details for every selectable row and auto-expand pickers for any
+  // mod with multiple files (e.g. LowPolyDox: full / lite / per-hero).
+  const [showAllVariants, setShowAllVariants] = useState(false);
+  const [variantScanProgress, setVariantScanProgress] = useState<
+    { done: number; total: number } | null
+  >(null);
   // Snapshot of which ids were submitted in the active batch. Determines
   // which mods belong in a post-install profile if the user opts in.
   const [batchIds, setBatchIds] = useState<Set<number>>(new Set());
@@ -174,6 +187,17 @@ export default function ImportCollectionModal({
   useEffect(() => {
     rowsRef.current = rows;
   }, [rows]);
+
+  // Per-row DOM refs so we can scroll the first ambiguous-variant row into
+  // view when the banner appears.
+  const rowRefs = useRef<Map<number, HTMLLIElement>>(new Map());
+  const setRowRef = useCallback(
+    (id: number) => (el: HTMLLIElement | null) => {
+      if (el) rowRefs.current.set(id, el);
+      else rowRefs.current.delete(id);
+    },
+    []
+  );
 
   // Track which mod ids this modal owns so global queue events don't bleed
   // into rows that came from elsewhere (e.g. the user kicked off a download
@@ -400,9 +424,74 @@ export default function ImportCollectionModal({
   const pickVariant = useCallback(
     (row: ItemRow, file: GameBananaFile) => {
       updateRow(row.item.id, { pickedFileId: file.id });
+      setNeedsVariantPicks((prev) => {
+        if (!prev.has(row.item.id)) return prev;
+        const next = new Set(prev);
+        next.delete(row.item.id);
+        return next;
+      });
     },
     [updateRow]
   );
+
+  // Toggle "Show all variants". Turning on fetches details for every
+  // selectable row that doesn't have them yet and opens the inline picker
+  // for any mod with more than one file. Turning off collapses everything
+  // we expanded. Per-row state set by individual chevron clicks is left
+  // alone (the user's explicit action wins).
+  const handleToggleShowAllVariants = useCallback(async () => {
+    if (showAllVariants) {
+      setShowAllVariants(false);
+      setRows((prev) =>
+        prev.map((r) =>
+          r.selectable && r.variantsOpen && (r.details?.files?.length ?? 0) > 1
+            ? { ...r, variantsOpen: false }
+            : r
+        )
+      );
+      return;
+    }
+
+    setShowAllVariants(true);
+    const targets = rowsRef.current.filter(
+      (r) => r.selectable && !r.details && !r.detailsLoading
+    );
+    setVariantScanProgress({ done: 0, total: targets.length });
+
+    let done = 0;
+    await Promise.all(
+      targets.map(async (r) => {
+        await ensureDetails(r);
+        done += 1;
+        setVariantScanProgress({ done, total: targets.length });
+      })
+    );
+
+    setRows((prev) =>
+      prev.map((r) => {
+        if (!r.selectable) return r;
+        if ((r.details?.files?.length ?? 0) > 1) {
+          return r.variantsOpen ? r : { ...r, variantsOpen: true };
+        }
+        return r;
+      })
+    );
+    setVariantScanProgress(null);
+  }, [showAllVariants, ensureDetails]);
+
+  // "Use most popular" escape hatch on the variant-required banner.
+  // Stamps each unresolved row with its primary file id so submission can
+  // proceed on the next Queue click without making the user pick manually.
+  const acceptDefaults = useCallback(() => {
+    setRows((prev) =>
+      prev.map((r) => {
+        if (!needsVariantPicks.has(r.item.id)) return r;
+        if (!r.details?.files || r.details.files.length === 0) return r;
+        return { ...r, pickedFileId: getPrimaryFile(r.details.files).id };
+      })
+    );
+    setNeedsVariantPicks(new Set());
+  }, [needsVariantPicks]);
 
   // ───────── Selection ─────────
 
@@ -470,23 +559,64 @@ export default function ImportCollectionModal({
     setSubmitting(true);
     setProfileStatus({ kind: 'idle' });
     const token = ++submitTokenRef.current;
-    const toQueue = rowsRef.current.filter(
+    const initialQueue = rowsRef.current.filter(
       (r) => selected.has(r.item.id) && r.status === 'idle'
+    );
+
+    // Pre-fetch details for every selected row we don't have yet so we can
+    // detect variant ambiguity up-front. ensureDetails is cache-aware and
+    // its underlying API calls are rate-limited in the main process, so a
+    // big collection just trickles instead of hammering GameBanana.
+    const needsFetch = initialQueue.filter((r) => !r.details);
+    if (needsFetch.length > 0) {
+      await Promise.all(needsFetch.map((r) => ensureDetails(r)));
+      if (submitTokenRef.current !== token) {
+        setSubmitting(false);
+        return;
+      }
+    }
+
+    // Re-read after pre-fetch: ensureDetails may have flipped some rows to
+    // files-unavailable (auto-deselected) and others now carry their files.
+    const ambiguous = rowsRef.current.filter((r) => {
+      if (!selected.has(r.item.id)) return false;
+      if (r.status !== 'idle') return false;
+      if (!r.selectable) return false;
+      if (!r.details?.files || r.details.files.length <= 1) return false;
+      return r.pickedFileId === undefined;
+    });
+
+    if (ambiguous.length > 0) {
+      const ambiguousIds = new Set(ambiguous.map((r) => r.item.id));
+      setRows((prev) =>
+        prev.map((r) =>
+          ambiguousIds.has(r.item.id) && !r.variantsOpen
+            ? { ...r, variantsOpen: true }
+            : r
+        )
+      );
+      setNeedsVariantPicks(ambiguousIds);
+      requestAnimationFrame(() => {
+        const firstEl = rowRefs.current.get(ambiguous[0].item.id);
+        if (firstEl) firstEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      });
+      setSubmitting(false);
+      return;
+    }
+
+    setNeedsVariantPicks(new Set());
+
+    // Refresh the snapshot so each row carries its now-cached details and
+    // any pickedFileId the user set while the banner was up.
+    const toQueue = rowsRef.current.filter(
+      (r) => selected.has(r.item.id) && r.status === 'idle' && r.selectable
     );
     setBatchIds(new Set(toQueue.map((r) => r.item.id)));
 
     for (const row of toQueue) {
       if (submitTokenRef.current !== token) break;
 
-      // Resolve files if we don't have them cached yet, needed to map
-      // pickedFileId (or the default primary) to a real GameBananaFile.
-      let details = row.details ?? null;
-      if (!details) {
-        updateRow(row.item.id, { status: 'resolving' });
-        details = await ensureDetails(row);
-        if (submitTokenRef.current !== token) break;
-      }
-
+      const details = row.details;
       if (!details?.files || details.files.length === 0) {
         // ensureDetails already marked this row unavailable (and removed it
         // from the selected set) when it discovered the empty file list, so
@@ -646,19 +776,61 @@ export default function ImportCollectionModal({
           )}
 
           {rows.length > 0 && (
-            <div className="px-6 py-3 sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10">
-              <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
-                <input
-                  type="checkbox"
-                  checked={allEligibleSelected}
-                  onChange={toggleSelectAll}
-                  disabled={eligibleRows.length === 0}
-                  className="accent-accent cursor-pointer"
-                />
-                <span>
-                  {allEligibleSelected ? 'Deselect all' : `Select all (${eligibleRows.length})`}
-                </span>
-              </label>
+            <div className="sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10">
+              <div className="px-6 py-3 flex items-center justify-between gap-3">
+                <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
+                  <input
+                    type="checkbox"
+                    checked={allEligibleSelected}
+                    onChange={toggleSelectAll}
+                    disabled={eligibleRows.length === 0}
+                    className="accent-accent cursor-pointer"
+                  />
+                  <span>
+                    {allEligibleSelected ? 'Deselect all' : `Select all (${eligibleRows.length})`}
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => void handleToggleShowAllVariants()}
+                  disabled={variantScanProgress !== null}
+                  className="text-xs inline-flex items-center gap-1.5 px-2 py-1 rounded-sm border border-white/10 text-text-secondary hover:text-text-primary hover:border-white/20 disabled:opacity-60 disabled:cursor-default cursor-pointer"
+                  title="Fetch every selectable mod's file list and expand any with multiple variants"
+                >
+                  {variantScanProgress ? (
+                    <>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      <span>
+                        Loading variants {variantScanProgress.done}/{variantScanProgress.total}
+                      </span>
+                    </>
+                  ) : showAllVariants ? (
+                    <>
+                      <ChevronDown className="w-3.5 h-3.5" />
+                      <span>Hide all variants</span>
+                    </>
+                  ) : (
+                    <>
+                      <ChevronRight className="w-3.5 h-3.5" />
+                      <span>Show all variants</span>
+                    </>
+                  )}
+                </button>
+              </div>
+              {needsVariantPicks.size > 0 && (
+                <div className="px-6 py-2.5 bg-amber-500/10 border-t border-amber-500/30 flex items-center justify-between gap-3">
+                  <div className="text-sm text-amber-200 flex items-center gap-2 min-w-0">
+                    <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+                    <span>
+                      Pick a variant for {needsVariantPicks.size} mod
+                      {needsVariantPicks.size === 1 ? '' : 's'} before queueing.
+                    </span>
+                  </div>
+                  <Button size="sm" variant="secondary" onClick={acceptDefaults}>
+                    Use most popular
+                  </Button>
+                </div>
+              )}
             </div>
           )}
 
@@ -674,7 +846,13 @@ export default function ImportCollectionModal({
                 : undefined;
 
               return (
-                <li key={row.item.id} className="px-6 py-4">
+                <li
+                  key={row.item.id}
+                  ref={setRowRef(row.item.id)}
+                  className={`px-6 py-4 transition-colors ${
+                    needsVariantPicks.has(row.item.id) ? 'bg-amber-500/5' : ''
+                  }`}
+                >
                   <div className="flex items-center gap-4">
                     <input
                       type="checkbox"

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Terminal,
   ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import { Button } from '../common/ui';
 import ModThumbnail from '../ModThumbnail';
@@ -18,6 +19,7 @@ import {
   resolvePortableProfile,
   finalizePortableImport,
   downloadMod,
+  getModDetails,
   type SocialProfileDetail,
 } from '../../lib/api';
 import type {
@@ -25,6 +27,7 @@ import type {
   PortableResolutionReport,
   PortableResolvedMod,
 } from '../../types/portableProfile';
+import type { GameBananaFile, GameBananaModDetails } from '../../types/gamebanana';
 
 interface ImportProfileDialogProps {
   activeDeadlockPath: string | null;
@@ -68,6 +71,15 @@ interface RowState {
   status: RowStatus;
   statusMessage?: string;
   progress?: { downloaded: number; total: number };
+  // Variant picker state. The profile pins a specific (submissionId, fileId),
+  // but mods like LowPolyDox ship multiple files (full / lite / per-hero).
+  // Letting the user swap to a different file here means importing someone
+  // else's profile doesn't force their exact taste on you.
+  details?: GameBananaModDetails;
+  detailsLoading?: boolean;
+  detailsError?: string;
+  pickedFileId?: number;
+  variantsOpen?: boolean;
 }
 
 function gbSubmissionId(mod: PortableResolvedMod): number | null {
@@ -76,16 +88,40 @@ function gbSubmissionId(mod: PortableResolvedMod): number | null {
   return ref.submissionId ?? null;
 }
 
+// Pick the file the download pipeline should actually fetch for this row.
+// Picked > resolved (set by the resolver, may differ from the pinned id on
+// "upgraded" rows) > the pinned id from the profile entry.
+function effectiveFileId(r: RowState): number | undefined {
+  if (r.pickedFileId !== undefined) return r.pickedFileId;
+  if (r.mod.resolvedFileId !== undefined) return r.mod.resolvedFileId;
+  if (r.mod.entry.source === 'gamebanana') {
+    const ref = r.mod.entry.ref as { fileId?: number };
+    return ref.fileId;
+  }
+  return undefined;
+}
+
+function effectiveFileName(r: RowState): string | undefined {
+  if (r.pickedFileId !== undefined && r.details?.files) {
+    const f = r.details.files.find((file) => file.id === r.pickedFileId);
+    if (f) return f.fileName;
+  }
+  return r.mod.resolvedFileName;
+}
+
 // Composite tracking key for download events. A submission can appear several
 // times in one import (different file versions, or multi-VPK siblings); keying
 // by submissionId alone would cross-update unrelated rows. Multi-VPK siblings
 // genuinely share (submissionId, fileId) and SHOULD update together, since
-// they all ride on a single archive download.
-function rowKey(mod: PortableResolvedMod): string | null {
-  if (mod.entry.source !== 'gamebanana') return null;
-  const ref = mod.entry.ref as { submissionId?: number; fileId?: number };
-  if (ref.submissionId === undefined || ref.fileId === undefined) return null;
-  return `${ref.submissionId}:${ref.fileId}`;
+// they all ride on a single archive download. Uses the effective fileId so a
+// user-picked variant flows through queue/complete/error matching.
+function rowKey(r: RowState): string | null {
+  if (r.mod.entry.source !== 'gamebanana') return null;
+  const ref = r.mod.entry.ref as { submissionId?: number };
+  if (ref.submissionId === undefined) return null;
+  const fid = effectiveFileId(r);
+  if (fid === undefined) return null;
+  return `${ref.submissionId}:${fid}`;
 }
 
 function eventKey(modId: number, fileId: number): string {
@@ -135,7 +171,7 @@ export default function ImportProfileDialog({
   const trackedKeys = useMemo(() => {
     const s = new Set<string>();
     for (const r of rows) {
-      const k = rowKey(r.mod);
+      const k = rowKey(r);
       if (k !== null) s.add(k);
     }
     return s;
@@ -154,7 +190,7 @@ export default function ImportProfileDialog({
   // Listen for download events to drive row status during import.
   useEffect(() => {
     const updateRowsByKey = (key: string, patch: Partial<RowState>) => {
-      setRows((prev) => prev.map((r) => (rowKey(r.mod) === key ? { ...r, ...patch } : r)));
+      setRows((prev) => prev.map((r) => (rowKey(r) === key ? { ...r, ...patch } : r)));
     };
 
     const unsubQueue = window.electronAPI.onDownloadQueueUpdated((data) => {
@@ -164,7 +200,7 @@ export default function ImportProfileDialog({
         : null;
       setRows((prev) =>
         prev.map((r) => {
-          const k = rowKey(r.mod);
+          const k = rowKey(r);
           if (k === null || !trackedKeysRef.current.has(k)) return r;
           if (
             r.status === 'installed' ||
@@ -196,7 +232,7 @@ export default function ImportProfileDialog({
       if (!trackedKeysRef.current.has(k)) return;
       setRows((prev) =>
         prev.map((r) =>
-          rowKey(r.mod) === k
+          rowKey(r) === k
             ? { ...r, progress: { downloaded, total } }
             : r
         )
@@ -292,41 +328,162 @@ export default function ImportProfileDialog({
     });
   }, []);
 
+  const updateRowAt = useCallback((idx: number, patch: Partial<RowState>) => {
+    setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  }, []);
+
+  // Fetch the GameBanana mod details for a row so we can show its full file
+  // list. Cached on the row so subsequent opens are instant.
+  const ensureDetailsForRow = useCallback(
+    async (idx: number): Promise<GameBananaModDetails | null> => {
+      const row = rowsRef.current[idx];
+      if (!row) return null;
+      if (row.details) return row.details;
+      if (row.detailsLoading) return null;
+      const submissionId = gbSubmissionId(row.mod);
+      if (submissionId === null) return null;
+      const ref = row.mod.entry.ref as { section?: string };
+      updateRowAt(idx, { detailsLoading: true, detailsError: undefined });
+      try {
+        const details = await getModDetails(submissionId, ref.section || 'Mod');
+        updateRowAt(idx, { details, detailsLoading: false });
+        return details;
+      } catch (err) {
+        updateRowAt(idx, {
+          detailsLoading: false,
+          detailsError: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    },
+    [updateRowAt]
+  );
+
+  const toggleVariants = useCallback(
+    async (idx: number) => {
+      const row = rowsRef.current[idx];
+      if (!row) return;
+      const opening = !row.variantsOpen;
+      updateRowAt(idx, { variantsOpen: opening });
+      if (opening) await ensureDetailsForRow(idx);
+    },
+    [ensureDetailsForRow, updateRowAt]
+  );
+
+  const pickVariant = useCallback(
+    (idx: number, file: GameBananaFile) => {
+      setRows((prev) =>
+        prev.map((r, i) => {
+          if (i !== idx) return r;
+          const patch: RowState = { ...r, pickedFileId: file.id };
+          // Picking a different file than what's currently on disk means
+          // the on-disk match no longer represents the user's choice. Flip
+          // to pending so handleConfirm queues a download.
+          if (
+            r.status === 'already-installed' &&
+            file.id !== r.mod.resolvedFileId
+          ) {
+            patch.status = 'pending';
+          }
+          return patch;
+        })
+      );
+    },
+    []
+  );
+
+  // Whether the user has opted into seeing every variant up-front. Mirrors
+  // the same toggle on the collection import modal.
+  const [showAllVariants, setShowAllVariants] = useState(false);
+  const [variantScanProgress, setVariantScanProgress] = useState<
+    { done: number; total: number } | null
+  >(null);
+
+  const handleToggleShowAllVariants = useCallback(async () => {
+    if (showAllVariants) {
+      setShowAllVariants(false);
+      setRows((prev) =>
+        prev.map((r) =>
+          r.variantsOpen && (r.details?.files?.length ?? 0) > 1
+            ? { ...r, variantsOpen: false }
+            : r
+        )
+      );
+      return;
+    }
+
+    setShowAllVariants(true);
+    const targets: number[] = [];
+    rowsRef.current.forEach((r, idx) => {
+      if (r.mod.status === 'unresolvable') return;
+      if (r.details || r.detailsLoading) return;
+      if (gbSubmissionId(r.mod) === null) return;
+      targets.push(idx);
+    });
+    setVariantScanProgress({ done: 0, total: targets.length });
+
+    let done = 0;
+    await Promise.all(
+      targets.map(async (idx) => {
+        await ensureDetailsForRow(idx);
+        done += 1;
+        setVariantScanProgress({ done, total: targets.length });
+      })
+    );
+
+    setRows((prev) =>
+      prev.map((r) => {
+        if (r.mod.status === 'unresolvable') return r;
+        if ((r.details?.files?.length ?? 0) > 1) {
+          return r.variantsOpen ? r : { ...r, variantsOpen: true };
+        }
+        return r;
+      })
+    );
+    setVariantScanProgress(null);
+  }, [showAllVariants, ensureDetailsForRow]);
+
   const handleConfirm = useCallback(async () => {
     if (!parsed || !report || !activeDeadlockPath) return;
     setImporting(true);
     setFinalizeError(null);
 
-    const toDownload: PortableResolvedMod[] = [];
+    const toDownload: RowState[] = [];
     const startingRows = rowsRef.current.map((r) => {
       if (!r.selected || r.mod.status === 'unresolvable') {
         return { ...r, status: 'skipped' as RowStatus };
       }
-      if (r.mod.alreadyInstalled) {
+      // The on-disk match is for the resolved file; if the user picked a
+      // different variant, we have to actually download it.
+      const pickedDiffers =
+        r.pickedFileId !== undefined && r.pickedFileId !== r.mod.resolvedFileId;
+      if (r.mod.alreadyInstalled && !pickedDiffers) {
         // Selected and on disk — no work to do, keep the badge and let
         // finalize wire the existing VPK into the new profile.
         return { ...r, status: 'already-installed' as RowStatus };
       }
-      toDownload.push(r.mod);
+      toDownload.push(r);
       return { ...r, status: 'queued' as RowStatus };
     });
     setRows(startingRows);
 
-    for (const mod of toDownload) {
-      if (mod.entry.source !== 'gamebanana') continue;
-      if (mod.resolvedFileId === undefined || !mod.resolvedFileName) continue;
-      const ref = mod.entry.ref as { submissionId: number; section?: string };
-      const failKey = eventKey(ref.submissionId, mod.resolvedFileId);
+    for (const row of toDownload) {
+      if (row.mod.entry.source !== 'gamebanana') continue;
+      const fileId = effectiveFileId(row);
+      const fileName = effectiveFileName(row);
+      if (fileId === undefined || !fileName) continue;
+      const ref = row.mod.entry.ref as { submissionId: number; section?: string };
+      const failKey = eventKey(ref.submissionId, fileId);
       void downloadMod(
         ref.submissionId,
-        mod.resolvedFileId,
-        mod.resolvedFileName,
+        fileId,
+        fileName,
         ref.section || 'Mod'
       ).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         setRows((prev) =>
           prev.map((r) =>
-            rowKey(r.mod) === failKey && r.status !== 'installed'
+            rowKey(r) === failKey && r.status !== 'installed'
               ? { ...r, status: 'failed', statusMessage: message }
               : r
           )
@@ -355,7 +512,19 @@ export default function ImportProfileDialog({
     (async () => {
       const installedEntries: PortableResolvedMod[] = [];
       for (const r of rowsRef.current) {
-        if (r.status === 'installed' || r.status === 'already-installed') {
+        if (r.status !== 'installed' && r.status !== 'already-installed') continue;
+        // When the user picked a different variant, finalize needs the
+        // picked fileId to find the VPK we just installed on disk.
+        const picked =
+          r.pickedFileId !== undefined &&
+          r.pickedFileId !== r.mod.resolvedFileId;
+        if (picked) {
+          installedEntries.push({
+            ...r.mod,
+            resolvedFileId: r.pickedFileId,
+            resolvedFileName: effectiveFileName(r) ?? r.mod.resolvedFileName,
+          });
+        } else {
           installedEntries.push(r.mod);
         }
       }
@@ -610,7 +779,7 @@ export default function ImportProfileDialog({
               })()
             ) : null}
 
-            <div className="px-4 sm:px-6 py-2 sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10 flex items-center justify-between gap-2">
+            <div className="px-4 sm:px-6 py-2 sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10 flex items-center justify-between gap-2 flex-wrap">
               <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer min-w-0">
                 <input
                   type="checkbox"
@@ -625,6 +794,32 @@ export default function ImportProfileDialog({
                     : `Select all (${selectableCount})`}
                 </span>
               </label>
+              <button
+                type="button"
+                onClick={() => void handleToggleShowAllVariants()}
+                disabled={importing || variantScanProgress !== null || selectableCount === 0}
+                className="text-xs inline-flex items-center gap-1.5 px-2 py-1 rounded-sm border border-white/10 text-text-secondary hover:text-text-primary hover:border-white/20 disabled:opacity-60 disabled:cursor-default cursor-pointer"
+                title="Fetch every mod's file list so you can swap to a different variant than the one pinned in the profile"
+              >
+                {variantScanProgress ? (
+                  <>
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    <span>
+                      Loading variants {variantScanProgress.done}/{variantScanProgress.total}
+                    </span>
+                  </>
+                ) : showAllVariants ? (
+                  <>
+                    <ChevronDown className="w-3.5 h-3.5" />
+                    <span>Hide all variants</span>
+                  </>
+                ) : (
+                  <>
+                    <ChevronRight className="w-3.5 h-3.5" />
+                    <span>Show all variants</span>
+                  </>
+                )}
+              </button>
               <div className="flex flex-wrap items-center gap-1.5 text-[11px] justify-end flex-shrink-0">
                 <span className="px-1.5 py-0.5 rounded-sm bg-green-500/10 text-green-300 border border-green-500/20">
                   {report.exactCount} exact
@@ -658,6 +853,14 @@ export default function ImportProfileDialog({
                   const mod = r.mod;
                   const hint = mod.entry.hint;
                   const isUnresolvable = mod.status === 'unresolvable';
+                  const submissionId = gbSubmissionId(mod);
+                  const fileCount = r.details?.files?.length ?? 0;
+                  const canPickVariants =
+                    !isUnresolvable && submissionId !== null;
+                  const pickedFile =
+                    r.pickedFileId !== undefined && r.details?.files
+                      ? r.details.files.find((f) => f.id === r.pickedFileId)
+                      : undefined;
                   const progressPct =
                     r.status === 'downloading' && r.progress && r.progress.total > 0
                       ? Math.min(100, (r.progress.downloaded / r.progress.total) * 100)
@@ -701,6 +904,38 @@ export default function ImportProfileDialog({
                             {hint?.fileLabel && <span className="hidden sm:inline">· {hint.fileLabel}</span>}
                             <span>· p{mod.entry.priority}</span>
                             {!mod.entry.enabled && <span className="text-text-tertiary">· disabled</span>}
+                            {canPickVariants && (
+                              <button
+                                type="button"
+                                onClick={() => void toggleVariants(idx)}
+                                disabled={importing}
+                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm hover:text-text-primary hover:bg-white/5 disabled:opacity-50 disabled:cursor-default cursor-pointer"
+                                title="Choose a different variant from this mod"
+                              >
+                                {r.variantsOpen ? (
+                                  <ChevronDown className="w-3 h-3" />
+                                ) : (
+                                  <ChevronRight className="w-3 h-3" />
+                                )}
+                                {r.detailsLoading ? (
+                                  <Loader2 className="w-3 h-3 animate-spin" />
+                                ) : fileCount > 1 ? (
+                                  <span>{fileCount} variants</span>
+                                ) : fileCount === 1 ? (
+                                  <span>1 file</span>
+                                ) : (
+                                  <span>Variants</span>
+                                )}
+                              </button>
+                            )}
+                            {pickedFile && (
+                              <span
+                                className="text-accent truncate max-w-[14rem]"
+                                title={pickedFile.fileName}
+                              >
+                                · {pickedFile.fileName}
+                              </span>
+                            )}
                           </div>
                           {mod.status === 'upgraded' && (
                             <div className="text-xs text-blue-300 mt-1 inline-flex items-center gap-1">
@@ -767,6 +1002,75 @@ export default function ImportProfileDialog({
                           )}
                         </div>
                       </div>
+
+                      {r.variantsOpen && (
+                        <div className="ml-[68px] sm:ml-[104px] mt-2 mb-1">
+                          {r.detailsLoading && (
+                            <div className="text-xs text-text-secondary flex items-center gap-1.5">
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                              Loading files...
+                            </div>
+                          )}
+                          {r.detailsError && (
+                            <div className="text-xs text-red-400 flex items-center gap-1.5">
+                              <AlertTriangle className="w-3.5 h-3.5" />
+                              {r.detailsError}
+                            </div>
+                          )}
+                          {!r.detailsLoading && !r.detailsError && r.details && (!r.details.files || r.details.files.length === 0) && (
+                            <div className="text-xs text-text-tertiary flex items-start gap-1.5">
+                              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+                              <span>
+                                GameBanana returned no downloadable files for this mod.
+                              </span>
+                            </div>
+                          )}
+                          {!r.detailsLoading && !r.detailsError && r.details?.files && r.details.files.length > 0 && (
+                            <ul className="space-y-1">
+                              {r.details.files.map((file) => {
+                                const selectedId =
+                                  r.pickedFileId !== undefined ? r.pickedFileId : r.mod.resolvedFileId;
+                                const isPicked = selectedId === file.id;
+                                return (
+                                  <li key={file.id}>
+                                    <label
+                                      className={`flex items-center gap-2.5 px-3 py-1.5 rounded-sm cursor-pointer text-sm border ${
+                                        isPicked
+                                          ? 'bg-accent/10 border-accent/40 text-text-primary'
+                                          : 'border-transparent hover:bg-white/5 text-text-secondary'
+                                      }`}
+                                    >
+                                      <input
+                                        type="radio"
+                                        name={`variant-${idx}`}
+                                        checked={isPicked}
+                                        onChange={() => pickVariant(idx, file)}
+                                        disabled={importing}
+                                        className="accent-accent cursor-pointer disabled:cursor-default"
+                                      />
+                                      <span className="truncate flex-1" title={file.fileName}>
+                                        {file.fileName}
+                                      </span>
+                                      {file.isArchived && (
+                                        <span className="text-text-tertiary text-[11px] uppercase tracking-wide">
+                                          archived
+                                        </span>
+                                      )}
+                                      <span
+                                        className="text-text-tertiary text-xs tabular-nums inline-flex items-center gap-1"
+                                        title={`${file.downloadCount.toLocaleString()} downloads`}
+                                      >
+                                        <Download className="w-3 h-3" />
+                                        {file.downloadCount.toLocaleString()}
+                                      </span>
+                                    </label>
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                        </div>
+                      )}
                     </li>
                   );
                 })}


### PR DESCRIPTION
## Summary
- Adds a **Show all variants** toggle and per-row inline variant pickers to both `ImportCollectionModal` and `ImportProfileDialog`. Users can pick which file of a multi-file mod (LowPolyDox full/lite/per-hero, etc.) actually gets downloaded instead of silently getting the most-popular default.
- Collection import also blocks on **Queue** when any selected mod has multiple variants with no manual pick, showing an amber banner with a "Use most popular" fallback.
- Profile import wires picked variants through download, event matching, and finalize so the new local profile points at the VPK you actually installed. Side effect: `rowKey` now uses the effective fileId, fixing a pre-existing event-match miss for resolver-upgraded rows.
- Bumps `package.json` to `1.11.1` for tagging after merge.

## Test plan
- [x] Import a GameBanana collection containing a multi-variant mod (e.g. LowPolyDox). Click **Show all variants**, confirm pickers auto-expand and progress counter shows.
- [x] Try queueing without picking; confirm the amber "Pick a variant for N mods" banner appears and submission is blocked.
- [x] Click **Use most popular**; confirm queue proceeds with the most-downloaded file.
- [x] Import a `.modprofile.json` (or `mp1:` share code) referencing the same mod. Click **Show all variants**, swap to a different variant, confirm the picked filename shows on the row in accent.
- [x] Confirm download fires for the picked variant (status flips queued -> downloading -> installed against the right row).
- [x] Confirm the resulting local profile points at the picked VPK after finalize.