### PR TITLE
chore(diagnostics): log conflict-scan timing and event-loop blocks

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -10,6 +10,13 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { initLogger } from './services/diagnostics';
 initLogger();
 
+// Start the event-loop lag monitor right after the logger so its periodic
+// "[event-loop] blocked Xms" warnings land in the same rolling file. The
+// monitor only logs when the loop is genuinely stalled (>=100ms in a 10s
+// window), so it stays quiet on a healthy session.
+import { initEventLoopMonitor } from './services/eventLoopMonitor';
+initEventLoopMonitor();
+
 import {
     GRIMOIRE_PROTOCOL,
     findGrimoireUrlInArgv,

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -1,5 +1,5 @@
 import { scanMods, Mod } from './mods';
-import { parseVpkDirectoryCached } from './vpk';
+import { parseVpkDirectoryCached, type VpkParseStats } from './vpk';
 import { loadSettings } from './settings';
 import { getModMetadata } from './metadata';
 
@@ -125,11 +125,19 @@ function createConflict(
  * Two mods conflict if they have overlapping file paths.
  */
 export async function detectConflicts(deadlockPath: string): Promise<ModConflict[]> {
+    // Track scan duration + cache hit rate so user-supplied diagnostic
+    // reports tell us whether the conflict scan is actually the thing
+    // freezing the main process on their machine. Without this we can
+    // only infer from code review.
+    const scanStart = Date.now();
+    const vpkStats: VpkParseStats = { hits: 0, misses: 0 };
+
     const mods = await scanMods(deadlockPath);
     const enabledMods = mods.filter(m => m.enabled);
     const conflicts: ModConflict[] = [];
 
     if (enabledMods.length < 2) {
+        console.log(`[detectConflicts] enabled=${enabledMods.length} took=${Date.now() - scanStart}ms (trivial)`);
         return [];
     }
 
@@ -167,7 +175,7 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     // Parse VPK file lists
     const modFileLists = new Map<string, Set<string>>();
     for (const mod of enabledMods) {
-        const files = parseVpkDirectoryCached(mod.path);
+        const files = parseVpkDirectoryCached(mod.path, vpkStats);
         if (files && files.length > 0) {
             modFileLists.set(mod.id, new Set(files));
         }
@@ -220,5 +228,11 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             !ignored.has(conflictPairKey(c.modA, c.modB))
         );
 
+    console.log(
+        `[detectConflicts] enabled=${enabledMods.length} ` +
+        `pairs=${filtered.length} ` +
+        `vpkCache=${vpkStats.hits}/${vpkStats.hits + vpkStats.misses} ` +
+        `took=${Date.now() - scanStart}ms`
+    );
     return filtered;
 }

--- a/electron/main/services/eventLoopMonitor.ts
+++ b/electron/main/services/eventLoopMonitor.ts
@@ -1,0 +1,44 @@
+// Event-loop lag monitor for the main process.
+//
+// Bug reports that say "the app stutters" or "window dragging is laggy" are
+// hard to triage without knowing whether the main-process event loop is
+// actually being blocked. Node's perf_hooks histogram samples loop delay in
+// native code (no JS overhead per sample), and we log a one-line summary
+// every WINDOW_MS but only when something noticeable happened. That keeps
+// the rolling log readable when the app is idle and surfaces real freezes
+// when they occur.
+
+import { monitorEventLoopDelay, IntervalHistogram } from 'perf_hooks';
+
+const SAMPLE_RESOLUTION_MS = 20;
+const WINDOW_MS = 10_000;
+// Only log when the worst sample in the window crossed this threshold. A
+// healthy loop sits well under 50ms; 100ms+ is where users start to feel it.
+const REPORT_THRESHOLD_MS = 100;
+
+let histogram: IntervalHistogram | null = null;
+let timer: NodeJS.Timeout | null = null;
+
+export function initEventLoopMonitor(): void {
+    if (histogram) return;
+    histogram = monitorEventLoopDelay({ resolution: SAMPLE_RESOLUTION_MS });
+    histogram.enable();
+
+    timer = setInterval(() => {
+        if (!histogram) return;
+        const maxMs = histogram.max / 1e6;
+        if (maxMs >= REPORT_THRESHOLD_MS) {
+            const p99Ms = histogram.percentile(99) / 1e6;
+            const meanMs = histogram.mean / 1e6;
+            console.warn(
+                `[event-loop] blocked max=${maxMs.toFixed(0)}ms ` +
+                `p99=${p99Ms.toFixed(0)}ms mean=${meanMs.toFixed(1)}ms ` +
+                `over last ${WINDOW_MS / 1000}s`
+            );
+        }
+        histogram.reset();
+    }, WINDOW_MS);
+    // Don't keep the process alive just for the monitor — app quit should
+    // close the loop normally even with the interval pending.
+    timer.unref();
+}

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -49,12 +49,20 @@ export function invalidateVpkParseCache(vpkPath?: string): void {
     }
 }
 
+/** Optional counters callers can pass through a batch of cache lookups to
+ *  measure hit rate. Conflict detection uses this to log whether the cache
+ *  is doing its job on a given user's machine. */
+export interface VpkParseStats {
+    hits: number;
+    misses: number;
+}
+
 /**
  * Parsed VPK file list with on-disk-aware caching. Re-uses the previous
  * parse when (path, mtime, size) is unchanged; otherwise falls through to
  * `parseVpkDirectory` and stores the fresh result.
  */
-export function parseVpkDirectoryCached(vpkPath: string): string[] | null {
+export function parseVpkDirectoryCached(vpkPath: string, stats?: VpkParseStats): string[] | null {
     let stat;
     try {
         stat = statSync(vpkPath);
@@ -65,9 +73,11 @@ export function parseVpkDirectoryCached(vpkPath: string): string[] | null {
 
     const cached = vpkParseCache.get(vpkPath);
     if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+        if (stats) stats.hits++;
         return cached.paths;
     }
 
+    if (stats) stats.misses++;
     const paths = parseVpkDirectory(vpkPath);
     vpkParseCache.set(vpkPath, { mtimeMs: stat.mtimeMs, size: stat.size, paths });
     return paths;


### PR DESCRIPTION
## Summary

Follow-up to #59. Two log additions that give us real numbers on the next "app stutters" report, since today's diagnostic file shows what called what but not how long anything took or whether the main thread was actually blocked.

- **\`detectConflicts\`** logs \`enabled=N pairs=K vpkCache=H/T took=Xms\` at the end of every scan. Tells us whether the VPK cache from #59 is actually helping on a real user's machine, and how long a scan takes there.
- **\`eventLoopMonitor\`** uses Node's \`perf_hooks\` histogram to sample main-process event-loop delay. Logs a one-line \`[event-loop] blocked Xms\` warning every 10s only when the worst sample crossed 100ms. Native sampling (no per-tick JS overhead), histogram \`unref()\`'d so it doesn't hold the process open.

## Why both

If the next diagnostic report shows \`took=20ms\` per scan but the loop blocks for 500ms, we know to look elsewhere. If \`took=800ms\` with \`vpkCache=2/70\`, the cache isn't doing its job and there's a bug in the invalidation. Either result is more actionable than today's "we think it's the scan."

## Test plan

- [x] \`pnpm exec tsc\` clean (both configs)
- [x] \`pnpm lint\` clean (3 pre-existing warnings, unrelated)
- [x] \`pnpm build\` succeeds
- [ ] Manual: launch dev build, confirm \`[detectConflicts]\` lines appear in main.log on mod toggle
- [ ] Manual: trigger a deliberate freeze (e.g. heavy sync work) and confirm \`[event-loop] blocked\` line shows up