### PR TITLE
Release v1.11.2: multi-select variant picker on import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -73,8 +73,18 @@ interface ItemRow {
   details?: GameBananaModDetails;
   detailsLoading?: boolean;
   detailsError?: string;
-  pickedFileId?: number;
+  // File ids the user explicitly checked. Empty means "fall back to the most
+  // popular file" so single-variant rows don't require interaction. Multi-
+  // select lets users grab e.g. several heroes from one Sounds listing.
+  pickedFileIds: number[];
   variantsOpen?: boolean;
+  // Per-file progress tracking. expectedFileIds is the snapshot taken at
+  // queue time (pickedFileIds or [primary]); installed/failed sets are
+  // populated by download events so the aggregate row status reflects all
+  // requested files, not just the first to finish.
+  expectedFileIds?: number[];
+  installedFileIds?: Set<number>;
+  failedFileIds?: Set<number>;
 }
 
 function classifySkip(item: GameBananaCollectionItem): SkipReason | undefined {
@@ -112,6 +122,7 @@ function buildRows(
       selectable: !skip,
       skip,
       status: skip ? 'idle' : initialStatus(item, installedIds, queuedIds),
+      pickedFileIds: [],
     };
   });
 }
@@ -240,14 +251,49 @@ export default function ImportCollectionModal({
       );
     });
 
-    const unsubComplete = window.electronAPI.onDownloadComplete(({ modId }) => {
+    const unsubComplete = window.electronAPI.onDownloadComplete(({ modId, fileId }) => {
       if (!trackedIdsRef.current.has(modId)) return;
-      updateRow(modId, { status: 'installed', statusMessage: undefined });
+      // Multi-variant: a row may expect several fileIds. Only flip the row
+      // to 'installed' once every expected file has landed; until then mark
+      // the file done and keep the aggregate status as 'downloading'.
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.item.id !== modId) return r;
+          const installed = new Set(r.installedFileIds ?? []);
+          installed.add(fileId);
+          const expected = r.expectedFileIds;
+          const allDone =
+            expected !== undefined &&
+            expected.length > 0 &&
+            expected.every((id) => installed.has(id));
+          return {
+            ...r,
+            installedFileIds: installed,
+            status: allDone ? 'installed' : r.status,
+            statusMessage: allDone ? undefined : r.statusMessage,
+          };
+        })
+      );
     });
 
-    const unsubError = window.electronAPI.onDownloadError(({ modId, message }) => {
+    const unsubError = window.electronAPI.onDownloadError(({ modId, fileId, message }) => {
       if (!trackedIdsRef.current.has(modId)) return;
-      updateRow(modId, { status: 'failed', statusMessage: message });
+      // Any file failing fails the whole row. Track which files failed so a
+      // future "retry just the failures" UX can target them, but flip the
+      // aggregate immediately so the user knows something went wrong.
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.item.id !== modId) return r;
+          const failed = new Set(r.failedFileIds ?? []);
+          failed.add(fileId);
+          return {
+            ...r,
+            failedFileIds: failed,
+            status: 'failed',
+            statusMessage: message,
+          };
+        })
+      );
     });
 
     return () => {
@@ -421,17 +467,34 @@ export default function ImportCollectionModal({
     [ensureDetails, updateRow]
   );
 
-  const pickVariant = useCallback(
+  // Toggle a file on or off in the row's pickedFileIds set. Empty set means
+  // "no explicit pick" and the queue falls back to the primary file; one or
+  // more picks means "download exactly these files". As soon as a row has at
+  // least one pick, we drop it from the variant-required banner.
+  const toggleVariantPick = useCallback(
     (row: ItemRow, file: GameBananaFile) => {
-      updateRow(row.item.id, { pickedFileId: file.id });
-      setNeedsVariantPicks((prev) => {
-        if (!prev.has(row.item.id)) return prev;
-        const next = new Set(prev);
-        next.delete(row.item.id);
-        return next;
-      });
+      let resultedInAtLeastOnePick = false;
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.item.id !== row.item.id) return r;
+          const has = r.pickedFileIds.includes(file.id);
+          const nextPicks = has
+            ? r.pickedFileIds.filter((id) => id !== file.id)
+            : [...r.pickedFileIds, file.id];
+          if (nextPicks.length > 0) resultedInAtLeastOnePick = true;
+          return { ...r, pickedFileIds: nextPicks };
+        })
+      );
+      if (resultedInAtLeastOnePick) {
+        setNeedsVariantPicks((prev) => {
+          if (!prev.has(row.item.id)) return prev;
+          const next = new Set(prev);
+          next.delete(row.item.id);
+          return next;
+        });
+      }
     },
-    [updateRow]
+    []
   );
 
   // Toggle "Show all variants". Turning on fetches details for every
@@ -479,15 +542,15 @@ export default function ImportCollectionModal({
     setVariantScanProgress(null);
   }, [showAllVariants, ensureDetails]);
 
-  // "Use most popular" escape hatch on the variant-required banner.
-  // Stamps each unresolved row with its primary file id so submission can
-  // proceed on the next Queue click without making the user pick manually.
+  // "Use most popular" escape hatch on the variant-required banner. Stamps
+  // each unresolved row with the primary file as its sole pick so submission
+  // proceeds on the next Queue click without forcing manual picks.
   const acceptDefaults = useCallback(() => {
     setRows((prev) =>
       prev.map((r) => {
         if (!needsVariantPicks.has(r.item.id)) return r;
         if (!r.details?.files || r.details.files.length === 0) return r;
-        return { ...r, pickedFileId: getPrimaryFile(r.details.files).id };
+        return { ...r, pickedFileIds: [getPrimaryFile(r.details.files).id] };
       })
     );
     setNeedsVariantPicks(new Set());
@@ -578,12 +641,14 @@ export default function ImportCollectionModal({
 
     // Re-read after pre-fetch: ensureDetails may have flipped some rows to
     // files-unavailable (auto-deselected) and others now carry their files.
+    // A multi-file row with no explicit pick is ambiguous; one or more picks
+    // resolves it (multi-select lets users grab several variants at once).
     const ambiguous = rowsRef.current.filter((r) => {
       if (!selected.has(r.item.id)) return false;
       if (r.status !== 'idle') return false;
       if (!r.selectable) return false;
       if (!r.details?.files || r.details.files.length <= 1) return false;
-      return r.pickedFileId === undefined;
+      return r.pickedFileIds.length === 0;
     });
 
     if (ambiguous.length > 0) {
@@ -607,7 +672,7 @@ export default function ImportCollectionModal({
     setNeedsVariantPicks(new Set());
 
     // Refresh the snapshot so each row carries its now-cached details and
-    // any pickedFileId the user set while the banner was up.
+    // any picks the user made while the banner was up.
     const toQueue = rowsRef.current.filter(
       (r) => selected.has(r.item.id) && r.status === 'idle' && r.selectable
     );
@@ -624,34 +689,52 @@ export default function ImportCollectionModal({
         continue;
       }
 
-      const file =
-        (row.pickedFileId !== undefined
-          ? details.files.find((f) => f.id === row.pickedFileId)
-          : undefined) ?? getPrimaryFile(details.files);
+      // Resolve the picked ids back to actual GameBananaFile objects (some
+      // could have disappeared between selection and queue), then fall back
+      // to the most-popular file when the row has no explicit picks.
+      const pickedFiles =
+        row.pickedFileIds.length > 0
+          ? row.pickedFileIds
+              .map((id) => details.files!.find((f) => f.id === id))
+              .filter((f): f is GameBananaFile => !!f)
+          : [];
+      const filesToFire =
+        pickedFiles.length > 0 ? pickedFiles : [getPrimaryFile(details.files)];
 
-      // Fire-and-forget: the main-process queue serializes downloads, and
-      // we drive UI state off its events. The catch is only to detect the
-      // user-cancellation rejection so we don't double-mark as failed.
-      updateRow(row.item.id, { status: 'queued', statusMessage: undefined });
-      void downloadMod(
-        row.item.id,
-        file.id,
-        file.fileName,
-        row.item.modelName,
-        row.item.rootCategory?.id
-      ).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message === 'Cancelled by user') {
-          // cancelRow / cancelAll already flipped the UI; nothing to do.
-          return;
-        }
-        // download-error event normally handles this, but if the rejection
-        // beats the event (or we lose the event), surface the failure.
-        const current = rowsRef.current.find((r) => r.item.id === row.item.id);
-        if (current && current.status !== 'failed' && current.status !== 'cancelled') {
-          updateRow(row.item.id, { status: 'failed', statusMessage: message });
-        }
+      // Snapshot expectations so download events can aggregate completion
+      // into a single row status even when multiple files share the modId.
+      updateRow(row.item.id, {
+        status: 'queued',
+        statusMessage: undefined,
+        expectedFileIds: filesToFire.map((f) => f.id),
+        installedFileIds: new Set<number>(),
+        failedFileIds: new Set<number>(),
       });
+
+      for (const file of filesToFire) {
+        // Fire-and-forget: the main-process queue serializes downloads, and
+        // we drive UI state off its events. The catch is only to detect the
+        // user-cancellation rejection so we don't double-mark as failed.
+        void downloadMod(
+          row.item.id,
+          file.id,
+          file.fileName,
+          row.item.modelName,
+          row.item.rootCategory?.id
+        ).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          if (message === 'Cancelled by user') {
+            // cancelRow / cancelAll already flipped the UI; nothing to do.
+            return;
+          }
+          // download-error event normally handles this, but if the rejection
+          // beats the event (or we lose the event), surface the failure.
+          const current = rowsRef.current.find((r) => r.item.id === row.item.id);
+          if (current && current.status !== 'failed' && current.status !== 'cancelled') {
+            updateRow(row.item.id, { status: 'failed', statusMessage: message });
+          }
+        });
+      }
     }
 
     setSubmitting(false);
@@ -841,9 +924,17 @@ export default function ImportCollectionModal({
               const lockedRow = !row.selectable || row.status !== 'idle';
 
               const fileCount = row.details?.files?.length ?? 0;
-              const pickedFile = row.pickedFileId !== undefined && row.details?.files
-                ? row.details.files.find((f) => f.id === row.pickedFileId)
-                : undefined;
+              const pickedFiles = row.details?.files
+                ? row.pickedFileIds
+                    .map((id) => row.details!.files!.find((f) => f.id === id))
+                    .filter((f): f is GameBananaFile => !!f)
+                : [];
+              const pickedSummary =
+                pickedFiles.length === 1
+                  ? pickedFiles[0].fileName
+                  : pickedFiles.length > 1
+                    ? `${pickedFiles.length} variants picked`
+                    : null;
 
               return (
                 <li
@@ -912,9 +1003,12 @@ export default function ImportCollectionModal({
                             )}
                           </button>
                         )}
-                        {pickedFile && (
-                          <span className="text-accent truncate max-w-[260px]" title={pickedFile.fileName}>
-                            · {pickedFile.fileName}
+                        {pickedSummary && (
+                          <span
+                            className="text-accent truncate max-w-[260px]"
+                            title={pickedFiles.map((f) => f.fileName).join('\n')}
+                          >
+                            · {pickedSummary}
                           </span>
                         )}
                       </div>
@@ -986,12 +1080,19 @@ export default function ImportCollectionModal({
                         </div>
                       )}
                       {!row.detailsLoading && !row.detailsError && row.details?.files && row.details.files.length > 0 && (
-                        <ul className="space-y-1">
-                          {row.details.files.map((file) => {
-                            const isPicked =
-                              row.pickedFileId !== undefined
-                                ? row.pickedFileId === file.id
-                                : file.id === getPrimaryFile(row.details!.files!).id;
+                        <>
+                          {row.details.files.length > 1 && (
+                            <p className="text-[11px] text-text-tertiary mb-1.5">
+                              Check one or more variants. Leaving everything unchecked falls back to the most popular file.
+                            </p>
+                          )}
+                          <ul className="space-y-1">
+                            {row.details.files.map((file) => {
+                              const explicit = row.pickedFileIds.includes(file.id);
+                              const isDefault =
+                                row.pickedFileIds.length === 0 &&
+                                file.id === getPrimaryFile(row.details!.files!).id;
+                              const isPicked = explicit || isDefault;
                             return (
                               <li key={file.id}>
                                 <label
@@ -1002,10 +1103,9 @@ export default function ImportCollectionModal({
                                   }`}
                                 >
                                   <input
-                                    type="radio"
-                                    name={`variant-${row.item.id}`}
-                                    checked={isPicked}
-                                    onChange={() => pickVariant(row, file)}
+                                    type="checkbox"
+                                    checked={explicit}
+                                    onChange={() => toggleVariantPick(row, file)}
                                     className="accent-accent cursor-pointer"
                                   />
                                   <span className="truncate flex-1" title={file.fileName}>
@@ -1025,7 +1125,8 @@ export default function ImportCollectionModal({
                               </li>
                             );
                           })}
-                        </ul>
+                          </ul>
+                        </>
                       )}
                     </div>
                   )}

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -73,13 +73,19 @@ interface RowState {
   progress?: { downloaded: number; total: number };
   // Variant picker state. The profile pins a specific (submissionId, fileId),
   // but mods like LowPolyDox ship multiple files (full / lite / per-hero).
-  // Letting the user swap to a different file here means importing someone
-  // else's profile doesn't force their exact taste on you.
+  // Multi-select lets the user swap to a different file or grab several at
+  // once. Empty array means "use the resolver-picked file" (default).
   details?: GameBananaModDetails;
   detailsLoading?: boolean;
   detailsError?: string;
-  pickedFileId?: number;
+  pickedFileIds: number[];
   variantsOpen?: boolean;
+  // Per-file completion tracking. expectedFileIds snapshots what we fired
+  // off at queue time; installed/failed sets aggregate event results so the
+  // single visible row status correctly waits for every download.
+  expectedFileIds?: number[];
+  installedFileIds?: Set<number>;
+  failedFileIds?: Set<number>;
 }
 
 function gbSubmissionId(mod: PortableResolvedMod): number | null {
@@ -88,40 +94,41 @@ function gbSubmissionId(mod: PortableResolvedMod): number | null {
   return ref.submissionId ?? null;
 }
 
-// Pick the file the download pipeline should actually fetch for this row.
-// Picked > resolved (set by the resolver, may differ from the pinned id on
-// "upgraded" rows) > the pinned id from the profile entry.
-function effectiveFileId(r: RowState): number | undefined {
-  if (r.pickedFileId !== undefined) return r.pickedFileId;
-  if (r.mod.resolvedFileId !== undefined) return r.mod.resolvedFileId;
+// Files the download pipeline should fetch for this row. Picks (one or more)
+// override the resolver-picked file. Empty array on a default-state row means
+// "fall back to the resolved file" so single-variant rows don't need any
+// interaction.
+function effectiveFileIds(r: RowState): number[] {
+  if (r.pickedFileIds.length > 0) return r.pickedFileIds;
+  if (r.mod.resolvedFileId !== undefined) return [r.mod.resolvedFileId];
   if (r.mod.entry.source === 'gamebanana') {
     const ref = r.mod.entry.ref as { fileId?: number };
-    return ref.fileId;
+    if (ref.fileId !== undefined) return [ref.fileId];
   }
+  return [];
+}
+
+// Find the display/download name for a specific file id in this row. Falls
+// back to the resolver's name when the id matches the resolved file (handles
+// rows the user hasn't expanded yet).
+function fileNameForId(r: RowState, fileId: number): string | undefined {
+  if (r.details?.files) {
+    const f = r.details.files.find((file) => file.id === fileId);
+    if (f) return f.fileName;
+  }
+  if (fileId === r.mod.resolvedFileId) return r.mod.resolvedFileName;
   return undefined;
 }
 
-function effectiveFileName(r: RowState): string | undefined {
-  if (r.pickedFileId !== undefined && r.details?.files) {
-    const f = r.details.files.find((file) => file.id === r.pickedFileId);
-    if (f) return f.fileName;
-  }
-  return r.mod.resolvedFileName;
-}
-
-// Composite tracking key for download events. A submission can appear several
+// Composite tracking keys for download events. A submission can appear several
 // times in one import (different file versions, or multi-VPK siblings); keying
-// by submissionId alone would cross-update unrelated rows. Multi-VPK siblings
-// genuinely share (submissionId, fileId) and SHOULD update together, since
-// they all ride on a single archive download. Uses the effective fileId so a
-// user-picked variant flows through queue/complete/error matching.
-function rowKey(r: RowState): string | null {
-  if (r.mod.entry.source !== 'gamebanana') return null;
+// by submissionId alone would cross-update unrelated rows. Multi-select means
+// one row can expect events for several fileIds at once.
+function rowEventKeys(r: RowState): string[] {
+  if (r.mod.entry.source !== 'gamebanana') return [];
   const ref = r.mod.entry.ref as { submissionId?: number };
-  if (ref.submissionId === undefined) return null;
-  const fid = effectiveFileId(r);
-  if (fid === undefined) return null;
-  return `${ref.submissionId}:${fid}`;
+  if (ref.submissionId === undefined) return [];
+  return effectiveFileIds(r).map((fid) => `${ref.submissionId}:${fid}`);
 }
 
 function eventKey(modId: number, fileId: number): string {
@@ -171,8 +178,7 @@ export default function ImportProfileDialog({
   const trackedKeys = useMemo(() => {
     const s = new Set<string>();
     for (const r of rows) {
-      const k = rowKey(r);
-      if (k !== null) s.add(k);
+      for (const k of rowEventKeys(r)) s.add(k);
     }
     return s;
   }, [rows]);
@@ -189,9 +195,7 @@ export default function ImportProfileDialog({
 
   // Listen for download events to drive row status during import.
   useEffect(() => {
-    const updateRowsByKey = (key: string, patch: Partial<RowState>) => {
-      setRows((prev) => prev.map((r) => (rowKey(r) === key ? { ...r, ...patch } : r)));
-    };
+    const matches = (r: RowState, key: string) => rowEventKeys(r).includes(key);
 
     const unsubQueue = window.electronAPI.onDownloadQueueUpdated((data) => {
       const queuedSet = new Set(data.queue.map((q) => eventKey(q.modId, q.fileId)));
@@ -200,16 +204,21 @@ export default function ImportProfileDialog({
         : null;
       setRows((prev) =>
         prev.map((r) => {
-          const k = rowKey(r);
-          if (k === null || !trackedKeysRef.current.has(k)) return r;
+          const keys = rowEventKeys(r);
+          if (keys.length === 0) return r;
+          if (!keys.some((k) => trackedKeysRef.current.has(k))) return r;
           if (
             r.status === 'installed' ||
             r.status === 'already-installed' ||
             r.status === 'failed' ||
             r.status === 'skipped'
           ) return r;
-          if (currentKey === k) return r.status === 'downloading' ? r : { ...r, status: 'downloading' };
-          if (queuedSet.has(k)) return r.status === 'queued' ? r : { ...r, status: 'queued' };
+          if (currentKey && keys.includes(currentKey)) {
+            return r.status === 'downloading' ? r : { ...r, status: 'downloading' };
+          }
+          if (keys.some((k) => queuedSet.has(k))) {
+            return r.status === 'queued' ? r : { ...r, status: 'queued' };
+          }
           return r;
         })
       );
@@ -218,23 +227,51 @@ export default function ImportProfileDialog({
     const unsubComplete = window.electronAPI.onDownloadComplete(({ modId, fileId }) => {
       const k = eventKey(modId, fileId);
       if (!trackedKeysRef.current.has(k)) return;
-      updateRowsByKey(k, { status: 'installed', statusMessage: undefined });
+      // Multi-select: hold the row in flight until every expected file lands.
+      setRows((prev) =>
+        prev.map((r) => {
+          if (!matches(r, k)) return r;
+          const installed = new Set(r.installedFileIds ?? []);
+          installed.add(fileId);
+          const expected = r.expectedFileIds;
+          const allDone =
+            expected !== undefined &&
+            expected.length > 0 &&
+            expected.every((id) => installed.has(id));
+          return {
+            ...r,
+            installedFileIds: installed,
+            status: allDone ? 'installed' : r.status,
+            statusMessage: allDone ? undefined : r.statusMessage,
+          };
+        })
+      );
     });
 
     const unsubError = window.electronAPI.onDownloadError(({ modId, fileId, message }) => {
       const k = eventKey(modId, fileId);
       if (!trackedKeysRef.current.has(k)) return;
-      updateRowsByKey(k, { status: 'failed', statusMessage: message });
+      // Any file failing fails the whole row so the user sees something is
+      // wrong; the per-file set records which one in case we add retries.
+      setRows((prev) =>
+        prev.map((r) => {
+          if (!matches(r, k)) return r;
+          const failed = new Set(r.failedFileIds ?? []);
+          failed.add(fileId);
+          return { ...r, failedFileIds: failed, status: 'failed', statusMessage: message };
+        })
+      );
     });
 
     const unsubProgress = window.electronAPI.onDownloadProgress(({ modId, fileId, downloaded, total }) => {
       const k = eventKey(modId, fileId);
       if (!trackedKeysRef.current.has(k)) return;
+      // With multi-select, several files share a row. Showing the latest
+      // file's progress (rather than averaging) keeps the bar responsive:
+      // when one file finishes, the bar jumps to the next file starting.
       setRows((prev) =>
         prev.map((r) =>
-          rowKey(r) === k
-            ? { ...r, progress: { downloaded, total } }
-            : r
+          matches(r, k) ? { ...r, progress: { downloaded, total } } : r
         )
       );
     });
@@ -264,6 +301,7 @@ export default function ImportProfileDialog({
           mod,
           selected: mod.status !== 'unresolvable',
           status: mod.alreadyInstalled ? 'already-installed' : 'pending',
+          pickedFileIds: [],
         }))
       );
     } catch (err) {
@@ -370,19 +408,24 @@ export default function ImportProfileDialog({
     [ensureDetailsForRow, updateRowAt]
   );
 
-  const pickVariant = useCallback(
+  const toggleVariantPick = useCallback(
     (idx: number, file: GameBananaFile) => {
       setRows((prev) =>
         prev.map((r, i) => {
           if (i !== idx) return r;
-          const patch: RowState = { ...r, pickedFileId: file.id };
-          // Picking a different file than what's currently on disk means
-          // the on-disk match no longer represents the user's choice. Flip
-          // to pending so handleConfirm queues a download.
-          if (
-            r.status === 'already-installed' &&
-            file.id !== r.mod.resolvedFileId
-          ) {
+          const has = r.pickedFileIds.includes(file.id);
+          const nextPicks = has
+            ? r.pickedFileIds.filter((id) => id !== file.id)
+            : [...r.pickedFileIds, file.id];
+          const patch: RowState = { ...r, pickedFileIds: nextPicks };
+          // The on-disk match was only for the resolver's file. As soon as
+          // the user picks anything other than (or in addition to) that
+          // file, finalize will need fresh downloads, so flip out of the
+          // already-installed badge.
+          const matchesResolvedOnly =
+            nextPicks.length === 0 ||
+            (nextPicks.length === 1 && nextPicks[0] === r.mod.resolvedFileId);
+          if (r.status === 'already-installed' && !matchesResolvedOnly) {
             patch.status = 'pending';
           }
           return patch;
@@ -448,47 +491,59 @@ export default function ImportProfileDialog({
     setImporting(true);
     setFinalizeError(null);
 
-    const toDownload: RowState[] = [];
-    const startingRows = rowsRef.current.map((r) => {
+    // Build per-row download plan and start each row in its initial status.
+    // Default-state already-installed rows skip the download pipeline; rows
+    // with explicit picks always queue, even if some picked file happens to
+    // be on disk (the user's choice trumps the optimization).
+    const plan: { idx: number; fileIds: number[] }[] = [];
+    const startingRows = rowsRef.current.map((r, idx) => {
       if (!r.selected || r.mod.status === 'unresolvable') {
         return { ...r, status: 'skipped' as RowStatus };
       }
-      // The on-disk match is for the resolved file; if the user picked a
-      // different variant, we have to actually download it.
-      const pickedDiffers =
-        r.pickedFileId !== undefined && r.pickedFileId !== r.mod.resolvedFileId;
-      if (r.mod.alreadyInstalled && !pickedDiffers) {
-        // Selected and on disk — no work to do, keep the badge and let
-        // finalize wire the existing VPK into the new profile.
+      if (r.pickedFileIds.length === 0 && r.mod.alreadyInstalled) {
         return { ...r, status: 'already-installed' as RowStatus };
       }
-      toDownload.push(r);
-      return { ...r, status: 'queued' as RowStatus };
+      const fileIds = effectiveFileIds(r);
+      if (fileIds.length === 0) {
+        return { ...r, status: 'skipped' as RowStatus };
+      }
+      plan.push({ idx, fileIds });
+      return {
+        ...r,
+        status: 'queued' as RowStatus,
+        expectedFileIds: fileIds,
+        installedFileIds: new Set<number>(),
+        failedFileIds: new Set<number>(),
+      };
     });
     setRows(startingRows);
 
-    for (const row of toDownload) {
+    for (const { idx, fileIds } of plan) {
+      const row = startingRows[idx];
       if (row.mod.entry.source !== 'gamebanana') continue;
-      const fileId = effectiveFileId(row);
-      const fileName = effectiveFileName(row);
-      if (fileId === undefined || !fileName) continue;
       const ref = row.mod.entry.ref as { submissionId: number; section?: string };
-      const failKey = eventKey(ref.submissionId, fileId);
-      void downloadMod(
-        ref.submissionId,
-        fileId,
-        fileName,
-        ref.section || 'Mod'
-      ).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        setRows((prev) =>
-          prev.map((r) =>
-            rowKey(r) === failKey && r.status !== 'installed'
-              ? { ...r, status: 'failed', statusMessage: message }
-              : r
-          )
-        );
-      });
+      for (const fileId of fileIds) {
+        const fileName = fileNameForId(row, fileId);
+        if (!fileName) continue;
+        const failKey = eventKey(ref.submissionId, fileId);
+        void downloadMod(
+          ref.submissionId,
+          fileId,
+          fileName,
+          ref.section || 'Mod'
+        ).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          setRows((prev) =>
+            prev.map((r) => {
+              if (!rowEventKeys(r).includes(failKey)) return r;
+              if (r.status === 'installed') return r;
+              const failed = new Set(r.failedFileIds ?? []);
+              failed.add(fileId);
+              return { ...r, failedFileIds: failed, status: 'failed', statusMessage: message };
+            })
+          );
+        });
+      }
     }
   }, [parsed, report, activeDeadlockPath]);
 
@@ -513,19 +568,25 @@ export default function ImportProfileDialog({
       const installedEntries: PortableResolvedMod[] = [];
       for (const r of rowsRef.current) {
         if (r.status !== 'installed' && r.status !== 'already-installed') continue;
-        // When the user picked a different variant, finalize needs the
-        // picked fileId to find the VPK we just installed on disk.
-        const picked =
-          r.pickedFileId !== undefined &&
-          r.pickedFileId !== r.mod.resolvedFileId;
-        if (picked) {
+        // Default state: no picks made, fall through to the resolver's
+        // single (submissionId, resolvedFileId) so finalize wires the
+        // already-on-disk VPK into the new profile unchanged.
+        if (r.pickedFileIds.length === 0) {
+          installedEntries.push(r.mod);
+          continue;
+        }
+        // Picked one or more variants: synthesize a PortableResolvedMod per
+        // picked file so finalize can look up each on-disk VPK and add it.
+        // Skip ids we can't name (very rare: a file vanished between scan
+        // and download).
+        for (const fileId of r.pickedFileIds) {
+          const fileName = fileNameForId(r, fileId);
+          if (!fileName) continue;
           installedEntries.push({
             ...r.mod,
-            resolvedFileId: r.pickedFileId,
-            resolvedFileName: effectiveFileName(r) ?? r.mod.resolvedFileName,
+            resolvedFileId: fileId,
+            resolvedFileName: fileName,
           });
-        } else {
-          installedEntries.push(r.mod);
         }
       }
       try {
@@ -857,10 +918,17 @@ export default function ImportProfileDialog({
                   const fileCount = r.details?.files?.length ?? 0;
                   const canPickVariants =
                     !isUnresolvable && submissionId !== null;
-                  const pickedFile =
-                    r.pickedFileId !== undefined && r.details?.files
-                      ? r.details.files.find((f) => f.id === r.pickedFileId)
-                      : undefined;
+                  const pickedFiles = r.details?.files
+                    ? r.pickedFileIds
+                        .map((id) => r.details!.files!.find((f) => f.id === id))
+                        .filter((f): f is GameBananaFile => !!f)
+                    : [];
+                  const pickedSummary =
+                    pickedFiles.length === 1
+                      ? pickedFiles[0].fileName
+                      : pickedFiles.length > 1
+                        ? `${pickedFiles.length} variants picked`
+                        : null;
                   const progressPct =
                     r.status === 'downloading' && r.progress && r.progress.total > 0
                       ? Math.min(100, (r.progress.downloaded / r.progress.total) * 100)
@@ -928,12 +996,12 @@ export default function ImportProfileDialog({
                                 )}
                               </button>
                             )}
-                            {pickedFile && (
+                            {pickedSummary && (
                               <span
                                 className="text-accent truncate max-w-[14rem]"
-                                title={pickedFile.fileName}
+                                title={pickedFiles.map((f) => f.fileName).join('\n')}
                               >
-                                · {pickedFile.fileName}
+                                · {pickedSummary}
                               </span>
                             )}
                           </div>
@@ -1026,28 +1094,34 @@ export default function ImportProfileDialog({
                             </div>
                           )}
                           {!r.detailsLoading && !r.detailsError && r.details?.files && r.details.files.length > 0 && (
-                            <ul className="space-y-1">
-                              {r.details.files.map((file) => {
-                                const selectedId =
-                                  r.pickedFileId !== undefined ? r.pickedFileId : r.mod.resolvedFileId;
-                                const isPicked = selectedId === file.id;
-                                return (
-                                  <li key={file.id}>
-                                    <label
-                                      className={`flex items-center gap-2.5 px-3 py-1.5 rounded-sm cursor-pointer text-sm border ${
-                                        isPicked
-                                          ? 'bg-accent/10 border-accent/40 text-text-primary'
-                                          : 'border-transparent hover:bg-white/5 text-text-secondary'
-                                      }`}
-                                    >
-                                      <input
-                                        type="radio"
-                                        name={`variant-${idx}`}
-                                        checked={isPicked}
-                                        onChange={() => pickVariant(idx, file)}
-                                        disabled={importing}
-                                        className="accent-accent cursor-pointer disabled:cursor-default"
-                                      />
+                            <>
+                              {r.details.files.length > 1 && (
+                                <p className="text-[11px] text-text-tertiary mb-1.5">
+                                  Check one or more variants. Leaving everything unchecked uses the file pinned by the profile.
+                                </p>
+                              )}
+                              <ul className="space-y-1">
+                                {r.details.files.map((file) => {
+                                  const explicit = r.pickedFileIds.includes(file.id);
+                                  const isDefault =
+                                    r.pickedFileIds.length === 0 && file.id === r.mod.resolvedFileId;
+                                  const isPicked = explicit || isDefault;
+                                  return (
+                                    <li key={file.id}>
+                                      <label
+                                        className={`flex items-center gap-2.5 px-3 py-1.5 rounded-sm cursor-pointer text-sm border ${
+                                          isPicked
+                                            ? 'bg-accent/10 border-accent/40 text-text-primary'
+                                            : 'border-transparent hover:bg-white/5 text-text-secondary'
+                                        }`}
+                                      >
+                                        <input
+                                          type="checkbox"
+                                          checked={explicit}
+                                          onChange={() => toggleVariantPick(idx, file)}
+                                          disabled={importing}
+                                          className="accent-accent cursor-pointer disabled:cursor-default"
+                                        />
                                       <span className="truncate flex-1" title={file.fileName}>
                                         {file.fileName}
                                       </span>
@@ -1067,7 +1141,8 @@ export default function ImportProfileDialog({
                                   </li>
                                 );
                               })}
-                            </ul>
+                              </ul>
+                            </>
                           )}
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- Variant picker on both Import Collection and Import Profile now uses **checkboxes** so users can grab several files from a single GameBanana listing in one pass (multi-hero sound mods, side-by-side cosmetics, full+lite combos, etc.).
- Leaving everything unchecked keeps the previous fallback: collection import grabs the most-popular file, profile import uses the file pinned by the source profile.
- Each row aggregates per-file download events: status stays in flight until every expected fileId has landed, then flips to *Installed*. Failures fail the whole row.
- Profile finalize synthesizes one `PortableResolvedMod` per picked file so all installed VPKs end up in the new local profile.
- Bumps `package.json` to `1.11.2`.

## Test plan
- [ ] Import a collection containing a multi-file Sounds mod (e.g. one with multiple heroes). Check several files in the variant picker, hit Queue, confirm all picked files download and the row status only flips to Installed once every download completes.
- [ ] Leave all variants unchecked and queue: confirm fallback to most-popular file still works (single download).
- [ ] In the variant-required banner flow (multi-file selection with no picks), confirm *Use most popular* still works.
- [ ] Import a `.modprofile.json` for a multi-variant mod. Check two extra variants in the picker, confirm both download, and verify the resulting local profile contains entries for the picked files.
- [ ] Confirm an already-on-disk row with no manual picks still shows *On disk* and skips download.
- [ ] Confirm picking a variant on a previously *On disk* row flips it to *Ready* so it actually downloads.