### PR TITLE
fix(installed): stop the bulk-action bar overlapping modals

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2773,7 +2773,11 @@ export default function Installed() {
       )}
 
       {selectMode && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-max max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-xl shadow-lg shadow-black/40 px-3 py-2 flex flex-wrap items-center gap-2">
+        // z-40 keeps this floating bar above the page + sticky header (z-30)
+        // but below modal overlays (z-50), so an open modal's backdrop dims it
+        // like the rest of the page instead of the bar painting over the modal
+        // (e.g. the variant picker overlapping it in a short window).
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 w-max max-w-[calc(100vw-2rem)] bg-bg-secondary border border-border rounded-xl shadow-lg shadow-black/40 px-3 py-2 flex flex-wrap items-center gap-2">
           {bulkProgress ? (
             <span className="text-sm text-text-primary tabular-nums px-2 flex items-center gap-2">
               <Loader2 className="w-4 h-4 animate-spin text-accent" />


### PR DESCRIPTION
## What

In short windows, the select-mode bulk-action bar overlapped open modals (reported with the variant picker).

## Why

The bulk bar was `z-50`, the same layer as modal overlays, and rendered later in the DOM, so it painted *on top of* an open modal instead of being covered by the modal's dimming backdrop like the rest of the page.

## Fix

Drop the bar to `z-40`: above the page content and the sticky header (`z-30`) but below modal overlays (`z-50`). One-line className change.

## Test

`pnpm lint` clean; typecheck/build unaffected (CSS class only). Verified the bar now dims under a modal backdrop instead of painting over it.