### PR TITLE
chore(release): v1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Patch bump to `1.12.1` for release. Ships the Global cosmetics axis with manual retagging (#74).

Tag `v1.12.1` will be pushed from `main` after merge to trigger `release.yml`.