### PR TITLE
feat(merge): extract individual sources from a merged VPK

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -20,9 +20,9 @@ import { inferHeroFromVpk, classifyGlobalModFromVpk } from '../services/vpk';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 import { detectUnknownModFilters, type UnknownModFilterGuess } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
-import { mergeMods, unmergeMod } from '../services/modMerger';
+import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
 import { getMainWindow } from '../index';
-import type { ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, EditLocalModArgs, GlobalModType, MergeModsArgs, UnmergeModResult } from '../../../src/types/mod';
+import type { ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, EditLocalModArgs, GlobalModType, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult } from '../../../src/types/mod';
 
 const unknownDetectionControllers = new Map<string, AbortController>();
 
@@ -647,6 +647,29 @@ ipcMain.handle(
         return {
             ...result,
             recovered: result.recovered.map(enrichMod),
+        };
+    }
+);
+
+// extract-merge-source — pull one source out of a merged VPK and restore it as
+// a standalone mod. The remaining sources are re-merged in place (or the merge
+// dissolves when fewer than two would remain).
+ipcMain.handle(
+    'extract-merge-source',
+    async (
+        _,
+        mergedModId: string,
+        sourceFileName: string
+    ): Promise<ExtractMergeSourceResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const result = await extractMergeSource(deadlockPath, mergedModId, sourceFileName);
+        return {
+            ...result,
+            merged: result.merged ? enrichMod(result.merged) : null,
+            restored: result.restored.map(enrichMod),
         };
     }
 );

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -4,7 +4,7 @@ import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
 import { getAddonsPath } from './deadlock';
-import { scanMods, disableMod, enableMod, findNextAvailablePriority, type Mod } from './mods';
+import { scanMods, disableMod, enableMod, setModPriority, findNextAvailablePriority, type Mod } from './mods';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { encodeShareCode } from './portableProfile';
@@ -14,7 +14,12 @@ import {
     type PortableProfile,
     type PortableModEntry,
 } from '../../../src/types/portableProfile';
-import type { MergedModInfo, MergedModSource, UnmergeModResult } from '../../../src/types/mod';
+import type {
+    MergedModInfo,
+    MergedModSource,
+    UnmergeModResult,
+    ExtractMergeSourceResult,
+} from '../../../src/types/mod';
 
 const DEADLOCK_STEAM_APP_ID = 1422450;
 const DEADLOCK_GAMEBANANA_GAME_ID = 20948;
@@ -337,6 +342,67 @@ function buildPortableForSources(sources: Mod[], profileName: string): PortableP
     };
 }
 
+interface SourceLocator {
+    /** Find a manifest source on disk and mark it consumed so a later lookup
+     *  can't claim the same file. Returns undefined when nothing matches. */
+    locate(src: MergedModSource): Promise<Mod | undefined>;
+}
+
+/**
+ * Build a one-shot locator that maps merged-mod manifest entries back to the
+ * VPKs still on disk. Resolution order per source: disabled folder by exact
+ * fileName, then a sha256 content match in the disabled folder (covers a
+ * reconcile rename), then a sha256 match in the enabled folder (covers a
+ * partial-disable or a user re-enable). Each on-disk file is claimed at most
+ * once. Hashes are cached and prefer the metadata-recorded sha256 over a fresh
+ * fingerprint. `candidates` should exclude the merged mod itself.
+ */
+function makeSourceLocator(candidates: Mod[]): SourceLocator {
+    const disabledCandidates = candidates.filter((m) => !m.enabled);
+    const enabledCandidates = candidates.filter((m) => m.enabled);
+
+    const hashCache = new Map<string, string>();
+    const getHash = async (mod: Mod): Promise<string> => {
+        const cached = hashCache.get(mod.fileName);
+        if (cached) return cached;
+        const fromMeta = getModMetadata(mod.fileName)?.sha256;
+        if (fromMeta) {
+            const lower = fromMeta.toLowerCase();
+            hashCache.set(mod.fileName, lower);
+            return lower;
+        }
+        const fp = await fingerprintFile(mod.path);
+        const lower = fp.sha256.toLowerCase();
+        hashCache.set(mod.fileName, lower);
+        return lower;
+    };
+
+    const consumedIds = new Set<string>();
+
+    const matchBySha = async (pool: Mod[], wanted: string): Promise<Mod | undefined> => {
+        for (const m of pool) {
+            if (consumedIds.has(m.id)) continue;
+            if ((await getHash(m)) === wanted) return m;
+        }
+        return undefined;
+    };
+
+    return {
+        async locate(src: MergedModSource): Promise<Mod | undefined> {
+            let onDisk: Mod | undefined = disabledCandidates.find(
+                (m) => !consumedIds.has(m.id) && m.fileName === src.fileName
+            );
+            if (!onDisk && src.sha256AtMergeTime) {
+                const wanted = src.sha256AtMergeTime.toLowerCase();
+                onDisk = (await matchBySha(disabledCandidates, wanted))
+                    ?? (await matchBySha(enabledCandidates, wanted));
+            }
+            if (onDisk) consumedIds.add(onDisk.id);
+            return onDisk;
+        },
+    };
+}
+
 /**
  * Reverse a merge: re-enable the source VPKs (if they're still on disk) and
  * delete the merged VPK. Sources that are missing are reported via
@@ -357,80 +423,19 @@ export async function unmergeMod(
     }
     const manifest = meta.merged;
 
-    // Candidates for source recovery, split by folder. Absorbed sources
-    // should live in `.disabled/` so we look there first; the `enabled`
-    // fallback handles partial-disable failures and external tampering.
-    // The merged mod itself is filtered out so the target VPK can never
-    // be misidentified as one of its own sources.
-    const otherMods = installed.filter((m) => m.id !== target.id);
-    const disabledCandidates: Mod[] = otherMods.filter((m) => !m.enabled);
-    const enabledCandidates: Mod[] = otherMods.filter((m) => m.enabled);
-
-    // Lazy fileName -> sha256 cache (lowercased) so we hash each candidate
-    // at most once across the loop. Prefers the metadata-recorded hash
-    // (set at install / merge time) over a fresh fingerprint.
-    const hashCache = new Map<string, string>();
-    const getHash = async (mod: Mod): Promise<string> => {
-        const cached = hashCache.get(mod.fileName);
-        if (cached) return cached;
-        const fromMeta = getModMetadata(mod.fileName)?.sha256;
-        if (fromMeta) {
-            const lower = fromMeta.toLowerCase();
-            hashCache.set(mod.fileName, lower);
-            return lower;
-        }
-        const fp = await fingerprintFile(mod.path);
-        const lower = fp.sha256.toLowerCase();
-        hashCache.set(mod.fileName, lower);
-        return lower;
-    };
-
-    const consumedIds = new Set<string>();
+    // Recover each source from disk via the shared locator (disabled folder by
+    // fileName, then a content-hash fallback, then the enabled folder). The
+    // merged mod itself is excluded so it can't be misidentified as a source.
+    const locator = makeSourceLocator(installed.filter((m) => m.id !== target.id));
     const recovered: Mod[] = [];
     const missingSourceFileNames: string[] = [];
 
     for (const src of manifest.sources) {
-        // 1. Happy path: disabled folder, fileName matches the manifest.
-        let onDisk: Mod | undefined = disabledCandidates.find(
-            (m) => !consumedIds.has(m.id) && m.fileName === src.fileName
-        );
-
-        // 2. Content fallback: disabled folder, sha256 matches. Covers the
-        //    case where reconcileEnabledDisabledCollisions renamed the
-        //    source between merge and unmerge.
-        if (!onDisk && src.sha256AtMergeTime) {
-            const wanted = src.sha256AtMergeTime.toLowerCase();
-            for (const m of disabledCandidates) {
-                if (consumedIds.has(m.id)) continue;
-                if ((await getHash(m)) === wanted) {
-                    onDisk = m;
-                    break;
-                }
-            }
-        }
-
-        // 3. Content fallback in the enabled folder. Covers partial-disable
-        //    failures (merge wrote the manifest but didn't finish disabling
-        //    every source) and user-driven re-enables. The source is
-        //    already enabled, so we leave it where it is.
-        if (!onDisk && src.sha256AtMergeTime) {
-            const wanted = src.sha256AtMergeTime.toLowerCase();
-            for (const m of enabledCandidates) {
-                if (consumedIds.has(m.id)) continue;
-                if ((await getHash(m)) === wanted) {
-                    onDisk = m;
-                    break;
-                }
-            }
-        }
-
+        const onDisk = await locator.locate(src);
         if (!onDisk) {
             missingSourceFileNames.push(src.fileName);
             continue;
         }
-
-        consumedIds.add(onDisk.id);
-
         if (src.enabledAtMergeTime && !onDisk.enabled) {
             recovered.push(await enableMod(deadlockPath, onDisk.id));
         } else {
@@ -446,4 +451,155 @@ export async function unmergeMod(
         missingSourceFileNames,
         shareCode: manifest.shareCode,
     };
+}
+
+/**
+ * Pull a single source VPK out of a merged mod and restore it as a standalone
+ * mod, without dissolving the whole merge. The remaining sources are re-merged
+ * into a fresh VPK that reclaims the original's load-order slot, so the merge
+ * keeps its priority.
+ *
+ * When extracting would leave fewer than two sources behind, a "merge of one"
+ * is meaningless, so the merge collapses: the lone survivor is restored too and
+ * the merged VPK is deleted (a normal full unmerge for what's left).
+ */
+export async function extractMergeSource(
+    deadlockPath: string,
+    mergedModId: string,
+    sourceFileName: string
+): Promise<ExtractMergeSourceResult> {
+    const installed = await scanMods(deadlockPath);
+    const target = installed.find((m) => m.id === mergedModId);
+    if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
+
+    const meta = getModMetadata(target.fileName);
+    if (!meta?.merged) {
+        throw new Error(`"${meta?.modName || target.name}" is not a merged mod.`);
+    }
+    const manifest = meta.merged;
+
+    const removedSnapshot = manifest.sources.find((s) => s.fileName === sourceFileName);
+    if (!removedSnapshot) {
+        throw new Error(`"${sourceFileName}" is not a source of this merge.`);
+    }
+    const remainingSnapshots = manifest.sources.filter((s) => s.fileName !== sourceFileName);
+
+    const locator = makeSourceLocator(installed.filter((m) => m.id !== target.id));
+
+    // Locate the source being extracted first so it can't be claimed as one of
+    // the remaining sources. Missing-on-disk is tolerated: its content drops
+    // from the rebuild regardless, there's just nothing left to restore.
+    const removedOnDisk = await locator.locate(removedSnapshot);
+
+    const restored: Mod[] = [];
+
+    // Restore the extracted source to its pre-merge enabled state. Deferred
+    // until after the rebuild/collapse so the slot math below sees a stable
+    // disabled set.
+    const restoreExtracted = async (): Promise<void> => {
+        if (!removedOnDisk) return;
+        if (removedSnapshot.enabledAtMergeTime && !removedOnDisk.enabled) {
+            restored.push(await enableMod(deadlockPath, removedOnDisk.id));
+        } else {
+            restored.push(removedOnDisk);
+        }
+    };
+
+    // ---- Collapse: fewer than two sources would remain, so fully unmerge. ----
+    if (remainingSnapshots.length < 2) {
+        const survivor = remainingSnapshots[0];
+        if (survivor) {
+            const onDisk = await locator.locate(survivor);
+            if (onDisk) {
+                if (survivor.enabledAtMergeTime && !onDisk.enabled) {
+                    restored.push(await enableMod(deadlockPath, onDisk.id));
+                } else {
+                    restored.push(onDisk);
+                }
+            }
+        }
+        await fs.unlink(target.path);
+        removeModMetadata(target.fileName);
+        await restoreExtracted();
+        return { collapsed: true, merged: null, restored };
+    }
+
+    // ---- Rebuild: re-merge the remaining sources into a fresh VPK. ----
+    // Every remaining source must be present on disk to faithfully reproduce
+    // the merge; refuse rather than silently dropping a source's content.
+    const remainingOnDisk: Mod[] = [];
+    const missing: string[] = [];
+    for (const snap of remainingSnapshots) {
+        const onDisk = await locator.locate(snap);
+        if (onDisk) remainingOnDisk.push(onDisk);
+        else missing.push(snap.modName || snap.fileName);
+    }
+    if (missing.length > 0) {
+        throw new Error(
+            `Can't rebuild the merge: ${missing.join(', ')} ${missing.length === 1 ? 'is' : 'are'} no longer on disk. Unmerge instead to recover what's left.`
+        );
+    }
+
+    // Order DESCENDING by merge-time priority so the highest-priority (lowest
+    // pakNN) source lands LAST in argv; vpkmerge is last-input-wins, matching
+    // mergeMods and Deadlock's lower-pakNN-wins collision rule. (remainingOnDisk
+    // is index-aligned with remainingSnapshots: the missing check above
+    // guarantees every snapshot resolved.)
+    const ordered = remainingOnDisk
+        .map((mod, i) => ({ mod, priority: remainingSnapshots[i].priorityAtMergeTime }))
+        .sort((a, b) => b.priority - a.priority)
+        .map((p) => p.mod);
+
+    const rebuildPriority = await findNextAvailablePriority(deadlockPath);
+    const rebuildFileName = `pak${String(rebuildPriority).padStart(2, '0')}_dir.vpk`;
+    const addonsPath = getAddonsPath(deadlockPath);
+    const rebuildPath = join(addonsPath, rebuildFileName);
+
+    await reserveOutputSlot(rebuildPath);
+    try {
+        await runVpkmerge([rebuildPath, ...ordered.map((m) => m.path)]);
+        await verifyVpkOutput(rebuildPath);
+    } catch (err) {
+        try { await fs.unlink(rebuildPath); } catch { /* ignore partial-output cleanup */ }
+        throw err;
+    }
+
+    // Fresh manifest: keep the surviving source snapshots (still accurate),
+    // regenerate the share code from the on-disk survivors, preserve createdAt.
+    const portable = buildPortableForSources(remainingOnDisk, meta.modName || target.name);
+    const newManifest: MergedModInfo = {
+        id: manifest.id,
+        createdAt: manifest.createdAt,
+        shareCode: encodeShareCode(JSON.stringify(portable)),
+        sources: remainingSnapshots,
+    };
+    const sha256 = await hashFile(rebuildPath);
+    removeModMetadata(rebuildFileName); // scrub any orphan from a prior slot occupant
+    setModMetadata(rebuildFileName, {
+        modName: meta.modName,
+        thumbnailUrl: meta.thumbnailUrl,
+        sha256,
+        merged: newManifest,
+    });
+
+    // Delete the old merged VPK to free its slot, then move the rebuilt VPK
+    // back into that slot so the merge keeps its load-order position.
+    const originalPriority = target.priority;
+    await fs.unlink(target.path);
+    removeModMetadata(target.fileName);
+
+    const afterBuild = await scanMods(deadlockPath);
+    const rebuilt = afterBuild.find((m) => m.fileName === rebuildFileName);
+    if (!rebuilt) {
+        throw new Error('Rebuilt merged VPK was created but could not be located in the rescan.');
+    }
+    const reslotted = await setModPriority(deadlockPath, rebuilt.id, originalPriority);
+
+    await restoreExtracted();
+
+    // Re-read so the returned merged mod reflects its final on-disk filename
+    // (setModPriority renamed it); the IPC layer enriches it with the manifest.
+    const finalScan = await scanMods(deadlockPath);
+    const finalMerged = finalScan.find((m) => m.fileName === reslotted.fileName) ?? reslotted;
+    return { collapsed: false, merged: finalMerged, restored };
 }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -16,6 +16,7 @@ import type {
     MergeModsArgs,
     Mod,
     ModConflict,
+    ExtractMergeSourceResult,
     UnknownModFilterGuess,
     UnmergeModResult,
 } from '../../src/types/mod';
@@ -66,6 +67,7 @@ export interface ElectronAPI {
     readImageDataUrl: (imagePath: string) => Promise<string>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
+    extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;
 
     // Launch
     launchModded: () => Promise<void>;
@@ -805,6 +807,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('read-image-data-url', imagePath),
     mergeMods: (args: MergeModsArgs) => ipcRenderer.invoke('merge-mods', args),
     unmergeMod: (mergedModId: string) => ipcRenderer.invoke('unmerge-mod', mergedModId),
+    extractMergeSource: (mergedModId: string, sourceFileName: string) =>
+        ipcRenderer.invoke('extract-merge-source', mergedModId, sourceFileName),
 
     // Launch
     launchModded: () => ipcRenderer.invoke('launch-modded'),

--- a/src/components/MergedContentsModal.tsx
+++ b/src/components/MergedContentsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Layers, X, ExternalLink, Share2, Scissors, Check } from 'lucide-react';
-import type { Mod } from '../types/mod';
+import { Layers, X, Share2, Scissors, Check, PackageOpen, Loader2, AlertTriangle } from 'lucide-react';
+import type { Mod, MergedModSource } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
 import { Button, Tag } from './common/ui';
 import { formatRelativeDate } from '../lib/dates';
@@ -10,24 +10,44 @@ interface Props {
   hideNsfw?: boolean;
   onClose: () => void;
   onUnmerge?: () => void;
+  /** Pull one source out of the merge, restoring it as a standalone mod.
+   *  Omitted to render the list read-only. */
+  onExtractSource?: (source: MergedModSource) => Promise<void>;
 }
 
 /**
- * Read-only view of what a merged VPK contains. Lists every source mod with
- * its thumbnail, the priority/enabled state captured at merge time, and a
- * GameBanana link when one exists. Also surfaces the share code (with a copy
- * button) and an Unmerge shortcut.
+ * View of what a merged VPK contains. Lists every source mod with its
+ * thumbnail and the priority/enabled state captured at merge time. Each source
+ * can be extracted back to a standalone mod; the footer surfaces the share code
+ * (with a copy button) and an Unmerge shortcut.
  */
-export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge }: Props) {
+export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge, onExtractSource }: Props) {
   const [copied, setCopied] = useState(false);
+  // The fileName of the source row currently being extracted, and the last
+  // error surfaced by an extract.
+  const [busyFileName, setBusyFileName] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const merged = mod.merged;
   // Render nothing if the prop is malformed rather than throwing; the parent
   // only opens this modal when `mod.merged` is truthy so this is defensive.
   if (!merged) return null;
 
-  const sectionForGb = (section?: string): string => {
-    const s = (section || 'Mod').toLowerCase();
-    return s === 'sound' ? 'sounds' : 'mods';
+  const canExtract = !!onExtractSource;
+
+  const handleExtract = async (src: MergedModSource) => {
+    if (!onExtractSource || busyFileName) return;
+    setActionError(null);
+    setBusyFileName(src.fileName);
+    try {
+      // The parent runs the IPC, refreshes mods, and then either re-syncs this
+      // modal's `mod` prop with the rebuilt merge (fewer sources) or closes it
+      // when the merge collapsed. Nothing else to do on success here.
+      await onExtractSource(src);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyFileName(null);
+    }
   };
 
   const handleCopy = async () => {
@@ -103,18 +123,25 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge 
           </div>
 
           <div>
-            <div className="text-xs uppercase tracking-wide text-text-secondary mb-1.5">
-              Sources ({merged.sources.length})
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="text-xs uppercase tracking-wide text-text-secondary">
+                Sources ({merged.sources.length})
+              </div>
+              {canExtract && merged.sources.length === 2 && (
+                <div className="text-[11px] text-amber-400/90">
+                  Extracting one dissolves the merge
+                </div>
+              )}
             </div>
             <ul className="space-y-1.5 max-h-72 overflow-y-auto pr-1">
               {merged.sources.map((src) => {
-                const gbHref = src.gameBananaId
-                  ? `https://gamebanana.com/${sectionForGb(src.section)}/${src.gameBananaId}`
-                  : null;
+                const busy = busyFileName === src.fileName;
+                // Dim and lock other rows while an extract is in flight.
+                const rowLocked = busyFileName !== null && !busy;
                 return (
                   <li
                     key={src.fileName}
-                    className="flex items-center gap-3 px-2 py-2 rounded bg-bg-tertiary/50 border border-border/60"
+                    className={`flex items-center gap-3 px-2 py-2 rounded bg-bg-tertiary/50 border border-border/60 ${rowLocked ? 'opacity-50' : ''}`}
                   >
                     <div className="w-12 h-12 flex-shrink-0 rounded overflow-hidden bg-bg-tertiary">
                       <ModThumbnail
@@ -147,30 +174,33 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge 
                           off
                         </span>
                       )}
-                      {gbHref ? (
-                        <a
-                          href={gbHref}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="p-1 text-text-secondary hover:text-accent transition-colors"
-                          title="View on GameBanana"
-                          aria-label={`View ${src.modName} on GameBanana`}
+                      {canExtract && (
+                        <button
+                          onClick={() => void handleExtract(src)}
+                          disabled={rowLocked}
+                          className="p-1 ml-0.5 text-text-secondary hover:text-accent transition-colors rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                          title="Extract: pull this out as its own mod"
+                          aria-label={`Extract ${src.modName}`}
                         >
-                          <ExternalLink className="w-4 h-4" />
-                        </a>
-                      ) : (
-                        <span
-                          className="text-[10px] uppercase tracking-wide text-text-secondary/70 px-1.5 py-0.5 rounded border border-border"
-                          title="Local mod — not in the share code"
-                        >
-                          local
-                        </span>
+                          {busy ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : (
+                            <PackageOpen className="w-4 h-4" />
+                          )}
+                        </button>
                       )}
                     </div>
                   </li>
                 );
               })}
             </ul>
+
+            {actionError && (
+              <div className="flex items-start gap-2 text-sm text-red-200 bg-red-500/10 border border-red-500/30 rounded-lg p-2.5 mt-2">
+                <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                <div>{actionError}</div>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ApplyHeroCardResult } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult } from '../types/mod';
 import type { HeroPortrait } from '../types/portrait';
 import type {
   GameBananaModsResponse,
@@ -168,7 +168,14 @@ export async function unmergeMod(mergedModId: string): Promise<UnmergeModResult>
   return window.electronAPI.unmergeMod(mergedModId);
 }
 
-export type { UnmergeModResult };
+export async function extractMergeSource(
+  mergedModId: string,
+  sourceFileName: string,
+): Promise<ExtractMergeSourceResult> {
+  return window.electronAPI.extractMergeSource(mergedModId, sourceFileName);
+}
+
+export type { UnmergeModResult, ExtractMergeSourceResult };
 
 // =====================
 // Launch API

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -32,10 +32,10 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, extractMergeSource, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
-import type { Mod, GlobalModType, UnknownModFilterGuess } from '../types/mod';
+import type { Mod, GlobalModType, UnknownModFilterGuess, MergedModSource } from '../types/mod';
 import type { GameBananaModDetails } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
@@ -1254,6 +1254,23 @@ export default function Installed() {
       console.error('[Installed] clipboard write failed:', err);
       setCopyToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`);
     }
+  };
+
+  // Extract one source out of the open merged mod back to a standalone mod.
+  // Errors propagate to the modal, which surfaces them inline; on success we
+  // refresh the mod list and either re-sync the modal with the rebuilt merge or
+  // close it when the merge collapsed (fewer than two sources left).
+  const handleExtractMergeSource = async (source: MergedModSource) => {
+    if (!mergedContentsMod) return;
+    const result = await extractMergeSource(mergedContentsMod.id, source.fileName);
+    await loadMods({ silent: true });
+    if (result.collapsed) {
+      setMergedContentsMod(null);
+      setCopyToast(`Merge dissolved (extracted ${source.modName})`);
+      return;
+    }
+    setMergedContentsMod(result.merged);
+    setCopyToast(`Extracted ${source.modName}`);
   };
 
   // Auto-dismiss the copy toast after a short read time.
@@ -2699,6 +2716,7 @@ export default function Installed() {
           hideNsfw={settings?.hideNsfwPreviews ?? true}
           onClose={() => setMergedContentsMod(null)}
           onUnmerge={() => setUnmergeTarget(mergedContentsMod)}
+          onExtractSource={handleExtractMergeSource}
         />
       )}
 
@@ -4418,20 +4436,27 @@ function ModCard({
                 Unmerge
               </button>
             )}
-            <div className="my-1 h-px bg-border" />
-            <button
-              type="button"
-              role="menuitem"
-              onClick={(e) => {
-                e.stopPropagation();
-                setMenuOpen(false);
-                onDelete();
-              }}
-              className={dangerMenuItemClasses}
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-              Delete
-            </button>
+            {/* A merged mod is removed via Unmerge (which deletes the merged VPK
+                and restores its sources), so a raw Delete alongside it would be
+                redundant and confusing. Non-merged mods keep Delete. */}
+            {!mod.merged && (
+              <>
+                <div className="my-1 h-px bg-border" />
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setMenuOpen(false);
+                    onDelete();
+                  }}
+                  className={dangerMenuItemClasses}
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                  Delete
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
     EditLocalModArgs,
     MergeModsArgs,
     UnmergeModResult,
+    ExtractMergeSourceResult,
     ApplyHeroCardResult,
 } from './mod';
 import type {
@@ -313,6 +314,7 @@ export interface ElectronAPI {
     readImageDataUrl: (imagePath: string) => Promise<string>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
+    extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;
 
     // Launch
     launchModded: () => Promise<void>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -160,6 +160,18 @@ export interface UnmergeModResult {
   shareCode: string;
 }
 
+export interface ExtractMergeSourceResult {
+  /** True when extracting the source left fewer than 2 behind, so the whole
+   *  merge was dissolved (the merged VPK is gone) rather than rebuilt. */
+  collapsed: boolean;
+  /** The rebuilt merged mod (same load-order slot as before). Null when the
+   *  merge collapsed. */
+  merged: Mod | null;
+  /** Mods that are now standalone again: the extracted source plus any source
+   *  restored when the merge collapsed. */
+  restored: Mod[];
+}
+
 export interface UnknownModFilterGuess {
   modId: string;
   fileName: string;


### PR DESCRIPTION
## What

Adds the ability to pull a single source VPK back out of a merged mod, from the merged-contents overlay.

- **Extract** (per source): restores that source as its own standalone mod and re-merges the remaining sources in place, reclaiming the original load-order slot. If fewer than two sources would remain, the merge dissolves (full unmerge of what's left).
- Merged mods are now removed via **Unmerge only**: the raw per-mod Delete is dropped from a merged mod's card menu (Unmerge already deletes the merged VPK and restores its sources), so Delete + Unmerge no longer sit side by side.
- The GameBanana link is removed from the contents overlay rows.

Net model: **Extract** (one source) + **Unmerge** (whole merge). No overlapping delete verbs.

## How

- New `extractMergeSource()` in `modMerger.ts` reuses the proven `mergeMods` sequence (`reserveOutputSlot` -> `runVpkmerge` -> `verifyVpkOutput`) and the `unmergeMod` source-recovery walk (extracted into a shared `makeSourceLocator`). The rebuilt VPK is moved back into the original slot via `setModPriority` so load priority is preserved.
- If a *remaining* source is missing on disk it aborts ("Unmerge instead") rather than silently dropping content. A missing *removed* source is tolerated.
- IPC/preload/api/types wired to mirror the existing `merge-mods` / `unmerge-mod` plumbing.

## Test

- `pnpm lint`, `pnpm exec tsc -b --noEmit`, and `electron-vite build` all clean.
- Manual: merge 3 mods, extract one (reappears as a card, merged slot unchanged), extract from a 2-source merge (dissolves cleanly).