### PR TITLE
fix: correct revoked-mod copy + drop unused compactEnabledMods

### DIFF
--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -586,7 +586,7 @@ async function executeDownload(
         throw new Error(
             'This mod has no downloadable files on GameBanana. It may have been ' +
             'revoked (copyright, moderation) or the author removed the file. ' +
-            'The catalog entry will clear on the next sync.'
+            'Open the mod page in Browse to check for a current version.'
         );
     }
 

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -715,23 +715,6 @@ export async function reorderMods(
 }
 
 /**
- * Dense-pack enabled mods to consecutive pak## slots in their current priority
- * order, skipping any slot reserved by a disabled mod. Wraps reorderMods so
- * callers (applyProfile, post-install, post-enable/disable) get a single
- * two-phase rename instead of per-mod setModPriority cascades that fail on
- * mid-operation slot collisions.
- */
-export async function compactEnabledMods(deadlockPath: string): Promise<void> {
-    const mods = await scanMods(deadlockPath);
-    const orderedFileNames = mods
-        .filter((m) => m.enabled)
-        .sort((a, b) => a.priority - b.priority)
-        .map((m) => m.fileName);
-    if (orderedFileNames.length === 0) return;
-    await reorderMods(deadlockPath, orderedFileNames);
-}
-
-/**
  * Swap the priorities of two mods (async).
  */
 export async function swapModPriority(


### PR DESCRIPTION
## Summary

Two residuals surfaced by the post-merge review of #48 and #49.

- **Revoked-mod install error (from #48) made a false promise.** The "no downloadable files" branch told users *"The catalog entry will clear on the next sync."* It does not: `syncService` is upsert-only (`upsertMods`, no DELETE/prune), so a revoked or removed GameBanana submission's cached entry persists. Reworded to point the user at the mod page in Browse for a current version, matching the sibling "file no longer on GameBanana" message.
- **`compactEnabledMods` (from #49) was dead code.** Added as a helper for future post-install / post-enable/disable callers, but it has zero callers anywhere in the tree and is not wired to an IPC handler. Removed. It remains in git history if a future caller wants it.

No behavior change beyond the corrected error string. The off-by-one in `commitPriorityForMod` and the profile resolver gaps noted in the same review were already fixed downstream in #66.

## Test plan

- [x] `pnpm exec tsc --noEmit -p tsconfig.node.json` clean
- [x] `grep` confirms no remaining `compactEnabledMods` references