### PR TITLE
feat(browse, installed): "No hero" sound filter + bulk locker tagging

### DIFF
--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -167,7 +167,7 @@ export default function Browse() {
   const setViewMode = useCallback((v: ViewMode) => setBrowseUi({ viewMode: v }), [setBrowseUi]);
   const setSort = useCallback((v: SortOption) => setBrowseUi({ sort: v }), [setBrowseUi]);
   const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
-  const setHeroCategoryId = useCallback((v: number | 'all') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
+  const setHeroCategoryId = useCallback((v: number | 'all' | 'none') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
   const setCategoryId = useCallback((v: number | 'all') => setBrowseUi({ categoryId: v }), [setBrowseUi]);
 
   // Hydrate from session cache on mount so navigating away + back doesn't
@@ -313,8 +313,11 @@ export default function Browse() {
     fetchInitialQueueState();
   }, []);
 
+  // 'none' = client-side post-filter for Sound mods without a hero in the
+  // title. The fetch path sees it as "no category filter" so the API doesn't
+  // get a nonsense id; the actual exclusion happens against displayMods.
   const effectiveCategoryId =
-    heroCategoryId === 'all'
+    heroCategoryId === 'all' || heroCategoryId === 'none'
       ? (categoryId === 'all' ? undefined : categoryId)
       : heroCategoryId;
 
@@ -1144,9 +1147,16 @@ export default function Browse() {
 
   // Just use all loaded mods - infinite scroll handles pagination.
   // Hide outdated mods if the user has opted in.
-  const displayMods = settings?.hideOutdatedMods
+  let displayMods = settings?.hideOutdatedMods
     ? mods.filter((m) => !m.dateModified || !isModOutdated(m.dateModified))
     : mods;
+  // "(No hero)" Sound filter — GameBanana Sound categories don't carry hero
+  // metadata, so hero association is purely from the title. When the user
+  // picks the pseudo-hero "none", drop anything whose title matches a known
+  // hero so they see item/UI/music/announcer sounds only.
+  if (section === 'Sound' && heroCategoryId === 'none') {
+    displayMods = displayMods.filter((m) => inferHeroFromTitle(m.name) === null);
+  }
 
   if (!activeDeadlockPath) {
     return (
@@ -1401,7 +1411,7 @@ export default function Browse() {
 
                   {filtersOpen && (
                     <div
-                      className="absolute right-0 top-full mt-2 z-20 w-72 bg-bg-secondary border border-border rounded-lg shadow-xl p-4 animate-fade-in"
+                      className="absolute right-0 top-full mt-2 z-50 w-72 bg-bg-secondary border border-border rounded-lg shadow-xl p-4 animate-fade-in"
                       role="dialog"
                       aria-label="Filters"
                     >
@@ -1427,10 +1437,18 @@ export default function Browse() {
                             <span className="block text-xs font-medium text-text-secondary mb-1.5">Hero</span>
                             <select
                               value={String(heroCategoryId)}
-                              onChange={(e) => setHeroCategoryId(e.target.value === 'all' ? 'all' : Number(e.target.value))}
+                              onChange={(e) => {
+                                const v = e.target.value;
+                                if (v === 'all') setHeroCategoryId('all');
+                                else if (v === 'none') setHeroCategoryId('none');
+                                else setHeroCategoryId(Number(v));
+                              }}
                               className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
                             >
                               <option value="all">All Heroes</option>
+                              {section === 'Sound' && (
+                                <option value="none">No hero (item / UI / music)</option>
+                              )}
                               {heroOptions.map((hero) => (
                                 <option key={hero.id} value={String(hero.id)}>{hero.label}</option>
                               ))}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -26,6 +26,7 @@ import {
   Scissors,
   Share2,
   Beaker,
+  Tag as TagIcon,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -42,7 +43,8 @@ import VariantPickerModal from '../components/VariantPickerModal';
 import MergeModsModal from '../components/MergeModsModal';
 import MergedContentsModal from '../components/MergedContentsModal';
 import PriorityEditor from '../components/PriorityEditor';
-import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition } from '../lib/lockerUtils';
+import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, HERO_NAMES } from '../lib/lockerUtils';
+import { setModLockerHero } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
 import { PageHeader, ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
@@ -259,7 +261,7 @@ export default function Installed() {
   // action bar swaps its buttons for a "Enabling 2/5…" line so users see
   // incremental progress on large selections.
   const [bulkProgress, setBulkProgress] = useState<{
-    verb: 'Enabling' | 'Disabling';
+    verb: 'Enabling' | 'Disabling' | 'Tagging';
     done: number;
     total: number;
   } | null>(null);
@@ -836,6 +838,48 @@ export default function Installed() {
     }
     setBulkProgress(null);
     exitSelectMode();
+  };
+
+  // Bulk lockerHero retag. Writes the manual tag for every selected mod and
+  // refreshes — Locker grouping picks the change up on its next mods read.
+  // Pass null to clear the manual tag and fall back to title/category inference.
+  const [tagMenuOpen, setTagMenuOpen] = useState(false);
+  const tagMenuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!tagMenuOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (tagMenuRef.current && !tagMenuRef.current.contains(e.target as Node)) {
+        setTagMenuOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setTagMenuOpen(false);
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [tagMenuOpen]);
+
+  const handleBulkTag = async (heroName: string | null) => {
+    if (selectedMods.length === 0) return;
+    setTagMenuOpen(false);
+    const targets = [...selectedMods];
+    setBulkProgress({ verb: 'Tagging', done: 0, total: targets.length });
+    try {
+      for (let i = 0; i < targets.length; i++) {
+        await setModLockerHero(targets[i].id, heroName);
+        setBulkProgress({ verb: 'Tagging', done: i + 1, total: targets.length });
+      }
+      await loadMods();
+    } catch (err) {
+      console.error('[Installed] Bulk tag failed:', err);
+    } finally {
+      setBulkProgress(null);
+      exitSelectMode();
+    }
   };
 
   const openBulkDeleteConfirm = () => {
@@ -2241,6 +2285,48 @@ export default function Installed() {
                   Merge{selectedMods.length >= 2 ? ` (${selectedMods.length})` : ''}
                 </Button>
               )}
+              <div className="relative" ref={tagMenuRef}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={selectedMods.length === 0}
+                  icon={TagIcon}
+                  onClick={() => setTagMenuOpen((v) => !v)}
+                  title={
+                    selectedMods.length === 0
+                      ? 'Select mods to tag for the Locker'
+                      : `Tag ${selectedMods.length} mod${selectedMods.length === 1 ? '' : 's'} for a hero in the Locker`
+                  }
+                >
+                  Tag{selectedMods.length > 0 ? ` (${selectedMods.length})` : ''}
+                </Button>
+                {tagMenuOpen && selectedMods.length > 0 && (
+                  <div
+                    role="dialog"
+                    aria-label="Tag selected mods for a hero"
+                    className="absolute bottom-full mb-2 right-0 z-[60] w-56 max-h-80 overflow-y-auto bg-bg-secondary border border-border rounded-lg shadow-xl p-1 animate-fade-in"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => handleBulkTag(null)}
+                      className="w-full text-left text-xs px-2 py-1.5 rounded hover:bg-bg-tertiary text-text-secondary hover:text-text-primary cursor-pointer"
+                    >
+                      Clear manual tag
+                    </button>
+                    <div className="my-1 h-px bg-border" />
+                    {HERO_NAMES.map((name) => (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={() => handleBulkTag(name)}
+                        className="w-full text-left text-xs px-2 py-1.5 rounded hover:bg-bg-tertiary text-text-primary cursor-pointer"
+                      >
+                        {name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
               <Button
                 variant="danger"
                 size="sm"

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -555,7 +555,7 @@ export function LockerHeroView({
               heroName={hero.name}
               emptyMessage={
                 activeSection === 'sounds'
-                  ? 'No sound mods tagged for this hero yet. Tag one from the Locker.'
+                  ? 'No sound mods tagged for this hero yet. Tag one from Installed (multi-select → Tag).'
                   : 'Download a skin for this hero to manage it here.'
               }
               minaPresets={activeSection === 'skins' ? minaPresets : []}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -22,7 +22,10 @@ export interface BrowseUiState {
   viewMode: BrowseViewMode;
   sort: BrowseSortOption;
   section: string;
-  heroCategoryId: number | 'all';
+  // 'none' is a Sound-only pseudo-hero: "show me sound mods whose title
+  // doesn't resolve to any known hero" (item sounds, UI, music, etc.).
+  // For Mod section it collapses to 'all' since every Skin lives under a hero.
+  heroCategoryId: number | 'all' | 'none';
   categoryId: number | 'all';
 }
 


### PR DESCRIPTION
## Summary

- **Browse → Sound section**: new "(No hero)" entry on the Hero filter dropdown. Hides any sound mod whose title resolves to a known hero, surfacing item / UI / music / announcer sounds. Client-side post-filter on `displayMods` since GameBanana sound categories don't carry hero metadata.
- **Browse → Filters popover**: bumped to `z-50` so the audio-player slider on mod cards behind it stops rendering on top.
- **Installed → bulk-edit action bar**: new **Tag** button. Multi-select mods, pick a hero (or "Clear manual tag"), and `setModLockerHero` is applied to every selection with progress shown in the existing bulk progress bar.

Resolves the kazmahtazz "no heroes" filter ask and thywhomstd "where do I tag a mod" ask from #feature-requests / #general today.

## Test plan

- [ ] Browse → Sounds section → open Filters → pick "(No hero)" → verify Pocket VOs / Haze ult mods disappear and Killsounds / music / UI sounds remain
- [ ] Same filter does NOT appear on the Mods (Skins) section
- [ ] Switching Mods ↔ Sounds resets the Hero filter back to "All Heroes"
- [ ] On a mod card with an audio preview, open Filters and confirm the popover sits above the slider
- [ ] Installed → enter selection mode → select 1+ mods → click Tag → pick a hero → confirm bar shows `Tagging X/Y…`, exits selection, and the mods appear under that hero in Locker
- [ ] Tag → "Clear manual tag" on a previously-tagged mod restores title/category inference
- [ ] Tag button disabled when no mods selected