### PR TITLE
Disabled mods no longer count toward the 99 active-slot limit

### DIFF
--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'crypto';
 import { setModMetadataWithHash, getModMetadata } from './metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
 import { fetchModDetails, GameBananaModDetails } from './gamebanana';
-import { getUsedPriorities, scanMods, disableMod, enableMod } from './mods';
+import { makeDisabledFileName, scanMods, disableMod, enableMod } from './mods';
 import { validateDownloadUrl, validateFileSize } from './security';
 import { loadSettings } from './settings';
 import { getVpkLabels, inferHeroFromVpk } from './vpk';
@@ -531,55 +531,33 @@ async function downloadFile(
 }
 
 /**
- * Rename VPK files to avoid priority conflicts (async)
- * Checks BOTH addons AND disabled folders to avoid overwriting disabled mods
- * Returns the list of renamed VPK filenames
+ * Stage extracted VPKs into the disabled folder under free-form, unique names
+ * (async). New mods are installed disabled and a disabled mod holds no pakNN
+ * load-order slot, so installs don't consume the 99 enabled slots and the
+ * library is effectively uncapped. A real pakNN slot is assigned later, on
+ * enable. Returns the final filenames.
  */
 async function renameVpksToAvoidConflicts(
-    deadlockPath: string,
+    _deadlockPath: string,
     targetPath: string,
-    extractedVpks: string[]
+    extractedVpks: string[],
+    nameHint?: string
 ): Promise<string[]> {
-    // Get used priorities from BOTH addons and disabled folders
-    const usedPriorities = await getUsedPriorities(deadlockPath);
+    const taken = existsSync(targetPath)
+        ? new Set((await fs.readdir(targetPath)).map((n) => n.toLowerCase()))
+        : new Set<string>();
     const renamedFiles: string[] = [];
-
-    const getNextAvailablePriority = () => {
-        let newPriority = 1;
-        while (usedPriorities.has(newPriority) && newPriority < 99) {
-            newPriority++;
-        }
-        if (newPriority >= 99 && usedPriorities.has(99)) {
-            throw new Error('No available priority slots (all 1-99 are used)');
-        }
-        return newPriority;
-    };
 
     for (const vpkPath of extractedVpks) {
         const fileName = basename(vpkPath);
-        let finalFileName: string;
+        // Prefer the extracted VPK's own descriptive name; for bare pakNN
+        // downloads fall back to the mod's GameBanana name so the disabled file
+        // is still readable on disk.
+        const finalFileName = makeDisabledFileName(fileName, taken, nameHint);
+        taken.add(finalFileName.toLowerCase());
 
-        // Check if this VPK has a priority that conflicts
-        const match = fileName.match(/^pak(\d{2})_/);
-        if (match) {
-            const currentPriority = parseInt(match[1], 10);
-
-            if (usedPriorities.has(currentPriority)) {
-                const newPriority = getNextAvailablePriority();
-                finalFileName = `pak${String(newPriority).padStart(2, '0')}_dir.vpk`;
-
-                console.log(`[renameVpks] Renaming ${fileName} to ${finalFileName} to avoid conflict`);
-                usedPriorities.add(newPriority);
-            } else {
-                usedPriorities.add(currentPriority);
-                finalFileName = fileName;
-            }
-        } else {
-            const newPriority = getNextAvailablePriority();
-            finalFileName = `pak${String(newPriority).padStart(2, '0')}_dir.vpk`;
-
-            console.log(`[renameVpks] Renaming ${fileName} to ${finalFileName} to add priority`);
-            usedPriorities.add(newPriority);
+        if (finalFileName !== fileName) {
+            console.log(`[renameVpks] Installing ${fileName} as ${finalFileName} (disabled)`);
         }
 
         await moveFileWithoutOverwrite(vpkPath, join(targetPath, finalFileName));
@@ -747,7 +725,7 @@ async function executeDownload(
         console.log(`[downloadMod] Extracted ${extractedVpks.length} VPK files:`, extractedVpks);
 
         // Rename VPKs to avoid conflicts
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks);
+        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, details.name);
 
         if (isMidnightMina && installedVpks.length > 1) {
             // Special handling for Midnight Mina:
@@ -841,7 +819,7 @@ async function executeDownload(
         }
     } else if (extname(downloadPath).toLowerCase() === '.vpk') {
         // Direct VPK download
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath]);
+        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath], details.name);
     }
 
     // Save metadata for each installed VPK
@@ -1273,7 +1251,7 @@ async function executeOneClickDownload(
             throw extractError;
         }
 
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks);
+        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, oneClickModName);
 
         // Multi-VPK 1-Click archive: prompt the user instead of silently
         // dropping all but the first entry. Same shape as the regular
@@ -1326,7 +1304,7 @@ async function executeOneClickDownload(
             await fs.unlink(downloadPath);
         }
     } else if (extname(downloadPath).toLowerCase() === '.vpk') {
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath]);
+        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath], oneClickModName);
     }
 
     for (const vpkFileName of installedVpks) {

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -32,6 +32,12 @@ export interface ModMetadata {
     /** Set when this VPK was produced by mergeMods. The share code +
      *  source list are the unroll payload. */
     merged?: import('../../../src/types/mod').MergedModInfo;
+    /** Load-order slot this mod last held while enabled. Disabled mods now
+     *  get free-form filenames (no pakNN), so the priority is no longer encoded
+     *  in the name; we stash it here on disable and try to restore it on enable
+     *  when that slot is still free, so re-enabling returns the mod to roughly
+     *  where it was in load order. */
+    lastPriority?: number;
     /** Manual opt-out from update detection. When true, the renderer
      *  excludes this mod from the "update available" check even if the
      *  installed gameBananaFileId is gone from the live file list. Useful

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -12,6 +12,13 @@ const MIN_VPK_PRIORITY = 1;
 const MAX_VPK_PRIORITY = 99;
 /** Default priority for mods without pak## prefix */
 const DEFAULT_MOD_PRIORITY = 50;
+/**
+ * Thrown by enableMod when all 99 enabled (pakNN) slots are taken. The renderer
+ * matches on the "99 mods enabled" phrase to surface this as a non-fatal toast
+ * instead of the full-page error screen, so keep that substring stable.
+ */
+export const ENABLE_LIMIT_MESSAGE =
+    'You can have at most 99 mods enabled at once. Disable one to make room.';
 
 type CollisionMetadataOwner = 'enabled' | 'disabled';
 
@@ -103,6 +110,96 @@ function extractModName(filename: string): string {
         .filter((word) => word.length > 0)
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(' ');
+}
+
+/**
+ * Build a free-form, unique filename for a mod living in the .disabled/ folder.
+ *
+ * Disabled VPKs are not loaded by the game, so they don't need a pakNN load-order
+ * slot. Naming them free-form (a) lifts the 99-name cap on the disabled library
+ * and (b) keeps the enabled (pakNN) and disabled namespaces disjoint, so
+ * `md5(fileName)` stays globally unique with no identity/metadata migration.
+ *
+ * The readable stem comes from the file's own name when it has one; for an
+ * enabled mod (always a bare pakNN with no descriptive stem) we fall back to the
+ * `preferredName` the caller pulls from metadata (the mod's display name), so a
+ * disabled file reads like `glamorous_geist_dir.vpk` instead of `mod_12ce`. A
+ * short token is appended only to stay unique, and the result is guaranteed not
+ * to parse back as a pakNN slot.
+ */
+export function makeDisabledFileName(
+    sourceFileName: string,
+    taken: Set<string>,
+    preferredName?: string
+): string {
+    // The file's own stem, minus any pak## load-order prefix (disabled files
+    // carry no slot). Empty for bare pakNN names, which is the disable case.
+    let stem = sourceFileName.replace(/_dir\.vpk$/i, '').replace(/\.vpk$/i, '');
+    stem = stem.replace(/^pak\d{2}_?/i, '').trim();
+
+    let base = slugify(stem) || slugify(preferredName ?? '') || 'mod';
+    // Guard against a base that still starts with "pak<digit>": parseVpkPriority
+    // is lenient (it reads chars 3-4 and parseInts them), so "pak1_foo" would be
+    // read back as slot 1 and loop forever below. Prefix it out of that shape.
+    if (/^pak\d/i.test(base)) base = `mod_${base}`;
+
+    const build = (suffix: string) => `${base}${suffix}_dir.vpk`;
+    let candidate = build('');
+    while (parseVpkPriority(candidate) !== null || taken.has(candidate.toLowerCase())) {
+        candidate = build(`_${randomBytes(2).toString('hex')}`);
+    }
+    return candidate;
+}
+
+/**
+ * Lowercase a display string into a filesystem-safe, pakNN-free filename stem:
+ * non-alphanumerics collapse to underscores, edges trimmed, length capped.
+ */
+function slugify(value: string): string {
+    const s = value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+    return s.slice(0, 48).replace(/_+$/, '');
+}
+
+/**
+ * The set of pakNN load-order numbers currently used by files in one folder.
+ * Free-form (disabled) filenames don't parse as pakNN, so they're excluded.
+ */
+async function folderPakNumbers(folder: string): Promise<Set<number>> {
+    const nums = new Set<number>();
+    if (!existsSync(folder)) return nums;
+    for (const entry of await fs.readdir(folder)) {
+        const priority = parseVpkPriority(entry);
+        if (priority !== null) nums.add(priority);
+    }
+    return nums;
+}
+
+/**
+ * Choose an enabled (pakNN) slot for a mod being enabled. Tries the preferred
+ * numbers in order (remembered last-priority, then the mod's own legacy number)
+ * and otherwise takes the lowest free slot. Throws the cap error when all 99 are
+ * taken. `forbidden` must include every addons number plus every OTHER disabled
+ * pakNN, so enabling can never collide an id with a still-disabled mod.
+ */
+function pickEnableSlot(forbidden: Set<number>, preferred: Array<number | undefined>): number {
+    for (const p of preferred) {
+        if (
+            p != null &&
+            Number.isInteger(p) &&
+            p >= MIN_VPK_PRIORITY &&
+            p <= MAX_VPK_PRIORITY &&
+            !forbidden.has(p)
+        ) {
+            return p;
+        }
+    }
+    for (let p = MIN_VPK_PRIORITY; p <= MAX_VPK_PRIORITY; p++) {
+        if (!forbidden.has(p)) return p;
+    }
+    throw new Error(ENABLE_LIMIT_MESSAGE);
 }
 
 /**
@@ -273,51 +370,32 @@ function fileNameForPriority(fileName: string, priority: number): string {
     return `pak${priorityStr}_dir.vpk`;
 }
 
-async function moveModToFolder(
-    deadlockPath: string,
+/**
+ * Move a mod to a folder under an explicit destination filename, migrating its
+ * metadata to follow the rename. Callers compute a collision-free destination
+ * (enableMod picks a free pakNN slot; disableMod mints a free-form unique name),
+ * so this is a straight rename - no slot-conflict healing needed here.
+ *
+ * `rememberPriority`, set on disable, is stashed in metadata BEFORE the rename
+ * so it travels with the migrated entry and can be restored on the next enable.
+ */
+async function moveModToFolderAs(
     targetMod: Mod,
     destinationFolder: string,
-    enabled: boolean
+    destinationFileName: string,
+    enabled: boolean,
+    rememberPriority?: number
 ): Promise<Mod> {
-    let destinationFileName = targetMod.fileName;
-    let collisionMetadata: ReturnType<typeof getModMetadata> | undefined;
-    let collisionMetadataOwner: CollisionMetadataOwner | undefined;
-    const destinationPath = join(destinationFolder, destinationFileName);
-    const hasConflict = targetMod.path !== destinationPath && existsSync(destinationPath);
-
-    if (hasConflict) {
-        const identical = await sameFileContents(
-            targetMod.path,
-            join(destinationFolder, destinationFileName)
-        );
-
-        if (identical) {
-            await fs.unlink(targetMod.path);
-            return {
-                ...targetMod,
-                enabled,
-                path: join(destinationFolder, destinationFileName),
-            };
-        }
-
-        const priority = await findNextAvailablePriority(deadlockPath);
-        collisionMetadata = getModMetadata(targetMod.fileName);
-        collisionMetadataOwner = await getCollisionMetadataOwner(
-            collisionMetadata?.sha256,
-            targetMod.path
-        );
-        destinationFileName = fileNameForPriority(targetMod.fileName, priority);
+    if (rememberPriority != null) {
+        setModMetadata(targetMod.fileName, { lastPriority: rememberPriority });
     }
 
     await fs.mkdir(destinationFolder, { recursive: true });
-    await fs.rename(targetMod.path, join(destinationFolder, destinationFileName));
+    const destinationPath = join(destinationFolder, destinationFileName);
+    await fs.rename(targetMod.path, destinationPath);
 
     if (destinationFileName !== targetMod.fileName) {
-        if (collisionMetadataOwner) {
-            moveCollisionMetadata(targetMod.fileName, destinationFileName, collisionMetadataOwner, collisionMetadata);
-        } else {
-            migrateModMetadata([{ from: targetMod.fileName, to: destinationFileName }]);
-        }
+        migrateModMetadata([{ from: targetMod.fileName, to: destinationFileName }]);
     }
 
     return {
@@ -326,7 +404,7 @@ async function moveModToFolder(
         fileName: destinationFileName,
         enabled,
         priority: parseVpkPriority(destinationFileName) ?? targetMod.priority,
-        path: join(destinationFolder, destinationFileName),
+        path: destinationPath,
     };
 }
 
@@ -373,7 +451,7 @@ export async function findNextAvailablePriority(deadlockPath: string, startFrom 
 
     // If all numbers up to 99 are taken, this is an error
     if (priority >= MAX_VPK_PRIORITY && usedPriorities.has(MAX_VPK_PRIORITY)) {
-        throw new Error('No available priority slots (all 1-99 are used)');
+        throw new Error(ENABLE_LIMIT_MESSAGE);
     }
 
     return priority;
@@ -395,7 +473,25 @@ export async function enableMod(deadlockPath: string, modId: string): Promise<Mo
     }
 
     const addonsPath = getAddonsPath(deadlockPath);
-    return moveModToFolder(deadlockPath, targetMod, addonsPath, true);
+    const disabledPath = getDisabledPath(deadlockPath);
+
+    // The destination slot must avoid every number already enabled, plus every
+    // OTHER disabled mod that still carries a legacy pakNN name (so the enabled
+    // copy can't share an id with a still-disabled file). The mod we're moving
+    // out is excluded from that disabled set.
+    const addonsUsed = await folderPakNumbers(addonsPath);
+    const disabledUsed = await folderPakNumbers(disabledPath);
+    const ownNumber = parseVpkPriority(targetMod.fileName);
+    if (ownNumber !== null) disabledUsed.delete(ownNumber);
+    const forbidden = new Set<number>([...addonsUsed, ...disabledUsed]);
+
+    // Prefer the slot the mod last held, then its own legacy number, so a
+    // re-enable returns it to roughly its old load-order position when free.
+    const meta = getModMetadata(targetMod.fileName);
+    const slot = pickEnableSlot(forbidden, [meta?.lastPriority, ownNumber ?? undefined]);
+    const destinationFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
+
+    return moveModToFolderAs(targetMod, addonsPath, destinationFileName, true);
 }
 
 /**
@@ -414,7 +510,20 @@ export async function disableMod(deadlockPath: string, modId: string): Promise<M
     }
 
     const disabledPath = getDisabledPath(deadlockPath);
-    return moveModToFolder(deadlockPath, targetMod, disabledPath, false);
+
+    // Disabled mods carry no load-order slot, so give them a free-form unique
+    // name (lifting the 99-name cap on the disabled library) and remember the
+    // priority they held so re-enabling can restore it.
+    const taken = existsSync(disabledPath)
+        ? new Set((await fs.readdir(disabledPath)).map((n) => n.toLowerCase()))
+        : new Set<string>();
+    // Name the disabled file after the mod's display name (an enabled mod's own
+    // filename is a bare pakNN with nothing readable to keep).
+    const meta = getModMetadata(targetMod.fileName);
+    const preferredName = meta?.modName ?? meta?.sourceFileName ?? meta?.variantLabel;
+    const destinationFileName = makeDisabledFileName(targetMod.fileName, taken, preferredName);
+
+    return moveModToFolderAs(targetMod, disabledPath, destinationFileName, false, targetMod.priority);
 }
 
 /**
@@ -519,16 +628,23 @@ export async function reorderMods(
     }
 
     const targetSet = new Set(orderedFileNames);
-    const reserved = new Set(
-        allMods.filter((m) => !targetSet.has(m.fileName)).map((m) => m.priority)
-    );
+    // Reserve only genuine pakNN slots held by mods outside the reorder list:
+    // enabled mods not being moved, plus any legacy disabled mod still named
+    // pakNN. Free-form disabled mods carry no slot (their parsed priority is
+    // null and they only report DEFAULT_MOD_PRIORITY), so they reserve nothing.
+    const reserved = new Set<number>();
+    for (const m of allMods) {
+        if (targetSet.has(m.fileName)) continue;
+        const slot = parseVpkPriority(m.fileName);
+        if (slot !== null) reserved.add(slot);
+    }
 
     const assignments: { mod: Mod; newPriority: number; newFileName: string }[] = [];
     let cursor = MIN_VPK_PRIORITY;
     for (const fileName of orderedFileNames) {
         while (reserved.has(cursor) && cursor <= MAX_VPK_PRIORITY) cursor++;
         if (cursor > MAX_VPK_PRIORITY) {
-            throw new Error('No available priority slots (all 1-99 are used)');
+            throw new Error(ENABLE_LIMIT_MESSAGE);
         }
         const mod = modByFileName.get(fileName)!;
         const newFileName = renameWithPriority(fileName, cursor);

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -17,6 +17,11 @@ export interface ProfileMod {
      *  can find the mod even if its fileName has changed since. */
     gameBananaId?: number;
     gameBananaFileId?: number;
+    /** Content fingerprint, populated from metadata at save time. The identity
+     *  of last resort for custom/local mods that carry no GameBanana ids: it
+     *  survives a fileName change (reorder, or the free-form rename a mod gets
+     *  when disabled), so apply can still re-enable the right local mod. */
+    sha256?: string;
 }
 
 export interface ProfileCrosshairSettings {
@@ -154,6 +159,7 @@ function toProfileMod(mod: { fileName: string; priority: number }, enabled: bool
     };
     if (typeof meta?.gameBananaId === 'number') out.gameBananaId = meta.gameBananaId;
     if (typeof meta?.gameBananaFileId === 'number') out.gameBananaFileId = meta.gameBananaFileId;
+    if (typeof meta?.sha256 === 'string') out.sha256 = meta.sha256;
     return out;
 }
 
@@ -284,6 +290,7 @@ function buildProfileModResolver(
 ): (pm: ProfileMod) => ResolvedMatch {
     const byFileName = new Map<string, typeof currentMods[number]>();
     const byGbFile = new Map<string, typeof currentMods[number]>();
+    const bySha256 = new Map<string, typeof currentMods[number]>();
     const metaByFileName = new Map<string, ReturnType<typeof getModMetadata>>();
     for (const mod of currentMods) {
         byFileName.set(mod.fileName, mod);
@@ -294,6 +301,9 @@ function buildProfileModResolver(
         if (typeof gbId === 'number' && typeof fileId === 'number') {
             const key = `${gbId}:${fileId}`;
             if (!byGbFile.has(key)) byGbFile.set(key, mod);
+        }
+        if (typeof meta?.sha256 === 'string' && !bySha256.has(meta.sha256)) {
+            bySha256.set(meta.sha256, mod);
         }
     }
     const claimed = new Set<string>();
@@ -307,6 +317,18 @@ function buildProfileModResolver(
             if (stable && !claimed.has(stable.id)) {
                 claimed.add(stable.id);
                 return { mod: stable, via: 'stable' };
+            }
+        }
+
+        // Content fingerprint: a reliable identity that survives a fileName
+        // change, so it's tried before the (slot-reuse-prone) fileName fallback.
+        // Mainly rescues custom/local mods after they've been renamed free-form
+        // by a disable, which no plain-fileName lookup could match.
+        if (typeof pm.sha256 === 'string') {
+            const byHash = bySha256.get(pm.sha256);
+            if (byHash && !claimed.has(byHash.id)) {
+                claimed.add(byHash.id);
+                return { mod: byHash, via: 'stable' };
             }
         }
 
@@ -426,29 +448,35 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     let enabledCount = 0;
     let disabledCount = 0;
     let orphanedDisabledCount = 0;
-    for (const mod of currentMods) {
-        const profileMod = profileModByCurrentId.get(mod.id);
 
+    // Two passes, disables BEFORE enables. The disabled library is uncapped now,
+    // so a profile that swaps a large enabled set for a large disabled one could,
+    // in a single interleaved pass, enable past the 99 active-slot ceiling before
+    // freeing the slots it's about to vacate - throwing mid-apply and leaving a
+    // half-applied profile. Freeing first guarantees every slot the profile needs
+    // is available, and the enable pass can never exceed 99 (a profile holds at
+    // most 99 enabled mods). The two passes act on disjoint sets of currentMods
+    // (was-enabled vs was-disabled), so the snapshot ids stay valid across both.
+    for (const mod of currentMods) {
+        if (!mod.enabled) continue;
+        const profileMod = profileModByCurrentId.get(mod.id);
+        if (profileMod && profileMod.enabled) continue; // keep it enabled
+        await disableMod(deadlockPath, mod.id);
         if (profileMod) {
-            if (profileMod.enabled !== mod.enabled) {
-                if (profileMod.enabled) {
-                    console.log(`[profiles] toggle enable: ${mod.fileName}`);
-                    await enableMod(deadlockPath, mod.id);
-                    enabledCount++;
-                } else {
-                    console.log(`[profiles] toggle disable: ${mod.fileName}`);
-                    await disableMod(deadlockPath, mod.id);
-                    disabledCount++;
-                }
-            }
+            console.log(`[profiles] toggle disable: ${mod.fileName}`);
+            disabledCount++;
         } else {
-            // Mod wasn't in the profile - disable it
-            if (mod.enabled) {
-                console.log(`[profiles] toggle disable (not in profile): ${mod.fileName}`);
-                await disableMod(deadlockPath, mod.id);
-                orphanedDisabledCount++;
-            }
+            console.log(`[profiles] toggle disable (not in profile): ${mod.fileName}`);
+            orphanedDisabledCount++;
         }
+    }
+    for (const mod of currentMods) {
+        if (mod.enabled) continue;
+        const profileMod = profileModByCurrentId.get(mod.id);
+        if (!profileMod || !profileMod.enabled) continue;
+        console.log(`[profiles] toggle enable: ${mod.fileName}`);
+        await enableMod(deadlockPath, mod.id);
+        enabledCount++;
     }
     console.log(
         `[profiles] toggle summary: ${enabledCount} enabled, ${disabledCount} disabled, ` +
@@ -462,9 +490,9 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     // until later iterations move them. reorderMods stages every rename via
     // a tmp prefix first, so transient mid-loop collisions can't happen.
     //
-    // Re-resolve after enable/disable: enableMod / disableMod may have
-    // renamed files (collision rename in moveModToFolder), so the previous
-    // resolver's id-to-mod mapping is stale.
+    // Re-resolve after enable/disable: enableMod assigns a fresh pakNN slot and
+    // disableMod renames to a free-form name, so the previous resolver's
+    // id-to-mod (and fileName) mapping is stale.
     const refreshedMods = await scanMods(deadlockPath);
     const resolveAgainstRefreshed = buildProfileModResolver(refreshedMods);
     const orderedFileNames: string[] = [];

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -288,6 +288,8 @@ export default function Installed() {
     mods,
     modsLoading,
     modsError,
+    modsNotice,
+    clearModsNotice,
     loadSettings,
     loadMods,
     toggleMod,
@@ -953,8 +955,11 @@ export default function Installed() {
     }
     setBulkProgress({ verb: 'Enabling', done: 0, total: targets.length });
     for (let i = 0; i < targets.length; i++) {
-      await toggleMod(targets[i].id);
+      const ok = await toggleMod(targets[i].id);
       setBulkProgress({ verb: 'Enabling', done: i + 1, total: targets.length });
+      // Stop the batch as soon as we hit the 99-enabled cap rather than firing
+      // a failing enable for every remaining selection.
+      if (!ok) break;
     }
     setBulkProgress(null);
     exitSelectMode();
@@ -1097,6 +1102,14 @@ export default function Installed() {
     const id = window.setTimeout(() => setCopyToast(null), 2200);
     return () => window.clearTimeout(id);
   }, [copyToast]);
+
+  // Surface a non-fatal store notice (e.g. the 99-enabled cap) through the same
+  // transient toast, then clear it from the store so it doesn't re-fire.
+  useEffect(() => {
+    if (!modsNotice) return;
+    setCopyToast(modsNotice);
+    clearModsNotice();
+  }, [modsNotice, clearModsNotice]);
 
 
   /**

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2578,7 +2578,7 @@ export default function Installed() {
       )}
 
       {selectMode && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-xl shadow-lg shadow-black/40 px-3 py-2 flex flex-wrap items-center gap-2">
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-max max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-xl shadow-lg shadow-black/40 px-3 py-2 flex flex-wrap items-center gap-2">
           {bulkProgress ? (
             <span className="text-sm text-text-primary tabular-nums px-2 flex items-center gap-2">
               <Loader2 className="w-4 h-4 animate-spin text-accent" />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -101,6 +101,9 @@ interface AppState {
   mods: Mod[];
   modsLoading: boolean;
   modsError: string | null;
+  // Non-fatal, transient message (e.g. hitting the 99-enabled cap). Shown as a
+  // toast rather than replacing the page the way modsError does.
+  modsNotice: string | null;
 
   // Download counts cache (mod id -> { downloadCount, timestamp })
   downloadCountsCache: Map<number, CacheEntry<number>>;
@@ -124,7 +127,10 @@ interface AppState {
    *  so background refreshes (e.g. on window focus) don't replace the
    *  page with the loading skeleton. */
   loadMods: (opts?: { silent?: boolean }) => Promise<void>;
-  toggleMod: (modId: string) => Promise<void>;
+  /** Returns false when the toggle was blocked (e.g. the 99-enabled cap), so
+   *  batch callers can stop early. */
+  toggleMod: (modId: string) => Promise<boolean>;
+  clearModsNotice: () => void;
   deleteMod: (modId: string) => Promise<void>;
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
@@ -148,6 +154,13 @@ interface AppState {
   setBrowseSession: (cache: BrowseSessionCache | null) => void;
 }
 
+// The main process throws this exact phrase from every "can't add a 100th
+// active mod" path (enable, reorder/compact, local import, merge). We surface
+// it as a transient toast instead of the full-page modsError screen.
+const ENABLE_CAP_NOTICE =
+  'You can have at most 99 mods enabled at once. Disable one to make room.';
+const isEnableCapError = (err: unknown): boolean => /99 mods enabled/.test(String(err));
+
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
   settings: null,
@@ -156,6 +169,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   mods: [],
   modsLoading: false,
   modsError: null,
+  modsNotice: null,
   downloadCountsCache: new Map(),
   soundVolume: 0.7,
   browseUi: { ...DEFAULT_BROWSE_UI },
@@ -213,7 +227,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Toggle mod enabled/disabled
   toggleMod: async (modId: string) => {
     const mod = get().mods.find((m) => m.id === modId);
-    if (!mod) return;
+    if (!mod) return false;
 
     try {
       const updatedMod = mod.enabled
@@ -223,10 +237,20 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({
         mods: get().mods.map((m) => (m.id === modId ? updatedMod : m)),
       });
+      return true;
     } catch (err) {
+      // The 99-enabled cap is an expected, recoverable outcome - surface it as
+      // a transient notice (toast) instead of the full-page modsError screen.
+      if (isEnableCapError(err)) {
+        set({ modsNotice: ENABLE_CAP_NOTICE });
+        return false;
+      }
       set({ modsError: String(err) });
+      return false;
     }
   },
+
+  clearModsNotice: () => set({ modsNotice: null }),
 
   // Delete a mod.
   // "Mod not found" is treated as idempotent success: the file is already
@@ -268,6 +292,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const updated = await api.swapModPriority(modIdA, modIdB);
       set({ mods: updated });
     } catch (err) {
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); return; }
       set({ modsError: String(err) });
     }
   },
@@ -279,7 +304,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       const updated = await api.reorderMods(orderedFileNames);
       set({ mods: updated });
     } catch (err) {
-      set({ modsError: String(err) });
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+      else { set({ modsError: String(err) }); }
       get().loadMods();
     }
   },
@@ -300,7 +326,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       const updated = await api.importCustomMod(args);
       set({ mods: updated });
     } catch (err) {
-      set({ modsError: String(err) });
+      // At the 99-active cap, importing (which lands enabled) can't claim a
+      // slot. Toast it rather than blanking the page; still rethrow so the
+      // import dialog knows it failed.
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+      else { set({ modsError: String(err) }); }
       throw err;
     }
   },


### PR DESCRIPTION
## Summary

Disabled mods no longer occupy a `pakNN` load-order slot, so the **99-mod limit now applies only to *enabled* (loaded) mods**. You can keep an unlimited library and install well past 99 mods; the cap is enforced at enable time.

Also includes a small layout fix (`ec446a2`): the bulk-action bar no longer wraps onto a second row.

## How it works

- Disabled mods get **free-form filenames** instead of `pakNN`, named from the mod's metadata (e.g. `glamorous_geist_dir.vpk`). This keeps the enabled (`pakNN`) and disabled namespaces disjoint, so `md5(fileName)` stays unique with **no identity/metadata migration**.
- `enableMod` mints the next free `pakNN` slot, forbidding addons numbers and any other disabled `pakNN` so ids never collide. It restores the mod's last-held slot when free (`lastPriority` stashed in metadata on disable).
- New installs stage to `.disabled/` with free-form names, uncapped.
- The 99 cap surfaces as a **toast** (enable, reorder, import) instead of the full-page error; bulk-enable stops cleanly at the limit.

## Migration

**None.** Existing disabled files are left untouched and convert to the new naming the next time they're toggled. This deliberately avoids any eager rename pass (which also sidesteps the vanilla-launch stash hazard).

## Safety (verified, not assumed)

- Metadata (names, thumbnails, GameBanana ids, hero grouping, sha256) migrates with every rename; confirmed lossless across a full disable/enable round-trip.
- **Profile apply** reworked to disable-before-enable so a large swap can't transiently exceed 99 and half-apply; resolver gains a `sha256` fallback so renamed local mods still match.
- Browse "installed" badges (keyed on `gameBananaId`), conflict detection (enabled-only), merge/unmerge (`sha256` fallback), locker, and stash all checked and safe.
- `pnpm build` + `pnpm lint` clean.

## Not included

Overflow addon-folder buckets (>99 *active* at once) remain in `docs/addon-folder-buckets.md`. They still need the folder-qualified identity rework, `gameinfo.gi` generation + launch re-assert, and in-game cross-bucket load-order verification, so they're a separate effort.