### PR TITLE
fix: sound-mod handling in Installed cards and Locker pinning

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -4147,11 +4147,6 @@ function ModCard({
             {mod.categoryName && (
               <span className={metaChipClasses}>{mod.categoryName}</span>
             )}
-            {mod.sourceSection === 'Sound' && (
-              <Tag tone="info" icon={Volume2} className="flex-shrink-0">
-                Sound
-              </Tag>
-            )}
             {mod.nsfw && (
               <Tag tone="danger" className="flex-shrink-0">18+</Tag>
             )}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -10,7 +10,6 @@ import {
   X,
   ImagePlus,
   Search,
-  Volume2,
   Download,
   Info,
   UploadCloud,
@@ -3649,11 +3648,6 @@ function ModListRowContent({
         </h3>
         <div className="mt-1 flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap text-xs text-text-secondary">
           {mod.categoryName && <span className={metaChipClasses}>{mod.categoryName}</span>}
-          {isSound && (
-            <Tag tone="info" icon={Volume2} className="flex-shrink-0">
-              Sound
-            </Tag>
-          )}
           {mod.nsfw && <Tag tone="danger" className="flex-shrink-0">18+</Tag>}
           <span className="flex-shrink-0">{formatBytes(mod.size)}</span>
           <span className="flex-shrink-0 tabular-nums" title={`Installed ${formatAbsoluteDate(mod.installedAt)}`}>

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -186,14 +186,18 @@ export default function Locker() {
       const bFav = favoriteHeroes.includes(b.id);
       // Favorites first
       if (aFav !== bFav) return aFav ? -1 : 1;
-      // Then heroes with skins
-      const aHasSkins = countLockerSkins(heroMods.map.get(a.id) ?? []) > 0;
-      const bHasSkins = countLockerSkins(heroMods.map.get(b.id) ?? []) > 0;
-      if (aHasSkins !== bHasSkins) return aHasSkins ? -1 : 1;
+      // Then heroes with any locker content (skins or sounds)
+      const aHasContent =
+        countLockerSkins(heroMods.map.get(a.id) ?? []) > 0 ||
+        countLockerSkins(heroSounds.map.get(a.id) ?? []) > 0;
+      const bHasContent =
+        countLockerSkins(heroMods.map.get(b.id) ?? []) > 0 ||
+        countLockerSkins(heroSounds.map.get(b.id) ?? []) > 0;
+      if (aHasContent !== bHasContent) return aHasContent ? -1 : 1;
       // Then alphabetically
       return a.name.localeCompare(b.name);
     });
-  }, [baseHeroList, favoriteHeroes, heroMods]);
+  }, [baseHeroList, favoriteHeroes, heroMods, heroSounds]);
   const allExpanded =
     heroList.length > 0 && heroList.every((hero) => expandedHeroes.has(hero.id));
   const toggleExpandAll = useCallback(() => {


### PR DESCRIPTION
Two small sound-mod fixes.

## 1. Installed: remove blue Sound tag from all card views

In the Installed tab's compact/grid view, the card metadata row has a fixed height (`h-[22px]`) with `overflow-hidden`. When the window narrows, the blue `Sound` tag crowded out and obscured the grey category label.

**Fix:** remove the `Sound` tag from every Installed view: grid, compact, and the list-view row. The inline **sound preview** player (list view) is unchanged. The now-unused `Volume2` import was dropped.

## 2. Locker: pin heroes that have only sound mods

Heroes get pinned above the alphabetical group when they have detected content, but the sort predicate only checked skins (`heroMods`). A hero whose only Locker content was a sound mod stayed unpinned.

**Fix:** the "has content" check now also consults `heroSounds` (already computed via `isLockerManagedSound`, which excludes global sounds like killsounds/announcer), and `heroSounds` is added to the `useMemo` deps.

## Testing

`pnpm lint` shows no new issues in `Installed.tsx` or `Locker.tsx` (pre-existing warnings/errors elsewhere are unrelated).