### PR TITLE
ci(discord): announce only the What's New block

### DIFF
--- a/.github/workflows/discord-announce.yml
+++ b/.github/workflows/discord-announce.yml
@@ -63,8 +63,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Announce only the "What's New" block (New Features / Changed / Bug
+          # Fixes), not the intro, Downloads, Requirements, or changelog footer.
+          # Slice from the "## What's New" heading to the next "## " heading.
+          # Fall back to the full body if the notes don't use that structure.
+          BODY="$(awk '
+            /^## / && !/^## What.?s New/ { if (cap) exit }
+            /^## What.?s New/ { cap=1 }
+            cap { print }
+          ' release_body.md)"
+          if [ -z "${BODY//[[:space:]]/}" ]; then
+            BODY="$(cat release_body.md)"
+          fi
+
           # Discord embed description limit is 4096; truncate with a link to the full notes.
-          BODY="$(cat release_body.md)"
           MAX=4000
           if [ "${#BODY}" -gt "$MAX" ]; then
             BODY="${BODY:0:$MAX}"$'\n\n... (truncated, full notes: '"$URL"')'


### PR DESCRIPTION
## What

The Discord release-announcement workflow (`discord-announce.yml`) posted the **entire** release body as the embed: intro paragraphs, What's New, Downloads, Requirements, and the changelog link.

This slices out just the `## What's New` section (New Features / Changed / Bug Fixes), from that heading up to the next h2, so the announcement is only the actual changes.

## Details

- `awk` captures from `## What's New` until the next `## ` heading (Downloads).
- Falls back to the full body if a release's notes don't use the `## What's New` structure (e.g. an auto-generated body), so non-templated releases still announce something.
- No change to the title, link, color, truncation, `@everyone` opt-in, or prerelease/draft skip.

## Testing

Verified the `awk` slice against the live v1.13.1 release body: it yields exactly the New Features / Changed / Bug Fixes block and nothing else.