### PR TITLE
fix(nsfw): hide NSFW previews by default

### DIFF
--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -50,7 +50,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     deadlockPath: null,
     devMode: false,
     devDeadlockPath: null,
-    hideNsfwPreviews: false,
+    hideNsfwPreviews: true,
     hideOutdatedMods: false,
     autoDisableSiblingVariants: true,
     steamLaunchOptions: '',

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1563,7 +1563,7 @@ export default function Browse() {
                     section={section}
                     volume={soundVolume}
                     onVolumeChange={setSoundVolume}
-                    hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+                    hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
                     isPlaying={playingModId === mod.id}
                     onPlayingChange={(playing) => {
                       setPlayingModId((prev) => {
@@ -1608,7 +1608,7 @@ export default function Browse() {
           downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
           extracting={extracting}
           progress={downloadProgress}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           dateAdded={selectedModDates?.dateAdded}
           dateModified={selectedModDates?.dateModified}
           onClose={() => setSelectedMod(null)}
@@ -1618,7 +1618,7 @@ export default function Browse() {
 
       {collectionModalOpen && (
         <ImportCollectionModal
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           installedIds={installedIds}
           queuedIds={new Set(downloadQueue.map((q) => q.modId))}
           activeDeadlockPath={activeDeadlockPath}
@@ -1629,7 +1629,7 @@ export default function Browse() {
       {importProfileOpen && (
         <ImportProfileDialog
           activeDeadlockPath={activeDeadlockPath}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           onClose={() => setImportProfileOpen(false)}
           onImported={() => { void loadMods(); }}
         />

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1901,7 +1901,7 @@ export default function Installed() {
           key={entry.key}
           mod={mod}
           viewMode={viewMode}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           conflicts={conflictMap.get(mod.id) || []}
           soundVolume={soundVolume}
           updateAvailable={updatesAvailable.has(mod.id)}
@@ -2017,7 +2017,7 @@ export default function Installed() {
           ),
         }}
         viewMode={viewMode}
-        hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+        hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
         conflicts={aggregateConflicts}
         soundVolume={soundVolume}
         updateAvailable={anyUpdateAvailable}
@@ -2553,7 +2553,7 @@ export default function Installed() {
           downloadingFileId={null}
           extracting={false}
           progress={null}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           dateAdded={detailsDates?.dateAdded}
           dateModified={detailsDates?.dateModified}
           updateAvailable={detailsUpdateAvailable}
@@ -2567,7 +2567,7 @@ export default function Installed() {
       {selectedUnknownState && unknownFixMode === 'single' && (
         <UnknownFilterGuessModal
           state={selectedUnknownState}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           autoMatchEnabled={autoMatchEnabled}
           onApplyMatch={applyUnknownMatch}
           onViewMatch={viewUnknownMatch}
@@ -2583,7 +2583,7 @@ export default function Installed() {
         <BulkUnknownFixModal
           unknownMods={unknownMods}
           state={selectedUnknownState}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           autoMatchEnabled={autoMatchEnabled}
           cache={unknownFilterCache}
           pendingIds={unknownFilterPendingIds}
@@ -2636,7 +2636,7 @@ export default function Installed() {
       {mergeSources && (
         <MergeModsModal
           sources={mergeSources}
-          hideNsfw={settings?.hideNsfwPreviews ?? false}
+          hideNsfw={settings?.hideNsfwPreviews ?? true}
           onCancel={() => setMergeSources(null)}
           onConfirm={handleMergeConfirm}
         />
@@ -2645,7 +2645,7 @@ export default function Installed() {
       {mergedContentsMod && (
         <MergedContentsModal
           mod={mergedContentsMod}
-          hideNsfw={settings?.hideNsfwPreviews ?? false}
+          hideNsfw={settings?.hideNsfwPreviews ?? true}
           onClose={() => setMergedContentsMod(null)}
           onUnmerge={() => setUnmergeTarget(mergedContentsMod)}
         />

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -615,7 +615,7 @@ export default function Locker() {
                     : [...prev, hero.id]
                 )
               }
-              hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+              hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
               minaPresets={hero.name === 'Mina' ? minaPresets : []}
               activeMinaPreset={hero.name === 'Mina' ? activeMinaPreset : undefined}
               minaTextures={hero.name === 'Mina' ? minaTextures : []}
@@ -659,7 +659,7 @@ export default function Locker() {
                       src={mod.thumbnailUrl}
                       alt={mod.name}
                       nsfw={mod.nsfw}
-                      hideNsfw={settings?.hideNsfwPreviews ?? false}
+                      hideNsfw={settings?.hideNsfwPreviews ?? true}
                       className="w-full h-full"
                       fallback={
                         <div className="w-full h-full flex items-center justify-center text-text-secondary text-xs">
@@ -723,7 +723,7 @@ export default function Locker() {
             }
             onSelect={(modId) => setActiveSkin(selectedHero.id, modId)}
             onToggleVariant={(modId) => toggleHeroVariant(selectedHero.id, modId)}
-            hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+            hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
             minaPresets={selectedHero.name === 'Mina' ? minaPresets : []}
             activeMinaPreset={selectedHero.name === 'Mina' ? activeMinaPreset : undefined}
             minaTextures={selectedHero.name === 'Mina' ? minaTextures : []}
@@ -767,7 +767,7 @@ export default function Locker() {
         >
           <LockerGlobalView
             groups={globalGroups}
-            hideNsfw={settings?.hideNsfwPreviews ?? false}
+            hideNsfw={settings?.hideNsfwPreviews ?? true}
             onBack={() => navigate('/locker')}
             onToggle={toggleMod}
             onSetGlobalType={tagModGlobalType}

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -302,7 +302,7 @@ export default function LockerHero() {
       }
       onSelect={setActiveSkin}
       onToggleVariant={toggleHeroVariant}
-      hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+      hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
       minaPresets={hero.name === 'Mina' ? minaPresets : []}
       activeMinaPreset={hero.name === 'Mina' ? activeMinaPreset : undefined}
       minaTextures={hero.name === 'Mina' ? minaTextures : []}

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -875,7 +875,7 @@ export default function Profiles() {
       {showImport && (
         <ImportProfileDialog
           activeDeadlockPath={getActiveDeadlockPath(settings)}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           onClose={() => setShowImport(false)}
           onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}
         />
@@ -886,7 +886,7 @@ export default function Profiles() {
       {restoringSnapshotJson !== null && (
         <ImportProfileDialog
           activeDeadlockPath={getActiveDeadlockPath(settings)}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? false}
+          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           initialInput={restoringSnapshotJson}
           onClose={() => setRestoringSnapshotJson(null)}
           onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -819,7 +819,7 @@ export default function Settings() {
         <Card title="Preferences" icon={Shield}>
           <div className="space-y-6">
             <Toggle
-              checked={settings?.hideNsfwPreviews ?? false}
+              checked={settings?.hideNsfwPreviews ?? true}
               onChange={handleHideNsfwChange}
               label="Hide NSFW Content"
               description="Blur thumbnail images for mods marked as NSFW."


### PR DESCRIPTION
## Summary

Closes #79. NSFW thumbnails were shown unblurred on first launch because the `hideNsfwPreviews` setting defaulted to `false`.

- Flip `DEFAULT_SETTINGS.hideNsfwPreviews` to `true` in `electron/main/services/settings.ts`, so NSFW previews are blurred out of the box.
- Align the renderer loading-state fallbacks from `?? false` to `?? true` across Browse, Installed, Locker, LockerHero, Profiles, and the Settings toggle, so nothing flashes unblurred before settings finish loading. This matches `Discover.tsx`, which already used `?? true`.

The blur mechanic itself (`ModThumbnail` blurs when `nsfw && hideNsfw`) was already correct; only the default was wrong.

## Scope note

`loadSettings` merges saved settings over `DEFAULT_SETTINGS`, so this new default applies to new installs and to any settings file that predates the field. Users who previously toggled the setting off keep their explicit choice (no forced migration that would override a user preference). The toggle remains under Settings > Preferences > "Hide NSFW Content".

## Test plan

- [ ] Fresh install (no settings file): NSFW thumbnails are blurred by default in Browse / Locker / Installed.
- [ ] Toggle "Hide NSFW Content" off in Settings, restart: setting persists as off.
- [ ] Existing user who never touched the setting picks up the blurred-by-default behavior.

https://claude.ai/code/session_01QkS6H3KLSbUkT4yDMfTYwi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkS6H3KLSbUkT4yDMfTYwi)_