### PR TITLE
feat(apt): host a Debian/Ubuntu apt repository on Cloudflare R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,3 +268,87 @@ jobs:
           fi
           git commit -m "Update to ${{ steps.meta.outputs.version }}"
           git push origin master
+
+  apt-publish:
+    needs: release
+    runs-on: ubuntu-latest
+    # Dormant until the R2 bucket + secrets exist and you set the repo variable
+    # APT_PUBLISH_ENABLED to "true". Until then this is skipped, so releases
+    # stay green while the apt repo isn't wired up. See docs/apt-repo.md.
+    if: startsWith(github.ref, 'refs/tags/') && inputs.draft != true && vars.APT_PUBLISH_ENABLED == 'true'
+
+    permissions:
+      contents: read
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      BUCKET: grimoire-apt
+
+    steps:
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-build
+          path: artifacts
+
+      - name: Install reprepro
+        run: sudo apt-get update && sudo apt-get install -y reprepro
+
+      # Import the dedicated (passphraseless) repo signing key into a throwaway
+      # GNUPGHOME and stash its fingerprint for reprepro's SignWith.
+      - name: Import signing key
+        shell: bash
+        run: |
+          set -euo pipefail
+          GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+          echo "${{ secrets.APT_GPG_PRIVATE_KEY }}" | base64 -d | gpg --batch --import
+          FPR="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+          echo "APT_GPG_FPR=$FPR" >> "$GITHUB_ENV"
+
+      # Rebuild a fresh, signed, latest-only repo from this release's .deb.
+      # reprepro keeps a single version per package, so the repo always offers
+      # exactly the current release; older versions remain on GitHub Releases.
+      - name: Build signed repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          DEB="artifacts/grimoire_${VERSION}_amd64.deb"
+          if [ ! -f "$DEB" ]; then
+            echo "ERROR: $DEB not found in artifacts"; ls -la artifacts; exit 1
+          fi
+          mkdir -p repo/conf
+          cat > repo/conf/distributions <<EOF
+          Origin: Grimoire
+          Label: Grimoire
+          Codename: stable
+          Suite: stable
+          Architectures: amd64
+          Components: main
+          Description: Grimoire (Deadlock mod manager) APT repository
+          SignWith: ${APT_GPG_FPR}
+          EOF
+          reprepro -b repo includedeb stable "$DEB"
+          gpg --export "$APT_GPG_FPR" > repo/grimoire.gpg
+
+      # Pool .debs are version-stamped and immutable, so cache them hard. The
+      # dists/ index reuses stable paths every release, so it must be no-cache
+      # or apt update sees a stale package list behind Cloudflare's CDN. Upload
+      # the pool before the index so the index never points at a missing .deb.
+      - name: Publish to R2
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws s3 sync repo/pool/ "s3://${BUCKET}/pool/" --delete \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable"
+          aws s3 sync repo/dists/ "s3://${BUCKET}/dists/" --delete \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache"
+          aws s3 cp repo/grimoire.gpg "s3://${BUCKET}/grimoire.gpg" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 - Windows: `Grimoire-Setup-x.y.z.exe`
 - Linux: `.AppImage` or `.deb`
+- Debian / Ubuntu (apt, auto-updates): add the repo, then `sudo apt install grimoire` (setup steps in [docs/apt-repo.md](docs/apt-repo.md))
 - Arch Linux: `yay -S grimoire-bin` ([AUR](https://aur.archlinux.org/packages/grimoire-bin))
 
 Requires Deadlock installed via Steam.

--- a/docs/apt-repo.md
+++ b/docs/apt-repo.md
@@ -1,0 +1,123 @@
+# APT repository (Debian / Ubuntu)
+
+Grimoire ships an APT repository at `https://apt.grimoiremods.com` so Debian and
+Ubuntu users can install and update via `apt` instead of manually downloading a
+`.deb` each release.
+
+This matters because the in-app updater (electron-updater) cannot self-update a
+`.deb` install. `getInstallSource()` in `electron/main/services/updater.ts`
+already detects `/opt` installs as `managed` and disables the in-app updater,
+telling those users to use their package manager. The apt repo is the package
+manager channel that message refers to.
+
+## How it works
+
+- Hosting: a Cloudflare **R2** bucket (`grimoire-apt`) exposed publicly through
+  the custom domain `apt.grimoiremods.com`. R2 has zero egress fees, so serving
+  large Electron debs costs effectively nothing.
+- Publishing: the `apt-publish` job in `.github/workflows/release.yml` runs on
+  each tagged release. It rebuilds a fresh, GPG-signed, **latest-only** repo
+  from that release's `.deb` with `reprepro`, then syncs it to R2.
+- Source of truth for old versions stays GitHub Releases. The apt repo only ever
+  offers the newest version (which is what `apt upgrade` wants).
+- Scope: `amd64` only. Arch users use the AUR (`grimoire-bin`).
+
+The job is gated on the repo variable `APT_PUBLISH_ENABLED == 'true'`, so it is
+skipped (and releases stay green) until the one-time setup below is complete.
+
+## One-time setup
+
+### 1. Enable R2, then create the bucket + custom domain
+
+R2 is a one-time, free per-account toggle and is not enabled yet: Cloudflare
+dashboard > R2 > enable. Then:
+
+```bash
+wrangler r2 bucket create grimoire-apt
+```
+
+Then in the Cloudflare dashboard: **R2 > grimoire-apt > Settings > Custom Domains**
+and add `apt.grimoiremods.com`. The DNS record is created automatically because
+the zone is already on Cloudflare.
+
+### 2. R2 API token
+
+**R2 > Manage API Tokens > Create** an **Object Read & Write** token scoped to
+the `grimoire-apt` bucket. Record the Access Key ID, the Secret Access Key, and
+your Cloudflare Account ID (the S3 endpoint is
+`https://<ACCOUNT_ID>.r2.cloudflarestorage.com`).
+
+### 3. Signing key
+
+Generate a dedicated, passphraseless RSA-4096 key (passphraseless because it runs
+unattended in CI; it lives only as an encrypted GitHub secret). RSA-4096 is used
+over ed25519 for the widest apt compatibility.
+
+```bash
+gpg --batch --gen-key <<'EOF'
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: Grimoire APT
+Name-Email: slusheliott@gmail.com
+Expire-Date: 0
+EOF
+
+# Value for the APT_GPG_PRIVATE_KEY secret:
+gpg --export-secret-keys --armor "Grimoire APT" | base64 -w0
+```
+
+### 4. GitHub secrets and variable
+
+Repo **Settings > Secrets and variables > Actions**.
+
+Secrets:
+
+| Name | Value |
+|---|---|
+| `APT_GPG_PRIVATE_KEY` | the base64 blob from step 3 |
+| `R2_ACCESS_KEY_ID` | R2 token Access Key ID |
+| `R2_SECRET_ACCESS_KEY` | R2 token Secret Access Key |
+| `R2_ACCOUNT_ID` | Cloudflare Account ID |
+
+Variable (this is what turns the job on):
+
+| Name | Value |
+|---|---|
+| `APT_PUBLISH_ENABLED` | `true` |
+
+### 5. Publish
+
+Cut a release as usual (push a `v*` tag). The `apt-publish` job populates the
+bucket. To backfill without a new version, re-run the latest release's workflow.
+
+## User install instructions
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://apt.grimoiremods.com/grimoire.gpg \
+  | sudo tee /etc/apt/keyrings/grimoire.gpg >/dev/null
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/grimoire.gpg] https://apt.grimoiremods.com stable main" \
+  | sudo tee /etc/apt/sources.list.d/grimoire.list >/dev/null
+sudo apt update
+sudo apt install grimoire
+```
+
+Updates thereafter come through `sudo apt update && sudo apt upgrade`.
+
+Verified clean dependency resolution on Ubuntu 22.04, Ubuntu 24.04, and Debian 12.
+
+## Notes
+
+- Storage stays at roughly one deb (~170 MB). The publish job rebuilds a fresh
+  latest-only repo each release and syncs with `--delete`, so the previous
+  version's deb is pruned from the bucket instead of accumulating. You stay far
+  under R2's 10 GB free tier no matter how many releases ship. Older versions
+  remain available on GitHub Releases.
+- The `dists/` index is uploaded with `Cache-Control: no-cache` and the `pool/`
+  debs with a long immutable max-age. This prevents Cloudflare's CDN from serving
+  a stale package index after a release while still caching the (immutable,
+  version-stamped) debs at the edge.
+- Key rotation: generate a new key, update `APT_GPG_PRIVATE_KEY`, and re-run a
+  release. The new public key publishes to `grimoire.gpg` automatically; existing
+  users would need to re-fetch the key, so rotate only when necessary.

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -117,7 +117,8 @@ export default function UpdateModal({ onClose }: Props) {
                             <Package className="w-5 h-5 flex-shrink-0 mt-0.5 text-accent" />
                             <div className="text-sm text-text-secondary space-y-2">
                                 <p className="text-text-primary font-medium">Managed by your package manager.</p>
-                                <p>This install was provided through a system package. Update with your distro's usual tools (for example <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch). If you installed the <code className="font-mono text-text-primary">.deb</code> directly, re-download the latest release.</p>
+                                <p>This install was provided through a system package. Update with your distro's tools: <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch, or <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code> on Debian/Ubuntu.</p>
+                                <p>If you installed the <code className="font-mono text-text-primary">.deb</code> manually, add the apt repository for automatic updates (instructions at <code className="font-mono text-text-primary">grimoiremods.com/download</code>).</p>
                             </div>
                         </div>
                     )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -658,9 +658,13 @@ export default function Settings() {
               <div className="rounded-lg bg-bg-tertiary border border-white/10 p-3 text-sm text-text-secondary space-y-2">
                 <p className="text-text-primary font-medium">Updates are managed by your package manager.</p>
                 <p>
-                  Grimoire was installed via a system package. Update with your distro's usual tools (for example{' '}
-                  <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch). If you installed the{' '}
-                  <code className="font-mono text-text-primary">.deb</code> directly, re-download the latest release.
+                  Grimoire was installed via a system package. Update with your distro's tools:{' '}
+                  <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch, or{' '}
+                  <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code> on Debian/Ubuntu.
+                </p>
+                <p>
+                  Installed the <code className="font-mono text-text-primary">.deb</code> manually? Add the apt repository for
+                  automatic updates (instructions at <code className="font-mono text-text-primary">grimoiremods.com/download</code>).
                 </p>
               </div>
             )}


### PR DESCRIPTION
## What

Hosts a Debian/Ubuntu apt repository for Grimoire on Cloudflare R2, served at `apt.grimoiremods.com`. Users get `apt install grimoire` plus real `apt upgrade` updates (the in-app updater can't self-update a `.deb`).

## Changes

- **`.github/workflows/release.yml`**: new `apt-publish` job. Builds a signed, latest-only apt repo from the release's `.deb` with reprepro and syncs to R2. Gated on `vars.APT_PUBLISH_ENABLED == 'true'` so it stays dormant (and releases stay green) until the bucket + secrets exist.
- **`docs/apt-repo.md`**: full setup runbook + user install instructions.
- **`src/components/UpdateModal.tsx`, `src/pages/Settings.tsx`**: the "managed by your package manager" message now gives Debian/Ubuntu users the apt update command and points manual-`.deb` users at the repo.
- **`README.md`**: apt install line.

## Before this goes live (manual, see `docs/apt-repo.md`)

1. Enable R2, create bucket `grimoire-apt`, connect custom domain `apt.grimoiremods.com`.
2. Create an R2 Object Read & Write API token.
3. Generate the signing key.
4. Add secrets `APT_GPG_PRIVATE_KEY`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID` and set variable `APT_PUBLISH_ENABLED=true`.

## Notes

- Storage stays at roughly one deb (rebuild latest-only + `--delete` prune).
- Verified the `.deb` resolves cleanly on Ubuntu 22.04, Ubuntu 24.04, and Debian 12.
- Verified the in-app managed-install copy renders correctly in both Settings and the update modal.
