### PR TITLE
fix(installed): treat already-gone mod as success in bulk delete

### DIFF
--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -228,12 +228,22 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  // Delete a mod
+  // Delete a mod.
+  // "Mod not found" is treated as idempotent success: the file is already
+  // gone (most often because scanMods' reconcile pass renamed a colliding
+  // pakNN file between the renderer's last load and this delete), so the
+  // desired end state is already reached. Surfacing it as modsError would
+  // replace the whole Installed page with the full-page error screen,
+  // which is especially bad mid-batch in bulk delete.
   deleteMod: async (modId: string) => {
     try {
       await api.deleteMod(modId);
       set({ mods: get().mods.filter((m) => m.id !== modId) });
     } catch (err) {
+      if (/Mod not found/.test(String(err))) {
+        set({ mods: get().mods.filter((m) => m.id !== modId) });
+        return;
+      }
       set({ modsError: String(err) });
     }
   },


### PR DESCRIPTION
## Summary

- Bulk delete from the multiselect bar was throwing \`Mod not found\` errors mid-batch and replacing the entire Installed page with the full-page error screen, even though the files on disk were correctly deleted.
- The store's \`deleteMod\` now treats \`Mod not found\` as idempotent success (drops the id from the in-memory list without setting \`modsError\`), since that error means the desired end state is already reached.

## Why this happens

\`scanMods\` runs \`reconcileEnabledDisabledCollisions\` on every call. When the user has the same \`pakNN_dir.vpk\` in both \`addons/\` and \`.disabled/\`, reconcile renames one of them. The mod id is \`md5(fileName)\`, so the rename changes the id. Bulk delete iterates ids captured at confirm time, so an id that gets renamed mid-loop no longer matches anything in the next \`scanMods\` and \`deleteMod\` throws.

Each iteration that throws was being caught in the store and written to \`modsError\`, which swaps the page for an \"Error Loading Mods\" screen. One stale id was enough to look like the whole bulk delete failed, even when the underlying file unlinks succeeded for the rest of the batch.

## Test plan

- [ ] Open Installed, enter multiselect, select many mods, bulk delete: completes without flipping to the error screen.
- [ ] Single-mod delete still works (and a real unexpected error, e.g. permission failure, still surfaces via \`modsError\`).
- [ ] Mods list reflects the post-delete state correctly.