### PR TITLE
fix(installed): stop update-available pulse from sticking after update

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -90,6 +90,7 @@ function enrichMod(mod: Mod): Mod {
             sourceFileName: metadata.sourceFileName,
             lockerHero,
             merged: metadata.merged,
+            ignoreUpdates: metadata.ignoreUpdates,
         };
     }
     return { ...mod, isUnknown };
@@ -326,6 +327,28 @@ ipcMain.handle(
         const trimmed = heroName?.trim() ?? '';
         setModMetadata(target.fileName, {
             lockerHero: trimmed.length > 0 ? trimmed : undefined,
+        });
+        return enrichMod(target);
+    }
+);
+
+// set-mod-ignore-updates — manual opt-out from the update-available flag.
+// Pass false to clear and resume normal update detection. Stored alongside
+// other per-mod metadata so it survives priority renames.
+ipcMain.handle(
+    'set-mod-ignore-updates',
+    async (_, modId: string, ignore: boolean): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const all = await scanMods(deadlockPath);
+        const target = all.find((m) => m.id === modId);
+        if (!target) {
+            throw new Error(`Mod not found: ${modId}`);
+        }
+        setModMetadata(target.fileName, {
+            ignoreUpdates: ignore ? true : undefined,
         });
         return enrichMod(target);
     }

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -32,6 +32,12 @@ export interface ModMetadata {
     /** Set when this VPK was produced by mergeMods. The share code +
      *  source list are the unroll payload. */
     merged?: import('../../../src/types/mod').MergedModInfo;
+    /** Manual opt-out from update detection. When true, the renderer
+     *  excludes this mod from the "update available" check even if the
+     *  installed gameBananaFileId is gone from the live file list. Useful
+     *  when the user wants to stay on a specific version after the author
+     *  replaces or rearranges files. */
+    ignoreUpdates?: boolean;
 }
 
 export type ModMetadataMap = Record<string, ModMetadata>;

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -55,6 +55,9 @@ export interface Mod {
     /** Populated when this VPK was produced by mergeMods. The metadata
      *  enricher reads this from the mod metadata sidecar. */
     merged?: import('../../../src/types/mod').MergedModInfo;
+    /** User opted out of the "update available" flag for this mod. The
+     *  enricher reads this from the mod metadata sidecar. */
+    ignoreUpdates?: boolean;
 }
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -50,6 +50,7 @@ export interface ElectronAPI {
     applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
+    setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (
         modId: string,
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
@@ -770,6 +771,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-variant-label', modId, label),
     setModLockerHero: (modId: string, heroName: string | null) =>
         ipcRenderer.invoke('set-mod-locker-hero', modId, heroName),
+    setModIgnoreUpdates: (modId: string, ignore: boolean) =>
+        ipcRenderer.invoke('set-mod-ignore-updates', modId, ignore),
     backfillGameBananaFileId: (
         modId: string,
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -15,6 +15,8 @@ import {
   CheckCircle2,
   Power,
   Maximize2,
+  BellOff,
+  Bell,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type { GameBananaModDetails, GameBananaComment, GameBananaFile } from '../types/gamebanana';
@@ -47,6 +49,11 @@ interface ModDetailsModalProps {
   dateAdded?: number;
   dateModified?: number;
   updateAvailable?: boolean;
+  /** When provided, render a toggle next to the Update/Installed badge that
+   *  flips the underlying mod's ignoreUpdates flag. Only meaningful in the
+   *  installed-mod path; Browse leaves both undefined. */
+  ignoreUpdates?: boolean;
+  onToggleIgnoreUpdates?: () => void;
   onClose: () => void;
   onDownload: (fileId: number, fileName: string) => void;
 }
@@ -66,6 +73,8 @@ export default function ModDetailsModal({
   dateAdded,
   dateModified,
   updateAvailable,
+  ignoreUpdates,
+  onToggleIgnoreUpdates,
   onClose,
   onDownload,
 }: ModDetailsModalProps) {
@@ -310,6 +319,38 @@ export default function ModDetailsModal({
                 <CheckCircle2 className="w-2.5 h-2.5" />
                 Installed
               </span>
+            )}
+            {/* Only surface the ignore-updates pill in the installed-mod
+                context (handler provided) and when it's actually relevant:
+                either there's an update available now, or the user already
+                opted out and might want to re-enable detection. */}
+            {onToggleIgnoreUpdates && installed && (ignoreUpdates || updateAvailable) && (
+              <button
+                type="button"
+                onClick={onToggleIgnoreUpdates}
+                className={
+                  ignoreUpdates
+                    ? 'inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-secondary border border-border hover:text-text-primary hover:border-accent/40 transition-colors'
+                    : 'inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-secondary border border-border hover:text-accent hover:border-accent/40 transition-colors'
+                }
+                title={
+                  ignoreUpdates
+                    ? 'Currently ignoring updates for this mod. Click to resume detection.'
+                    : 'Stop flagging updates for this mod (you can re-enable later).'
+                }
+              >
+                {ignoreUpdates ? (
+                  <>
+                    <BellOff className="w-2.5 h-2.5" />
+                    Updates ignored
+                  </>
+                ) : (
+                  <>
+                    <Bell className="w-2.5 h-2.5" />
+                    Ignore updates
+                  </>
+                )}
+              </button>
             )}
             {outdated && (
               <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-400 border border-yellow-500/40">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -88,6 +88,13 @@ export async function setModLockerHero(
   return window.electronAPI.setModLockerHero(modId, heroName);
 }
 
+export async function setModIgnoreUpdates(
+  modId: string,
+  ignore: boolean
+): Promise<Mod> {
+  return window.electronAPI.setModIgnoreUpdates(modId, ignore);
+}
+
 export async function backfillGameBananaFileId(
   modId: string,
   payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -724,6 +724,16 @@ export default function Installed() {
       }
     }
 
+    // Drop touched gbIds from the update-check cache before we re-derive
+    // the updatesAvailable set. The cache is module-scoped and never expires
+    // otherwise, so the post-update useEffect would otherwise reuse the same
+    // liveIds snapshot that flagged the mod in the first place and the
+    // "update available" pulse would stick around on the freshly installed
+    // file.
+    for (const gbId of groups.keys()) {
+      updateCheckCache.delete(gbId);
+    }
+
     // Refresh once so the new installs are in the store with their new ids,
     // then re-enable anything that was enabled before. Match by GB ids; the
     // local mod id changes on reinstall.

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -31,7 +31,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, UnknownModFilterGuess } from '../types/mod';
@@ -299,6 +299,7 @@ export default function Installed() {
   const [detailsLoading, setDetailsLoading] = useState(false);
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const [detailsUpdateAvailable, setDetailsUpdateAvailable] = useState(false);
+  const [detailsIgnoreUpdates, setDetailsIgnoreUpdates] = useState(false);
   const [detailsInstalledFileIds, setDetailsInstalledFileIds] = useState<Set<number>>(new Set());
   // GameBanana fileIds of enabled files in the group. Drives the "Active"
   // badges in the details modal when multiple files are enabled together.
@@ -345,6 +346,7 @@ export default function Installed() {
     setDetailsInstalledFileIds(siblingFileIds);
     setDetailsActiveFileIds(activeFileIds);
     setDetailsUpdateAvailable(updatesAvailable.has(m.id));
+    setDetailsIgnoreUpdates(!!m.ignoreUpdates);
     setDetailsDates(null);
     try {
       const [details, cached] = await Promise.all([
@@ -366,9 +368,28 @@ export default function Installed() {
     setDetailsMod(null);
     setDetailsError(null);
     setDetailsUpdateAvailable(false);
+    setDetailsIgnoreUpdates(false);
     setDetailsSourceModId(null);
     setDetailsActiveFileIds(new Set());
     setDetailsDates(null);
+  };
+
+  // Flip the ignoreUpdates flag for the currently-open installed mod and
+  // refresh the mods store so the next updatesAvailable recompute (driven by
+  // the [mods] useEffect) picks the new flag up. Optimistically toggle the
+  // local state first so the pill flips immediately even if the IPC + scan
+  // round-trip is slow.
+  const handleToggleIgnoreUpdates = async () => {
+    if (!detailsSourceModId) return;
+    const next = !detailsIgnoreUpdates;
+    setDetailsIgnoreUpdates(next);
+    try {
+      await setModIgnoreUpdates(detailsSourceModId, next);
+      await loadMods({ silent: true });
+    } catch (err) {
+      console.error('[Installed] toggle ignoreUpdates failed:', err);
+      setDetailsIgnoreUpdates(!next);
+    }
   };
 
   const inspectUnknownModFilters = async (
@@ -1199,11 +1220,15 @@ export default function Installed() {
       // Absorbed merge sources are intentionally excluded: updating them on
       // disk would leave the merged VPK stale, so we don't flag updates the
       // user can't act on without unmerging first.
+      // Mods with `ignoreUpdates` set are excluded too: the user pinned the
+      // installed version on purpose (e.g. the author replaced the file with
+      // one they don't want) and shouldn't see the pulse.
       const targets = visibleMods.filter(
         (m) =>
           !!m.gameBananaId &&
           typeof m.gameBananaFileId === 'number' &&
-          m.gameBananaFileId > 0,
+          m.gameBananaFileId > 0 &&
+          !m.ignoreUpdates,
       );
       if (targets.length === 0) {
         setUpdatesAvailable(new Set());
@@ -2062,6 +2087,8 @@ export default function Installed() {
           dateAdded={detailsDates?.dateAdded}
           dateModified={detailsDates?.dateModified}
           updateAvailable={detailsUpdateAvailable}
+          ignoreUpdates={detailsIgnoreUpdates}
+          onToggleIgnoreUpdates={handleToggleIgnoreUpdates}
           onClose={closeModDetails}
           onDownload={handleDetailsDownload}
         />

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -289,6 +289,7 @@ export interface ElectronAPI {
     applyUnknownCustomMod: (modId: string, args: ApplyUnknownCustomModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
+    setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (
       modId: string,
       payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -68,6 +68,9 @@ export interface Mod {
   /** Set when this mod was produced by mergeMods. Carries the unroll payload
    *  (share code + source list). */
   merged?: MergedModInfo;
+  /** User opted out of the "update available" flag for this mod. Persisted
+   *  in metadata; toggled from the mod details modal. */
+  ignoreUpdates?: boolean;
 }
 
 export interface MergeModsArgs {


### PR DESCRIPTION
## Summary

Two related fixes for the \"update available\" indicator persisting after an actual update.

1. **Clear the update cache for refreshed gbIds in \`runUpdate\`.** \`updateCheckCache\` is module-scoped and was never invalidated. After \`runUpdate\` finished, the post-\`loadMods\` \`useEffect\` skipped the refetch for already-cached gbIds (\`!updateCheckCache.has(gbId)\` guard) and re-derived \`updatesAvailable\` against the same liveIds snapshot that flagged the mod originally, so the pulse stayed on the freshly installed file. Drop touched gbIds from the cache before the final \`loadMods\` so the next pass refetches truth.
2. **Per-mod \`ignoreUpdates\` opt-out.** Manual escape hatch for the cases the auto-detect gets wrong: author replaces a file with a variant the user doesn't want, or shuffles their file list repeatedly. Stored in the metadata sidecar; surfaced via a \"Ignore updates\" / \"Updates ignored\" pill next to the existing Update/Installed badges in the mod details modal. Filtered out of the \`updatesAvailable\` targets, so no badge or animation renders while ignored.

## Test plan

- [ ] Trigger an update on a mod, confirm the pulse disappears after the update finishes (without needing a restart).
- [ ] Open an installed mod's details, toggle \"Ignore updates\": pulse disappears, card no longer animates.
- [ ] Re-open details for an ignored mod: pill reads \"Updates ignored\", clicking it resumes detection.
- [ ] Confirm pill is hidden on Browse-context modal opens (no \`onToggleIgnoreUpdates\` handler passed there).
- [ ] Restart app: ignore flag persists (lives in metadata.json).