### PR TITLE
perf(conflicts): cache VPK parse + dedupe getConflicts IPC

### DIFF
--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -1,5 +1,5 @@
 import { scanMods, Mod } from './mods';
-import { parseVpkDirectory } from './vpk';
+import { parseVpkDirectoryCached } from './vpk';
 import { loadSettings } from './settings';
 import { getModMetadata } from './metadata';
 
@@ -167,7 +167,7 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     // Parse VPK file lists
     const modFileLists = new Map<string, Set<string>>();
     for (const mod of enabledMods) {
-        const files = parseVpkDirectory(mod.path);
+        const files = parseVpkDirectoryCached(mod.path);
         if (files && files.length > 0) {
             modFileLists.set(mod.id, new Set(files));
         }

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -1,4 +1,4 @@
-import { openSync, readSync, closeSync, existsSync } from 'fs';
+import { openSync, readSync, closeSync, existsSync, statSync } from 'fs';
 import { heroForSoundCodename } from './heroSoundCodenames';
 
 /**
@@ -27,6 +27,50 @@ function readNullTerminatedString(buffer: Buffer, offset: number): { str: string
     }
     const str = buffer.slice(offset, end).toString('utf-8');
     return { str, bytesRead: end - offset + 1 }; // +1 for null terminator
+}
+
+// Cache parsed VPK file lists keyed by (path, mtime, size). Conflict
+// detection re-parses every enabled VPK on each scan, which previously
+// pinned the main process for hundreds of ms with 60+ mods. Invalidates
+// automatically when the file changes on disk; entries for deleted/missing
+// VPKs are dropped opportunistically.
+interface VpkCacheEntry {
+    mtimeMs: number;
+    size: number;
+    paths: string[] | null;
+}
+const vpkParseCache = new Map<string, VpkCacheEntry>();
+
+export function invalidateVpkParseCache(vpkPath?: string): void {
+    if (vpkPath) {
+        vpkParseCache.delete(vpkPath);
+    } else {
+        vpkParseCache.clear();
+    }
+}
+
+/**
+ * Parsed VPK file list with on-disk-aware caching. Re-uses the previous
+ * parse when (path, mtime, size) is unchanged; otherwise falls through to
+ * `parseVpkDirectory` and stores the fresh result.
+ */
+export function parseVpkDirectoryCached(vpkPath: string): string[] | null {
+    let stat;
+    try {
+        stat = statSync(vpkPath);
+    } catch {
+        vpkParseCache.delete(vpkPath);
+        return null;
+    }
+
+    const cached = vpkParseCache.get(vpkPath);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+        return cached.paths;
+    }
+
+    const paths = parseVpkDirectory(vpkPath);
+    vpkParseCache.set(vpkPath, { mtimeMs: stat.mtimeMs, size: stat.size, paths });
+    return paths;
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -335,8 +335,21 @@ export interface ModConflict {
   details: string;
 }
 
+// Conflict detection re-parses every enabled VPK on the main process, so
+// firing it twice for the same store update (Sidebar badge + Installed
+// page) doubled the freeze window. Concurrent callers share the in-flight
+// promise; once it resolves, the next call starts a fresh scan so any
+// state change since then is picked up immediately.
+let conflictsInFlight: Promise<ModConflict[]> | null = null;
+
 export async function getConflicts(): Promise<ModConflict[]> {
-  return window.electronAPI.getConflicts();
+  if (conflictsInFlight) return conflictsInFlight;
+  const promise = window.electronAPI.getConflicts();
+  conflictsInFlight = promise;
+  promise.finally(() => {
+    if (conflictsInFlight === promise) conflictsInFlight = null;
+  });
+  return promise;
 }
 
 export async function getIgnoredConflicts(): Promise<string[]> {


### PR DESCRIPTION
## Summary

Fixes the ANR / stutter reported in Discord (#bugs → "App not responding"). At ~60-70 installed mods the app would stutter on window-drag, mod clicks, and route changes. The reporter was on v1.10.5; the same code path is present on main.

Root cause: two effects (Sidebar badge + Installed page) both watch the Zustand mods array ref and call \`getConflicts()\` whenever it changes. Each call hits \`detectConflicts\` in main, which synchronously parses every enabled VPK and does O(n²) set intersection. Window focus also fires \`loadMods()\`, so alt-tabbing back was triggering two full disk-bound scans in parallel and pinning the main process event loop. Main-process pin = window drag jank + queued IPCs = stutter on every click.

## Changes

- **\`parseVpkDirectoryCached\`** in \`electron/main/services/vpk.ts\` — caches parsed file lists keyed by \`(path, mtimeMs, size)\`. Cache invalidates automatically when the VPK is overwritten (re-download) or deleted, so no explicit flush is needed.
- **\`conflicts.ts\`** swapped to the cached parser. Existing \`parseVpkDirectory\` callers (unknown-mod CRC matcher, hero extraction in vpk.ts itself) are unchanged.
- **\`getConflicts\`** in \`src/lib/api.ts\` shares one in-flight promise across concurrent callers, so the Sidebar/Installed pair only triggers one IPC roundtrip per store update. No post-resolve hold — subsequent toggles still see fresh data.

## Expected impact (70 installed mods)

- First scan: same cost as today (cold cache).
- Every scan after: ~70 cache hits, only newly-installed mods do a real VPK parse. Per-scan cost drops from hundreds of ms to tens of ms.
- Window focus / mod toggle no longer fires two parallel scans.

## Test plan

- [x] \`pnpm exec tsc -p tsconfig.node.json --noEmit\` clean
- [x] \`pnpm exec tsc -p tsconfig.app.json --noEmit\` clean
- [x] \`pnpm lint\` clean (3 pre-existing warnings unrelated to this PR)
- [x] \`pnpm build\` succeeds for main + preload + renderer
- [ ] Manual: install many mods, watch main-process responsiveness while toggling / alt-tabbing
- [ ] Manual: ignore/unignore a conflict on the Conflicts page — badge updates correctly (no stale cache)