### PR TITLE
fix(update): replace old files on update + fix Update all reinstalling archived files

### DIFF
--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -833,12 +833,15 @@ async function executeDownload(
         await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
     }
 
-    // Auto-disable previously installed variants of the same GameBanana mod so
-    // the newest pick is the active one. Avoids file-conflict warnings between
-    // sibling variants and matches the "Browse vs Installed" expectation that
-    // re-downloading swaps which variant is active without losing the others.
+    // Switching variants: when the user installs a different file of a mod they
+    // already have enabled, disable the previously-enabled sibling so only the
+    // new pick is active. Avoids file-conflict warnings between sibling variants
+    // (they usually touch the same in-game files). This only matters for non-
+    // update installs (Browse, one-click, collection import); the explicit
+    // update paths delete the old file before downloading, so there is no
+    // enabled sibling left for this to act on.
     // Opt-out: settings.autoDisableSiblingVariants = false keeps every variant
-    // enabled (user may rely on intentional overlap between mods).
+    // enabled (e.g. a mod page whose separate files are meant to run together).
     const settings = loadSettings();
     if (settings.autoDisableSiblingVariants !== false) {
         try {

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -8,7 +8,7 @@ export interface AppSettings {
     devDeadlockPath: string | null;
     hideNsfwPreviews: boolean;
     hideOutdatedMods: boolean;       // Hide GameBanana mods flagged as outdated in Browse
-    autoDisableSiblingVariants: boolean; // When re-downloading a GB mod, auto-disable older variants
+    autoDisableSiblingVariants: boolean; // Installing a different file of an already-enabled mod disables the prior variant (not about updates)
     steamLaunchOptions: string;      // Args written to Steam's localconfig.vdf for Deadlock just before launch
     activeProfileId: string | null;  // Currently active profile
     autoSaveProfile: boolean;        // Auto-save when mods change

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -169,9 +169,15 @@ export default function ModDetailsModal({
     setCurrentImageIndex((prev) => (prev < images.length - 1 ? prev + 1 : 0));
   };
 
-  const actionLabel = (fileId: number) => {
-    if (updateAvailable && installedFileIds.has(fileId)) return 'Update';
+  const actionLabel = (fileId: number, archived = false) => {
+    // A file you already own re-downloads itself = "Reinstall". A not-installed
+    // current file shown while an update is available is the update target:
+    // clicking it replaces the now-superseded installed version, so call it
+    // "Update". Archived files are never update targets (they're the old ones).
+    // Browse never sets updateAvailable, so its non-installed files stay
+    // "Install" (Browse adds files, it doesn't replace).
     if (installedFileIds.has(fileId)) return 'Reinstall';
+    if (updateAvailable && !archived) return 'Update';
     return 'Install';
   };
 
@@ -183,7 +189,10 @@ export default function ModDetailsModal({
 
   const renderFileRow = (file: GameBananaFile, archived = false) => {
     const isInstalled = installedFileIds.has(file.id);
-    const isUpdate = updateAvailable && isInstalled;
+    // Highlight the update *target* (the new, not-yet-installed current file),
+    // not the superseded file the user currently has, so the accent points at
+    // the row they should click to update. Archived files are never targets.
+    const isUpdate = !!updateAvailable && !isInstalled && !archived;
     const isActive = activeFileIds.has(file.id);
     const isDownloadingThis = downloadingFileId === file.id;
     const installedFileState = installedFileStates?.get(file.id);
@@ -295,7 +304,7 @@ export default function ModDetailsModal({
           ) : (
             <>
               <Download className="w-4 h-4" />
-              {actionLabel(file.id)}
+              {actionLabel(file.id, archived)}
             </>
           )}
         </button>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -765,14 +765,63 @@ export default function Installed() {
   const handleDetailsDownload = async (fileId: number, fileName: string) => {
     if (!detailsMod) return;
     try {
-      // Same-file picks (true reinstall/update) replace the source install;
-      // different-file picks add a new entry and the download backend will
-      // auto-disable any prior enabled sibling files of the same GameBanana mod.
+      // Decide whether this pick replaces the source install or adds a sibling:
+      //  - same-file pick = a true reinstall -> replace.
+      //  - different-file pick when the source has an update available = a
+      //    version update -> delete the old version like "Update all" does, so
+      //    the superseded file isn't left lingering (disabled) on disk.
+      //  - different-file pick with no update available = an intentional variant
+      //    add -> leave the source in place (the download backend auto-disables
+      //    the prior enabled sibling instead of deleting it).
       const sourceMod = detailsSourceModId ? mods.find((m) => m.id === detailsSourceModId) : null;
-      if (sourceMod && sourceMod.gameBananaFileId === fileId) {
+      const pickedIsArchived = !!detailsMod.files?.find((f) => f.id === fileId)?.isArchived;
+      const isReinstall = !!sourceMod && sourceMod.gameBananaFileId === fileId;
+      // A not-installed, non-archived file picked while the source has an update
+      // available is the update target. Guard on !installed so clicking a
+      // *different* file the user already owns (a second variant) reinstalls it
+      // rather than deleting the source; guard on !archived so picking an old
+      // file from the archived list never replaces a newer install.
+      const isUpdate =
+        !!sourceMod &&
+        detailsUpdateAvailable &&
+        !detailsInstalledFileIds.has(fileId) &&
+        !pickedIsArchived;
+      const replacing = isReinstall || isUpdate;
+      const restoreEnabled = replacing && !!sourceMod?.enabled;
+
+      if (replacing && sourceMod) {
+        // Snapshot before the destructive delete so the user can roll back,
+        // matching runUpdate's pre-update snapshot. Non-fatal on failure: a
+        // missing snapshot must not block the update the user just asked for.
+        try {
+          await createSnapshot('pre-update');
+        } catch (err) {
+          console.warn('[Update] failed to capture pre-update snapshot:', err);
+        }
         await deleteMod(sourceMod.id);
       }
+
       await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
+
+      // Deleting the source removes the only enabled sibling, so the backend's
+      // auto-disable promotion never fires and the freshly downloaded file stays
+      // in /disabled. Re-enable it so an update/reinstall preserves the source's
+      // enabled state instead of silently turning the mod off. (Match by GB ids;
+      // the local mod id changes on reinstall.)
+      if (restoreEnabled) {
+        await loadMods();
+        const newMod = useAppStore
+          .getState()
+          .mods.find((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
+        if (newMod && !newMod.enabled) {
+          try {
+            await toggleMod(newMod.id);
+          } catch (err) {
+            console.warn('[Update] failed to re-enable updated mod:', err);
+          }
+        }
+      }
+
       closeModDetails();
       loadMods();
     } catch (err) {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -885,18 +885,24 @@ export default function Installed() {
         continue;
       }
 
-      const liveFiles = details.files ?? [];
+      // Consider only current (non-archived) files, mirroring the update-check
+      // effect below. An author's most common "update" is to archive the old
+      // version and upload a new current file; counting archived files as live
+      // would let the installed-but-now-archived row match Pass 1 1:1, so we'd
+      // re-download the same stale file (the mod stays flagged "update
+      // available" forever and "Update all" silently no-ops).
+      const liveFiles = (details.files ?? []).filter((f) => !f.isArchived);
       const liveFileIds = new Set(liveFiles.map((f) => f.id));
 
       // Resolve every snapshot to a target file *before* any delete/download
       // runs, so an unrecoverable row keeps its existing install rather than
       // getting deleted into a failed re-download.
       //
-      // Pass 1: rows whose stored fileId is still on GameBanana (genuine
-      // multi-file mods stay 1:1).
-      // Pass 2: rows whose fileId is gone. Fall back to a single-file
-      // consolidation only when the mod now ships exactly one file and no
-      // other row already claimed it.
+      // Pass 1: rows whose stored fileId is still a current file on GameBanana
+      // (genuine multi-file mods stay 1:1).
+      // Pass 2: rows whose fileId is gone or archived. Fall back to a
+      // single-file consolidation only when the mod now ships exactly one
+      // current file and no other row already claimed it.
       type Resolution =
         | { ok: true; snapshot: (typeof snapshots)[number]; fileId: number; fileName: string }
         | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -839,8 +839,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.autoDisableSiblingVariants ?? true}
               onChange={handleAutoDisableSiblingsChange}
-              label="Auto-disable older variants on re-download"
-              description="When you re-download a GameBanana mod with a different file, automatically disable the previously installed variant. Disable this if you want to keep multiple variants enabled at once."
+              label="Switch variants instead of stacking them"
+              description="When you install a different file of a mod you already have enabled, disable the previous variant so only the new one is active. Turn off to keep multiple variants of the same mod enabled at once. (Updates always replace the old file regardless of this setting.)"
             />
 
             <div className="h-px bg-white/5" />


### PR DESCRIPTION
## Problem

Updating an installed mod kept the old file around instead of replacing it, against normal update expectations. Two distinct bugs:

1. **Per-mod update kept the old file.** The details-modal "Update"/install path only deleted the old file on a *same-file* reinstall. A real update is a *different* fileId, so it fell through to disable-and-keep, leaving the superseded `.vpk` sitting in `.disabled/`. Only the bulk "Update all" path deleted the old version.
2. **"Update all" silently no-oped on archived files.** Update *detection* counts only non-archived files, but `runUpdate` resolved against `details.files` unfiltered. The common GameBanana update pattern (author archives the old version, uploads a new one) left the installed-but-now-archived fileId matching 1:1, so "Update all" re-downloaded the same stale file and the update pulse stuck on.

## Changes

- **`handleDetailsDownload`** now deletes the source install on a real update (different, non-archived, not-already-installed file picked while an update is available), matching `runUpdate`. A `pre-update` snapshot is taken first for rollback, and the new file is re-enabled if the source was enabled (the backend auto-disable promotion never fires once the only enabled sibling is gone). Guards skip the replace when the picked file is already installed (a second variant) or archived (would downgrade).
- **`runUpdate`** filters archived files out of its live-file set, mirroring detection, so an archived install is treated as gone and consolidates onto the current file.
- **`ModDetailsModal`** label/highlight now track the action: a not-installed current file under an available update reads **"Update"** and gets the accent; the superseded file reads **"Reinstall"**; archived files stay **"Install"**. (Previously the old file was mislabeled "Update".)
- **Variant setting reworded** ("Switch variants instead of stacking them") and comments tightened to decouple it from updates: it now only governs non-update installs (Browse, one-click, collection import). Updates always replace regardless of the setting. `ignoreUpdates` still pins an old version on purpose.

Browse installs of a genuinely different file still keep both variants (Browse never sets `updateAvailable`), preserving intentional color/style variants.

## Testing

- Installed an archived file to trigger "update available", confirmed both the per-mod **Update** and **Update all** now delete the old `.vpk`, install + enable the current file, leave a `pre-update` snapshot, and clear the pulse.
- `tsc --noEmit` (renderer + node) and `eslint` clean on all touched files.

No tests in this repo (TS strict + ESLint per CLAUDE.md).