### PR TITLE
feat(locker): hero card picker, Cards/Sounds tabs, and Global cosmetic categories

### DIFF
--- a/docs/locker-hero-card-apply.md
+++ b/docs/locker-hero-card-apply.md
@@ -15,7 +15,8 @@ nothing to the game.
 
 APPLY is the missing half: make the chosen card the one Deadlock actually shows,
 independent of which skin (or none) is active for that hero, and let the user
-revert or swap cleanly.
+revert or swap cleanly, without proliferating VPKs against the ~100-VPK mount
+limit.
 
 ## Why this needs a design and not just "enable the mod"
 
@@ -30,13 +31,34 @@ Card art rarely ships alone:
 So APPLY must be surgical: peel out exactly one hero's panorama files and make
 just those win, leaving skin selection and other heroes untouched.
 
+## Decided model: one consolidated Locker cosmetics VPK
+
+Every applied card lives in a SINGLE Locker-managed VPK (call it the Locker
+cosmetics VPK), rebuilt from a selection set whenever a card is applied,
+swapped, or reverted. It wins in-game purely by sitting at a low pakNN.
+
+Why this and not "merge the card into each hero's skin VPK":
+
+- **Decoupled lifecycle.** Changing or disabling a skin never touches cards, and
+  a card has a home even when the hero has no active skin (cards are independent
+  of skins).
+- **One slot for all cards.** Per-hero card paths are disjoint
+  (`<codenameA>_` vs `<codenameB>_`), so every chosen card coexists in one VPK
+  with zero collisions. N applied cards cost 1 enabled slot, not N.
+- **Composes by slot, not by merge.** A card in a low-pakNN VPK beats a
+  skin+card bundle for that path via Deadlock's lowest-pakNN-wins rule, so we
+  never have to rebuild a skin VPK to make a card win.
+
+The only thing per-skin merge would buy is saving ~1 slot per hero, not worth
+the coupling churn and the no-skin breakage.
+
 ## Primitives we build on (all verified in code)
 
 - **Load model.** Deadlock mounts addon VPKs; on a file-path collision the
   LOWER pakNN wins (pak01 beats pak02). The lowest-pakNN VPK that ships a path
   is the one the game uses. Confirmed by `modMerger.ts` (the merge sorts so the
-  lowest-pakNN source lands last in vpkmerge's last-input-wins argv) and the
-  commit `c8bf075`.
+  lowest-pakNN source lands last in vpkmerge's last-input-wins argv) and commit
+  `c8bf075`.
 - **`vpkmerge split`** (shipped, vpkmerge `main`). Routes entries from one input
   VPK into N outputs by path predicate, copying the compiled bytes unchanged.
   Plan JSON:
@@ -44,105 +66,102 @@ just those win, leaving skin selection and other heroes untouched.
   {
     "outputs": [
       { "path": "<abs out.vpk>", "prefixes": ["panorama/images/heroes/hornet_"] }
-    ],
-    "residual": "<abs residual.vpk>"
+    ]
   }
   ```
-  Predicate is `AnyPrefix` (case-sensitive `startsWith`). Unmatched entries go to
-  `residual` if given, else are dropped. `--strict` errors on multi-output match;
-  default routes each path to the first matching output.
-  This is the right tool: it emits the raw `.vtex_c` the game loads. (`portrait`
-  re-encodes to PNG and is only for the preview grid.)
-- **Slot + metadata machinery** (in `mods.ts` / `metadata.ts` / `modMerger.ts`):
-  `findNextAvailablePriority`, `reorderMods`, `setModPriority`, `enableMod`,
+  Predicate is `AnyPrefix` (case-sensitive `startsWith`). Unmatched entries are
+  dropped when no `residual` is given. This emits the raw `.vtex_c` the game
+  loads. (`portrait` re-encodes to PNG and is only for the preview grid.)
+- **`vpkmerge merge`** (shipped). Combines >= 2 input VPKs into one,
+  last-input-wins on collision, `--strict` to refuse on any collision. We use
+  `--strict` when combining per-hero card chunks: the chunks are disjoint by
+  construction (one selection per hero), so a collision means a bug.
+- **Slot + metadata machinery** (`mods.ts` / `metadata.ts` / `modMerger.ts`):
+  `findNextAvailablePriority`, `reorderMods`, `setModPriority`,
   `reserveOutputSlot` (TOCTOU-safe slot claim), `verifyVpkOutput` (VPK magic
-  check), the `merged` sidecar manifest pattern, and `migrateModMetadata`.
-  The card-override feature reuses all of these rather than inventing new ones.
+  check), the `merged` sidecar manifest pattern, `migrateModMetadata`. The
+  cosmetics VPK reuses all of these.
 
-## The APPLY pipeline
+## State: the selection set
 
-Inputs: `heroName`, the chosen source VPK `A` (the picker already knows the
-source `modFileName` per card), and the deadlock path.
-
-1. **Resolve codename** for `heroName` via the reversed `HERO_SOUND_CODENAMES`
-   table (same lookup `heroPortraits.ts` already does).
-2. **Locate `A` on disk** (enabled `addons/` or parked `.disabled/`). A disabled
-   source is fine: we copy out of it, it stays disabled. This is the feature's
-   payoff (apply a card from a mod you do not otherwise run).
-3. **Build the split plan.** One output, prefix
-   `panorama/images/heroes/<codename>_`, NO residual (we want only this hero's
-   card files; everything else is dropped). The trailing `_` keeps the prefix
-   from leaking into a different hero whose codename shares a stem, and matches
-   the `<codename>_<variant>` and `<codename>_card_psd/` folder conventions.
-   Scope = the whole per-hero panorama set from `A` (card, vertical, mm, sm,
-   critical, gloat) so the minimap and card identities stay consistent. See
-   open decision (1) if we want single-variant scope instead.
-4. **Allocate and reserve the output slot.** Compute a winning pakNN (algorithm
-   below), then `reserveOutputSlot` it before spawning vpkmerge, exactly as
-   `mergeMods` does.
-5. **Run** `vpkmerge split --plan <plan.json> <A>` and `verifyVpkOutput` the
-   result. On any failure, unlink the partial output (mirrors `mergeMods`).
-6. **Stamp metadata** on the new fileName: an `appliedCard` manifest (shape
-   below). Its presence also marks the VPK as a Locker-managed override artifact
-   so other surfaces hide it (see "Hiding override VPKs").
-7. **Rescan**, return the updated mod list.
-
-### Deterministic priority (the slot algorithm)
-
-A card override only has to outrank the few VPKs that actually ship the same
-`panorama/images/heroes/<codename>` path. Find those competitors among ENABLED
-mods with `parseVpkDirectoryCached` (the prototype already prefilters this way):
-
-- **No enabled competitor:** place the override at `findNextAvailablePriority`.
-  It wins by being the only owner of the path. Done, no reorder.
-- **Competitors exist:** the override must sit at a pakNN strictly below
-  `min(competitor slots)`. If a free slot below that minimum exists, take it.
-  Otherwise do a targeted `reorderMods`: insert the override immediately ahead
-  of the lowest competitor and shift that competitor (and anything between) up
-  by one. Reusing `reorderMods` keeps the two-phase rename + metadata migration
-  guarantees; we only touch the affected band, not the whole load order.
-
-This is the minimal, honest version of memory thread (1) ("pak01 priority by
-convention"): we do not reserve a global low band, we just guarantee the
-override outranks its specific collision set.
-
-### `appliedCard` manifest
-
-Add to `ModMetadata` (and surface on `Mod` via `enrichMod`, exactly like
-`merged`):
+The source of truth is a manifest stored in the metadata sidecar keyed by the
+cosmetics VPK fileName (mirrors how `merged` is stored). Its presence also marks
+the VPK as Locker-managed so other surfaces hide it.
 
 ```ts
-interface AppliedCardInfo {
-  heroCodename: string;       // "hornet"
-  heroName: string;           // "Vindicta"
-  variants: string[];         // captured variants, e.g. ["card","vertical","mm"]
+interface LockerCardSelection {
+  heroCodename: string;        // "hornet"
+  heroName: string;            // "Vindicta"
+  variants: string[];          // captured variants, e.g. ["card","vertical","mm"]
   source: {
-    fileName: string;         // source VPK name at apply time
+    fileName: string;          // source VPK name at apply time
     modName?: string;
     gameBananaId?: number;
-    sha256AtApplyTime: string; // content identity, for repair/rebuild + dedupe
+    sha256AtApplyTime: string; // content identity, to relocate a renamed source
   };
-  createdAt: string;
+  addedAt: string;
+}
+
+interface LockerCosmeticsInfo {
+  cards: LockerCardSelection[]; // one entry per hero (keyed by heroCodename)
+  rebuiltAt: string;
 }
 ```
 
-`sha256AtApplyTime` lets a future rebuild or "repair" step re-locate the source
-by content if it was renamed (same trick `unmergeMod` uses for its sources).
+Add `lockerCosmetics?: LockerCosmeticsInfo` to `ModMetadata`, surfaced on `Mod`
+via `enrichMod` like `merged`. This is a distinct type from `merged`: the
+cosmetics VPK is rebuilt automatically and must NOT show the user-facing
+unmerge UI.
 
-### REVERT and REPLACE
+## The rebuild operation (the heart of it)
 
-- **Revert** (hero X back to default): find the override VPK by
-  `appliedCard.heroCodename`, `deleteMod` it (unlinks + `removeModMetadata`).
-  The game falls back to whatever else ships the card (the active skin bundle,
-  or the Valve default). No reorder needed; deleting only frees a slot.
-- **Replace** (pick a different card for hero X): revert the existing override,
-  then apply the new one. One override VPK per hero at a time is the invariant.
+`rebuildLockerCosmetics(deadlockPath, selections)` is the one operation; apply,
+swap, and revert are all just "edit the selection set, then rebuild".
 
-## Hiding override VPKs from other surfaces (cross-cutting cost)
+1. **Empty set:** delete the cosmetics VPK and its metadata. Done.
+2. For each selection, **locate its source VPK** on disk (enabled or
+   `.disabled/`) by fileName, falling back to `sha256AtApplyTime` if renamed
+   (same recovery `unmergeMod` uses). A source that is gone is dropped from the
+   set with a warning (report it, like unmerge's `missingSourceFileNames`).
+3. **Split each source** into a temp VPK under `userData`, prefix
+   `panorama/images/heroes/<codename>_`, no residual (card files only). The
+   trailing `_` keeps the prefix from leaking into a hero whose codename shares
+   a stem and matches the `<codename>_<variant>` / `<codename>_card_psd/`
+   conventions. Scope = the whole per-hero panorama set from that source (card,
+   vertical, mm, sm, critical, gloat) so card and minimap stay consistent; see
+   open decision (1) for single-variant scope.
+4. **Combine** to a temp output VPK:
+   - 0 sources left: see step 1.
+   - 1 source: the single split output IS the cosmetics VPK (skip merge,
+     `merge` requires >= 2 inputs).
+   - >= 2 sources: `vpkmerge merge --strict <temps...> <tempOut>` (disjoint by
+     construction, so strict should never fire).
+5. **Verify** (`verifyVpkOutput`) the temp output, then **swap it into the
+   cosmetics slot atomically** (write to temp, reserve/replace the slot, rename
+   in). Reuse `reserveOutputSlot` for the slot claim.
+6. **Slot to win:** keep the cosmetics VPK at a pakNN below every enabled
+   competitor that ships any included `panorama/images/heroes/<codename>_` path
+   (found via `parseVpkDirectoryCached`, as the prototype already prefilters).
+   With one stable VPK this is: if a competitor sits below it, `reorderMods` the
+   cosmetics VPK just under the lowest competitor; otherwise leave it. Usually
+   there are zero or one competitors per hero (the active skin bundle, an
+   enabled multi-hero icon pack).
+7. **Stamp** `lockerCosmetics` with the (possibly pruned) selection set and
+   `rebuiltAt`. Clean up temp files.
 
-The override is a real `pakNN_dir.vpk` in `addons/`, so without filtering it
-would appear as a mystery mod in Installed, the Locker skins/sounds lists,
-Conflicts, and profile export. Treat "metadata has `appliedCard`" as the hide
+### Apply / swap / revert
+
+- **Apply** (hero X from source A): upsert the hero-X entry into the set
+  (keyed by codename, so it replaces any prior choice for X), rebuild.
+- **Revert** (hero X to default): remove hero X from the set, rebuild. The game
+  falls back to whatever else ships the card (active skin bundle, or Valve
+  default).
+- **Swap** is just apply with a different source.
+
+## Hiding the cosmetics VPK from other surfaces (cross-cutting cost)
+
+The cosmetics VPK is a real `pakNN_dir.vpk` in `addons/`, so without filtering
+it appears as a mystery mod. Treat "metadata has `lockerCosmetics`" as the hide
 signal and filter it out in:
 
 - `src/pages/Installed.tsx` (mod list)
@@ -150,65 +169,48 @@ signal and filter it out in:
   lands in a hero's skin/sound pile or the "Unassigned" bucket)
 - Conflicts scanning (`electron/main/services/conflicts.ts`)
 - Portable profile export (`modMerger.ts` `buildPortableForSources`,
-  `portableProfile.ts`) so overrides are not shared as if they were mods
+  `portableProfile.ts`) so it is not shared as if it were a mod
 
-This is the largest surface-area cost of the feature and the main reason to
-design before coding. `merged` mods are NOT hidden today (they are first-class),
-so there is no existing filter to piggyback on; this is new plumbing.
-
-## Scale path: consolidated roll-up (memory thread 2)
-
-One override VPK per applied card consumes one enabled slot each. A user who
-sets cards for 20 heroes burns 20 of the ~99 slots. Because card overrides for
-different heroes touch DISJOINT paths (`<codenameA>_` vs `<codenameB>_`), they
-can be merged with zero collisions into a single consolidated VPK:
-
-- Persist the selection set (hero -> {sourceFileName, sha256, variants}) in a
-  manifest.
-- On any change, split each selected source into a temp VPK (card paths only),
-  `merge` them all into one `pakNN_dir.vpk` at a single winning slot, swap it in
-  atomically.
-
-Recommend shipping the one-VPK-per-card model first (simpler, trivially
-reversible) and moving to the consolidated build only if slot pressure shows up
-in practice. The `appliedCard` manifest is forward-compatible with both.
+Only ONE VPK to hide (vs one per card), but `merged` mods are NOT hidden today,
+so this is still new plumbing with no existing filter to piggyback on. This is
+the biggest part of the work and the main reason to design before coding.
 
 ## Failure handling and edge cases
 
-- Source VPK deleted between preview and apply: split fails, surface a friendly
-  error, no slot leaked (we unlink the reserved output on failure).
-- `vpkmerge` binary missing/too old (no `split`): `vpkmergeBinaryPath()` already
-  throws a clear message; the picker surfaces it.
+- Source VPK deleted between preview and apply (or since last rebuild): dropped
+  from the set with a reported warning; the rebuild still succeeds for the rest.
+- `vpkmerge` binary missing/too old (no `split`/`merge`): `vpkmergeBinaryPath()`
+  already throws a clear message; the picker surfaces it.
 - 99-slot limit reached: `reserveOutputSlot`/`findNextAvailablePriority` already
-  throw `ENABLE_LIMIT_MESSAGE`; reuse it.
+  throw `ENABLE_LIMIT_MESSAGE`; reuse it. The cosmetics VPK keeps its slot
+  across rebuilds, so steady state adds at most one slot.
 - Unsupported card format in the source: only affects the PREVIEW (morphic
   decode); APPLY copies bytes regardless of format, so an undecodable preview
-  can still be applied. Decide whether to allow applying a card we could not
-  preview (recommend: yes, with a generic tile).
-- In-game verification: split output is an unsigned v2 VPK, same as `merge`
-  output which is confirmed to mount. Still verify a real card swap in-game once
-  before calling this done.
+  can still be applied. See open decision (3).
+- In-game verification: split/merge output is an unsigned v2 VPK, same as
+  existing `merge` output which is confirmed to mount. Still verify a real card
+  swap in-game once before calling this done.
 
 ## Open decisions
 
-1. **Variant scope:** apply the whole per-hero panorama set from the chosen
+1. **Variant scope:** capture the whole per-hero panorama set from the chosen
    source (recommended, keeps card + minimap consistent) vs only the single
    previewed variant.
-2. **Override model:** one VPK per applied card (recommended for v1) vs the
-   consolidated roll-up from the start.
+2. **Roll-up model:** RESOLVED. One consolidated Locker cosmetics VPK (see
+   "Decided model" above).
 3. **Apply an unpreviewable card?** Allow applying when morphic could not decode
-   the preview (recommended yes) vs hide it.
+   the preview (recommended yes, show a generic tile) vs hide it.
 
 ## Phased implementation plan
 
-- **Phase 1 (apply/revert core):** `applyHeroCard` / `revertHeroCard` in a new
-  `heroPortraits` sibling (or extend it); `AppliedCardInfo` on
-  `ModMetadata`/`Mod`; the split + slot + verify + metadata steps; IPC +
-  preload + `api.ts`; wire the picker's selection to apply/revert.
-- **Phase 2 (hygiene):** hide override VPKs across Installed / Locker /
+- **Phase 1 (rebuild core, main process):** `LockerCosmeticsInfo` /
+  `LockerCardSelection` on `ModMetadata`/`Mod`; `rebuildLockerCosmetics` plus
+  `applyHeroCard` / `revertHeroCard` wrappers (split + merge + verify + slot +
+  manifest); IPC + preload + `api.ts`.
+- **Phase 2 (hygiene):** hide the cosmetics VPK across Installed / Locker /
   Conflicts / profile export.
-- **Phase 3 (polish):** show the active card as selected on load (read back the
-  `appliedCard` manifest), "Reset to default" affordance, error toasts.
-- **Phase 4 (scale, optional):** consolidated roll-up VPK.
+- **Phase 3 (UI):** wire the picker's selection to apply/revert, reflect the
+  active card on load by reading back `lockerCosmetics`, add a "Reset to
+  default" affordance and error toasts.
 
-Phases 1 and 2 ship together (without 2 the override pollutes the UI).
+Phases 1 and 2 ship together (without 2 the cosmetics VPK pollutes the UI).

--- a/docs/locker-hero-card-apply.md
+++ b/docs/locker-hero-card-apply.md
@@ -1,0 +1,214 @@
+# Locker Hero Card: APPLY pipeline design
+
+Status: design (not yet built). Supersedes the "next step" note in the
+`feat/locker-hero-card-picker` prototype. Read alongside the project memory
+`project_global_mod_type_signals.md` for the verified path signals and decode
+notes.
+
+## Problem
+
+The Locker "Hero Card" picker (prototype, `src/components/locker/HeroCardPicker.tsx`)
+surfaces every `panorama/images/heroes/<codename>_<variant>` card a user's
+installed mods ship for one hero, decoded to PNG on demand via
+`vpkmerge portrait`. It is preview-only: selecting a card highlights it and does
+nothing to the game.
+
+APPLY is the missing half: make the chosen card the one Deadlock actually shows,
+independent of which skin (or none) is active for that hero, and let the user
+revert or swap cleanly.
+
+## Why this needs a design and not just "enable the mod"
+
+Card art rarely ships alone:
+
+- A skin bundle ships skin + that hero's card together (e.g. bunnydicta =
+  `models/heroes_staging/hornet_v3/` + `panorama/images/heroes/hornet_card*`).
+  Enabling the whole VPK to get the card drags the skin along, and vice versa.
+- A multi-hero icon pack (catlock, irl_hero_icons) ships cards for many heroes.
+  Enabling it to get one hero's card applies every other hero's card too.
+
+So APPLY must be surgical: peel out exactly one hero's panorama files and make
+just those win, leaving skin selection and other heroes untouched.
+
+## Primitives we build on (all verified in code)
+
+- **Load model.** Deadlock mounts addon VPKs; on a file-path collision the
+  LOWER pakNN wins (pak01 beats pak02). The lowest-pakNN VPK that ships a path
+  is the one the game uses. Confirmed by `modMerger.ts` (the merge sorts so the
+  lowest-pakNN source lands last in vpkmerge's last-input-wins argv) and the
+  commit `c8bf075`.
+- **`vpkmerge split`** (shipped, vpkmerge `main`). Routes entries from one input
+  VPK into N outputs by path predicate, copying the compiled bytes unchanged.
+  Plan JSON:
+  ```json
+  {
+    "outputs": [
+      { "path": "<abs out.vpk>", "prefixes": ["panorama/images/heroes/hornet_"] }
+    ],
+    "residual": "<abs residual.vpk>"
+  }
+  ```
+  Predicate is `AnyPrefix` (case-sensitive `startsWith`). Unmatched entries go to
+  `residual` if given, else are dropped. `--strict` errors on multi-output match;
+  default routes each path to the first matching output.
+  This is the right tool: it emits the raw `.vtex_c` the game loads. (`portrait`
+  re-encodes to PNG and is only for the preview grid.)
+- **Slot + metadata machinery** (in `mods.ts` / `metadata.ts` / `modMerger.ts`):
+  `findNextAvailablePriority`, `reorderMods`, `setModPriority`, `enableMod`,
+  `reserveOutputSlot` (TOCTOU-safe slot claim), `verifyVpkOutput` (VPK magic
+  check), the `merged` sidecar manifest pattern, and `migrateModMetadata`.
+  The card-override feature reuses all of these rather than inventing new ones.
+
+## The APPLY pipeline
+
+Inputs: `heroName`, the chosen source VPK `A` (the picker already knows the
+source `modFileName` per card), and the deadlock path.
+
+1. **Resolve codename** for `heroName` via the reversed `HERO_SOUND_CODENAMES`
+   table (same lookup `heroPortraits.ts` already does).
+2. **Locate `A` on disk** (enabled `addons/` or parked `.disabled/`). A disabled
+   source is fine: we copy out of it, it stays disabled. This is the feature's
+   payoff (apply a card from a mod you do not otherwise run).
+3. **Build the split plan.** One output, prefix
+   `panorama/images/heroes/<codename>_`, NO residual (we want only this hero's
+   card files; everything else is dropped). The trailing `_` keeps the prefix
+   from leaking into a different hero whose codename shares a stem, and matches
+   the `<codename>_<variant>` and `<codename>_card_psd/` folder conventions.
+   Scope = the whole per-hero panorama set from `A` (card, vertical, mm, sm,
+   critical, gloat) so the minimap and card identities stay consistent. See
+   open decision (1) if we want single-variant scope instead.
+4. **Allocate and reserve the output slot.** Compute a winning pakNN (algorithm
+   below), then `reserveOutputSlot` it before spawning vpkmerge, exactly as
+   `mergeMods` does.
+5. **Run** `vpkmerge split --plan <plan.json> <A>` and `verifyVpkOutput` the
+   result. On any failure, unlink the partial output (mirrors `mergeMods`).
+6. **Stamp metadata** on the new fileName: an `appliedCard` manifest (shape
+   below). Its presence also marks the VPK as a Locker-managed override artifact
+   so other surfaces hide it (see "Hiding override VPKs").
+7. **Rescan**, return the updated mod list.
+
+### Deterministic priority (the slot algorithm)
+
+A card override only has to outrank the few VPKs that actually ship the same
+`panorama/images/heroes/<codename>` path. Find those competitors among ENABLED
+mods with `parseVpkDirectoryCached` (the prototype already prefilters this way):
+
+- **No enabled competitor:** place the override at `findNextAvailablePriority`.
+  It wins by being the only owner of the path. Done, no reorder.
+- **Competitors exist:** the override must sit at a pakNN strictly below
+  `min(competitor slots)`. If a free slot below that minimum exists, take it.
+  Otherwise do a targeted `reorderMods`: insert the override immediately ahead
+  of the lowest competitor and shift that competitor (and anything between) up
+  by one. Reusing `reorderMods` keeps the two-phase rename + metadata migration
+  guarantees; we only touch the affected band, not the whole load order.
+
+This is the minimal, honest version of memory thread (1) ("pak01 priority by
+convention"): we do not reserve a global low band, we just guarantee the
+override outranks its specific collision set.
+
+### `appliedCard` manifest
+
+Add to `ModMetadata` (and surface on `Mod` via `enrichMod`, exactly like
+`merged`):
+
+```ts
+interface AppliedCardInfo {
+  heroCodename: string;       // "hornet"
+  heroName: string;           // "Vindicta"
+  variants: string[];         // captured variants, e.g. ["card","vertical","mm"]
+  source: {
+    fileName: string;         // source VPK name at apply time
+    modName?: string;
+    gameBananaId?: number;
+    sha256AtApplyTime: string; // content identity, for repair/rebuild + dedupe
+  };
+  createdAt: string;
+}
+```
+
+`sha256AtApplyTime` lets a future rebuild or "repair" step re-locate the source
+by content if it was renamed (same trick `unmergeMod` uses for its sources).
+
+### REVERT and REPLACE
+
+- **Revert** (hero X back to default): find the override VPK by
+  `appliedCard.heroCodename`, `deleteMod` it (unlinks + `removeModMetadata`).
+  The game falls back to whatever else ships the card (the active skin bundle,
+  or the Valve default). No reorder needed; deleting only frees a slot.
+- **Replace** (pick a different card for hero X): revert the existing override,
+  then apply the new one. One override VPK per hero at a time is the invariant.
+
+## Hiding override VPKs from other surfaces (cross-cutting cost)
+
+The override is a real `pakNN_dir.vpk` in `addons/`, so without filtering it
+would appear as a mystery mod in Installed, the Locker skins/sounds lists,
+Conflicts, and profile export. Treat "metadata has `appliedCard`" as the hide
+signal and filter it out in:
+
+- `src/pages/Installed.tsx` (mod list)
+- `lockerUtils.ts` `isLockerManagedMod` / `isLockerManagedSound` (so it never
+  lands in a hero's skin/sound pile or the "Unassigned" bucket)
+- Conflicts scanning (`electron/main/services/conflicts.ts`)
+- Portable profile export (`modMerger.ts` `buildPortableForSources`,
+  `portableProfile.ts`) so overrides are not shared as if they were mods
+
+This is the largest surface-area cost of the feature and the main reason to
+design before coding. `merged` mods are NOT hidden today (they are first-class),
+so there is no existing filter to piggyback on; this is new plumbing.
+
+## Scale path: consolidated roll-up (memory thread 2)
+
+One override VPK per applied card consumes one enabled slot each. A user who
+sets cards for 20 heroes burns 20 of the ~99 slots. Because card overrides for
+different heroes touch DISJOINT paths (`<codenameA>_` vs `<codenameB>_`), they
+can be merged with zero collisions into a single consolidated VPK:
+
+- Persist the selection set (hero -> {sourceFileName, sha256, variants}) in a
+  manifest.
+- On any change, split each selected source into a temp VPK (card paths only),
+  `merge` them all into one `pakNN_dir.vpk` at a single winning slot, swap it in
+  atomically.
+
+Recommend shipping the one-VPK-per-card model first (simpler, trivially
+reversible) and moving to the consolidated build only if slot pressure shows up
+in practice. The `appliedCard` manifest is forward-compatible with both.
+
+## Failure handling and edge cases
+
+- Source VPK deleted between preview and apply: split fails, surface a friendly
+  error, no slot leaked (we unlink the reserved output on failure).
+- `vpkmerge` binary missing/too old (no `split`): `vpkmergeBinaryPath()` already
+  throws a clear message; the picker surfaces it.
+- 99-slot limit reached: `reserveOutputSlot`/`findNextAvailablePriority` already
+  throw `ENABLE_LIMIT_MESSAGE`; reuse it.
+- Unsupported card format in the source: only affects the PREVIEW (morphic
+  decode); APPLY copies bytes regardless of format, so an undecodable preview
+  can still be applied. Decide whether to allow applying a card we could not
+  preview (recommend: yes, with a generic tile).
+- In-game verification: split output is an unsigned v2 VPK, same as `merge`
+  output which is confirmed to mount. Still verify a real card swap in-game once
+  before calling this done.
+
+## Open decisions
+
+1. **Variant scope:** apply the whole per-hero panorama set from the chosen
+   source (recommended, keeps card + minimap consistent) vs only the single
+   previewed variant.
+2. **Override model:** one VPK per applied card (recommended for v1) vs the
+   consolidated roll-up from the start.
+3. **Apply an unpreviewable card?** Allow applying when morphic could not decode
+   the preview (recommended yes) vs hide it.
+
+## Phased implementation plan
+
+- **Phase 1 (apply/revert core):** `applyHeroCard` / `revertHeroCard` in a new
+  `heroPortraits` sibling (or extend it); `AppliedCardInfo` on
+  `ModMetadata`/`Mod`; the split + slot + verify + metadata steps; IPC +
+  preload + `api.ts`; wire the picker's selection to apply/revert.
+- **Phase 2 (hygiene):** hide override VPKs across Installed / Locker /
+  Conflicts / profile export.
+- **Phase 3 (polish):** show the active card as selected on load (read back the
+  `appliedCard` manifest), "Reset to default" affordance, error toasts.
+- **Phase 4 (scale, optional):** consolidated roll-up VPK.
+
+Phases 1 and 2 ship together (without 2 the override pollutes the UI).

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -53,6 +53,7 @@ import './ipc/updater';
 import './ipc/launch';
 import './ipc/social';
 import './ipc/diagnostics';
+import './ipc/portraits';
 
 import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -111,6 +111,7 @@ function enrichMod(mod: Mod): Mod {
             lockerHeroSource,
             globalType: globalType ?? undefined,
             merged: metadata.merged,
+            lockerCosmetics: metadata.lockerCosmetics,
             ignoreUpdates: metadata.ignoreUpdates,
         };
     }

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -1,7 +1,9 @@
 import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import { getHeroPortraits } from '../services/heroPortraits';
+import { applyHeroCard, revertHeroCard, getActiveHeroCard } from '../services/heroCards';
 import type { HeroPortrait } from '../../../src/types/portrait';
+import type { ApplyHeroCardResult } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/mods.ts). */
 function getActiveDeadlockPath(): string | null {
@@ -18,5 +20,32 @@ ipcMain.handle(
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) return [];
         return getHeroPortraits(deadlockPath, heroName);
+    }
+);
+
+ipcMain.handle(
+    'apply-hero-card',
+    async (_, heroName: string, sourceFileName: string): Promise<ApplyHeroCardResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return applyHeroCard(deadlockPath, heroName, sourceFileName);
+    }
+);
+
+ipcMain.handle(
+    'revert-hero-card',
+    async (_, heroName: string): Promise<ApplyHeroCardResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return revertHeroCard(deadlockPath, heroName);
+    }
+);
+
+ipcMain.handle(
+    'get-active-hero-card',
+    async (_, heroName: string): Promise<{ sourceFileName: string; variants: string[] } | null> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) return null;
+        return getActiveHeroCard(deadlockPath, heroName);
     }
 );

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -1,0 +1,22 @@
+import { ipcMain } from 'electron';
+import { loadSettings } from '../services/settings';
+import { getHeroPortraits } from '../services/heroPortraits';
+import type { HeroPortrait } from '../../../src/types/portrait';
+
+/** Active Deadlock install path (dev override wins, same as ipc/mods.ts). */
+function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+ipcMain.handle(
+    'get-hero-portraits',
+    async (_, heroName: string): Promise<HeroPortrait[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) return [];
+        return getHeroPortraits(deadlockPath, heroName);
+    }
+);

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -133,7 +133,10 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     const vpkStats: VpkParseStats = { hits: 0, misses: 0 };
 
     const mods = await scanMods(deadlockPath);
-    const enabledMods = mods.filter(m => m.enabled);
+    // The Locker cosmetics VPK deliberately overrides the card paths of the
+    // skin/icon mods it pulled from (that's how a chosen card wins), so it would
+    // otherwise report a file conflict against every source. Exclude it.
+    const enabledMods = mods.filter(m => m.enabled && !getModMetadata(m.fileName)?.lockerCosmetics);
     const conflicts: ModConflict[] = [];
 
     if (enabledMods.length < 2) {

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -1,0 +1,357 @@
+/**
+ * Hero card APPLY pipeline.
+ *
+ * The Locker "Hero Card" picker lets a user choose alternative card art
+ * (`panorama/images/heroes/<codename>_<variant>`) per hero, independent of skin
+ * selection. Every applied card lives in ONE Locker-managed cosmetics VPK,
+ * rebuilt from a selection set on each apply/revert, slotted at a low pakNN so
+ * it wins Deadlock's lowest-pakNN-wins collision against any skin or icon pack
+ * that ships the same card path. See docs/locker-hero-card-apply.md.
+ *
+ * The card files are extracted byte-for-byte with `vpkmerge split` (the raw
+ * `.vtex_c` the game loads). Decoding to PNG (`vpkmerge portrait`) is only for
+ * the preview grid in heroPortraits.ts.
+ */
+import { promises as fs } from 'fs';
+import { basename, join } from 'path';
+import { randomUUID } from 'crypto';
+import { app } from 'electron';
+import { getAddonsPath, getDisabledPath } from './deadlock';
+import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
+import {
+    runVpkmerge,
+    vpkmergeBinaryPath,
+    verifyVpkOutput,
+    reserveOutputSlot,
+} from './modMerger';
+import { scanMods, reorderMods, findNextAvailablePriority } from './mods';
+import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import { fingerprintFile } from './fileMatch';
+import { codenameForHero } from './heroPortraits';
+import type {
+    ApplyHeroCardResult,
+    LockerCardSelection,
+    LockerCosmeticsInfo,
+} from '../../../src/types/mod';
+
+const PANORAMA_HERO_PREFIX = 'panorama/images/heroes/';
+
+/** Split predicate / collision prefix for one hero's card art. The trailing
+ *  underscore keeps `hornet_` from leaking into a hero whose codename shares a
+ *  stem and matches the `<codename>_<variant>` / `<codename>_card_psd/`
+ *  conventions. */
+function cardPrefix(codename: string): string {
+    return `${PANORAMA_HERO_PREFIX}${codename}_`;
+}
+
+interface VpkRef {
+    fileName: string;
+    path: string;
+    enabled: boolean;
+}
+
+/** Enabled addon VPKs plus the ones parked in `.disabled/`. */
+async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
+    const out: VpkRef[] = [];
+    const folders: Array<[string, boolean]> = [
+        [getAddonsPath(deadlockPath), true],
+        [getDisabledPath(deadlockPath), false],
+    ];
+    for (const [dir, enabled] of folders) {
+        let entries: string[];
+        try {
+            entries = await fs.readdir(dir);
+        } catch {
+            continue; // .disabled may not exist
+        }
+        for (const entry of entries) {
+            if (entry.toLowerCase().endsWith('_dir.vpk')) {
+                out.push({ fileName: entry, path: join(dir, entry), enabled });
+            }
+        }
+    }
+    return out;
+}
+
+/** The single Locker cosmetics VPK (the one whose metadata carries the
+ *  `lockerCosmetics` manifest), or null when no card has ever been applied. */
+function findCosmeticsVpk(
+    vpks: VpkRef[]
+): { ref: VpkRef; info: LockerCosmeticsInfo } | null {
+    for (const v of vpks) {
+        const info = getModMetadata(v.fileName)?.lockerCosmetics;
+        if (info) return { ref: v, info };
+    }
+    return null;
+}
+
+/** Locate a source VPK by filename, falling back to content hash if reconcile
+ *  renamed it since apply time (same recovery unmergeMod uses). */
+async function locateSource(
+    vpks: VpkRef[],
+    fileName: string,
+    sha256?: string
+): Promise<VpkRef | null> {
+    const byName = vpks.find((v) => v.fileName === fileName);
+    if (byName) return byName;
+    if (!sha256) return null;
+    const wanted = sha256.toLowerCase();
+    for (const v of vpks) {
+        try {
+            const fp = await fingerprintFile(v.path);
+            if (fp.sha256.toLowerCase() === wanted) return v;
+        } catch {
+            // unreadable VPK; keep looking
+        }
+    }
+    return null;
+}
+
+/** Paths under this hero's card prefix that the VPK actually ships. Matched
+ *  case-insensitively (Deadlock VPK paths are lowercase by convention). */
+function heroCardPaths(vpkPath: string, codename: string): string[] {
+    const tree = parseVpkDirectoryCached(vpkPath);
+    if (!tree) return [];
+    const prefix = cardPrefix(codename);
+    return tree.filter((p) => p.toLowerCase().startsWith(prefix));
+}
+
+/** Distinct variant tokens (card, vertical, mm, ...) derived from the matched
+ *  card filenames. Informational for the manifest; the split takes the whole
+ *  per-hero prefix regardless. */
+function variantsFor(cardPaths: string[], codename: string): string[] {
+    const variants = new Set<string>();
+    const lead = `${codename}_`;
+    for (const p of cardPaths) {
+        const base = (p.split('/').pop() ?? '').toLowerCase().replace(/\.[^.]+$/, '');
+        if (base.startsWith(lead)) {
+            const v = base.slice(lead.length);
+            if (v) variants.add(v);
+        }
+    }
+    return [...variants];
+}
+
+interface RebuildResult {
+    /** Final cosmetics VPK filename, or null when the set emptied (deleted). */
+    fileName: string | null;
+    /** Source filenames dropped because the VPK was gone at rebuild time. */
+    missing: string[];
+}
+
+/**
+ * Rebuild the consolidated Locker cosmetics VPK from `desired` selections.
+ * Apply/revert are just "edit the set, then rebuild". Split each source down to
+ * its hero's card prefix, combine the disjoint chunks into one VPK, swap it in,
+ * and slot it below any enabled competitor for the same card path.
+ */
+async function rebuildLockerCosmetics(
+    deadlockPath: string,
+    desired: LockerCardSelection[]
+): Promise<RebuildResult> {
+    const addonsPath = getAddonsPath(deadlockPath);
+    const vpks = await listAddonVpks(deadlockPath);
+    const existing = findCosmeticsVpk(vpks);
+
+    // Resolve each selection's source (relocating by hash if renamed) and
+    // confirm it still ships this hero's cards. Anything unresolved is dropped.
+    const valid: LockerCardSelection[] = [];
+    const missing: string[] = [];
+    for (const sel of desired) {
+        const src = await locateSource(vpks, sel.source.fileName, sel.source.sha256AtApplyTime);
+        if (!src || heroCardPaths(src.path, sel.heroCodename).length === 0) {
+            missing.push(sel.source.fileName);
+            continue;
+        }
+        valid.push({ ...sel, source: { ...sel.source, fileName: src.fileName } });
+    }
+
+    // Empty set: tear down the cosmetics VPK entirely.
+    if (valid.length === 0) {
+        if (existing) {
+            await fs.unlink(existing.ref.path).catch(() => {});
+            removeModMetadata(existing.ref.fileName);
+            invalidateVpkParseCache(existing.ref.path);
+        }
+        return { fileName: null, missing };
+    }
+
+    // Build artifacts live in the addons dir as dotfiles (not `_dir.vpk`, so
+    // scanMods ignores them) to keep every rename same-filesystem. Plans go to
+    // userData. Everything here is cleaned up in the finally block.
+    const tag = `.locker-cards-build-${randomUUID()}`;
+    const planDir = join(app.getPath('userData'), 'locker-cosmetics-build', randomUUID());
+    const buildOut = join(addonsPath, `${tag}.out.vpk`);
+    const chunkPaths: string[] = [];
+    try {
+        await fs.mkdir(planDir, { recursive: true });
+        for (let i = 0; i < valid.length; i++) {
+            const sel = valid[i];
+            const src = vpks.find((v) => v.fileName === sel.source.fileName)!;
+            const chunkPath = join(addonsPath, `${tag}.chunk${i}.vpk`);
+            const planPath = join(planDir, `plan${i}.json`);
+            await fs.writeFile(
+                planPath,
+                JSON.stringify({ outputs: [{ path: chunkPath, prefixes: [cardPrefix(sel.heroCodename)] }] })
+            );
+            await runVpkmerge(['split', '--plan', planPath, src.path], 120000);
+            await verifyVpkOutput(chunkPath);
+            chunkPaths.push(chunkPath);
+        }
+
+        if (chunkPaths.length === 1) {
+            await fs.rename(chunkPaths[0], buildOut);
+            chunkPaths.length = 0;
+        } else {
+            // Per-hero prefixes are disjoint, so --strict should never fire;
+            // if it does, a selection set invariant is broken and we want to know.
+            await runVpkmerge(['--strict', buildOut, ...chunkPaths], 120000);
+        }
+        await verifyVpkOutput(buildOut);
+
+        // Swap the freshly built VPK into place. Reuse the existing slot (keeps
+        // the load-order position + metadata) or reserve a new low slot.
+        let destFileName: string;
+        let destPath: string;
+        if (existing) {
+            destFileName = existing.ref.fileName;
+            destPath = existing.ref.path;
+            await fs.rename(buildOut, destPath);
+        } else {
+            const slot = await findNextAvailablePriority(deadlockPath);
+            destFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
+            destPath = join(addonsPath, destFileName);
+            await reserveOutputSlot(destPath);
+            await fs.rename(buildOut, destPath);
+            removeModMetadata(destFileName); // scrub any orphan from a prior occupant
+        }
+        invalidateVpkParseCache(destPath);
+
+        const info: LockerCosmeticsInfo = { cards: valid, rebuiltAt: new Date().toISOString() };
+        // globalType: null keeps the multi-hero panorama payload out of the
+        // Locker's Global "Icon Packs" bucket (enrichMod skips classification).
+        setModMetadata(destFileName, { modName: 'Locker Cards', lockerCosmetics: info, globalType: null });
+
+        await ensureCosmeticsWins(deadlockPath, destFileName, valid);
+        return { fileName: destFileName, missing };
+    } finally {
+        await Promise.all([
+            ...chunkPaths.map((p) => fs.unlink(p).catch(() => {})),
+            fs.unlink(buildOut).catch(() => {}),
+            fs.rm(planDir, { recursive: true, force: true }).catch(() => {}),
+        ]);
+    }
+}
+
+/**
+ * Guarantee the cosmetics VPK outranks every enabled mod that ships any of its
+ * heroes' card paths (lowest pakNN wins). Only reorders when an enabled
+ * competitor currently sits below it, and only then moves the cosmetics VPK to
+ * the front of the enabled load order. No competitor means it already wins.
+ */
+async function ensureCosmeticsWins(
+    deadlockPath: string,
+    cosmeticsFileName: string,
+    cards: LockerCardSelection[]
+): Promise<void> {
+    const mods = await scanMods(deadlockPath);
+    const cosmetics = mods.find((m) => m.fileName === cosmeticsFileName);
+    if (!cosmetics || !cosmetics.enabled) return;
+
+    const codenames = cards.map((c) => c.heroCodename);
+    const competesForCards = (vpkPath: string): boolean => {
+        const tree = parseVpkDirectoryCached(vpkPath);
+        if (!tree) return false;
+        return tree.some((p) => {
+            const lower = p.toLowerCase();
+            return codenames.some((cn) => lower.startsWith(cardPrefix(cn)));
+        });
+    };
+
+    const lowestCompetitor = mods
+        .filter((m) => m.enabled && m.id !== cosmetics.id && competesForCards(m.path))
+        .reduce((min, m) => Math.min(min, m.priority), Infinity);
+
+    if (cosmetics.priority <= lowestCompetitor) return; // already wins
+
+    const enabled = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
+    const ordered = [
+        cosmetics.fileName,
+        ...enabled.filter((m) => m.id !== cosmetics.id).map((m) => m.fileName),
+    ];
+    await reorderMods(deadlockPath, ordered);
+}
+
+/**
+ * Apply hero X's card from `sourceFileName`, replacing any prior choice for X.
+ */
+export async function applyHeroCard(
+    deadlockPath: string,
+    heroName: string,
+    sourceFileName: string
+): Promise<ApplyHeroCardResult> {
+    vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    const codename = codenameForHero(heroName);
+    if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+
+    const vpks = await listAddonVpks(deadlockPath);
+    const src = vpks.find((v) => v.fileName === sourceFileName);
+    if (!src) throw new Error(`Source mod not found: ${sourceFileName}`);
+
+    const cardPaths = heroCardPaths(src.path, codename);
+    if (cardPaths.length === 0) {
+        throw new Error(`${basename(sourceFileName)} has no card art for ${heroName}.`);
+    }
+
+    const fp = await fingerprintFile(src.path);
+    const srcMeta = getModMetadata(src.fileName);
+    const selection: LockerCardSelection = {
+        heroCodename: codename,
+        heroName,
+        variants: variantsFor(cardPaths, codename),
+        source: {
+            fileName: src.fileName,
+            modName: srcMeta?.modName,
+            gameBananaId: srcMeta?.gameBananaId,
+            sha256AtApplyTime: fp.sha256,
+        },
+        addedAt: new Date().toISOString(),
+    };
+
+    const current = findCosmeticsVpk(vpks)?.info.cards ?? [];
+    const next = [...current.filter((c) => c.heroCodename !== codename), selection];
+    const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    return {
+        activeSourceFileName: missing.includes(src.fileName) ? null : src.fileName,
+        missingSourceFileNames: missing,
+    };
+}
+
+/** Remove hero X's card, reverting it to whatever else ships it (skin / default). */
+export async function revertHeroCard(
+    deadlockPath: string,
+    heroName: string
+): Promise<ApplyHeroCardResult> {
+    const codename = codenameForHero(heroName);
+    if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+
+    const vpks = await listAddonVpks(deadlockPath);
+    const existing = findCosmeticsVpk(vpks);
+    if (!existing) return { activeSourceFileName: null, missingSourceFileNames: [] };
+
+    const next = existing.info.cards.filter((c) => c.heroCodename !== codename);
+    const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    return { activeSourceFileName: null, missingSourceFileNames: missing };
+}
+
+/** The card currently applied for a hero (to reflect selection in the picker). */
+export async function getActiveHeroCard(
+    deadlockPath: string,
+    heroName: string
+): Promise<{ sourceFileName: string; variants: string[] } | null> {
+    const codename = codenameForHero(heroName);
+    if (!codename) return null;
+    const vpks = await listAddonVpks(deadlockPath);
+    const card = findCosmeticsVpk(vpks)?.info.cards.find((c) => c.heroCodename === codename);
+    return card ? { sourceFileName: card.source.fileName, variants: card.variants } : null;
+}

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -27,7 +27,7 @@ import {
 import { scanMods, reorderMods, findNextAvailablePriority } from './mods';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
-import { codenameForHero } from './heroPortraits';
+import { codenamesForHero } from './heroPortraits';
 import type {
     ApplyHeroCardResult,
     LockerCardSelection,
@@ -107,24 +107,31 @@ async function locateSource(
     return null;
 }
 
-/** Paths under this hero's card prefix that the VPK actually ships. Matched
- *  case-insensitively (Deadlock VPK paths are lowercase by convention). */
-function heroCardPaths(vpkPath: string, codename: string): string[] {
+/** Every card prefix a hero's art might be filed under (current class_name +
+ *  legacy aliases). */
+function heroCardPrefixes(heroName: string): string[] {
+    return codenamesForHero(heroName).map(cardPrefix);
+}
+
+/** Paths under any of this hero's card prefixes that the VPK actually ships.
+ *  Matched case-insensitively (Deadlock VPK paths are lowercase by convention). */
+function heroCardPaths(vpkPath: string, heroName: string): string[] {
     const tree = parseVpkDirectoryCached(vpkPath);
     if (!tree) return [];
-    const prefix = cardPrefix(codename);
-    return tree.filter((p) => p.toLowerCase().startsWith(prefix));
+    const prefixes = heroCardPrefixes(heroName);
+    return tree.filter((p) => prefixes.some((pre) => p.toLowerCase().startsWith(pre)));
 }
 
 /** Distinct variant tokens (card, vertical, mm, ...) derived from the matched
  *  card filenames. Informational for the manifest; the split takes the whole
  *  per-hero prefix regardless. */
-function variantsFor(cardPaths: string[], codename: string): string[] {
+function variantsFor(cardPaths: string[], heroName: string): string[] {
+    const leads = codenamesForHero(heroName).map((c) => `${c}_`);
     const variants = new Set<string>();
-    const lead = `${codename}_`;
     for (const p of cardPaths) {
         const base = (p.split('/').pop() ?? '').toLowerCase().replace(/\.[^.]+$/, '');
-        if (base.startsWith(lead)) {
+        const lead = leads.find((l) => base.startsWith(l));
+        if (lead) {
             const v = base.slice(lead.length);
             if (v) variants.add(v);
         }
@@ -159,7 +166,7 @@ async function rebuildLockerCosmetics(
     const missing: string[] = [];
     for (const sel of desired) {
         const src = await locateSource(vpks, sel.source.fileName, sel.source.sha256AtApplyTime);
-        if (!src || heroCardPaths(src.path, sel.heroCodename).length === 0) {
+        if (!src || heroCardPaths(src.path, sel.heroName).length === 0) {
             missing.push(sel.source.fileName);
             continue;
         }
@@ -192,7 +199,7 @@ async function rebuildLockerCosmetics(
             const planPath = join(planDir, `plan${i}.json`);
             await fs.writeFile(
                 planPath,
-                JSON.stringify({ outputs: [{ path: chunkPath, prefixes: [cardPrefix(sel.heroCodename)] }] })
+                JSON.stringify({ outputs: [{ path: chunkPath, prefixes: heroCardPrefixes(sel.heroName) }] })
             );
             await runVpkmerge(['split', '--plan', planPath, src.path], 120000);
             await verifyVpkOutput(chunkPath);
@@ -258,13 +265,13 @@ async function ensureCosmeticsWins(
     const cosmetics = mods.find((m) => m.fileName === cosmeticsFileName);
     if (!cosmetics || !cosmetics.enabled) return;
 
-    const codenames = cards.map((c) => c.heroCodename);
+    const prefixes = cards.flatMap((c) => heroCardPrefixes(c.heroName));
     const competesForCards = (vpkPath: string): boolean => {
         const tree = parseVpkDirectoryCached(vpkPath);
         if (!tree) return false;
         return tree.some((p) => {
             const lower = p.toLowerCase();
-            return codenames.some((cn) => lower.startsWith(cardPrefix(cn)));
+            return prefixes.some((pre) => lower.startsWith(pre));
         });
     };
 
@@ -291,14 +298,15 @@ export async function applyHeroCard(
     sourceFileName: string
 ): Promise<ApplyHeroCardResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
-    const codename = codenameForHero(heroName);
-    if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) throw new Error(`Unknown hero: ${heroName}`);
+    const primaryCodename = codenames[0];
 
     const vpks = await listAddonVpks(deadlockPath);
     const src = vpks.find((v) => v.fileName === sourceFileName);
     if (!src) throw new Error(`Source mod not found: ${sourceFileName}`);
 
-    const cardPaths = heroCardPaths(src.path, codename);
+    const cardPaths = heroCardPaths(src.path, heroName);
     if (cardPaths.length === 0) {
         throw new Error(`${basename(sourceFileName)} has no card art for ${heroName}.`);
     }
@@ -306,9 +314,9 @@ export async function applyHeroCard(
     const fp = await fingerprintFile(src.path);
     const srcMeta = getModMetadata(src.fileName);
     const selection: LockerCardSelection = {
-        heroCodename: codename,
+        heroCodename: primaryCodename,
         heroName,
-        variants: variantsFor(cardPaths, codename),
+        variants: variantsFor(cardPaths, heroName),
         source: {
             fileName: src.fileName,
             modName: srcMeta?.modName,
@@ -319,7 +327,7 @@ export async function applyHeroCard(
     };
 
     const current = findCosmeticsVpk(vpks)?.info.cards ?? [];
-    const next = [...current.filter((c) => c.heroCodename !== codename), selection];
+    const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return {
         activeSourceFileName: missing.includes(src.fileName) ? null : src.fileName,
@@ -332,14 +340,15 @@ export async function revertHeroCard(
     deadlockPath: string,
     heroName: string
 ): Promise<ApplyHeroCardResult> {
-    const codename = codenameForHero(heroName);
-    if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) throw new Error(`Unknown hero: ${heroName}`);
+    const primaryCodename = codenames[0];
 
     const vpks = await listAddonVpks(deadlockPath);
     const existing = findCosmeticsVpk(vpks);
     if (!existing) return { activeSourceFileName: null, missingSourceFileNames: [] };
 
-    const next = existing.info.cards.filter((c) => c.heroCodename !== codename);
+    const next = existing.info.cards.filter((c) => c.heroCodename !== primaryCodename);
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return { activeSourceFileName: null, missingSourceFileNames: missing };
 }
@@ -349,9 +358,10 @@ export async function getActiveHeroCard(
     deadlockPath: string,
     heroName: string
 ): Promise<{ sourceFileName: string; variants: string[] } | null> {
-    const codename = codenameForHero(heroName);
-    if (!codename) return null;
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) return null;
+    const primaryCodename = codenames[0];
     const vpks = await listAddonVpks(deadlockPath);
-    const card = findCosmeticsVpk(vpks)?.info.cards.find((c) => c.heroCodename === codename);
+    const card = findCosmeticsVpk(vpks)?.info.cards.find((c) => c.heroCodename === primaryCodename);
     return card ? { sourceFileName: card.source.fileName, variants: card.variants } : null;
 }

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -17,21 +17,96 @@ import { app } from 'electron';
 import { getAddonsPath } from './deadlock';
 import { parseVpkDirectoryCached } from './vpk';
 import { vpkmergeBinaryPath, runVpkmerge } from './modMerger';
-import { HERO_SOUND_CODENAMES } from './heroSoundCodenames';
+import { getModMetadata } from './metadata';
 import type { HeroPortrait } from '../../../src/types/portrait';
 
-// Display name -> internal codename. Reverse of the sound-codename table; the
-// panorama portrait paths use the same internal codename (e.g. Vindicta ->
-// "hornet"), so this table doubles as the portrait codename lookup.
-const CODENAME_BY_HERO: Readonly<Record<string, string>> = Object.fromEntries(
-    Object.entries(HERO_SOUND_CODENAMES).map(([codename, display]) => [display, codename])
-);
+// Display name -> panorama codename. This is the `class_name` namespace
+// (deadlock-api `hero_<codename>`, stripped of the `hero_` prefix) that hero
+// card art lives under as `panorama/images/heroes/<codename>_<variant>`.
+//
+// This deliberately does NOT reuse the sound-codename table (heroSoundCodenames
+// .ts). That table is scoped to the ~35 heroes that ship ability sounds, so it
+// (a) omits heroes whose only modded art is panorama cards (Doorman, Graves,
+// Rem, Sinclair, Venator, Victor, Warden, Wraith) and (b) uses the sound-path
+// codename, which diverges from the panorama/class_name codename for Abrams
+// (sound `abrams` vs panorama `atlas`) and Mo & Krill (`mokrill` vs `krill`).
+// Both bugs made the card picker silently return nothing for those heroes.
+//
+// Source of truth: assets.deadlock-api.com/v2/heroes `class_name`. Both
+// "Doorman" (GameBanana's category name) and "The Doorman" (the API/roster
+// name) are keyed so the lookup works whichever name flows in.
+const PANORAMA_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
+    Abrams: 'atlas',
+    Apollo: 'fencer',
+    Bebop: 'bebop',
+    Billy: 'punkgoat',
+    Calico: 'nano',
+    Celeste: 'unicorn',
+    Doorman: 'doorman',
+    'The Doorman': 'doorman',
+    Drifter: 'drifter',
+    Dynamo: 'dynamo',
+    Graves: 'necro',
+    'Grey Talon': 'orion',
+    Haze: 'haze',
+    Holliday: 'astro',
+    Infernus: 'inferno',
+    Ivy: 'tengu',
+    Kelvin: 'kelvin',
+    'Lady Geist': 'ghost',
+    Lash: 'lash',
+    McGinnis: 'forge',
+    Mina: 'vampirebat',
+    Mirage: 'mirage',
+    'Mo & Krill': 'krill',
+    Paige: 'bookworm',
+    Paradox: 'chrono',
+    Pocket: 'synth',
+    Rem: 'familiar',
+    Seven: 'gigawatt',
+    Shiv: 'shiv',
+    Silver: 'werewolf',
+    Sinclair: 'magician',
+    Venator: 'priest',
+    Victor: 'frank',
+    Vindicta: 'hornet',
+    Viscous: 'viscous',
+    Vyper: 'viper',
+    Warden: 'warden',
+    Wraith: 'wraith',
+    Yamato: 'yamato',
+};
 
-/** Resolve a hero display name (e.g. "Vindicta") to its panorama/sound codename
- *  (e.g. "hornet"), or undefined when the name is unknown. Shared with the
- *  card-apply pipeline so both halves agree on the codename mapping. */
+// LEGACY panorama codenames. Six heroes were renamed during development; the
+// deadlock-api `class_name` (above) is the current name, but a lot of shipped
+// community icon packs (catlock, irl_hero_icons, "did you see that", ...) still
+// author their card art under the OLD codename. Verified against the user's
+// installed packs: e.g. "did_you_see_that_icons" ships `archer`/`engineer`/
+// `bull`/`spectre`/`digger`/`sumo`, never `orion`/`forge`/`atlas`/`ghost`/
+// `krill`/`dynamo`. We match BOTH so cards from old and new packs both show.
+const PANORAMA_CODENAME_ALIASES: Readonly<Record<string, string[]>> = {
+    'Grey Talon': ['archer'],
+    McGinnis: ['engineer'],
+    Abrams: ['bull'],
+    'Lady Geist': ['spectre'],
+    'Mo & Krill': ['digger'],
+    Dynamo: ['sumo'],
+};
+
+/** Resolve a hero display name (e.g. "Vindicta") to its primary panorama
+ *  codename (e.g. "hornet"), or undefined when the name is unknown. */
 export function codenameForHero(heroName: string): string | undefined {
-    return CODENAME_BY_HERO[heroName];
+    return PANORAMA_CODENAME_BY_HERO[heroName];
+}
+
+/** Every panorama codename a hero's card art might be filed under: the current
+ *  class_name first, then any legacy aliases. Empty when the name is unknown.
+ *  Card scanning and apply both iterate this so neither old nor new packs are
+ *  missed. */
+export function codenamesForHero(heroName: string): string[] {
+    const primary = PANORAMA_CODENAME_BY_HERO[heroName];
+    if (!primary) return [];
+    return [primary, ...(PANORAMA_CODENAME_ALIASES[heroName] ?? [])];
 }
 
 function sanitize(value: string): string {
@@ -78,45 +153,59 @@ export async function getHeroPortraits(
     deadlockPath: string,
     heroName: string
 ): Promise<HeroPortrait[]> {
-    const codename = codenameForHero(heroName);
-    if (!codename) return [];
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) return [];
     // Surface a clear error early if the bundled binary is missing/too old.
     vpkmergeBinaryPath();
 
-    const prefix = `panorama/images/heroes/${codename}`;
     const cacheRoot = join(app.getPath('userData'), 'portrait-cache');
     const vpks = await listAddonVpks(deadlockPath);
 
     const results: HeroPortrait[] = [];
     for (const vpk of vpks) {
-        const tree = parseVpkDirectoryCached(vpk);
-        if (!tree || !tree.some((p) => p.startsWith(prefix))) continue;
+        // Skip our own Locker cosmetics VPK: it holds the already-applied card,
+        // so decoding it would surface a duplicate tile of whatever source it
+        // was built from (the source itself is still scanned and stays the
+        // selectable, "Applied"-marked option).
+        if (getModMetadata(basename(vpk))?.lockerCosmetics) continue;
 
-        const outDir = join(cacheRoot, sanitize(basename(vpk)), codename);
-        const manifestPath = join(outDir, 'manifest.json');
-        try {
-            await runVpkmerge(
-                ['portrait', vpk, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
-                60000
-            );
-            const manifest = JSON.parse(
-                await fs.readFile(manifestPath, 'utf-8')
-            ) as PortraitManifest;
-            for (const p of manifest.portraits) {
-                if (!p.output_path) continue;
-                const png = await fs.readFile(p.output_path);
-                results.push({
-                    modFileName: basename(vpk),
-                    variant: p.variant,
-                    width: p.width,
-                    height: p.height,
-                    formatName: p.format_name,
-                    dataUrl: `data:image/png;base64,${png.toString('base64')}`,
-                });
+        const tree = parseVpkDirectoryCached(vpk);
+        if (!tree) continue;
+        // A pack uses one codename per hero, but packs disagree on which (the
+        // current class_name vs a legacy alias), so decode whichever this VPK
+        // actually carries. Usually one; both is harmless.
+        const matched = codenames.filter((c) =>
+            tree.some((p) => p.startsWith(`panorama/images/heroes/${c}`))
+        );
+        if (matched.length === 0) continue;
+
+        for (const codename of matched) {
+            const outDir = join(cacheRoot, sanitize(basename(vpk)), codename);
+            const manifestPath = join(outDir, 'manifest.json');
+            try {
+                await runVpkmerge(
+                    ['portrait', vpk, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
+                    60000
+                );
+                const manifest = JSON.parse(
+                    await fs.readFile(manifestPath, 'utf-8')
+                ) as PortraitManifest;
+                for (const p of manifest.portraits) {
+                    if (!p.output_path) continue;
+                    const png = await fs.readFile(p.output_path);
+                    results.push({
+                        modFileName: basename(vpk),
+                        variant: p.variant,
+                        width: p.width,
+                        height: p.height,
+                        formatName: p.format_name,
+                        dataUrl: `data:image/png;base64,${png.toString('base64')}`,
+                    });
+                }
+            } catch (err) {
+                // One malformed VPK shouldn't sink the whole picker.
+                console.warn(`[heroPortraits] skipping ${basename(vpk)} (${codename}): ${String(err)}`);
             }
-        } catch (err) {
-            // One malformed VPK shouldn't sink the whole picker.
-            console.warn(`[heroPortraits] skipping ${basename(vpk)}: ${String(err)}`);
         }
     }
     return results;

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -1,0 +1,116 @@
+/**
+ * Hero portrait / card extraction (PROTOTYPE).
+ *
+ * Deadlock skins and icon packs ship hero portrait art under
+ * `panorama/images/heroes/<codename>_<variant>`. This service finds which
+ * installed mods carry that art for a given hero and shells out to the bundled
+ * `vpkmerge portrait` subcommand to decode it to PNG, returning data URLs for
+ * the Locker "pick your hero card" picker.
+ *
+ * Note: this only SURFACES the available card art. Actually applying a chosen
+ * card to the game (splitting it out of its source mod and rolling it into the
+ * load order) is a separate, not-yet-built step.
+ */
+import { promises as fs } from 'fs';
+import { basename, join } from 'path';
+import { app } from 'electron';
+import { getAddonsPath } from './deadlock';
+import { parseVpkDirectoryCached } from './vpk';
+import { vpkmergeBinaryPath, runVpkmerge } from './modMerger';
+import { HERO_SOUND_CODENAMES } from './heroSoundCodenames';
+import type { HeroPortrait } from '../../../src/types/portrait';
+
+// Display name -> internal codename. Reverse of the sound-codename table; the
+// panorama portrait paths use the same internal codename (e.g. Vindicta ->
+// "hornet"), so this table doubles as the portrait codename lookup.
+const CODENAME_BY_HERO: Readonly<Record<string, string>> = Object.fromEntries(
+    Object.entries(HERO_SOUND_CODENAMES).map(([codename, display]) => [display, codename])
+);
+
+function sanitize(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
+}
+
+/** Enabled addon VPKs plus the ones parked in `.disabled/`. */
+async function listAddonVpks(deadlockPath: string): Promise<string[]> {
+    const addonsPath = getAddonsPath(deadlockPath);
+    const vpks: string[] = [];
+    for (const dir of [addonsPath, join(addonsPath, '.disabled')]) {
+        let entries: string[];
+        try {
+            entries = await fs.readdir(dir);
+        } catch {
+            continue; // .disabled may not exist
+        }
+        for (const entry of entries) {
+            if (entry.endsWith('_dir.vpk')) vpks.push(join(dir, entry));
+        }
+    }
+    return vpks;
+}
+
+interface PortraitManifest {
+    portraits: Array<{
+        variant: string;
+        width: number;
+        height: number;
+        format_name: string;
+        output_path: string | null;
+    }>;
+}
+
+/**
+ * Decode every hero portrait/card the installed mods ship for `heroName`.
+ *
+ * Scans enabled + disabled addon VPKs, cheaply pre-filters by the VPK file
+ * tree (reusing the cached parser so we don't re-read every pak), then shells
+ * out to `vpkmerge portrait` only for VPKs that actually carry this hero's
+ * panorama art.
+ */
+export async function getHeroPortraits(
+    deadlockPath: string,
+    heroName: string
+): Promise<HeroPortrait[]> {
+    const codename = CODENAME_BY_HERO[heroName];
+    if (!codename) return [];
+    // Surface a clear error early if the bundled binary is missing/too old.
+    vpkmergeBinaryPath();
+
+    const prefix = `panorama/images/heroes/${codename}`;
+    const cacheRoot = join(app.getPath('userData'), 'portrait-cache');
+    const vpks = await listAddonVpks(deadlockPath);
+
+    const results: HeroPortrait[] = [];
+    for (const vpk of vpks) {
+        const tree = parseVpkDirectoryCached(vpk);
+        if (!tree || !tree.some((p) => p.startsWith(prefix))) continue;
+
+        const outDir = join(cacheRoot, sanitize(basename(vpk)), codename);
+        const manifestPath = join(outDir, 'manifest.json');
+        try {
+            await runVpkmerge(
+                ['portrait', vpk, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
+                60000
+            );
+            const manifest = JSON.parse(
+                await fs.readFile(manifestPath, 'utf-8')
+            ) as PortraitManifest;
+            for (const p of manifest.portraits) {
+                if (!p.output_path) continue;
+                const png = await fs.readFile(p.output_path);
+                results.push({
+                    modFileName: basename(vpk),
+                    variant: p.variant,
+                    width: p.width,
+                    height: p.height,
+                    formatName: p.format_name,
+                    dataUrl: `data:image/png;base64,${png.toString('base64')}`,
+                });
+            }
+        } catch (err) {
+            // One malformed VPK shouldn't sink the whole picker.
+            console.warn(`[heroPortraits] skipping ${basename(vpk)}: ${String(err)}`);
+        }
+    }
+    return results;
+}

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -27,6 +27,13 @@ const CODENAME_BY_HERO: Readonly<Record<string, string>> = Object.fromEntries(
     Object.entries(HERO_SOUND_CODENAMES).map(([codename, display]) => [display, codename])
 );
 
+/** Resolve a hero display name (e.g. "Vindicta") to its panorama/sound codename
+ *  (e.g. "hornet"), or undefined when the name is unknown. Shared with the
+ *  card-apply pipeline so both halves agree on the codename mapping. */
+export function codenameForHero(heroName: string): string | undefined {
+    return CODENAME_BY_HERO[heroName];
+}
+
 function sanitize(value: string): string {
     return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }
@@ -71,7 +78,7 @@ export async function getHeroPortraits(
     deadlockPath: string,
     heroName: string
 ): Promise<HeroPortrait[]> {
-    const codename = CODENAME_BY_HERO[heroName];
+    const codename = codenameForHero(heroName);
     if (!codename) return [];
     // Surface a clear error early if the bundled binary is missing/too old.
     vpkmergeBinaryPath();

--- a/electron/main/services/heroSoundCodenames.ts
+++ b/electron/main/services/heroSoundCodenames.ts
@@ -48,6 +48,20 @@ export const HERO_SOUND_CODENAMES: Readonly<Record<string, string>> = {
     werewolf: 'Silver',
     wrecker: 'Wrecker',
     yamato: 'Yamato',
+    // Released heroes appended after the original table. Their sound mods had
+    // no VPK-path inference here, so they never auto-tagged to a hero and went
+    // missing from the Locker. Sound-path codename == class_name for these (the
+    // abrams/mokrill divergence does not apply). Verified present in real
+    // installed sound mods: familiar (Rem, 38 files), frank (Victor), priest
+    // (Venator), necro (Graves).
+    doorman: 'Doorman',
+    familiar: 'Rem',
+    frank: 'Victor',
+    magician: 'Sinclair',
+    necro: 'Graves',
+    priest: 'Venator',
+    warden: 'Warden',
+    wraith: 'Wraith',
 };
 
 /**

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -41,6 +41,10 @@ export interface ModMetadata {
     /** Set when this VPK was produced by mergeMods. The share code +
      *  source list are the unroll payload. */
     merged?: import('../../../src/types/mod').MergedModInfo;
+    /** Set on the single Locker cosmetics VPK that holds applied hero cards.
+     *  The card selection set; rebuilt on every apply/revert. Presence marks
+     *  the VPK as Locker-managed so other surfaces hide it. */
+    lockerCosmetics?: import('../../../src/types/mod').LockerCosmeticsInfo;
     /** Load-order slot this mod last held while enabled. Disabled mods now
      *  get free-form filenames (no pakNN), so the priority is no longer encoded
      *  in the name; we stash it here on disable and try to restore it on enable

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -32,7 +32,7 @@ const VPKMERGE_BINARY_BY_PLATFORM: Record<SupportedPlatform, string> = {
  * the repo's resources/; in a packaged build electron-builder's
  * extraResources places it at process.resourcesPath/vpkmerge/.
  */
-function vpkmergeBinaryPath(): string {
+export function vpkmergeBinaryPath(): string {
     const key = `${process.platform}-${process.arch}` as SupportedPlatform;
     const assetName = VPKMERGE_BINARY_BY_PLATFORM[key];
     if (!assetName) {
@@ -52,7 +52,7 @@ function vpkmergeBinaryPath(): string {
     return full;
 }
 
-function runVpkmerge(args: string[], timeoutMs = 300000): Promise<void> {
+export function runVpkmerge(args: string[], timeoutMs = 300000): Promise<void> {
     return new Promise((resolve, reject) => {
         const bin = vpkmergeBinaryPath();
         const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -103,7 +103,7 @@ const VPK_MAGIC = 0x55aa1234;
  * is a real VPK: catches truncated writes, empty files, and any future
  * vpkmerge bug that exits 0 with junk on disk.
  */
-async function verifyVpkOutput(path: string): Promise<void> {
+export async function verifyVpkOutput(path: string): Promise<void> {
     const stats = await fs.stat(path);
     if (stats.size < 4) {
         throw new Error(`vpkmerge output is too small to be a VPK (${stats.size} bytes).`);
@@ -130,7 +130,7 @@ async function verifyVpkOutput(path: string): Promise<void> {
  * concurrent download or 1-Click install could otherwise claim the slot.
  * Throws a friendly error if the slot was lost to a race.
  */
-async function reserveOutputSlot(path: string): Promise<void> {
+export async function reserveOutputSlot(path: string): Promise<void> {
     try {
         const fd = await fs.open(path, 'wx');
         await fd.close();

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -344,6 +344,11 @@ const SOUL_CONTAINER_PATTERN = /(?:^|\/)models\/props_gameplay\/soul_container\/
 const HIDEOUT_PATTERN = /(?:^|\/)models\/hideout\//i;
 const HUD_PATTERN = /(?:^|\/)panorama\/(?:layout|styles|images\/hud)\//i;
 const HERO_IMAGE_PREFIX = /(?:^|\/)panorama\/images\/heroes\//i;
+// `sounds/mods/` is the file-level home for global SFX / announcer frameworks
+// (QOL Lock and its announcer packs). Distinct from hero SFX, which live under
+// `sounds/abilities|heroes|vo/<codename>/` (SOUND_HERO_PATTERNS), so this never
+// catches a hero-tied sound.
+const ANNOUNCER_PATTERN = /(?:^|\/)sounds\/mods\//i;
 
 /**
  * Distinct hero codenames referenced by panorama/images/heroes files. The
@@ -394,6 +399,7 @@ export function classifyGlobalModType(paths: string[]): GlobalModType | null {
     if (heroImages.size === 1) return null; // one hero = that hero's content
 
     if (paths.some((p) => HUD_PATTERN.test(p))) return 'hud';
+    if (paths.some((p) => ANNOUNCER_PATTERN.test(p))) return 'announcer';
     return null;
 }
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -777,6 +777,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-variant-label', modId, label),
     setModLockerHero: (modId: string, heroName: string | null) =>
         ipcRenderer.invoke('set-mod-locker-hero', modId, heroName),
+    getHeroPortraits: (heroName: string) =>
+        ipcRenderer.invoke('get-hero-portraits', heroName),
     setModGlobalType: (modId: string, globalType: GlobalModType | null) =>
         ipcRenderer.invoke('set-mod-global-type', modId, globalType),
     setModIgnoreUpdates: (modId: string, ignore: boolean) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -779,6 +779,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-mod-locker-hero', modId, heroName),
     getHeroPortraits: (heroName: string) =>
         ipcRenderer.invoke('get-hero-portraits', heroName),
+    applyHeroCard: (heroName: string, sourceFileName: string) =>
+        ipcRenderer.invoke('apply-hero-card', heroName, sourceFileName),
+    revertHeroCard: (heroName: string) =>
+        ipcRenderer.invoke('revert-hero-card', heroName),
+    getActiveHeroCard: (heroName: string) =>
+        ipcRenderer.invoke('get-active-hero-card', heroName),
     setModGlobalType: (modId: string, globalType: GlobalModType | null) =>
         ipcRenderer.invoke('set-mod-global-type', modId, globalType),
     setModIgnoreUpdates: (modId: string, ignore: boolean) =>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   BookMarked,
   Settings2,
   AlertTriangle,
+  ArrowRight,
   Download,
   Play,
   Wand2,
@@ -114,7 +115,6 @@ export default function Sidebar() {
 
   useEffect(() => clearCollapseTimer, [clearCollapseTimer]);
 
-  const isFullyCollapsed = collapsed && !labelMounted;
   const labelTransitionClass = `overflow-hidden whitespace-nowrap transition-[opacity,max-width] duration-200 ease-out ${
     labelsVisible ? 'opacity-100 max-w-40' : 'opacity-0 max-w-0'
   }`;
@@ -276,7 +276,6 @@ export default function Sidebar() {
       { to: '/stats', icon: Activity, label: 'Stats', tooltip: 'Match history and personal stats.', experimental: 'stats' },
       { to: '/conflicts', icon: Swords, label: 'Conflicts', tooltip: 'Mods that overwrite the same game files.', badge: conflictCount, badgeTone: 'warning' },
       { to: '/profiles', icon: BookMarked, label: 'Profiles', tooltip: 'Save and swap sets of enabled mods.' },
-      { to: '/settings', icon: Settings2, label: 'Settings', tooltip: 'Configure game path, NSFW, and preferences.' },
     ];
 
     return items.filter((item) => {
@@ -627,41 +626,67 @@ export default function Sidebar() {
           )}
         </div>
 
+        {/* Update flag: kept separate from the Settings button so it reads as an
+            unmistakable "act now" row. Only mounted when an update is actually
+            available. Wears the same `update-stripes` texture as Installed cards
+            with a pending update: a neutral surface under animated white diagonal
+            stripes, so the two read as the same "needs update" language without
+            leaning on the (user-configurable) accent color. */}
+        {updateAvailable && (
+          <button
+            type="button"
+            onClick={() => setUpdateModalOpen(true)}
+            title="Update available. Click to view release notes."
+            className="group update-stripes flex w-full h-10 items-center overflow-hidden rounded-sm border border-white/[0.08] bg-bg-tertiary text-text-primary hover:bg-bg-secondary hover:border-white/[0.14] text-sm font-semibold tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
+          >
+            <span className={actionIconClass}>
+              <Download className="w-[18px] h-[18px]" strokeWidth={2} />
+            </span>
+            {labelMounted && (
+              <span className={actionLabelClass} aria-hidden={!labelsVisible}>
+                Update available
+              </span>
+            )}
+            {labelMounted && (
+              <span
+                className={`flex h-full w-10 flex-shrink-0 items-center justify-center transition-opacity duration-200 ${
+                  labelsVisible ? 'opacity-100' : 'opacity-0'
+                }`}
+                aria-hidden={!labelsVisible}
+              >
+                <ArrowRight className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+              </span>
+            )}
+          </button>
+        )}
+
+        {/* Settings shortcut + version. A bordered button (not muted text) so it
+            reads as a real control; the app version sits on the trailing edge.
+            Always visible, including collapsed (gear only), since it's now the
+            bottom rail's anchor rather than an afterthought. */}
         <button
-          onClick={() => {
-            if (updateAvailable) setUpdateModalOpen(true);
-            else navigate('/settings');
-          }}
-          className={`flex w-full items-center rounded-sm text-xs text-text-secondary cursor-pointer hover:text-accent hover:bg-bg-tertiary transition-[color,background-color,padding,height,opacity] duration-200 ${
-            isFullyCollapsed
-              ? updateAvailable
-                ? 'h-7 justify-center px-0 opacity-100'
-                : 'h-0 px-[19px] opacity-0 pointer-events-none overflow-hidden'
-              : 'h-6 justify-center gap-2 pt-1 opacity-100'
-          }`}
-          title={updateAvailable ? 'Update available. Click to view release notes.' : 'Open Settings'}
-          aria-hidden={isFullyCollapsed && !updateAvailable}
-          tabIndex={isFullyCollapsed && !updateAvailable ? -1 : undefined}
+          type="button"
+          onClick={() => navigate('/settings')}
+          title="Open Settings"
+          className="flex w-full h-10 items-center overflow-hidden rounded-sm border border-border bg-bg-tertiary/30 text-text-secondary hover:bg-accent/5 hover:border-accent/30 hover:text-text-primary text-sm transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
         >
-          {!updateAvailable && (
-            <Settings2
-              className={`w-3.5 h-3.5 flex-shrink-0 transition-transform duration-200 ${
-                isFullyCollapsed ? 'translate-y-0' : '-translate-y-px'
-              }`}
-              strokeWidth={1.75}
-            />
-          )}
+          <span className={actionIconClass}>
+            <Settings2 className="w-[18px] h-[18px]" strokeWidth={1.75} />
+          </span>
           {labelMounted && (
-            <span className={labelTransitionClass} aria-hidden={!labelsVisible}>
-              {appVersion || 'v...'}
+            <span className={`font-medium ${actionLabelClass}`} aria-hidden={!labelsVisible}>
+              Settings
             </span>
           )}
-          {updateAvailable && (
-            <Download
-              className={`w-3.5 h-3.5 flex-shrink-0 text-accent animate-pulse transition-transform duration-200 ${
-                isFullyCollapsed ? 'translate-y-0' : '-translate-y-px'
+          {labelMounted && (
+            <span
+              className={`flex h-full flex-shrink-0 items-center pr-3 text-[11px] tabular-nums text-text-secondary/70 transition-opacity duration-200 ${
+                labelsVisible ? 'opacity-100' : 'opacity-0'
               }`}
-            />
+              aria-hidden={!labelsVisible}
+            >
+              {appVersion || 'v...'}
+            </span>
           )}
         </button>
       </div>

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Images, Loader2, AlertCircle } from 'lucide-react';
-import { getHeroPortraits } from '../../lib/api';
+import { Images, Loader2, AlertCircle, Check } from 'lucide-react';
+import { applyHeroCard, getActiveHeroCard, getHeroPortraits, revertHeroCard } from '../../lib/api';
+import { useAppStore } from '../../stores/appStore';
 import type { HeroPortrait } from '../../types/portrait';
 
 interface HeroCardPickerProps {
@@ -18,26 +19,34 @@ const VARIANT_LABEL: Record<string, string> = {
 };
 
 /**
- * EXPERIMENTAL prototype: surfaces the hero card/portrait art that the user's
- * installed mods ship, decoded on demand via `vpkmerge portrait`. Selecting a
- * card only highlights it for now: actually applying it to the game (splitting
- * the panorama art out of its source mod and rolling it into the load order)
- * is a separate, not-yet-built step.
+ * EXPERIMENTAL: surfaces the hero card/portrait art the user's installed mods
+ * ship (decoded on demand via `vpkmerge portrait`) and applies the chosen one.
+ * Applying splits that hero's `panorama/images/heroes/<codename>_` art out of
+ * its source mod and folds it into a single Locker-managed cosmetics VPK that
+ * wins by load order. Clicking the active card again reverts to default.
  */
 export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
+  const loadMods = useAppStore((s) => s.loadMods);
   // This component is remounted per hero (the parent LockerHeroView is keyed
-  // by hero.id), so initial state stands in for the per-hero reset and the
-  // effect only needs to set state from its async callbacks.
+  // by hero.id), so initial state stands in for the per-hero reset.
   const [portraits, setPortraits] = useState<HeroPortrait[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  // The source VPK filename whose card is currently applied for this hero.
+  const [activeSource, setActiveSource] = useState<string | null>(null);
+  // The source filename mid-apply/revert (drives the per-tile spinner).
+  const [busySource, setBusySource] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
-    getHeroPortraits(heroName)
-      .then((list) => {
-        if (active) setPortraits(list);
+    setLoading(true);
+    setError(null);
+    Promise.all([getHeroPortraits(heroName), getActiveHeroCard(heroName)])
+      .then(([list, activeCard]) => {
+        if (!active) return;
+        setPortraits(list);
+        setActiveSource(activeCard?.sourceFileName ?? null);
       })
       .catch((err) => {
         if (active) setError(String(err));
@@ -49,6 +58,28 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       active = false;
     };
   }, [heroName]);
+
+  const handlePick = async (modFileName: string) => {
+    if (busySource) return;
+    setBusySource(modFileName);
+    setActionError(null);
+    try {
+      if (activeSource === modFileName) {
+        await revertHeroCard(heroName);
+        setActiveSource(null);
+      } else {
+        const result = await applyHeroCard(heroName, modFileName);
+        setActiveSource(result.activeSourceFileName);
+      }
+      // Rebuild changed the cosmetics VPK and possibly the load order; refresh
+      // the shared mod list so Installed/Locker stay in sync.
+      await loadMods({ silent: true });
+    } catch (err) {
+      setActionError(String(err));
+    } finally {
+      setBusySource(null);
+    }
+  };
 
   // Prefer the full "card" cover for the grid; fall back to whatever exists.
   const covers = portraits.filter((p) => p.variant === 'card');
@@ -64,8 +95,8 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
         </span>
       </div>
       <p className="text-xs text-text-secondary">
-        Card art found in your installed mods. Preview only for now: selecting one
-        does not change the game yet.
+        Card art found in your installed mods. Click one to apply it for {heroName};
+        click the applied card again to revert to default.
       </p>
 
       {loading && (
@@ -81,6 +112,13 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
         </div>
       )}
 
+      {actionError && (
+        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+          <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <span className="break-words">{actionError}</span>
+        </div>
+      )}
+
       {!loading && !error && display.length === 0 && (
         <p className="py-2 text-xs text-text-secondary">
           No card art found in your installed mods for {heroName}.
@@ -91,24 +129,36 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
         <div className="grid grid-cols-3 gap-2">
           {display.map((p, i) => {
             const key = `${p.modFileName}:${p.variant}:${i}`;
-            const isSelected = selected === key;
+            const isApplied = activeSource === p.modFileName;
+            const isBusy = busySource === p.modFileName;
             return (
               <button
                 type="button"
                 key={key}
-                onClick={() => setSelected(isSelected ? null : key)}
+                disabled={busySource !== null}
+                onClick={() => handlePick(p.modFileName)}
                 title={`${p.modFileName} · ${VARIANT_LABEL[p.variant] ?? p.variant} · ${p.width}x${p.height} · ${p.formatName}`}
-                className={`group relative overflow-hidden rounded-lg border bg-bg-tertiary transition-colors cursor-pointer ${
-                  isSelected
+                className={`group relative overflow-hidden rounded-lg border bg-bg-tertiary transition-colors disabled:cursor-not-allowed ${
+                  isApplied
                     ? 'border-accent ring-2 ring-accent/50'
                     : 'border-border hover:border-accent/50'
-                }`}
+                } ${busySource !== null && !isBusy ? 'opacity-60' : 'cursor-pointer'}`}
               >
                 <img
                   src={p.dataUrl}
                   alt={`${heroName} card from ${p.modFileName}`}
                   className="w-full aspect-[3/4] object-contain"
                 />
+                {isApplied && !isBusy && (
+                  <span className="absolute top-1 right-1 flex items-center gap-0.5 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
+                    <Check className="w-2.5 h-2.5" /> Applied
+                  </span>
+                )}
+                {isBusy && (
+                  <span className="absolute inset-0 flex items-center justify-center bg-black/50">
+                    <Loader2 className="w-5 h-5 animate-spin text-white" />
+                  </span>
+                )}
                 <span className="block truncate px-1.5 py-1 text-left text-[10px] text-text-secondary">
                   {p.modFileName.replace(/_dir\.vpk$/, '')}
                 </span>

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Images, Loader2, AlertCircle } from 'lucide-react';
+import { getHeroPortraits } from '../../lib/api';
+import type { HeroPortrait } from '../../types/portrait';
+
+interface HeroCardPickerProps {
+  heroName: string;
+}
+
+const VARIANT_LABEL: Record<string, string> = {
+  card: 'Card',
+  vertical: 'Vertical',
+  card_critical: 'Low HP',
+  card_gloat: 'Gloat',
+  minimap: 'Minimap',
+  small: 'Small',
+  other: 'Other',
+};
+
+/**
+ * EXPERIMENTAL prototype: surfaces the hero card/portrait art that the user's
+ * installed mods ship, decoded on demand via `vpkmerge portrait`. Selecting a
+ * card only highlights it for now: actually applying it to the game (splitting
+ * the panorama art out of its source mod and rolling it into the load order)
+ * is a separate, not-yet-built step.
+ */
+export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
+  // This component is remounted per hero (the parent LockerHeroView is keyed
+  // by hero.id), so initial state stands in for the per-hero reset and the
+  // effect only needs to set state from its async callbacks.
+  const [portraits, setPortraits] = useState<HeroPortrait[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getHeroPortraits(heroName)
+      .then((list) => {
+        if (active) setPortraits(list);
+      })
+      .catch((err) => {
+        if (active) setError(String(err));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [heroName]);
+
+  // Prefer the full "card" cover for the grid; fall back to whatever exists.
+  const covers = portraits.filter((p) => p.variant === 'card');
+  const display = covers.length > 0 ? covers : portraits;
+
+  return (
+    <section className="space-y-3 border-t border-border/60 pt-5">
+      <div className="flex items-center gap-2">
+        <Images className="w-4 h-4 text-accent" />
+        <h3 className="text-sm font-semibold text-text-primary">Hero Card</h3>
+        <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+          Experimental
+        </span>
+      </div>
+      <p className="text-xs text-text-secondary">
+        Card art found in your installed mods. Preview only for now: selecting one
+        does not change the game yet.
+      </p>
+
+      {loading && (
+        <div className="flex items-center gap-2 py-4 text-xs text-text-secondary">
+          <Loader2 className="w-4 h-4 animate-spin" /> Decoding portraits...
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+          <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <span className="break-words">{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && display.length === 0 && (
+        <p className="py-2 text-xs text-text-secondary">
+          No card art found in your installed mods for {heroName}.
+        </p>
+      )}
+
+      {display.length > 0 && (
+        <div className="grid grid-cols-3 gap-2">
+          {display.map((p, i) => {
+            const key = `${p.modFileName}:${p.variant}:${i}`;
+            const isSelected = selected === key;
+            return (
+              <button
+                type="button"
+                key={key}
+                onClick={() => setSelected(isSelected ? null : key)}
+                title={`${p.modFileName} · ${VARIANT_LABEL[p.variant] ?? p.variant} · ${p.width}x${p.height} · ${p.formatName}`}
+                className={`group relative overflow-hidden rounded-lg border bg-bg-tertiary transition-colors cursor-pointer ${
+                  isSelected
+                    ? 'border-accent ring-2 ring-accent/50'
+                    : 'border-border hover:border-accent/50'
+                }`}
+              >
+                <img
+                  src={p.dataUrl}
+                  alt={`${heroName} card from ${p.modFileName}`}
+                  className="w-full aspect-[3/4] object-contain"
+                />
+                <span className="block truncate px-1.5 py-1 text-left text-[10px] text-text-secondary">
+                  {p.modFileName.replace(/_dir\.vpk$/, '')}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Images, Loader2, AlertCircle, Check } from 'lucide-react';
 import { applyHeroCard, getActiveHeroCard, getHeroPortraits, revertHeroCard } from '../../lib/api';
 import { useAppStore } from '../../stores/appStore';
@@ -17,6 +17,20 @@ const VARIANT_LABEL: Record<string, string> = {
   small: 'Small',
   other: 'Other',
 };
+
+/** Display order for the variant strip. The full "card" cover reads first,
+ *  then the rest roughly by prominence; unknown variants sort last. */
+const VARIANT_ORDER = ['card', 'vertical', 'card_critical', 'card_gloat', 'minimap', 'small', 'other'];
+
+function variantRank(variant: string): number {
+  const i = VARIANT_ORDER.indexOf(variant);
+  return i === -1 ? VARIANT_ORDER.length : i;
+}
+
+interface PortraitFileGroup {
+  modFileName: string;
+  variants: HeroPortrait[];
+}
 
 /**
  * EXPERIMENTAL: surfaces the hero card/portrait art the user's installed mods
@@ -81,9 +95,22 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
     }
   };
 
-  // Prefer the full "card" cover for the grid; fall back to whatever exists.
-  const covers = portraits.filter((p) => p.variant === 'card');
-  const display = covers.length > 0 ? covers : portraits;
+  // Group every decoded portrait under the mod file it came from. A single
+  // file usually ships several variants (card, vertical, low-HP, gloat...), and
+  // apply works on the whole per-hero prefix, so the file is the selectable
+  // unit and its variants are shown side by side for preview.
+  const fileGroups = useMemo<PortraitFileGroup[]>(() => {
+    const byFile = new Map<string, HeroPortrait[]>();
+    for (const p of portraits) {
+      const arr = byFile.get(p.modFileName) ?? [];
+      arr.push(p);
+      byFile.set(p.modFileName, arr);
+    }
+    return Array.from(byFile.entries()).map(([modFileName, variants]) => ({
+      modFileName,
+      variants: [...variants].sort((a, b) => variantRank(a.variant) - variantRank(b.variant)),
+    }));
+  }, [portraits]);
 
   return (
     <section className="space-y-3 border-t border-border/60 pt-5">
@@ -95,8 +122,9 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
         </span>
       </div>
       <p className="text-xs text-text-secondary">
-        Card art found in your installed mods. Click one to apply it for {heroName};
-        click the applied card again to revert to default.
+        Card art found in your installed mods. Each mod may ship several portrait
+        variants; click a card to apply that mod's full set for {heroName}, and click
+        the applied card again to revert to default.
       </p>
 
       {loading && (
@@ -119,49 +147,74 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
         </div>
       )}
 
-      {!loading && !error && display.length === 0 && (
+      {!loading && !error && fileGroups.length === 0 && (
         <p className="py-2 text-xs text-text-secondary">
           No card art found in your installed mods for {heroName}.
         </p>
       )}
 
-      {display.length > 0 && (
-        <div className="grid grid-cols-3 gap-2">
-          {display.map((p, i) => {
-            const key = `${p.modFileName}:${p.variant}:${i}`;
-            const isApplied = activeSource === p.modFileName;
-            const isBusy = busySource === p.modFileName;
+      {fileGroups.length > 0 && (
+        <div className="space-y-2.5">
+          {fileGroups.map((group) => {
+            const isApplied = activeSource === group.modFileName;
+            const isBusy = busySource === group.modFileName;
             return (
               <button
                 type="button"
-                key={key}
+                key={group.modFileName}
                 disabled={busySource !== null}
-                onClick={() => handlePick(p.modFileName)}
-                title={`${p.modFileName} · ${VARIANT_LABEL[p.variant] ?? p.variant} · ${p.width}x${p.height} · ${p.formatName}`}
-                className={`group relative overflow-hidden rounded-lg border bg-bg-tertiary transition-colors disabled:cursor-not-allowed ${
+                onClick={() => handlePick(group.modFileName)}
+                title={`${group.modFileName} · ${group.variants.length} portrait(s)`}
+                // Frosted-glass surface matching HeroSkinsPanel's card tokens so
+                // the Cards tab reads as a sibling of Skins. backdrop-blur on the
+                // resting state too (not just active) since these sit directly
+                // over the hero portrait.
+                className={`group relative block w-full overflow-hidden rounded-md border text-left backdrop-blur-sm transition-colors disabled:cursor-not-allowed ${
                   isApplied
-                    ? 'border-accent ring-2 ring-accent/50'
-                    : 'border-border hover:border-accent/50'
+                    ? 'border-accent/60 bg-white/[0.05] ring-1 ring-accent/30'
+                    : 'border-border bg-bg-secondary/70 hover:border-accent/60 hover:bg-bg-secondary/85'
                 } ${busySource !== null && !isBusy ? 'opacity-60' : 'cursor-pointer'}`}
               >
-                <img
-                  src={p.dataUrl}
-                  alt={`${heroName} card from ${p.modFileName}`}
-                  className="w-full aspect-[3/4] object-contain"
-                />
-                {isApplied && !isBusy && (
-                  <span className="absolute top-1 right-1 flex items-center gap-0.5 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
-                    <Check className="w-2.5 h-2.5" /> Applied
+                <div className="flex items-center justify-between gap-2 border-b border-border/50 px-3 py-2">
+                  <span className="truncate text-xs font-semibold text-text-primary">
+                    {group.modFileName.replace(/_dir\.vpk$/, '')}
                   </span>
-                )}
+                  {isApplied ? (
+                    <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
+                      <Check className="h-2.5 w-2.5" /> Applied
+                    </span>
+                  ) : (
+                    <span className="flex-shrink-0 text-[10px] uppercase tracking-wide text-text-secondary">
+                      {group.variants.length} portrait{group.variants.length !== 1 ? 's' : ''}
+                    </span>
+                  )}
+                </div>
+                {/* Uniform aspect-3/4 tiles in a fixed grid keep the strip tidy
+                    regardless of each variant's native aspect. max-w/h-full
+                    contains the art without ever upscaling it, so tiny minimap
+                    art stays crisp instead of blurring up to a forced height. */}
+                <div className="grid grid-cols-4 gap-2 p-3">
+                  {group.variants.map((p, i) => (
+                    <figure key={`${p.variant}:${i}`} className="min-w-0">
+                      <div className="flex aspect-[3/4] items-center justify-center overflow-hidden rounded-md border border-border/50 bg-bg-primary/40">
+                        <img
+                          src={p.dataUrl}
+                          alt={`${heroName} ${VARIANT_LABEL[p.variant] ?? p.variant}`}
+                          title={`${VARIANT_LABEL[p.variant] ?? p.variant} · ${p.width}x${p.height} · ${p.formatName}`}
+                          className="max-h-full max-w-full object-contain"
+                        />
+                      </div>
+                      <figcaption className="mt-1 truncate text-center text-[9px] uppercase tracking-wide text-text-secondary">
+                        {VARIANT_LABEL[p.variant] ?? p.variant}
+                      </figcaption>
+                    </figure>
+                  ))}
+                </div>
                 {isBusy && (
-                  <span className="absolute inset-0 flex items-center justify-center bg-black/50">
-                    <Loader2 className="w-5 h-5 animate-spin text-white" />
+                  <span className="absolute inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+                    <Loader2 className="h-5 w-5 animate-spin text-white" />
                   </span>
                 )}
-                <span className="block truncate px-1.5 py-1 text-left text-[10px] text-text-secondary">
-                  {p.modFileName.replace(/_dir\.vpk$/, '')}
-                </span>
               </button>
             );
           })}

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from 'lucide-react';
 import type { Mod } from '../../types/mod';
 import { getLockerSkinKey, type MinaPreset, type MinaSelection, type MinaVariant } from '../../lib/lockerUtils';
 import ModThumbnail from '../ModThumbnail';
+import AudioPreviewPlayer from '../AudioPreviewPlayer';
 import DownloadableSkinsSection from './DownloadableSkinsSection';
 import { Skeleton } from '../common/Skeleton';
 
@@ -461,6 +462,20 @@ export default function HeroSkinsPanel({
                   <span className="text-xs text-accent font-semibold">Active</span>
                 )}
               </button>
+              {/* Sound preview. All variants of one GameBanana submission share
+                  the same preview clip, so the group's primary audioUrl is the
+                  representative sample. Rendered as a sibling of the toggle
+                  button (not nested) so its own click handlers can stopPropagation
+                  without fighting the card toggle. */}
+              {primary.sourceSection === 'Sound' && primary.audioUrl && (
+                <div
+                  className="px-3 pb-3"
+                  onClick={(e) => e.stopPropagation()}
+                  onMouseDown={(e) => e.stopPropagation()}
+                >
+                  <AudioPreviewPlayer src={primary.audioUrl} compact />
+                </div>
+              )}
               {isMulti && (
                 <div
                   className={`flex flex-wrap items-center gap-1.5 px-2.5 pb-2.5 pt-2 border-t ${

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult } from '../types/mod';
+import type { HeroPortrait } from '../types/portrait';
 import type {
   GameBananaModsResponse,
   GameBananaModDetails,
@@ -90,6 +91,10 @@ export async function setModLockerHero(
   heroName: string | null
 ): Promise<Mod> {
   return window.electronAPI.setModLockerHero(modId, heroName);
+}
+
+export async function getHeroPortraits(heroName: string): Promise<HeroPortrait[]> {
+  return window.electronAPI.getHeroPortraits(heroName);
 }
 
 export async function setModGlobalType(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ApplyHeroCardResult } from '../types/mod';
 import type { HeroPortrait } from '../types/portrait';
 import type {
   GameBananaModsResponse,
@@ -95,6 +95,23 @@ export async function setModLockerHero(
 
 export async function getHeroPortraits(heroName: string): Promise<HeroPortrait[]> {
   return window.electronAPI.getHeroPortraits(heroName);
+}
+
+export async function applyHeroCard(
+  heroName: string,
+  sourceFileName: string
+): Promise<ApplyHeroCardResult> {
+  return window.electronAPI.applyHeroCard(heroName, sourceFileName);
+}
+
+export async function revertHeroCard(heroName: string): Promise<ApplyHeroCardResult> {
+  return window.electronAPI.revertHeroCard(heroName);
+}
+
+export async function getActiveHeroCard(
+  heroName: string
+): Promise<{ sourceFileName: string; variants: string[] } | null> {
+  return window.electronAPI.getActiveHeroCard(heroName);
 }
 
 export async function setModGlobalType(

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -248,6 +248,13 @@ export function isLockerManagedMod(mod: Mod): boolean {
   // a hero skin card in its own right.
   if (mod.lockerCosmetics) return false;
 
+  // Sound-section mods are the Sounds tab's domain (see isLockerManagedSound),
+  // never hero skins. They get an auto hero-tag at download time, so guard on
+  // the section explicitly before the lockerHero escape hatch below — otherwise
+  // a hero-tagged sound (e.g. a "Seven Ult Sound Replacer") falls through that
+  // hatch and surfaces in the Skins pile.
+  if (mod.sourceSection === 'Sound') return false;
+
   // A manual Locker hero tag is an explicit user intent to manage this VPK as
   // a hero skin, including custom local imports that do not have GameBanana
   // section metadata.
@@ -287,6 +294,13 @@ const GLOBAL_SOUND_CATEGORIES: ReadonlySet<string> = new Set([
  */
 export function isLockerManagedSound(mod: Mod): boolean {
   if (mod.sourceSection !== 'Sound') return false;
+  // An explicit hero tag (auto-set from the title at download, or set by hand)
+  // means this sound is hero-specific and belongs in that hero's Sounds tab,
+  // even when GameBanana filed it under a global music/UI category. The
+  // GLOBAL_SOUND_CATEGORIES drop exists only for sounds with no hero to tag;
+  // without this short-circuit, a "Seven Ult Sound Replacer" categorized as
+  // "In-Game Music" gets dropped here and then mis-surfaces under Skins.
+  if (mod.lockerHero) return true;
   const category = mod.categoryName?.trim().toLowerCase();
   if (category && GLOBAL_SOUND_CATEGORIES.has(category)) return false;
   return true;

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -325,6 +325,24 @@ export function isKillstreakMusicSound(mod: Mod): boolean {
   );
 }
 
+/** Lowercased GameBanana "Announcer" sound category name. */
+const ANNOUNCER_CATEGORY = 'announcer';
+
+/**
+ * True for Sound mods filed under GameBanana's "Announcer" category. These play
+ * match-wide with no hero, so the Locker surfaces them on the Global card's
+ * Announcer / SFX slide rather than dropping them (GLOBAL_SOUND_CATEGORIES) or
+ * mis-filing them under a hero. Path-classifiable announcer frameworks (QOL
+ * Lock, `sounds/mods/`) already carry a 'announcer' globalType from the
+ * main-process classifier; this rescues the sound-only packs that don't.
+ */
+export function isAnnouncerSound(mod: Mod): boolean {
+  return (
+    mod.sourceSection === 'Sound' &&
+    mod.categoryName?.trim().toLowerCase() === ANNOUNCER_CATEGORY
+  );
+}
+
 /**
  * A mod's effective Locker global type. Prefers the persisted globalType (the
  * VPK-path classification, or a manual override set via the Global card's
@@ -339,6 +357,8 @@ export function isKillstreakMusicSound(mod: Mod): boolean {
 export function getEffectiveGlobalType(mod: Mod): GlobalModType | undefined {
   if (mod.globalType) return mod.globalType;
   if (isKillstreakMusicSound(mod)) return 'killstreak-music';
+  // A hero tag wins: hero-tied SFX belong on that hero's Sounds tab, not here.
+  if (!mod.lockerHero && isAnnouncerSound(mod)) return 'announcer';
   return undefined;
 }
 
@@ -487,6 +507,7 @@ export const GLOBAL_MOD_TYPE_LABELS: Record<GlobalModType, string> = {
   hideout: 'Hideout',
   icons: 'Icon Packs',
   hud: 'HUD',
+  announcer: 'Announcer / SFX',
   'killstreak-music': 'Killstreak Music',
 };
 
@@ -496,6 +517,7 @@ export const GLOBAL_MOD_TYPE_ORDER: readonly GlobalModType[] = [
   'hideout',
   'icons',
   'hud',
+  'announcer',
   'killstreak-music',
 ];
 
@@ -513,6 +535,7 @@ export function groupGlobalMods(mods: Mod[]): GlobalModGroups {
     hideout: [],
     icons: [],
     hud: [],
+    announcer: [],
     'killstreak-music': [],
   };
   for (const mod of mods) {

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -244,6 +244,10 @@ export function detectMinaTextures(mods: Mod[]) {
 }
 
 export function isLockerManagedMod(mod: Mod): boolean {
+  // The Locker cosmetics VPK (applied hero cards) is a managed artifact, never
+  // a hero skin card in its own right.
+  if (mod.lockerCosmetics) return false;
+
   // A manual Locker hero tag is an explicit user intent to manage this VPK as
   // a hero skin, including custom local imports that do not have GameBanana
   // section metadata.

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -306,6 +306,42 @@ export function isLockerManagedSound(mod: Mod): boolean {
   return true;
 }
 
+/**
+ * Lowercased GameBanana category name for the Killstreak Music sound category
+ * (cat 5895 — see docs/gamebanana_categories_reference.md).
+ */
+const KILLSTREAK_MUSIC_CATEGORY = 'killstreak music';
+
+/**
+ * True for Sound mods filed under GameBanana's "Killstreak Music" category.
+ * This music plays match-wide (no hero), so the Locker treats it as a global
+ * type on the Global card rather than per-hero sounds. Used by
+ * getEffectiveGlobalType; kept narrow (category only) on purpose.
+ */
+export function isKillstreakMusicSound(mod: Mod): boolean {
+  return (
+    mod.sourceSection === 'Sound' &&
+    mod.categoryName?.trim().toLowerCase() === KILLSTREAK_MUSIC_CATEGORY
+  );
+}
+
+/**
+ * A mod's effective Locker global type. Prefers the persisted globalType (the
+ * VPK-path classification, or a manual override set via the Global card's
+ * retag menu), then derives 'killstreak-music' from the GameBanana category.
+ *
+ * Killstreak music can't be path-classified (a Sound VPK is just `sounds/`),
+ * so it's derived here instead of in the main-process classifier. Deriving it
+ * live also means it lights up for mods that were already installed before the
+ * category existed, with no metadata migration. A manual override still wins,
+ * since `mod.globalType` is checked first.
+ */
+export function getEffectiveGlobalType(mod: Mod): GlobalModType | undefined {
+  if (mod.globalType) return mod.globalType;
+  if (isKillstreakMusicSound(mod)) return 'killstreak-music';
+  return undefined;
+}
+
 export function getLockerSkinKey(mod: Mod): string {
   return typeof mod.gameBananaId === 'number' && mod.gameBananaId > 0
     ? `gamebanana:${mod.gameBananaId}`
@@ -451,6 +487,7 @@ export const GLOBAL_MOD_TYPE_LABELS: Record<GlobalModType, string> = {
   hideout: 'Hideout',
   icons: 'Icon Packs',
   hud: 'HUD',
+  'killstreak-music': 'Killstreak Music',
 };
 
 /** Carousel/section order for the global types. */
@@ -459,6 +496,7 @@ export const GLOBAL_MOD_TYPE_ORDER: readonly GlobalModType[] = [
   'hideout',
   'icons',
   'hud',
+  'killstreak-music',
 ];
 
 export type GlobalModGroups = Record<GlobalModType, Mod[]>;
@@ -475,10 +513,12 @@ export function groupGlobalMods(mods: Mod[]): GlobalModGroups {
     hideout: [],
     icons: [],
     hud: [],
+    'killstreak-music': [],
   };
   for (const mod of mods) {
-    if (mod.globalType && groups[mod.globalType]) {
-      groups[mod.globalType].push(mod);
+    const type = getEffectiveGlobalType(mod);
+    if (type && groups[type]) {
+      groups[type].push(mod);
     }
   }
   for (const type of GLOBAL_MOD_TYPE_ORDER) {
@@ -492,7 +532,7 @@ export function groupGlobalMods(mods: Mod[]): GlobalModGroups {
 
 /** Total number of mods classified into any global type. */
 export function countGlobalMods(mods: Mod[]): number {
-  return mods.reduce((n, mod) => (mod.globalType ? n + 1 : n), 0);
+  return mods.reduce((n, mod) => (getEffectiveGlobalType(mod) ? n + 1 : n), 0);
 }
 
 export function groupModsByCategory(mods: Mod[], heroList?: { id: number; name: string }[]) {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -318,9 +318,12 @@ export default function Installed() {
       for (const src of m.merged.sources) absorbedFileNames.add(src.fileName);
     }
   }
-  const visibleMods = absorbedFileNames.size > 0
-    ? mods.filter((m) => !absorbedFileNames.has(m.fileName))
-    : mods;
+  // The Locker cosmetics VPK is a Locker-managed artifact (applied hero cards),
+  // not a user-installed mod, so it never shows as a card here. It's managed
+  // entirely from the Locker's Hero Card picker.
+  const visibleMods = mods.filter(
+    (m) => !m.lockerCosmetics && !absorbedFileNames.has(m.fileName)
+  );
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = localStorage.getItem('installedViewMode');
     return stored === 'grid' || stored === 'compact' || stored === 'list' ? stored : 'grid';

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2292,9 +2292,9 @@ export default function Installed() {
           <div
             className={
               viewMode === 'compact'
-                ? 'grid [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))] gap-3'
+                ? 'grid [grid-template-columns:repeat(auto-fill,minmax(210px,1fr))] gap-3'
                 : viewMode === 'grid'
-                  ? 'grid [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))] gap-4'
+                  ? 'grid [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))] gap-4'
                   : 'space-y-1.5'
             }
           >
@@ -2313,9 +2313,9 @@ export default function Installed() {
           <div
             className={
               viewMode === 'compact'
-                ? 'grid [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))] gap-3'
+                ? 'grid [grid-template-columns:repeat(auto-fill,minmax(210px,1fr))] gap-3'
                 : viewMode === 'grid'
-                  ? 'grid [grid-template-columns:repeat(auto-fill,minmax(360px,1fr))] gap-4'
+                  ? 'grid [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))] gap-4'
                   : 'space-y-1.5'
             }
           >
@@ -2894,9 +2894,9 @@ function InstalledSkeleton({ viewMode }: { viewMode: ViewMode }) {
       <div
         className={
           viewMode === 'compact'
-            ? 'grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2'
+            ? 'grid [grid-template-columns:repeat(auto-fill,minmax(210px,1fr))] gap-3'
             : viewMode === 'grid'
-              ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4'
+              ? 'grid [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))] gap-4'
               : 'space-y-2'
         }
       >

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -15,6 +15,7 @@ import { getAssetPath } from '../lib/assetPath';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import { LockerHeroView } from './LockerHero';
 import ModThumbnail from '../components/ModThumbnail';
+import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { GlobalModType, Mod } from '../types/mod';
 import { ViewModeToggle, EmptyState, SectionHeader } from '../components/common/PageComponents';
@@ -32,6 +33,7 @@ import {
   countLockerSkins,
   detectMinaTextures,
   findMinaVariant,
+  getEffectiveGlobalType,
   getHeroFacePosition,
   getHeroNamePath,
   getHeroRenderPath,
@@ -222,11 +224,14 @@ export default function Locker() {
   // match would file e.g. "Lowpoly Holliday Soul Container" into Holliday's
   // pile instead of Soul Containers.
   const lockerMods = useMemo(
-    () => mods.filter((m) => isLockerManagedMod(m) && !m.globalType),
+    () => mods.filter((m) => isLockerManagedMod(m) && !getEffectiveGlobalType(m)),
     [mods]
   );
+  // Killstreak Music sounds are global (match-wide, no hero), so keep them off
+  // the per-hero Sounds axis even when GameBanana filed them under a hero or
+  // inferHeroFromTitle tagged one. getEffectiveGlobalType reflects that routing.
   const lockerSounds = useMemo(
-    () => mods.filter((m) => isLockerManagedSound(m) && !m.globalType),
+    () => mods.filter((m) => isLockerManagedSound(m) && !getEffectiveGlobalType(m)),
     [mods]
   );
   const globalGroups = useMemo(() => groupGlobalMods(mods), [mods]);
@@ -1092,30 +1097,35 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                         )}
                         {/* Retag control: sits above the full-card toggle overlay
                             (z-20 > z-10) and stops propagation so opening it never
-                            also toggles the mod. */}
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const r = e.currentTarget.getBoundingClientRect();
-                            const MENU_W = 208;
-                            const MENU_H = 220;
-                            const x = Math.max(
-                              8,
-                              Math.min(r.right - MENU_W, window.innerWidth - MENU_W - 8)
-                            );
-                            const y =
-                              r.bottom + MENU_H > window.innerHeight
-                                ? Math.max(8, r.top - MENU_H - 4)
-                                : r.bottom + 4;
-                            setRetagMenu({ id: mod.id, x, y });
-                          }}
-                          aria-label={`Change category for ${mod.name}`}
-                          title="Change category"
-                          className="absolute right-2 top-2 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-white/15 bg-black/45 text-white/85 opacity-0 backdrop-blur-sm transition-opacity hover:bg-black/65 focus:opacity-100 focus-visible:opacity-100 group-hover/card:opacity-100"
-                        >
-                          <MoreVertical className="h-4 w-4" />
-                        </button>
+                            also toggles the mod. Hidden for Killstreak Music: that
+                            type is derived from the GameBanana category, not a
+                            manual assignment, and the sound belongs to no hero, so
+                            there's nowhere meaningful to retag it. */}
+                        {activeType !== 'killstreak-music' && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              const r = e.currentTarget.getBoundingClientRect();
+                              const MENU_W = 208;
+                              const MENU_H = 220;
+                              const x = Math.max(
+                                8,
+                                Math.min(r.right - MENU_W, window.innerWidth - MENU_W - 8)
+                              );
+                              const y =
+                                r.bottom + MENU_H > window.innerHeight
+                                  ? Math.max(8, r.top - MENU_H - 4)
+                                  : r.bottom + 4;
+                              setRetagMenu({ id: mod.id, x, y });
+                            }}
+                            aria-label={`Change category for ${mod.name}`}
+                            title="Change category"
+                            className="absolute right-2 top-2 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-white/15 bg-black/45 text-white/85 opacity-0 backdrop-blur-sm transition-opacity hover:bg-black/65 focus:opacity-100 focus-visible:opacity-100 group-hover/card:opacity-100"
+                          >
+                            <MoreVertical className="h-4 w-4" />
+                          </button>
+                        )}
                       </div>
 
                       {/* Title only — the whole card is the enable/disable control. */}
@@ -1127,6 +1137,20 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                           {mod.name}
                         </h3>
                       </div>
+
+                      {/* Audio preview for sound-backed global mods (Killstreak
+                          Music). Sits above the full-card toggle overlay (z-20 >
+                          z-10) and stops propagation so play/seek never also
+                          toggles the mod, mirroring the hero Sounds tab. */}
+                      {mod.audioUrl && (
+                        <div
+                          className="relative z-20 mt-2 px-0.5"
+                          onClick={(e) => e.stopPropagation()}
+                          onMouseDown={(e) => e.stopPropagation()}
+                        >
+                          <AudioPreviewPlayer src={mod.audioUrl} compact />
+                        </div>
+                      )}
 
                       {/* Full-card click target: clicking anywhere enables/disables
                           the mod. Kept as a transparent overlay (not a wrapping
@@ -1168,7 +1192,9 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
             <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
               Move to category
             </div>
-            {GLOBAL_MOD_TYPE_ORDER.map((type) => {
+            {/* Killstreak Music is derived from the GameBanana category, not a
+                manual destination, so it's not offered as a move target. */}
+            {GLOBAL_MOD_TYPE_ORDER.filter((type) => type !== 'killstreak-music').map((type) => {
               const isCurrent = type === activeType;
               return (
                 <button

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -832,7 +832,7 @@ function GlobalGalleryCard({ count, typeCount, onNavigate }: GlobalGalleryCardPr
   return (
     <div
       onClick={onNavigate}
-      className="group relative w-full cursor-pointer overflow-hidden rounded-2xl border border-accent/40 bg-bg-secondary text-left shadow-sm transition-transform duration-300 hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+      className="group relative w-full cursor-pointer overflow-hidden rounded-2xl border border-border bg-bg-secondary text-left shadow-sm transition-transform duration-300 hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
     >
       <div className="relative aspect-[3/4]">
         <img
@@ -847,11 +847,11 @@ function GlobalGalleryCard({ count, typeCount, onNavigate }: GlobalGalleryCardPr
           {count} mod{count !== 1 ? 's' : ''}
         </div>
       </div>
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2 sm:p-3">
-        <div className="text-sm font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
+      <div className="absolute inset-x-0 bottom-0 flex flex-col items-end bg-gradient-to-t from-black/70 to-transparent p-2 text-right sm:p-3">
+        <div className="font-reaver text-lg leading-tight tracking-wide text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
           Global
         </div>
-        <div className="text-[11px] text-white/70">
+        <div className="text-[11px] text-white/70 drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
           {typeCount} categor{typeCount !== 1 ? 'ies' : 'y'}
         </div>
       </div>

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -11,6 +11,7 @@ import {
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
+import HeroCardPicker from '../components/locker/HeroCardPicker';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { Mod } from '../types/mod';
 import {
@@ -584,6 +585,9 @@ export function LockerHeroView({
               onApplyMinaVariant={activeSection === 'skins' ? onApplyMinaVariant : undefined}
             />
           </div>
+
+          {/* Hero card / portrait picker (experimental prototype) */}
+          <HeroCardPicker heroName={hero.name} />
 
         </div>
       </div>

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Layers, Star, Music, Shirt } from 'lucide-react';
+import { ArrowLeft, Layers, Star, Music, Shirt, Images } from 'lucide-react';
 import { Skeleton } from '../components/common/Skeleton';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -349,7 +349,7 @@ export function LockerHeroView({
 }: LockerHeroViewProps) {
   const [renderFallbackStep, setRenderFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
-  const [section, setSection] = useState<'skins' | 'sounds'>('skins');
+  const [section, setSection] = useState<'skins' | 'sounds' | 'cards'>('skins');
   const hasSounds = soundList.length > 0;
   // If the active section runs out of mods (e.g. user deleted their last
   // sound for this hero) drop back to skins so the panel isn't stuck empty.
@@ -496,38 +496,40 @@ export function LockerHeroView({
               />
             )}
             <span className="text-sm text-text-secondary">
-              {activeSection === 'sounds'
-                ? soundCount > 0
-                  ? `${soundCount} sound${soundCount !== 1 ? 's' : ''}`
-                  : 'No sounds'
-                : skinCount > 0
-                  ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}`
-                  : 'No skins'}
+              {activeSection === 'cards'
+                ? 'Card art'
+                : activeSection === 'sounds'
+                  ? soundCount > 0
+                    ? `${soundCount} sound${soundCount !== 1 ? 's' : ''}`
+                    : 'No sounds'
+                  : skinCount > 0
+                    ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}`
+                    : 'No skins'}
             </span>
           </div>
 
-          {/* Section toggle: only when this hero has at least one Sound mod;
-              the toggle would be empty noise for heroes with skins-only piles. */}
-          {hasSounds && (
-            <div
-              role="tablist"
-              aria-label="Section"
-              className="inline-flex items-center rounded-full border border-border bg-bg-tertiary p-0.5 text-xs"
+          {/* Section toggle. Skins and Cards are always available; Sounds only
+              shows when this hero has at least one tagged Sound mod. */}
+          <div
+            role="tablist"
+            aria-label="Section"
+            className="inline-flex items-center rounded-full border border-border bg-bg-tertiary p-0.5 text-xs"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeSection === 'skins'}
+              onClick={() => setSection('skins')}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
+                activeSection === 'skins'
+                  ? 'bg-accent/15 text-text-primary border border-accent/40'
+                  : 'text-text-secondary hover:text-text-primary border border-transparent'
+              }`}
             >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeSection === 'skins'}
-                onClick={() => setSection('skins')}
-                className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
-                  activeSection === 'skins'
-                    ? 'bg-accent/15 text-text-primary border border-accent/40'
-                    : 'text-text-secondary hover:text-text-primary border border-transparent'
-                }`}
-              >
-                <Shirt className="w-3.5 h-3.5" />
-                Skins
-              </button>
+              <Shirt className="w-3.5 h-3.5" />
+              Skins
+            </button>
+            {hasSounds && (
               <button
                 type="button"
                 role="tab"
@@ -542,11 +544,28 @@ export function LockerHeroView({
                 <Music className="w-3.5 h-3.5" />
                 Sounds
               </button>
-            </div>
-          )}
+            )}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeSection === 'cards'}
+              onClick={() => setSection('cards')}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
+                activeSection === 'cards'
+                  ? 'bg-accent/15 text-text-primary border border-accent/40'
+                  : 'text-text-secondary hover:text-text-primary border border-transparent'
+              }`}
+            >
+              <Images className="w-3.5 h-3.5" />
+              Cards
+            </button>
+          </div>
 
-          {/* Skin / Sound Selection */}
+          {/* Skin / Sound / Card selection */}
           <div className="space-y-4">
+            {activeSection === 'cards' ? (
+              <HeroCardPicker heroName={hero.name} />
+            ) : (
             <HeroSkinsPanel
               mods={activeList}
               onSelect={onSelect}
@@ -584,10 +603,8 @@ export function LockerHeroView({
               }
               onApplyMinaVariant={activeSection === 'skins' ? onApplyMinaVariant : undefined}
             />
+            )}
           </div>
-
-          {/* Hero card / portrait picker (experimental prototype) */}
-          <HeroCardPicker heroName={hero.name} />
 
         </div>
       </div>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -19,6 +19,7 @@ import type {
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
 } from './gamebanana';
+import type { HeroPortrait } from './portrait';
 
 export interface BrowseModsArgs {
     page: number;
@@ -292,6 +293,7 @@ export interface ElectronAPI {
     editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<Mod>;
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
+    getHeroPortraits: (heroName: string) => Promise<HeroPortrait[]>;
     setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<Mod>;
     setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
     EditLocalModArgs,
     MergeModsArgs,
     UnmergeModResult,
+    ApplyHeroCardResult,
 } from './mod';
 import type {
     GameBananaModsResponse,
@@ -294,6 +295,11 @@ export interface ElectronAPI {
     setVariantLabel: (modId: string, label: string) => Promise<Mod>;
     setModLockerHero: (modId: string, heroName: string | null) => Promise<Mod>;
     getHeroPortraits: (heroName: string) => Promise<HeroPortrait[]>;
+    applyHeroCard: (heroName: string, sourceFileName: string) => Promise<ApplyHeroCardResult>;
+    revertHeroCard: (heroName: string) => Promise<ApplyHeroCardResult>;
+    getActiveHeroCard: (
+        heroName: string
+    ) => Promise<{ sourceFileName: string; variants: string[] } | null>;
     setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<Mod>;
     setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -81,12 +81,16 @@ export interface ApplyHeroCardResult {
 
 /**
  * Global (non-hero) cosmetic mod types the Locker groups on a second axis,
- * alongside the per-hero piles. Derived from the VPK file tree by
+ * alongside the per-hero piles. Most are derived from the VPK file tree by
  * `classifyGlobalModType` (electron/main/services/vpk.ts), since GameBanana's
- * category labels are unreliable for these. Shared here so the classifier
- * (main) and the Locker grouping/UI (renderer) agree on the union.
+ * category labels are unreliable for them. The exception is 'killstreak-music':
+ * a Sound mod's VPK is just `sounds/`, so it can't be path-classified, and is
+ * instead derived from the GameBanana "Killstreak Music" category (cat 5895)
+ * by `getEffectiveGlobalType` in the renderer (src/lib/lockerUtils.ts). Shared
+ * here so the classifier (main) and the Locker grouping/UI (renderer) agree on
+ * the union.
  */
-export type GlobalModType = 'soul-container' | 'hideout' | 'icons' | 'hud';
+export type GlobalModType = 'soul-container' | 'hideout' | 'icons' | 'hud' | 'killstreak-music';
 export type LockerHeroSource = 'manual' | 'title' | 'vpk' | 'download-title' | 'download-vpk';
 
 export interface Mod {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -37,6 +37,49 @@ export interface MergedModInfo {
 }
 
 /**
+ * One hero-card choice inside the Locker cosmetics VPK. The user picked this
+ * hero's card art out of `source` (a mod they may or may not otherwise run);
+ * the rebuild splits just this hero's `panorama/images/heroes/<codename>_`
+ * files out of the source and folds them into the consolidated VPK.
+ */
+export interface LockerCardSelection {
+  heroCodename: string;
+  heroName: string;
+  /** Variant tokens captured from the source (e.g. ["card","vertical","mm"]).
+   *  Informational: the split takes the whole per-hero panorama prefix. */
+  variants: string[];
+  source: {
+    /** Source VPK filename at apply time. May drift if reconcile renames it;
+     *  `sha256AtApplyTime` is the content-identity fallback for relocation. */
+    fileName: string;
+    modName?: string;
+    gameBananaId?: number;
+    sha256AtApplyTime: string;
+  };
+  addedAt: string;
+}
+
+/**
+ * Manifest stamped on the single Locker-managed cosmetics VPK that holds every
+ * applied hero card. Its presence marks the VPK as Locker-managed so the rest
+ * of the UI (Installed, Locker piles, Conflicts, profile export) hides it.
+ * Rebuilt automatically on every apply/revert; unlike `merged`, there is no
+ * user-facing unmerge.
+ */
+export interface LockerCosmeticsInfo {
+  /** One entry per hero, keyed by heroCodename. */
+  cards: LockerCardSelection[];
+  rebuiltAt: string;
+}
+
+export interface ApplyHeroCardResult {
+  /** Source VPK filename now providing this hero's card, or null if reverted. */
+  activeSourceFileName: string | null;
+  /** Selections dropped because their source VPK was gone at rebuild time. */
+  missingSourceFileNames: string[];
+}
+
+/**
  * Global (non-hero) cosmetic mod types the Locker groups on a second axis,
  * alongside the per-hero piles. Derived from the VPK file tree by
  * `classifyGlobalModType` (electron/main/services/vpk.ts), since GameBanana's
@@ -86,6 +129,9 @@ export interface Mod {
   /** Set when this mod was produced by mergeMods. Carries the unroll payload
    *  (share code + source list). */
   merged?: MergedModInfo;
+  /** Set on the single Locker-managed cosmetics VPK that holds applied hero
+   *  cards. Other surfaces treat a truthy value as "hide this artifact". */
+  lockerCosmetics?: LockerCosmeticsInfo;
   /** User opted out of the "update available" flag for this mod. Persisted
    *  in metadata; toggled from the mod details modal. */
   ignoreUpdates?: boolean;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -83,14 +83,17 @@ export interface ApplyHeroCardResult {
  * Global (non-hero) cosmetic mod types the Locker groups on a second axis,
  * alongside the per-hero piles. Most are derived from the VPK file tree by
  * `classifyGlobalModType` (electron/main/services/vpk.ts), since GameBanana's
- * category labels are unreliable for them. The exception is 'killstreak-music':
- * a Sound mod's VPK is just `sounds/`, so it can't be path-classified, and is
- * instead derived from the GameBanana "Killstreak Music" category (cat 5895)
- * by `getEffectiveGlobalType` in the renderer (src/lib/lockerUtils.ts). Shared
+ * category labels are unreliable for them. 'announcer' is path-classified from
+ * `sounds/mods/` (global SFX / announcer frameworks like QOL Lock) but is ALSO
+ * derived from the GameBanana "Announcer" category for sound packs whose VPK is
+ * just `sounds/`. The other exception is 'killstreak-music': a Sound mod's VPK
+ * is just `sounds/`, so it can't be path-classified, and is instead derived
+ * from the GameBanana "Killstreak Music" category (cat 5895) by
+ * `getEffectiveGlobalType` in the renderer (src/lib/lockerUtils.ts). Shared
  * here so the classifier (main) and the Locker grouping/UI (renderer) agree on
  * the union.
  */
-export type GlobalModType = 'soul-container' | 'hideout' | 'icons' | 'hud' | 'killstreak-music';
+export type GlobalModType = 'soul-container' | 'hideout' | 'icons' | 'hud' | 'announcer' | 'killstreak-music';
 export type LockerHeroSource = 'manual' | 'title' | 'vpk' | 'download-title' | 'download-vpk';
 
 export interface Mod {

--- a/src/types/portrait.ts
+++ b/src/types/portrait.ts
@@ -1,0 +1,18 @@
+/**
+ * A hero portrait/card texture decoded out of an installed mod's VPK by the
+ * `vpkmerge portrait` subcommand. This is the prototype surface for the Locker
+ * "pick your hero card" picker. Decoding/extraction happens in the main
+ * process; the renderer only ever sees the ready-to-display data URL.
+ */
+export interface HeroPortrait {
+  /** File name of the mod VPK this portrait came from (e.g. "pak42_dir.vpk"). */
+  modFileName: string;
+  /** card | vertical | minimap | small | card_critical | card_gloat | other */
+  variant: string;
+  width: number;
+  height: number;
+  /** VTEX source format, e.g. "BGRA8888", "PNG_RGBA8888". */
+  formatName: string;
+  /** Decoded PNG as a data URL, ready to drop into an <img src>. */
+  dataUrl: string;
+}


### PR DESCRIPTION
## Summary

Scoped slice of the Locker work: the hero **card picker** and supporting cosmetic tabs/categories, plus a couple of small UI wins that rode along. The live-3D backdrop pipeline and the Maps page are intentionally held back for their own PRs.

## What's included

**Locker hero cards (the core)**
- Hero card picker with per-file portrait variants surfaced in a dedicated **Cards** tab
- Apply hero cards via a consolidated cosmetics VPK roll-up (see `docs/locker-hero-card-apply.md`)
- Corrected hero card/sound codename mapping and picker de-duplication
- **Sounds** tab: keep hero-tagged sounds out of Skins, add inline audio preview
- New **Global** cosmetic categories: Killstreak Music, Announcer / SFX (border + label matched to hero cards)

**Small wins**
- Sidebar: textured update banner + dedicated Settings button
- Installed: denser card grids (3-up Cards, 4-up Compact)

## Not in this PR (follow-ups)
- Live-3D per-hero backdrops (`three` / `@react-three/*`) — still WIP
- Maps page (launch custom maps / game modes)

## Verification
- `electron-vite build` passes (main + preload + renderer) — branch is self-contained, no stray `three.js` deps or imports.
