### PR TITLE
feat(import): add per-import "Skip NSFW" toggle to collection and profile imports

### DIFF
--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -160,6 +160,10 @@ export default function ImportCollectionModal({
   const [loadingItems, setLoadingItems] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  // Per-import filter: when on, NSFW items are treated as skipped (shown with
+  // an "NSFW" reason, deselected, and never queued). Off by default; a one-off
+  // choice rather than a saved setting.
+  const [skipNsfw, setSkipNsfw] = useState(false);
   // We use a separate "submitting" flag rather than blocking on the
   // submission loop — once items are in the main-process queue, the modal
   // stays interactive (cancel buttons, variant pickers for not-yet-queued
@@ -558,14 +562,37 @@ export default function ImportCollectionModal({
 
   // ───────── Selection ─────────
 
+  // A row can't be queued when it carries a structural skip (wrong game,
+  // unsupported type, no files) or when the per-import NSFW filter is on and
+  // the item is NSFW.
+  const isRowBlocked = useCallback(
+    (r: ItemRow) => !r.selectable || (skipNsfw && r.item.nsfw),
+    [skipNsfw]
+  );
+
+  // Turning the NSFW filter on drops any already-selected NSFW rows so they
+  // can't slip into the queue. Turning it back off leaves selection as-is
+  // (the user can Select all to re-add them).
+  useEffect(() => {
+    if (!skipNsfw) return;
+    setSelected((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const r of rowsRef.current) {
+        if (r.item.nsfw && next.delete(r.item.id)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [skipNsfw]);
+
   const eligibleRows = useMemo(
-    () => rows.filter((r) => r.selectable && r.status === 'idle'),
-    [rows]
+    () => rows.filter((r) => !isRowBlocked(r) && r.status === 'idle'),
+    [rows, isRowBlocked]
   );
 
   const skippedCount = useMemo(
-    () => rows.filter((r) => !r.selectable).length,
-    [rows]
+    () => rows.filter((r) => isRowBlocked(r)).length,
+    [rows, isRowBlocked]
   );
 
   const allEligibleSelected =
@@ -623,7 +650,7 @@ export default function ImportCollectionModal({
     setProfileStatus({ kind: 'idle' });
     const token = ++submitTokenRef.current;
     const initialQueue = rowsRef.current.filter(
-      (r) => selected.has(r.item.id) && r.status === 'idle'
+      (r) => selected.has(r.item.id) && r.status === 'idle' && !(skipNsfw && r.item.nsfw)
     );
 
     // Pre-fetch details for every selected row we don't have yet so we can
@@ -674,7 +701,7 @@ export default function ImportCollectionModal({
     // Refresh the snapshot so each row carries its now-cached details and
     // any picks the user made while the banner was up.
     const toQueue = rowsRef.current.filter(
-      (r) => selected.has(r.item.id) && r.status === 'idle' && r.selectable
+      (r) => selected.has(r.item.id) && r.status === 'idle' && r.selectable && !(skipNsfw && r.item.nsfw)
     );
     setBatchIds(new Set(toQueue.map((r) => r.item.id)));
 
@@ -738,7 +765,7 @@ export default function ImportCollectionModal({
     }
 
     setSubmitting(false);
-  }, [activeDeadlockPath, ensureDetails, selected, updateRow]);
+  }, [activeDeadlockPath, ensureDetails, selected, skipNsfw, updateRow]);
 
   // ───────── Footer summary ─────────
 
@@ -861,18 +888,29 @@ export default function ImportCollectionModal({
           {rows.length > 0 && (
             <div className="sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10">
               <div className="px-6 py-3 flex items-center justify-between gap-3">
-                <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
-                  <input
-                    type="checkbox"
-                    checked={allEligibleSelected}
-                    onChange={toggleSelectAll}
-                    disabled={eligibleRows.length === 0}
-                    className="accent-accent cursor-pointer"
-                  />
-                  <span>
-                    {allEligibleSelected ? 'Deselect all' : `Select all (${eligibleRows.length})`}
-                  </span>
-                </label>
+                <div className="flex items-center gap-4">
+                  <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
+                    <input
+                      type="checkbox"
+                      checked={allEligibleSelected}
+                      onChange={toggleSelectAll}
+                      disabled={eligibleRows.length === 0}
+                      className="accent-accent cursor-pointer"
+                    />
+                    <span>
+                      {allEligibleSelected ? 'Deselect all' : `Select all (${eligibleRows.length})`}
+                    </span>
+                  </label>
+                  <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
+                    <input
+                      type="checkbox"
+                      checked={skipNsfw}
+                      onChange={(e) => setSkipNsfw(e.target.checked)}
+                      className="accent-accent cursor-pointer"
+                    />
+                    <span>Skip NSFW</span>
+                  </label>
+                </div>
                 <button
                   type="button"
                   onClick={() => void handleToggleShowAllVariants()}
@@ -920,8 +958,9 @@ export default function ImportCollectionModal({
           <ul className="divide-y divide-white/5">
             {rows.map((row) => {
               const thumb = previewThumb(row.item.previewMedia);
-              const checked = selected.has(row.item.id);
-              const lockedRow = !row.selectable || row.status !== 'idle';
+              const nsfwSkipped = skipNsfw && row.item.nsfw && !row.skip;
+              const checked = selected.has(row.item.id) && !isRowBlocked(row);
+              const lockedRow = isRowBlocked(row) || row.status !== 'idle';
 
               const fileCount = row.details?.files?.length ?? 0;
               const pickedFiles = row.details?.files
@@ -1019,6 +1058,8 @@ export default function ImportCollectionModal({
                     <div className="text-sm flex-shrink-0 text-right">
                       {row.skip ? (
                         <span className="text-text-tertiary">{skipReasonLabel(row.skip)}</span>
+                      ) : nsfwSkipped ? (
+                        <span className="text-text-tertiary">Skipped: NSFW</span>
                       ) : row.status === 'installed' ? (
                         <span className="text-green-400 inline-flex items-center gap-1.5 justify-end">
                           <CheckCircle2 className="w-4 h-4" /> Installed

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -163,8 +163,37 @@ export default function ImportProfileDialog({
   const [includeAutoexec, setIncludeAutoexec] = useState(true);
   const [autoexecExpanded, setAutoexecExpanded] = useState(false);
 
+  // Per-import filter: when on, NSFW mods are treated as locked (deselected,
+  // never imported, shown as "Skipped: NSFW"). Off by default; a one-off
+  // choice rather than a saved setting.
+  const [skipNsfw, setSkipNsfw] = useState(false);
+
   const rowsRef = useRef<RowState[]>([]);
   useEffect(() => { rowsRef.current = rows; }, [rows]);
+
+  // A row can't be imported when it's unresolvable or when the per-import
+  // NSFW filter is on and the mod is flagged NSFW in the profile hint.
+  const isRowBlocked = useCallback(
+    (r: RowState) => r.mod.status === 'unresolvable' || (skipNsfw && !!r.mod.entry.hint?.nsfw),
+    [skipNsfw]
+  );
+
+  // Turning the NSFW filter on deselects any NSFW rows so they can't be
+  // imported. Turning it back off leaves selection alone (Select all re-adds).
+  useEffect(() => {
+    if (!skipNsfw) return;
+    setRows((prev) => {
+      let changed = false;
+      const next = prev.map((r) => {
+        if (r.selected && r.mod.entry.hint?.nsfw) {
+          changed = true;
+          return { ...r, selected: false };
+        }
+        return r;
+      });
+      return changed ? next : prev;
+    });
+  }, [skipNsfw]);
 
   // Mirror the editable name so the finalize effect can read it without
   // depending on profileName: depending on it would re-trigger the finalize
@@ -299,7 +328,8 @@ export default function ImportProfileDialog({
       setRows(
         r.resolved.map((mod) => ({
           mod,
-          selected: mod.status !== 'unresolvable',
+          selected:
+            mod.status !== 'unresolvable' && !(skipNsfw && !!mod.entry.hint?.nsfw),
           status: mod.alreadyInstalled ? 'already-installed' : 'pending',
           pickedFileIds: [],
         }))
@@ -309,7 +339,7 @@ export default function ImportProfileDialog({
     } finally {
       setResolving(false);
     }
-  }, [input]);
+  }, [input, skipNsfw]);
 
   const handleFile = useCallback(async (file: File) => {
     const text = await file.text();
@@ -358,13 +388,13 @@ export default function ImportProfileDialog({
 
   const toggleAll = useCallback(() => {
     setRows((prev) => {
-      const selectable = prev.filter((r) => r.mod.status !== 'unresolvable');
+      const selectable = prev.filter((r) => !isRowBlocked(r));
       const allOn = selectable.every((r) => r.selected);
       return prev.map((r) =>
-        r.mod.status === 'unresolvable' ? r : { ...r, selected: !allOn }
+        isRowBlocked(r) ? { ...r, selected: false } : { ...r, selected: !allOn }
       );
     });
-  }, []);
+  }, [isRowBlocked]);
 
   const updateRowAt = useCallback((idx: number, patch: Partial<RowState>) => {
     setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
@@ -497,7 +527,7 @@ export default function ImportProfileDialog({
     // be on disk (the user's choice trumps the optimization).
     const plan: { idx: number; fileIds: number[] }[] = [];
     const startingRows = rowsRef.current.map((r, idx) => {
-      if (!r.selected || r.mod.status === 'unresolvable') {
+      if (!r.selected || isRowBlocked(r)) {
         return { ...r, status: 'skipped' as RowStatus };
       }
       if (r.pickedFileIds.length === 0 && r.mod.alreadyInstalled) {
@@ -545,7 +575,7 @@ export default function ImportProfileDialog({
         });
       }
     }
-  }, [parsed, report, activeDeadlockPath]);
+  }, [parsed, report, activeDeadlockPath, isRowBlocked]);
 
   const downloadsSettled = useMemo(() => {
     if (!importing) return false;
@@ -630,8 +660,8 @@ export default function ImportProfileDialog({
     return c;
   }, [rows]);
 
-  const selectableCount = rows.filter((r) => r.mod.status !== 'unresolvable').length;
-  const selectedCount = rows.filter((r) => r.selected).length;
+  const selectableCount = rows.filter((r) => !isRowBlocked(r)).length;
+  const selectedCount = rows.filter((r) => r.selected && !isRowBlocked(r)).length;
 
   // Tri-state UI. Important: there's a transient window inside handleParse
   // where parsed is set but report is not yet (we awaited parse, are now
@@ -841,20 +871,32 @@ export default function ImportProfileDialog({
             ) : null}
 
             <div className="px-4 sm:px-6 py-2 sticky top-0 bg-bg-secondary/95 backdrop-blur border-b border-white/5 z-10 flex items-center justify-between gap-2 flex-wrap">
-              <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer min-w-0">
-                <input
-                  type="checkbox"
-                  checked={selectableCount > 0 && selectedCount === selectableCount}
-                  onChange={toggleAll}
-                  disabled={selectableCount === 0 || importing}
-                  className="accent-accent cursor-pointer flex-shrink-0"
-                />
-                <span className="truncate">
-                  {selectedCount === selectableCount && selectableCount > 0
-                    ? 'Deselect all'
-                    : `Select all (${selectableCount})`}
-                </span>
-              </label>
+              <div className="flex items-center gap-4 min-w-0">
+                <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer min-w-0">
+                  <input
+                    type="checkbox"
+                    checked={selectableCount > 0 && selectedCount === selectableCount}
+                    onChange={toggleAll}
+                    disabled={selectableCount === 0 || importing}
+                    className="accent-accent cursor-pointer flex-shrink-0"
+                  />
+                  <span className="truncate">
+                    {selectedCount === selectableCount && selectableCount > 0
+                      ? 'Deselect all'
+                      : `Select all (${selectableCount})`}
+                  </span>
+                </label>
+                <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer w-fit">
+                  <input
+                    type="checkbox"
+                    checked={skipNsfw}
+                    onChange={(e) => setSkipNsfw(e.target.checked)}
+                    disabled={importing}
+                    className="accent-accent cursor-pointer flex-shrink-0"
+                  />
+                  <span>Skip NSFW</span>
+                </label>
+              </div>
               <button
                 type="button"
                 onClick={() => void handleToggleShowAllVariants()}
@@ -914,6 +956,8 @@ export default function ImportProfileDialog({
                   const mod = r.mod;
                   const hint = mod.entry.hint;
                   const isUnresolvable = mod.status === 'unresolvable';
+                  const nsfwBlocked = skipNsfw && !!hint?.nsfw && !isUnresolvable;
+                  const blocked = isRowBlocked(r);
                   const submissionId = gbSubmissionId(mod);
                   const fileCount = r.details?.files?.length ?? 0;
                   const canPickVariants =
@@ -950,9 +994,9 @@ export default function ImportProfileDialog({
                       <div className="flex items-center gap-3 sm:gap-4">
                         <input
                           type="checkbox"
-                          checked={r.selected}
+                          checked={r.selected && !blocked}
                           onChange={() => toggleRow(idx)}
-                          disabled={isUnresolvable || importing}
+                          disabled={blocked || importing}
                           className="w-4 h-4 accent-accent cursor-pointer disabled:cursor-not-allowed flex-shrink-0"
                           aria-label={`Toggle ${hint?.name ?? 'mod'}`}
                         />
@@ -972,6 +1016,7 @@ export default function ImportProfileDialog({
                             {hint?.fileLabel && <span className="hidden sm:inline">· {hint.fileLabel}</span>}
                             <span>· p{mod.entry.priority}</span>
                             {!mod.entry.enabled && <span className="text-text-tertiary">· disabled</span>}
+                            {nsfwBlocked && <span className="text-text-tertiary">· NSFW skipped</span>}
                             {canPickVariants && (
                               <button
                                 type="button"


### PR DESCRIPTION
## What

Adds a per-import **Skip NSFW** checkbox to both import surfaces, **off by default** (a one-off choice, not a saved setting).

When checked, NSFW mods are deselected, locked out of selection and the queue, and shown with a skipped label, matching how each modal already surfaces unsupported / unresolvable rows. The NSFW flag arrives with the listing, so nothing NSFW is ever downloaded.

## Details

**Collection import** (`ImportCollectionModal.tsx`)
- Checkbox next to "Select all".
- NSFW rows show `Skipped: NSFW`, drop out of the eligible/select-all counts, fold into the "N skipped" tally, and are guarded out of `handleQueue`.
- Source: `GameBananaCollectionItem.nsfw`.

**Profile import** (`ImportProfileDialog.tsx`)
- Checkbox next to "Select all".
- NSFW rows get a `· NSFW skipped` tag and a disabled checkbox, are excluded from the selectable/selected counts, and are skipped in `handleConfirm`.
- Source: the portable profile's `hint.nsfw`.

Both use an `isRowBlocked()` helper combining the existing structural lock (unsupported/unresolvable) with the NSFW filter, so selection, counts, select-all, and submit stay consistent. A small effect prunes already-selected NSFW rows the moment the box is ticked; initial selection (including re-parse while the filter is on) respects it too.

## Testing

- `tsc --noEmit -p tsconfig.app.json` and `eslint` clean on both files.
- Manual: open an import with a known-NSFW collection / profile, tick "Skip NSFW", confirm those rows go unchecked + locked with the label and are excluded from download.

Renderer-only; no schema, settings, or main-process changes. No tests in this repo (TS strict + ESLint per CLAUDE.md).