### PR TITLE
fix(merge): lower pakNN wins on collision to match in-game load order

### DIFF
--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -151,8 +151,8 @@ export interface MergeOptions {
      *  from the source mod thumbnails. */
     thumbnailDataUrl?: string;
     /** Pass --strict to vpkmerge so any file-path collision aborts the merge
-     *  instead of silently letting later inputs win. Off by default to match
-     *  Deadlock's runtime "higher pakNN loads later, last write wins" model. */
+     *  instead of silently picking a winner. Off by default to match Deadlock's
+     *  runtime model, where the LOWER pakNN wins a file collision. */
     strict?: boolean;
 }
 
@@ -184,10 +184,11 @@ export async function mergeMods(
         sources.push(found);
     }
 
-    // Sort by priority ascending so the highest-priority source is last in
-    // the vpkmerge argv. vpkmerge's last-input-wins matches Deadlock's
-    // higher-pakNN-loads-later override semantics.
-    sources.sort((a, b) => a.priority - b.priority);
+    // In Deadlock a LOWER pakNN wins a file collision (pak09 overrides pak10),
+    // so the lowest-pakNN source is the highest priority. vpkmerge is
+    // last-input-wins, so sort DESCENDING to put that highest-priority
+    // (lowest-pakNN) source LAST in the argv and reproduce the in-game winner.
+    sources.sort((a, b) => b.priority - a.priority);
 
     // Hash every source BEFORE any filesystem mutation. sha256AtMergeTime
     // is the content-identity fallback unmerge uses when the manifest

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -18,8 +18,9 @@ interface Props {
  * variant per group enters the merge, because variants of the same mod
  * occupy the same in-game file paths and would just override each other.
  *
- * The merger itself sorts inputs by priority so the highest-priority source
- * wins on collisions (matches Deadlock's higher-pakNN-wins behavior).
+ * The merger itself orders inputs by priority so the highest-priority source
+ * (the lowest pakNN) wins on collisions, matching Deadlock's lower-pakNN-wins
+ * behavior.
  *
  * No thumbnail upload here. Users can override the merged mod's thumbnail
  * from the mod details modal after the fact if they want to.
@@ -238,7 +239,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
             <span>
               Strict mode
               <span className="block text-xs text-text-secondary mt-0.5">
-                Abort if two mods touch the same file path. Off by default (later/higher-priority wins).
+                Abort if two mods touch the same file path. Off by default (higher-priority mod wins).
               </span>
             </span>
           </label>


### PR DESCRIPTION
## Problem

Merging two mods for the same hero (e.g. **Pink Seven** `pak09` and **Tu'er Shen** `pak10`) produced a different result than the game would: Tu'er Shen's textures overrode Pink Seven on their 6 shared Seven material paths, even though Pink Seven is the higher-priority mod.

## Root cause

`modMerger.ts` sorted sources **ascending** by priority and relied on vpkmerge's default last-input-wins, so the **higher** pakNN ended up last in the argv and won collisions (pak10 over pak09).

But in Deadlock a **lower pakNN wins** a file collision (pak09 overrides pak10). So the merge winner was inverted relative to the in-game winner. The surrounding comments and the `MergeModsModal` copy also documented the wrong (higher-pakNN-wins) rule.

Refs: [Installing Mods](https://deadlockmodding.pages.dev/installing-mods), [deadlocker.net install guide](https://deadlocker.net/install-guide) (lower pak number = higher priority).

## Fix

- Sort sources **descending** so the highest-priority (lowest-pakNN) source is **last** in the argv; vpkmerge's last-input-wins then keeps it, reproducing the in-game winner.
- Corrected the stale comments in `modMerger.ts` and the user-facing copy in `MergeModsModal.tsx`.

## Verification

Ran the bundled vpkmerge CLI on the real `pak09`/`pak10` files in the new order: **Pink Seven (pak09) now wins all 6 shared Seven texture paths** (`seven_bunnysuit_diff`, normal, roughness, tintmask, `.vmat_c`). ESLint clean on both changed files.

## Scope note

This fixes the in-Grimoire merge only. The same lower-vs-higher-pakNN assumption still exists in the Installed-page reorder UI (separate, untouched here).