### PR TITLE
perf(mods): cache metadata reads and hero-inference VPK parse

### DIFF
--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'fs';
+import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, statSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { getAddonsPath, getDisabledPath } from './deadlock';
@@ -36,6 +36,19 @@ export interface ModMetadata {
 
 export type ModMetadataMap = Record<string, ModMetadata>;
 
+// In-memory cache of the parsed metadata.json. Without this, every enrichMod
+// call (one per installed mod) re-reads + re-parses the whole sidecar from
+// disk on the main thread; users with many mods see noticeable freezes on
+// import/get-mods. Invalidated via (mtimeMs, size) so external writes still
+// get picked up, and refreshed eagerly inside saveMetadata to avoid an
+// immediate re-read after we just wrote.
+interface MetadataCacheEntry {
+    mtimeMs: number;
+    size: number;
+    data: ModMetadataMap;
+}
+let metadataCache: MetadataCacheEntry | null = null;
+
 /**
  * Load mod metadata from disk
  */
@@ -43,14 +56,27 @@ export function loadMetadata(): ModMetadataMap {
     const path = getMetadataPath();
 
     if (!existsSync(path)) {
+        metadataCache = null;
         return {};
     }
 
     try {
+        const stat = statSync(path);
+        if (
+            metadataCache &&
+            metadataCache.mtimeMs === stat.mtimeMs &&
+            metadataCache.size === stat.size
+        ) {
+            return metadataCache.data;
+        }
+
         const content = readFileSync(path, 'utf-8');
-        return JSON.parse(content) as ModMetadataMap;
+        const data = JSON.parse(content) as ModMetadataMap;
+        metadataCache = { mtimeMs: stat.mtimeMs, size: stat.size, data };
+        return data;
     } catch (error) {
         console.warn('[Metadata] Failed to load metadata, returning empty:', error);
+        metadataCache = null;
         return {};
     }
 }
@@ -66,6 +92,12 @@ export function saveMetadata(metadata: ModMetadataMap): void {
     try {
         writeFileSync(tempPath, JSON.stringify(metadata, null, 2), 'utf-8');
         renameSync(tempPath, path);
+        try {
+            const stat = statSync(path);
+            metadataCache = { mtimeMs: stat.mtimeMs, size: stat.size, data: metadata };
+        } catch {
+            metadataCache = null;
+        }
     } catch (error) {
         try {
             if (existsSync(tempPath)) unlinkSync(tempPath);

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -296,9 +296,13 @@ export function inferHeroFromVpkPaths(paths: string[]): string | null {
 /**
  * Convenience wrapper: parse the VPK directory and run the path-based
  * inference. Returns null when the VPK can't be parsed or no hero matches.
+ *
+ * Uses the cached parser because enrichMod calls this once per Sound mod on
+ * every scan, and failed inferences are not persisted: without the cache we
+ * re-open the same VPK on every get-mods, import, enable, and reorder.
  */
 export function inferHeroFromVpk(vpkPath: string): string | null {
-    const paths = parseVpkDirectory(vpkPath);
+    const paths = parseVpkDirectoryCached(vpkPath);
     if (!paths || paths.length === 0) return null;
     return inferHeroFromVpkPaths(paths);
 }


### PR DESCRIPTION
## Summary

Users report severe lag when importing local mods once their library grows past a few dozen. Two hot paths inside `enrichMod` (called once per installed mod on `get-mods`, `import-custom-mod`, `enable-mod`, `disable-mod`, `set-mod-priority`, etc.) re-read disk on every call:

- **`getModMetadata`** did a full `readFileSync` + `JSON.parse` of `metadata.json` per invocation. A 60-mod user paid 60 synchronous disk reads on the main thread for one operation. Added an in-memory cache keyed by `(mtimeMs, size)` and refresh it inside `saveMetadata` so writes from this process don't bust it. External writers still invalidate via the stat check.
- **`inferHeroFromVpk`** used the uncached `parseVpkDirectory`. Failed inferences are not persisted, so any Sound mod whose title didn't match a hero got its VPK re-opened and re-parsed on every `enrichMod` call. Switched to `parseVpkDirectoryCached` (the same cache PR #59 added for conflict scans).

## Test plan

- [ ] `pnpm dev`, open Installed with 30+ mods, watch the `[detectConflicts]` timing log from PR #61 stay low after the first scan.
- [ ] Import a custom `.vpk` from the Installed page; confirm UI stays responsive and the mod appears.
- [ ] Toggle enable/disable on a few mods rapidly; no perceptible freeze.
- [ ] Reorder mods (swap priority); metadata renames still land on the right rows.
- [ ] Edit `metadata.json` externally while the app is open, reload mods; the cache picks up the change.