### PR TITLE
QOL from #91: stale-sound fix, broader filters, dense view, gameinfo self-heal

### DIFF
--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -39,6 +39,83 @@ function findGameinfoCandidates(deadlockPath: string): string[] {
     }
 }
 
+// Suffix for the one-time backup Grimoire takes before its first edit to
+// gameinfo.gi, so a bad patch is recoverable without verifying/reinstalling.
+const GAMEINFO_BACKUP_SUFFIX = '.grimoire-bak';
+
+// Locate the first SearchPaths { ... } block using balanced-brace scanning.
+// The previous regex (/SearchPaths\s*\{[^}]*\}/) stops at the first '}', so any
+// nested brace would truncate the match and corrupt the replacement. A foreign
+// gameinfo.gi left by another mod manager could be matched wrong or missed
+// entirely. Returns the block's bounds (relative to content) and inner body,
+// or null when there's no parseable SearchPaths section.
+function findSearchPathsBlock(
+    content: string
+): { start: number; end: number; body: string } | null {
+    const keyword = /SearchPaths\s*\{/g;
+    const match = keyword.exec(content);
+    if (!match) return null;
+
+    const braceStart = match.index + match[0].length - 1; // index of the '{'
+    let depth = 0;
+    for (let i = braceStart; i < content.length; i++) {
+        const ch = content[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                return {
+                    start: match.index,
+                    end: i + 1,
+                    body: content.slice(braceStart + 1, i),
+                };
+            }
+        }
+    }
+    return null; // unbalanced braces
+}
+
+// True when the SearchPaths body has an active (non-commented) entry pointing the
+// engine at citadel/addons. Checking inside the block and ignoring // comments
+// means a stray "citadel/addons" in a comment or elsewhere in the file no longer
+// reads as configured: that false positive is what let a DLM-mangled gameinfo.gi
+// look healthy while mods silently failed to load.
+function hasActiveAddonPath(searchPathsBody: string): boolean {
+    return searchPathsBody.split(/\r?\n/).some((line) => {
+        const code = line.split('//')[0]; // drop any trailing line comment
+        // Match citadel/addons only as a complete path token. A subfolder path
+        // like citadel/addons/profile_default (which Deadlock Mod Manager writes
+        // in its profile mode) must NOT count as configured: the engine would
+        // search that subfolder, not the addons root where Grimoire drops its
+        // VPKs. The bare substring check this replaces treated that prefix as
+        // healthy, so Grimoire reported "configured" while no mods loaded.
+        return /citadel[\\/]+addons(?![\\/\w])/i.test(code);
+    });
+}
+
+// Preserve the first version we touch. Never overwrites an existing backup so the
+// oldest (closest-to-original) copy is kept. Best-effort: a failed backup must
+// not block the repair itself.
+function backupGameinfoOnce(gameinfoPath: string, original: string): void {
+    const backupPath = `${gameinfoPath}${GAMEINFO_BACKUP_SUFFIX}`;
+    if (existsSync(backupPath)) return;
+    try {
+        writeFileSync(backupPath, original, 'utf-8');
+    } catch {
+        // Ignore: recovery backup is a nice-to-have, not a hard requirement.
+    }
+}
+
+// Insert the canonical SearchPaths block just inside the FileSystem section, for
+// the case where another tool stripped SearchPaths out entirely. Returns null if
+// there's no FileSystem block to repair (don't guess at an unknown structure).
+function insertSearchPaths(content: string): string | null {
+    const match = /FileSystem\s*\{/.exec(content);
+    if (!match) return null;
+    const insertAt = match.index + match[0].length;
+    return `${content.slice(0, insertAt)}\n\t\t${SEARCH_PATHS_BLOCK}${content.slice(insertAt)}`;
+}
+
 export interface CleanupResult {
     removedArchives: number;
     renamedMinaPresets: number;
@@ -64,8 +141,9 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
 
     try {
         const content = readFileSync(gameinfoPath, 'utf-8');
+        const block = findSearchPathsBlock(content);
 
-        if (content.includes('citadel/addons')) {
+        if (block && hasActiveAddonPath(block.body)) {
             return {
                 configured: true,
                 missing: false,
@@ -74,11 +152,24 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
             };
         }
 
+        // A SearchPaths block exists but doesn't load citadel/addons: fixable in place.
+        if (block) {
+            return {
+                configured: false,
+                missing: false,
+                message: 'Addon search paths are missing from gameinfo.gi',
+                candidates: [],
+            };
+        }
+
+        // No parseable SearchPaths block: the classic state another mod manager
+        // leaves behind. Surface any leftover gameinfo.* it dropped, and note that
+        // Fix Configuration can rebuild the section (see fixGameinfo).
         return {
             configured: false,
             missing: false,
-            message: 'Addon search paths are missing from gameinfo.gi',
-            candidates: [],
+            message: 'gameinfo.gi has no usable SearchPaths section (it may have been altered by another mod manager). Use Fix Configuration to rebuild it.',
+            candidates: findGameinfoCandidates(deadlockPath),
         };
     } catch (err) {
         return {
@@ -107,10 +198,11 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
     }
 
     try {
-        let content = readFileSync(gameinfoPath, 'utf-8');
+        const content = readFileSync(gameinfoPath, 'utf-8');
+        const block = findSearchPathsBlock(content);
 
-        // Check if already configured
-        if (content.includes('citadel/addons')) {
+        // Already correct: an active addon path inside a real SearchPaths block.
+        if (block && hasActiveAddonPath(block.body)) {
             return {
                 configured: true,
                 missing: false,
@@ -119,23 +211,38 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
             };
         }
 
-        // Find the SearchPaths section using regex to match the entire block
-        // Matches: SearchPaths followed by whitespace, {, any content, and closing }
-        const searchPathsRegex = /SearchPaths\s*\{[^}]*\}/s;
-
-        if (!searchPathsRegex.test(content)) {
+        let next: string;
+        if (block) {
+            // Canonicalize: swap whatever SearchPaths block is present (including
+            // one a different mod manager rewrote) for our known-good version.
+            next = content.slice(0, block.start) + SEARCH_PATHS_BLOCK + content.slice(block.end);
+        } else if (!/SearchPaths/.test(content)) {
+            // Another tool stripped SearchPaths out entirely. Rebuild it inside the
+            // FileSystem section so mods load again without a game reinstall.
+            const rebuilt = insertSearchPaths(content);
+            if (!rebuilt) {
+                return {
+                    configured: false,
+                    missing: false,
+                    message: 'Could not find a FileSystem section to repair in gameinfo.gi. In Steam, verify the integrity of game files, then try again.',
+                    candidates: findGameinfoCandidates(deadlockPath),
+                };
+            }
+            next = rebuilt;
+        } else {
+            // SearchPaths text is present but its braces do not parse (corrupted or
+            // an unusual format). Don't guess; let the user restore a clean file.
             return {
                 configured: false,
                 missing: false,
-                message: 'Could not find SearchPaths section in gameinfo.gi',
-                candidates: [],
+                message: 'The SearchPaths section in gameinfo.gi could not be parsed. In Steam, verify the integrity of game files, then try again.',
+                candidates: findGameinfoCandidates(deadlockPath),
             };
         }
 
-        // Replace the entire SearchPaths block with our canonical version
-        content = content.replace(searchPathsRegex, SEARCH_PATHS_BLOCK);
-
-        writeFileSync(gameinfoPath, content, 'utf-8');
+        // Keep a one-time recovery copy before the first write.
+        backupGameinfoOnce(gameinfoPath, content);
+        writeFileSync(gameinfoPath, next, 'utf-8');
 
         return {
             configured: true,

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   LayoutGrid,
   Grid3x3,
+  Grip,
   List,
   AlertTriangle,
   Clock,
@@ -51,19 +52,17 @@ import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition } from '../l
 
 const DEFAULT_PER_PAGE = 20;
 type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
-type ViewMode = 'grid' | 'compact' | 'list';
+type ViewMode = 'grid' | 'compact' | 'dense' | 'list';
 const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
 // Persist filter UI inputs across page navigation. The store keeps these in
 // memory so visiting Installed and coming back doesn't blow away the user's
 // current search/filter context. Kept out of localStorage so a fresh launch
 // starts clean — sessions, not preferences.
 
-// Only show these categories in the dropdown (lowercase for matching)
-const ALLOWED_CATEGORIES = new Set(['hud', 'other/misc', 'maps']);
-
 type CategoryOption = {
   id: number;
   label: string;
+  itemCount: number;
 };
 
 type FlattenOptions = {
@@ -87,7 +86,7 @@ function flattenCategories(
 
     const nextPath = parentPath ? `${parentPath} / ${node.name}` : node.name;
     if (includeEmpty || node.itemCount > 0) {
-      results.push({ id: node.id, label: nextPath });
+      results.push({ id: node.id, label: nextPath, itemCount: node.itemCount });
     }
 
     if (node.children && node.children.length > 0) {
@@ -1000,18 +999,28 @@ export default function Browse() {
   }, [modCategories]);
 
   const categoryOptions = useMemo(() => {
+    // Per-hero entries under Skins are handled by the dedicated Hero filter, so
+    // exclude them here. Everything else (Skins, Model Replacement, HUD,
+    // Gameplay Modifications, Maps, Music, Killsounds, ...) becomes a mod-type
+    // filter. This surfaces GameBanana's real categories instead of the old
+    // hardcoded hud/other-misc/maps allowlist (issue #91).
     const heroIds = new Set(heroOptions.map((hero) => hero.id));
+    const flat = flattenCategories(categories, '', { excludeIds: heroIds, includeEmpty: false });
 
-    // Get all flattened categories
-    let options = flattenCategories(categories, '', { excludeIds: heroIds, includeEmpty: false });
+    // GameBanana keeps several legacy duplicate categories that share a name
+    // (e.g. multiple "Skins" / "Other/Misc" buckets). Collapse by label and keep
+    // the most populated one so the dropdown stays short and points at the
+    // canonical category.
+    const byLabel = new Map<string, CategoryOption>();
+    for (const opt of flat) {
+      const key = opt.label.toLowerCase();
+      const existing = byLabel.get(key);
+      if (!existing || opt.itemCount > existing.itemCount) {
+        byLabel.set(key, opt);
+      }
+    }
 
-    // Only keep allowed categories (HUD, Other/Misc, Maps)
-    options = options.filter(opt => {
-      const lowerLabel = opt.label.toLowerCase();
-      return ALLOWED_CATEGORIES.has(lowerLabel);
-    });
-
-    return options;
+    return Array.from(byLabel.values()).sort((a, b) => a.label.localeCompare(b.label));
   }, [categories, heroOptions]);
 
   const installedIds = useMemo(() => {
@@ -1310,6 +1319,17 @@ export default function Browse() {
               </button>
               <button
                 type="button"
+                onClick={() => setViewMode('dense')}
+                className={`p-2 rounded-md transition-colors cursor-pointer ${viewMode === 'dense'
+                  ? 'bg-bg-tertiary text-text-primary'
+                  : 'text-text-secondary hover:text-text-primary'
+                  }`}
+                title="Dense view"
+              >
+                <Grip className="w-5 h-5" />
+              </button>
+              <button
+                type="button"
                 onClick={() => setViewMode('list')}
                 className={`p-2 rounded-md transition-colors cursor-pointer ${viewMode === 'list'
                   ? 'bg-bg-tertiary text-text-primary'
@@ -1494,9 +1514,11 @@ export default function Browse() {
           const gridClass =
             viewMode === 'list'
               ? 'flex flex-col gap-3'
-              : viewMode === 'compact'
-                ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3'
-                : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3';
+              : viewMode === 'dense'
+                ? 'grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-2'
+                : viewMode === 'compact'
+                  ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3'
+                  : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3';
           const hasActiveFilters =
             search.trim().length > 0 || heroCategoryId !== 'all' || categoryId !== 'all' || sort !== 'default';
 
@@ -1672,7 +1694,7 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
       </div>
     );
   }
-  const aspect = viewMode === 'compact' ? 'aspect-[4/3]' : 'aspect-[3/2]';
+  const aspect = viewMode === 'compact' || viewMode === 'dense' ? 'aspect-[4/3]' : 'aspect-[3/2]';
   return (
     <div className={`relative bg-bg-tertiary border border-border rounded-lg overflow-hidden ${aspect}`}>
       <div className="absolute inset-0 skeleton-shimmer bg-bg-secondary" />
@@ -1687,7 +1709,9 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
 function ModCard({ mod, installed, installedDisabled, downloading, queuePosition, viewMode, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, onPlayingChange, onClick, onQuickDownload, onEnable }: ModCardProps) {
   const thumbnail = getModThumbnail(mod);
   const audioPreview = section === 'Sound' ? getSoundPreviewUrl(mod) : undefined;
-  const isCompact = viewMode === 'compact';
+  // Dense reuses the compact card chrome (4:3 aspect, smaller text/padding); it
+  // only differs in how many columns the grid packs in.
+  const isCompact = viewMode === 'compact' || viewMode === 'dense';
   const isList = viewMode === 'list';
   const isSoundSection = section === 'Sound';
   const hasAudioPreview = Boolean(audioPreview);

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -194,6 +194,10 @@ export default function LockerHero() {
     const heroModList = listForMod(modId);
     if (!heroModList?.some((m) => m.id === modId)) return;
     await toggleMod(modId);
+    // toggleMod only patches the single mod's enabled flag in the store; the
+    // sound/skin lists derive from a fresh scan. Without a reload the page can
+    // show a just-swapped sound until the user manually refreshes (issue #91).
+    await loadMods({ silent: true });
   };
 
   const toggleHeroVariant = async (modId: string) => {
@@ -201,6 +205,7 @@ export default function LockerHero() {
     const heroModList = listForMod(modId);
     if (!heroModList?.some((m) => m.id === modId)) return;
     await toggleMod(modId);
+    await loadMods({ silent: true });
   };
 
   const applyMinaPreset = async (presetFileName: string) => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -17,7 +17,7 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 // survives navigation away from /browse and back — user complaint: search
 // query, view mode, and filters all reset when switching pages.
 export type BrowseSortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
-export type BrowseViewMode = 'grid' | 'compact' | 'list';
+export type BrowseViewMode = 'grid' | 'compact' | 'dense' | 'list';
 export interface BrowseUiState {
   search: string;
   viewMode: BrowseViewMode;
@@ -37,7 +37,7 @@ export interface BrowseUiState {
 const VIEW_MODE_KEY = 'browseViewMode';
 const SORT_KEY = 'browseSort';
 
-const VIEW_MODES: BrowseViewMode[] = ['grid', 'compact', 'list'];
+const VIEW_MODES: BrowseViewMode[] = ['grid', 'compact', 'dense', 'list'];
 const SORT_OPTIONS: BrowseSortOption[] = ['default', 'popular', 'recent', 'updated', 'views', 'name'];
 
 function readPersistedViewMode(): BrowseViewMode {


### PR DESCRIPTION
Addresses several items from #91 (the issue stays open: the rest are tracked there).

## Bug fixes
- **Stale sound after swapping** (`LockerHero`): toggling a sound/skin only patched the single mod in the store, so a swap could linger until a manual refresh. Now reloads mods after the toggle.
- **DLM coexistence / "forced game reinstall"** (`system.ts`): detection used a bare `citadel/addons` substring check, so a subfolder path like `citadel/addons/profile_default` (what Deadlock Mod Manager writes in profile mode) read as "Configured" while no mods loaded. Now matches `citadel/addons` as a complete path token, finds the SearchPaths block with balanced-brace scanning, backs up to `.grimoire-bak` before the first write, and canonicalizes / rebuilds the block. **Fix Configuration now repairs a DMM-mangled file instead of needing a reinstall.**

## QOL
- **Broader category filters** (`Browse`): dropped the hardcoded hud/other-misc/maps allowlist; now surfaces all real GameBanana categories (Skins, Model Replacement, Music, Killsounds, Gameplay, ...), collapsing legacy duplicate-name buckets.
- **Dense view mode** (`Browse`): a fourth grid option (8-wide on xl) for smaller blocks, persisted alongside grid/compact/list.

## Not in this PR (still open on #91)
Parallel/multi downloads, sidebar regrouping, time-bounded sorts, NSFW-only toggle, Deadlocker aggregation.

## Verification
`tsc` clean on both `tsconfig.app.json` and `tsconfig.node.json`; ESLint clean on all changed files. Ran in `pnpm dev`.

Design note on DMM: rather than tracking DMM's exact format, the fix canonicalizes whatever SearchPaths block is present, so it is robust across DMM versions. "Verify integrity in Steam" remains only as the last-resort message for an unparseable file.
