### PR TITLE
ui(installed): card polish, page header cleanup, toolbar rebalance

### DIFF
--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket } from 'lucide-react';
 import { getSettings, setSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
-import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
+import { ConfirmModal } from '../components/common/PageComponents';
 import type { AppSettings } from '../types/mod';
 import type { SteamLaunchOptionsStatus } from '../types/electron';
 
@@ -213,12 +213,6 @@ export default function Autoexec() {
 
     return (
         <div className="flex flex-col min-h-0 flex-1 p-6 space-y-6 overflow-auto">
-            <PageHeader
-                title="Autoexec Commands"
-                description="Manage startup commands and game configuration"
-                className="shrink-0"
-            />
-
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
                 {/* Left Panel - Command Presets */}
                 <div className="w-full lg:w-1/2 flex flex-col gap-4 overflow-hidden order-2 lg:order-1">

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Copy, Check, RotateCcw, Crosshair as CrosshairIcon, Save, Trash2, Play, Pin, XCircle } from 'lucide-react';
+import { Copy, Check, RotateCcw, Save, Trash2, Play, Pin, XCircle } from 'lucide-react';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import { getSettings } from '../lib/api';
@@ -186,16 +186,6 @@ export default function Crosshair() {
 
     return (
         <div className="p-6 space-y-6">
-            <div className="flex items-center gap-3">
-                <div className="p-3 bg-accent/10 rounded-xl">
-                    <CrosshairIcon className="w-8 h-8 text-accent" />
-                </div>
-                <div>
-                    <h1 className="text-2xl md:text-3xl font-bold font-reaver tracking-wide">Crosshair Designer</h1>
-                    <p className="text-sm text-text-secondary">Customize your in-game crosshair appearance</p>
-                </div>
-            </div>
-
             <div className="flex flex-col lg:flex-row gap-6">
                 {/* Left Panel - Settings */}
                 <div className="w-full lg:w-1/3 flex flex-col gap-6">

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -46,7 +46,7 @@ import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, HERO_NAMES 
 import { setModLockerHero } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
-import { PageHeader, ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
+import { ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -2065,10 +2065,7 @@ export default function Installed() {
 
   return (
     <div className="px-4 py-5 sm:px-6">
-      <PageHeader
-        title="Installed Mods"
-        action={
-          <div className="flex items-center gap-3">
+      <div className="mb-4 flex flex-wrap items-center justify-end gap-3">
             <div className="relative">
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
               <input
@@ -2124,10 +2121,7 @@ export default function Installed() {
               ]}
               onChange={setViewMode}
             />
-          </div>
-        }
-        className="mb-4 !flex-nowrap"
-      />
+      </div>
 
       {searchNeedle && totalMatches === 0 && (
         <div className="flex flex-col items-center justify-center py-16 text-text-secondary">

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2065,15 +2065,15 @@ export default function Installed() {
 
   return (
     <div className="px-4 py-5 sm:px-6">
-      <div className="mb-4 flex flex-wrap items-center justify-end gap-3">
-            <div className="relative">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div className="relative flex-1 min-w-[12rem] max-w-md">
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
               <input
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search installed..."
-                className={`bg-bg-secondary border border-border rounded-lg pl-8 ${search ? 'pr-8' : 'pr-3'} py-2 text-sm text-text-primary placeholder:text-text-primary/55 focus:outline-none focus:ring-2 focus:ring-accent w-40`}
+                className={`bg-bg-secondary border border-border rounded-lg pl-8 ${search ? 'pr-8' : 'pr-3'} py-2 text-sm text-text-primary placeholder:text-text-primary/55 focus:outline-none focus:ring-2 focus:ring-accent w-full`}
               />
               {search && (
                 <button
@@ -2086,22 +2086,23 @@ export default function Installed() {
                 </button>
               )}
             </div>
+            <div className="flex flex-wrap items-center gap-3">
             <Button
               variant="secondary"
               onClick={() => setImportOpen(true)}
               icon={FilePlus}
-              title="Import a VPK from disk with a custom name and thumbnail"
-            >
-              Add Custom Mod
-            </Button>
+              className="!px-2.5"
+              aria-label="Add custom mod"
+              title="Add custom mod: import a VPK from disk with a custom name and thumbnail"
+            />
             <Button
               variant="secondary"
               onClick={() => openModsFolder().catch(() => {})}
               icon={FolderOpen}
+              className="!px-2.5"
+              aria-label="Open mods folder"
               title="Open mods folder"
-            >
-              Open Folder
-            </Button>
+            />
             <Button
               variant={selectMode ? 'primary' : 'secondary'}
               onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
@@ -2121,6 +2122,7 @@ export default function Installed() {
               ]}
               onChange={setViewMode}
             />
+            </div>
       </div>
 
       {searchNeedle && totalMatches === 0 && (

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -3739,6 +3739,15 @@ function ModCard({
       ? 'bg-[#242424] border-white/[0.08] hover:border-white/[0.14] hover:bg-bg-secondary'
       : 'bg-[#242424]/85 border-white/[0.08] text-text-primary/80 hover:border-white/[0.14] hover:bg-bg-secondary hover:text-text-primary';
 
+  // Glass surface for grid/compact cards: a translucent base over which a
+  // blurred copy of the cover art (see glassBackdropUrl) bleeds, so the card
+  // is tinted by its own thumbnail. List view keeps the solid stateClasses.
+  const glassStateClasses = hasConflicts
+    ? 'border-state-warning/45 bg-state-warning/[0.07]'
+    : mod.enabled
+      ? 'border-white/[0.12] bg-[#141414]/65 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)] hover:border-white/[0.2]'
+      : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary';
+
   // Merged mods get a "stacked card" silhouette via two offset box-shadows
   // that read as cards-behind-the-card. Uses only neutral surface/border
   // tokens so it stays correct under any accent color the user picks.
@@ -3761,11 +3770,17 @@ function ModCard({
   const draggingPlaceholderClasses =
     'border-dashed border-accent/45 bg-bg-tertiary/25 shadow-none opacity-100';
   const isList = viewMode === 'list';
+  // Cover-art source for the glass backdrop. Skipped when NSFW previews are
+  // hidden so we never bleed hidden imagery, even blurred.
+  const glassBackdropUrl =
+    !isList && mod.thumbnailUrl && !(mod.nsfw && hideNsfwPreviews)
+      ? mod.thumbnailUrl
+      : null;
   const shellClasses = isList
     ? 'grid min-h-[62px] grid-cols-[48px_72px_minmax(0,1fr)_auto] items-center gap-2 px-3.5 py-2'
-    : 'flex flex-col gap-0 p-3';
-  const mediaSpacingClasses = 'mb-3';
-  const titleClasses = 'h-10 text-[15px] font-semibold leading-[19px] [-webkit-line-clamp:2]';
+    : 'flex flex-col gap-0 p-2.5';
+  const mediaSpacingClasses = 'mb-2';
+  const titleClasses = 'text-[15px] font-semibold leading-[19px]';
   const gridTagsClasses = 'h-[22px] flex-nowrap overflow-hidden';
   const actions = (
     <div className="ml-auto flex items-center gap-1">
@@ -3852,7 +3867,7 @@ function ModCard({
   return (
     <div
       data-mod-entry-key={entryKey}
-      className={`group/card relative rounded-[10px] border transform-gpu transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ${stateClasses} ${isDropTarget ? 'ring-1 ring-accent/50' : ''} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${
+      className={`group/card relative rounded-[10px] border transform-gpu transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ${isList ? stateClasses : glassStateClasses} ${isDropTarget ? 'ring-1 ring-accent/50' : ''} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${
         isDragging ? draggingPlaceholderClasses : ''
       } ${dragSourceClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
       draggable={draggable}
@@ -4003,6 +4018,20 @@ function ModCard({
           />
         ) : (
         <>
+        {glassBackdropUrl && (
+          <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[10px]">
+            <img
+              src={glassBackdropUrl}
+              alt=""
+              aria-hidden
+              draggable={false}
+              className={`h-full w-full scale-[1.35] object-cover blur-2xl saturate-[1.4] transition-opacity duration-200 ${
+                mod.enabled ? 'opacity-55' : 'opacity-30 grayscale-[0.4]'
+              }`}
+            />
+            <div className="absolute inset-0 bg-gradient-to-b from-[#0f0f0f]/45 via-[#0f0f0f]/65 to-[#0f0f0f]/[0.88]" />
+          </div>
+        )}
         {(() => {
         const overlayBadges = (
           <>
@@ -4080,16 +4109,14 @@ function ModCard({
         <div className="min-w-0">
           <div className="min-w-0">
             <h3
-              className={`min-w-0 overflow-hidden text-text-primary [display:-webkit-box] [-webkit-box-orient:vertical] ${
-                titleClasses
-              }`}
+              className={`min-w-0 truncate text-text-primary ${titleClasses}`}
               title={mod.name}
             >
               {mod.name}
             </h3>
           </div>
           <div
-            className={`mt-2 flex items-center gap-1.5 text-xs text-text-secondary min-w-0 ${gridTagsClasses}`}
+            className={`mt-1.5 flex items-center gap-1.5 text-xs text-text-secondary min-w-0 ${gridTagsClasses}`}
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             {mod.categoryName && (
@@ -4111,6 +4138,12 @@ function ModCard({
                 {variantStatusLabel} files
               </span>
             )}
+            <span
+              className="ml-auto flex-shrink-0 pl-1.5 text-[11px] tabular-nums text-text-secondary/55 opacity-0 transition-opacity duration-200 group-hover/card:opacity-100"
+              title={`Installed ${formatAbsoluteDate(mod.installedAt)}`}
+            >
+              {formatRelativeDate(mod.installedAt)}
+            </span>
           </div>
         </div>
 

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -15,7 +15,7 @@ import { LockerHeroView } from './LockerHero';
 import ModThumbnail from '../components/ModThumbnail';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { Mod } from '../types/mod';
-import { PageHeader, ViewModeToggle, EmptyState, SectionHeader } from '../components/common/PageComponents';
+import { ViewModeToggle, EmptyState, SectionHeader } from '../components/common/PageComponents';
 import { Skeleton } from '../components/common/Skeleton';
 import {
   FAVORITE_HEROES_KEY,
@@ -294,10 +294,6 @@ export default function Locker() {
   if (modsLoading || categoriesLoading) {
     return (
       <div className="p-6 space-y-6">
-        <PageHeader
-          title="Hero Locker"
-          description="Manage hero-specific mods"
-        />
         <div
           className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3"
           aria-busy="true"
@@ -325,34 +321,32 @@ export default function Locker() {
   return (
     <>
       <div className="p-6 space-y-6">
-      <PageHeader
-        title="Hero Locker"
-        description="Manage hero-specific mods"
-        stats={`${heroList.length} heroes • ${installedSkinCount} installed skins`}
-        action={
-          <div className="flex items-center gap-3">
-            {viewMode === 'gallery' &&
-              unassignedSkins.length + unassignedSounds.length > 0 && (
-                <button
-                  onClick={() => setViewMode('list')}
-                  className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-md bg-yellow-500/10 border border-yellow-500/50 text-yellow-400 hover:bg-yellow-500/20 transition-colors"
-                  title="Switch to List view to see unassigned mods"
-                >
-                  <Layers className="w-3 h-3" />
-                  {unassignedSkins.length + unassignedSounds.length} unassigned
-                </button>
-              )}
-            <ViewModeToggle
-              value={viewMode}
-              options={[
-                { value: 'gallery', label: 'Gallery' },
-                { value: 'list', label: 'List' },
-              ]}
-              onChange={(mode) => setViewMode(mode as 'gallery' | 'list')}
-            />
-          </div>
-        }
-      />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm text-text-secondary">
+          {`${heroList.length} heroes • ${installedSkinCount} installed skins`}
+        </div>
+        <div className="flex items-center gap-3">
+          {viewMode === 'gallery' &&
+            unassignedSkins.length + unassignedSounds.length > 0 && (
+              <button
+                onClick={() => setViewMode('list')}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-md bg-yellow-500/10 border border-yellow-500/50 text-yellow-400 hover:bg-yellow-500/20 transition-colors"
+                title="Switch to List view to see unassigned mods"
+              >
+                <Layers className="w-3 h-3" />
+                {unassignedSkins.length + unassignedSounds.length} unassigned
+              </button>
+            )}
+          <ViewModeToggle
+            value={viewMode}
+            options={[
+              { value: 'gallery', label: 'Gallery' },
+              { value: 'list', label: 'List' },
+            ]}
+            onChange={(mode) => setViewMode(mode as 'gallery' | 'list')}
+          />
+        </div>
+      </div>
 
       {heroList.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-64 text-text-secondary">

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -21,7 +21,7 @@ import { useAppStore } from '../stores/appStore';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import { useSocialStore } from '../stores/socialStore';
 import { Card, Badge, Button } from '../components/common/ui';
-import { ConfirmModal, EmptyState, PageHeader } from '../components/common/PageComponents';
+import { ConfirmModal, EmptyState } from '../components/common/PageComponents';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import ExportProfileModal from '../components/profiles/ExportProfileModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
@@ -377,12 +377,6 @@ export default function Profiles() {
 
   return (
     <div className="p-6 h-full max-w-5xl mx-auto w-full flex flex-col overflow-hidden">
-      <PageHeader
-        title="Profiles"
-        description="Save and restore your mod configurations"
-        className="mb-6 shrink-0"
-      />
-
       <div className="flex flex-col gap-6 flex-1 overflow-auto px-1">
         <div className="space-y-6 pr-1">
           {error && (


### PR DESCRIPTION
## Summary

Visual cleanup pass on the Installed page and the main page chrome.

**Installed mod cards (grid + compact)**
- Single-line titles with truncation; full title shows on hover (the `title` tooltip).
- Dropped the 2-line title reserve and trimmed padding/gaps to shrink the card footer.
- Install date reveals on hover at the right of the meta row (relative text, absolute date as tooltip), mirroring the list view.
- Glass surface: a blurred, scrim-dimmed copy of the cover art bleeds behind the card, tinting each by its own thumbnail. The crisp thumbnail stays crisp; NSFW-hidden cards skip the backdrop.

**Page headers removed**
- Profiles, Autoexec, and Crosshair Designer lose their title/subheading header entirely.
- Hero Locker and Installed lose their titles but keep their control bars (view toggle, search, action buttons, locker stats).
- Cleaned up the now-unused `PageHeader` / `CrosshairIcon` imports.

**Installed toolbar rebalance**
- After the title removal the toolbar was bunched right with a dead gap on the left. Now `justify-between`: search anchors the left and grows to fill (capped at `max-w-md`), action cluster stays right.
- Add Custom Mod and Open Folder are now icon-only (tooltip + aria-label retained) to match the select button.

## Notes
- No test framework in this repo. `pnpm lint` (ESLint) and `tsc -p tsconfig.app.json --noEmit` both pass.
- List view is unchanged throughout.