### PR TITLE
feat(settings): graduate VPK Merger out of experimental + release v1.13.0

### DIFF
--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -22,14 +22,6 @@ export interface AppSettings {
      *  but the search/find buttons and bulk auto-find are hidden, leaving
      *  only the manual "Make Custom Mod" path. */
     experimentalUnknownModMatching: boolean;
-    /** Combine multiple installed mods into one VPK via the bundled vpkmerge
-     *  CLI. Off by default while the workflow gathers field signal. When off,
-     *  the Merge button is hidden from the Installed bulk-select toolbar, but
-     *  any merged mods that already exist remain fully interactive: their
-     *  MergedContentsModal opens, Unmerge still runs, absorbed sources stay
-     *  hidden from the list until unmerged. This avoids stranding sources
-     *  when a user creates a merge and later toggles the flag off. */
-    experimentalVpkMerger: boolean;
     hasCompletedSetup: boolean;      // First-run setup completed
     /** Mod pairs the user has dismissed in the Conflicts page. New entries use
      *  stable per-mod identities (GameBanana mod/file ids when available)
@@ -60,7 +52,6 @@ const DEFAULT_SETTINGS: AppSettings = {
     experimentalCrosshair: false,
     experimentalSocial: false,
     experimentalUnknownModMatching: false,
-    experimentalVpkMerger: false,
     hasCompletedSetup: false,
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1580,10 +1580,6 @@ export default function Installed() {
   // limited path. Gated behind an experimental toggle while it's being
   // reworked; when off, only the manual "Make Custom Mod" path is offered.
   const autoMatchEnabled = settings?.experimentalUnknownModMatching ?? false;
-  // VPK merger (bulk Merge action). Hidden by default while the feature
-  // gathers field signal. Existing merged mods stay interactive regardless
-  // of the flag so unmerge always works.
-  const vpkMergerEnabled = settings?.experimentalVpkMerger ?? false;
   const selectedUnknownState = unknownFilterGuess
     ? {
         mod: unknownFilterGuess.mod,
@@ -2771,27 +2767,25 @@ export default function Installed() {
               >
                 Disable{selectedEnabledCount > 0 ? ` (${selectedEnabledCount})` : ''}
               </Button>
-              {vpkMergerEnabled && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled={
-                    selectedMods.length < 2 ||
-                    selectedMods.some((m) => !!m.merged)
-                  }
-                  icon={Layers}
-                  onClick={openBulkMerge}
-                  title={
-                    selectedMods.length < 2
-                      ? 'Select 2+ mods to merge'
-                      : selectedMods.some((m) => !!m.merged)
-                        ? 'Cannot merge an already-merged mod. Unmerge it first.'
-                        : `Combine ${selectedMods.length} mods into one VPK`
-                  }
-                >
-                  Merge{selectedMods.length >= 2 ? ` (${selectedMods.length})` : ''}
-                </Button>
-              )}
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={
+                  selectedMods.length < 2 ||
+                  selectedMods.some((m) => !!m.merged)
+                }
+                icon={Layers}
+                onClick={openBulkMerge}
+                title={
+                  selectedMods.length < 2
+                    ? 'Select 2+ mods to merge'
+                    : selectedMods.some((m) => !!m.merged)
+                      ? 'Cannot merge an already-merged mod. Unmerge it first.'
+                      : `Combine ${selectedMods.length} mods into one VPK`
+                }
+              >
+                Merge{selectedMods.length >= 2 ? ` (${selectedMods.length})` : ''}
+              </Button>
               <div className="relative" ref={tagMenuRef}>
                 <Button
                   variant="secondary"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -941,15 +941,6 @@ export default function Settings() {
               label="Fix Unknown Mods"
               description="Auto-match unknown local VPKs against GameBanana to recover their names and thumbnails. Currently hits rate limits on larger libraries while we rework it. The manual Custom Mod path stays available either way."
             />
-
-            <div className="h-px bg-white/5" />
-
-            <Toggle
-              checked={settings?.experimentalVpkMerger ?? false}
-              onChange={(checked) => settings && saveSettings({ ...settings, experimentalVpkMerger: checked })}
-              label="VPK Merger"
-              description="Combine 2+ installed mods into one VPK from the Installed page bulk-select toolbar. Includes Unmerge recovery via the merged mod's contents view. Any merges you create remain interactive even if you turn this off later."
-            />
           </div>
         </Card>
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -264,7 +264,6 @@ export interface AppSettings {
   experimentalCrosshair: boolean;
   experimentalSocial: boolean;
   experimentalUnknownModMatching: boolean;
-  experimentalVpkMerger: boolean;
   hasCompletedSetup: boolean;
   ignoredConflicts: string[];
   ignoreConflictsByDefault: boolean;


### PR DESCRIPTION
Graduates the VPK Merger from an Experimental toggle into a standard, always-on feature, and bumps the version to **v1.13.0** for release.

## What changed

- Removed the `experimentalVpkMerger` flag entirely from both `AppSettings` definitions (`electron/main/services/settings.ts`, `src/types/mod.ts`), its default, and the Experimental Features toggle in `src/pages/Settings.tsx`.
- The Merge button in the Installed bulk-select toolbar now always renders (still disabled for fewer than 2 selected mods or any already-merged mod).
- Bumped `package.json` to `1.13.0`.

## Why on by default is safe

- **Binary ships in packaged builds.** `electron-builder.yml` copies `resources/vpkmerge` via `extraResources` to `process.resourcesPath/vpkmerge/`, exactly where `vpkmergeBinaryPath()` resolves it in packaged mode.
- **CI fetches per-platform.** `release.yml` builds natively on `ubuntu-latest` + `windows-latest`; each `pnpm install` runs the `fetch-vpkmerge` postinstall (pinned `v0.2.0`, SHA256-verified). A failed fetch fails the build, so a release can't ship without the binary.
- **Errors surface.** Merge failures (missing binary, timeout, collision under `--strict`) are caught in `MergeModsModal` and shown inline.

## Migration

Existing experimental users keep an orphaned `experimentalVpkMerger` key in their settings file. It is never read again, so no migration is needed.

## Verification

- `pnpm exec eslint` clean on all touched files.
- `electron-vite build` passes (main + preload + renderer).
- Rebased onto `origin/main` to include #80 (NSFW default); clean, no conflicts.

## Release scope (v1.13.0)

Folds together everything since v1.12.1: this graduation, #76 (local mod editing + locker tag provenance), #77 (merge collision order fix), #78 (Locker hero card picker, Cards/Sounds tabs, Global cosmetics), #80 (NSFW hidden by default). Release notes drafted separately; tag `v1.13.0` to be pushed from `main` after merge.