### PR TITLE
feat(browse): NSFW/SFW + recency filters (#91)

### DIFF
--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -19,6 +19,10 @@ export interface SearchOptions {
     heroName?: string;
     skinsCategoryId?: number;
     sortBy?: 'relevance' | 'likes' | 'date' | 'date_added' | 'views' | 'name';
+    // Content-rating filter: 'all' (default), SFW only, or NSFW only.
+    nsfw?: 'all' | 'sfw' | 'nsfw';
+    // Recency window on date_added: 'all' (default), last day/week/month.
+    addedWithin?: 'all' | 'today' | 'week' | 'month';
     limit?: number;
     offset?: number;
 }
@@ -54,6 +58,31 @@ function buildOrderBy(sortBy: SearchOptions['sortBy'], hasQuery: boolean): strin
 }
 
 /**
+ * Append the content-rating and recency filters shared by the FTS and fallback
+ * paths. Mutates the passed conditions/params so both code paths stay in sync.
+ */
+function applyContentFilters(
+    conditions: string[],
+    params: Record<string, unknown>,
+    nsfw: SearchOptions['nsfw'],
+    addedWithin: SearchOptions['addedWithin']
+): void {
+    if (nsfw === 'sfw') {
+        conditions.push('mods.is_nsfw = 0');
+    } else if (nsfw === 'nsfw') {
+        conditions.push('mods.is_nsfw = 1');
+    }
+
+    if (addedWithin && addedWithin !== 'all') {
+        // date_added is a Unix timestamp in seconds (GameBanana's _tsDateAdded).
+        const windowSeconds =
+            addedWithin === 'today' ? 86_400 : addedWithin === 'week' ? 7 * 86_400 : 30 * 86_400;
+        params.addedAfter = Math.floor(Date.now() / 1000) - windowSeconds;
+        conditions.push('mods.date_added >= @addedAfter');
+    }
+}
+
+/**
  * Fallback search used when the FTS5 path returns zero results. FTS5 is
  * tokenized and prefix-only, so creative names ("MìnaMod-v2", typos, partial
  * substrings inside a word) miss even when they should match. This runs a
@@ -68,6 +97,8 @@ function runFallbackSubstringSearch(
     heroName: string | undefined,
     skinsCategoryId: number | undefined,
     sortBy: SearchOptions['sortBy'],
+    nsfw: SearchOptions['nsfw'],
+    addedWithin: SearchOptions['addedWithin'],
     limit: number,
     offset: number
 ): SearchResult {
@@ -102,6 +133,8 @@ function runFallbackSubstringSearch(
             params.categoryId = categoryId;
         }
     }
+
+    applyContentFilters(conditions, params, nsfw, addedWithin);
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const orderBy = buildOrderBy(sortBy, false); // no FTS rank in fallback
@@ -139,6 +172,8 @@ export function searchMods(options: SearchOptions): SearchResult {
         heroName,
         skinsCategoryId,
         sortBy = 'relevance',
+        nsfw = 'all',
+        addedWithin = 'all',
     } = options;
 
     // Validate and cap pagination values
@@ -195,6 +230,8 @@ export function searchMods(options: SearchOptions): SearchResult {
         }
     }
 
+    applyContentFilters(conditions, params, nsfw, addedWithin);
+
     // Build WHERE clause
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
@@ -229,6 +266,8 @@ export function searchMods(options: SearchOptions): SearchResult {
             heroName,
             skinsCategoryId,
             sortBy,
+            nsfw,
+            addedWithin,
             limit,
             offset
         );

--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -21,8 +21,13 @@ export interface SearchOptions {
     sortBy?: 'relevance' | 'likes' | 'date' | 'date_added' | 'views' | 'name';
     // Content-rating filter: 'all' (default), SFW only, or NSFW only.
     nsfw?: 'all' | 'sfw' | 'nsfw';
-    // Recency window on date_added: 'all' (default), last day/week/month.
-    addedWithin?: 'all' | 'today' | 'week' | 'month';
+    // Recency window on date_added: 'all' (default), a preset (day/week/month),
+    // or 'custom' bounded by addedFrom/addedTo.
+    addedWithin?: 'all' | 'today' | 'week' | 'month' | 'custom';
+    // Custom-range bounds (Unix seconds, inclusive). Only used when
+    // addedWithin === 'custom'; either bound may be omitted for an open range.
+    addedFrom?: number;
+    addedTo?: number;
     limit?: number;
     offset?: number;
 }
@@ -65,7 +70,9 @@ function applyContentFilters(
     conditions: string[],
     params: Record<string, unknown>,
     nsfw: SearchOptions['nsfw'],
-    addedWithin: SearchOptions['addedWithin']
+    addedWithin: SearchOptions['addedWithin'],
+    addedFrom?: number,
+    addedTo?: number
 ): void {
     if (nsfw === 'sfw') {
         conditions.push('mods.is_nsfw = 0');
@@ -73,8 +80,17 @@ function applyContentFilters(
         conditions.push('mods.is_nsfw = 1');
     }
 
-    if (addedWithin && addedWithin !== 'all') {
-        // date_added is a Unix timestamp in seconds (GameBanana's _tsDateAdded).
+    // date_added is a Unix timestamp in seconds (GameBanana's _tsDateAdded).
+    if (addedWithin === 'custom') {
+        if (typeof addedFrom === 'number') {
+            params.addedAfter = addedFrom;
+            conditions.push('mods.date_added >= @addedAfter');
+        }
+        if (typeof addedTo === 'number') {
+            params.addedBefore = addedTo;
+            conditions.push('mods.date_added <= @addedBefore');
+        }
+    } else if (addedWithin && addedWithin !== 'all') {
         const windowSeconds =
             addedWithin === 'today' ? 86_400 : addedWithin === 'week' ? 7 * 86_400 : 30 * 86_400;
         params.addedAfter = Math.floor(Date.now() / 1000) - windowSeconds;
@@ -99,6 +115,8 @@ function runFallbackSubstringSearch(
     sortBy: SearchOptions['sortBy'],
     nsfw: SearchOptions['nsfw'],
     addedWithin: SearchOptions['addedWithin'],
+    addedFrom: number | undefined,
+    addedTo: number | undefined,
     limit: number,
     offset: number
 ): SearchResult {
@@ -134,7 +152,7 @@ function runFallbackSubstringSearch(
         }
     }
 
-    applyContentFilters(conditions, params, nsfw, addedWithin);
+    applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const orderBy = buildOrderBy(sortBy, false); // no FTS rank in fallback
@@ -174,6 +192,8 @@ export function searchMods(options: SearchOptions): SearchResult {
         sortBy = 'relevance',
         nsfw = 'all',
         addedWithin = 'all',
+        addedFrom,
+        addedTo,
     } = options;
 
     // Validate and cap pagination values
@@ -230,7 +250,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         }
     }
 
-    applyContentFilters(conditions, params, nsfw, addedWithin);
+    applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
 
     // Build WHERE clause
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -268,6 +288,8 @@ export function searchMods(options: SearchOptions): SearchResult {
             sortBy,
             nsfw,
             addedWithin,
+            addedFrom,
+            addedTo,
             limit,
             offset
         );

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -39,6 +39,7 @@ import type {
 } from '../types/gamebanana';
 import { getModThumbnail, getSoundPreviewUrl, getPrimaryFile, formatDate, isModOutdated } from '../types/gamebanana';
 import { useAppStore } from '../stores/appStore';
+import type { BrowseNsfwFilter, BrowseTimeRange } from '../stores/appStore';
 import ModThumbnail from '../components/ModThumbnail';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
@@ -162,11 +163,13 @@ export default function Browse() {
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
-  const { search, viewMode, sort, section, heroCategoryId, categoryId } = browseUi;
+  const { search, viewMode, sort, section, nsfw, addedWithin, heroCategoryId, categoryId } = browseUi;
   const setSearch = useCallback((v: string) => setBrowseUi({ search: v }), [setBrowseUi]);
   const setViewMode = useCallback((v: ViewMode) => setBrowseUi({ viewMode: v }), [setBrowseUi]);
   const setSort = useCallback((v: SortOption) => setBrowseUi({ sort: v }), [setBrowseUi]);
   const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
+  const setNsfw = useCallback((v: BrowseNsfwFilter) => setBrowseUi({ nsfw: v }), [setBrowseUi]);
+  const setAddedWithin = useCallback((v: BrowseTimeRange) => setBrowseUi({ addedWithin: v }), [setBrowseUi]);
   const setHeroCategoryId = useCallback((v: number | 'all' | 'none') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
   const setCategoryId = useCallback((v: number | 'all') => setBrowseUi({ categoryId: v }), [setBrowseUi]);
 
@@ -415,14 +418,18 @@ export default function Browse() {
   const useLocalSearch = useMemo(() => {
     const hasSearchQuery = debouncedSearch.trim().length > 0;
     const hasHeroFilter = heroCategoryId !== 'all';
-    return (hasSearchQuery || hasHeroFilter) && hasLocalCache && !localSearchFailed;
-  }, [debouncedSearch, heroCategoryId, hasLocalCache, localSearchFailed]);
+    // NSFW and recency filters only the local catalog mirror can satisfy: the
+    // live API enriches NSFW after the fact and doesn't window by date, so route
+    // those through local search (the cache is a full mirror of the index).
+    const hasContentFilter = nsfw !== 'all' || addedWithin !== 'all';
+    return (hasSearchQuery || hasHeroFilter || hasContentFilter) && hasLocalCache && !localSearchFailed;
+  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, hasLocalCache, localSearchFailed]);
 
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
   useEffect(() => {
     setLocalSearchFailed(false);
-  }, [debouncedSearch, heroCategoryId, section]);
+  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
@@ -431,7 +438,7 @@ export default function Browse() {
     // we already loaded. Covers cache hydration on mount AND React
     // StrictMode's double-effect setup. Set BEFORE the network call so
     // a second setup hitting this line sees the stamp and returns.
-    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}`;
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}`;
     if (lastFetchedStampRef.current === stamp) return;
     lastFetchedStampRef.current = stamp;
 
@@ -500,6 +507,8 @@ export default function Browse() {
     perPage,
     effectiveCategoryId,
     heroCategoryId,
+    nsfw,
+    addedWithin,
     useLocalSearch,
   ]);
 
@@ -507,7 +516,7 @@ export default function Browse() {
   const searchLocal = useCallback(async () => {
     // Same value-compare gate as fetchMods so the shared stamp prevents
     // re-fetching cached state and survives StrictMode double-mount.
-    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}`;
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}`;
     if (lastFetchedStampRef.current === stamp) return;
     lastFetchedStampRef.current = stamp;
     // Same anti-flash logic as fetchMods: skeleton only on truly empty first
@@ -552,6 +561,8 @@ export default function Browse() {
         heroName: selectedHeroName,
         skinsCategoryId: skinsCat?.id,
         sortBy: sortMap[sort] || 'relevance',
+        nsfw,
+        addedWithin,
         limit: perPage,
         offset: (page - 1) * perPage,
       });
@@ -601,7 +612,7 @@ export default function Browse() {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, modCategories]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, modCategories]);
 
   // Value-compare gate for the filter-reset: remember what filters last
   // triggered a reset; only reset when the new combination is actually
@@ -609,10 +620,10 @@ export default function Browse() {
   // StrictMode's double-effect run (the second setup sees the same stamp
   // and short-circuits, instead of consuming a one-shot skip flag).
   const lastResetFiltersRef = useRef<string | null>(
-    `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${perPage}`
+    `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${perPage}`
   );
   useEffect(() => {
-    const current = `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${perPage}`;
+    const current = `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${perPage}`;
     if (lastResetFiltersRef.current === current) return;
     lastResetFiltersRef.current = current;
     // Reset pagination when filters change but keep previous results visible
@@ -620,7 +631,7 @@ export default function Browse() {
     // skeleton flash on every keystroke pre-debounce.
     setPage(1);
     setHasMore(true);
-  }, [debouncedSearch, sort, section, effectiveCategoryId, perPage]);
+  }, [debouncedSearch, sort, section, effectiveCategoryId, nsfw, addedWithin, perPage]);
 
   useEffect(() => {
     let active = true;
@@ -1404,10 +1415,12 @@ export default function Browse() {
 
             {/* Filters popover — houses hero + category selectors. Collapses two
                 always-visible dropdowns into one control with an active-count badge. */}
-            {(heroOptions.length > 0 || categoryOptions.length > 0) && (() => {
+            {(heroOptions.length > 0 || categoryOptions.length > 0 || hasLocalCache) && (() => {
               const filterCount =
                 (heroCategoryId !== 'all' ? 1 : 0) +
-                (categoryId !== 'all' ? 1 : 0);
+                (categoryId !== 'all' ? 1 : 0) +
+                (nsfw !== 'all' ? 1 : 0) +
+                (addedWithin !== 'all' ? 1 : 0);
               return (
                 <div className="relative" ref={filtersRef}>
                   <button
@@ -1444,6 +1457,8 @@ export default function Browse() {
                             onClick={() => {
                               setHeroCategoryId('all');
                               setCategoryId('all');
+                              setNsfw('all');
+                              setAddedWithin('all');
                             }}
                             className="text-xs text-text-secondary hover:text-accent cursor-pointer"
                           >
@@ -1496,6 +1511,39 @@ export default function Browse() {
                             {heroCategoryId !== 'all' && (
                               <span className="block text-[11px] text-text-tertiary mt-1">Hero filter overrides categories.</span>
                             )}
+                          </label>
+                        )}
+
+                        {/* Content rating + recency are served by the local catalog
+                            mirror, so they only show once it's available. */}
+                        {hasLocalCache && (
+                          <label className="block">
+                            <span className="block text-xs font-medium text-text-secondary mb-1.5">Content</span>
+                            <select
+                              value={nsfw}
+                              onChange={(e) => setNsfw(e.target.value as BrowseNsfwFilter)}
+                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                            >
+                              <option value="all">All</option>
+                              <option value="sfw">SFW only</option>
+                              <option value="nsfw">NSFW only</option>
+                            </select>
+                          </label>
+                        )}
+
+                        {hasLocalCache && (
+                          <label className="block">
+                            <span className="block text-xs font-medium text-text-secondary mb-1.5">Added</span>
+                            <select
+                              value={addedWithin}
+                              onChange={(e) => setAddedWithin(e.target.value as BrowseTimeRange)}
+                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                            >
+                              <option value="all">Any time</option>
+                              <option value="today">Today</option>
+                              <option value="week">This week</option>
+                              <option value="month">This month</option>
+                            </select>
                           </label>
                         )}
                       </div>

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -163,13 +163,15 @@ export default function Browse() {
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
-  const { search, viewMode, sort, section, nsfw, addedWithin, heroCategoryId, categoryId } = browseUi;
+  const { search, viewMode, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId } = browseUi;
   const setSearch = useCallback((v: string) => setBrowseUi({ search: v }), [setBrowseUi]);
   const setViewMode = useCallback((v: ViewMode) => setBrowseUi({ viewMode: v }), [setBrowseUi]);
   const setSort = useCallback((v: SortOption) => setBrowseUi({ sort: v }), [setBrowseUi]);
   const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
   const setNsfw = useCallback((v: BrowseNsfwFilter) => setBrowseUi({ nsfw: v }), [setBrowseUi]);
   const setAddedWithin = useCallback((v: BrowseTimeRange) => setBrowseUi({ addedWithin: v }), [setBrowseUi]);
+  const setAddedFrom = useCallback((v: string) => setBrowseUi({ addedFrom: v }), [setBrowseUi]);
+  const setAddedTo = useCallback((v: string) => setBrowseUi({ addedTo: v }), [setBrowseUi]);
   const setHeroCategoryId = useCallback((v: number | 'all' | 'none') => setBrowseUi({ heroCategoryId: v }), [setBrowseUi]);
   const setCategoryId = useCallback((v: number | 'all') => setBrowseUi({ categoryId: v }), [setBrowseUi]);
 
@@ -336,6 +338,20 @@ export default function Browse() {
 
   const effectiveSearch = debouncedSearch;
 
+  // Custom-range date inputs (YYYY-MM-DD) -> inclusive Unix-second bounds for the
+  // local query. Parsed as UTC to line up with date_added (a UTC timestamp).
+  // Undefined when not in custom mode, blank, or unparseable.
+  const customAddedFrom = useMemo(() => {
+    if (addedWithin !== 'custom' || !addedFrom) return undefined;
+    const t = Date.parse(`${addedFrom}T00:00:00Z`);
+    return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
+  }, [addedWithin, addedFrom]);
+  const customAddedTo = useMemo(() => {
+    if (addedWithin !== 'custom' || !addedTo) return undefined;
+    const t = Date.parse(`${addedTo}T23:59:59Z`);
+    return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
+  }, [addedWithin, addedTo]);
+
   // Keep a fresh `mods` reference outside the fetch closures so they can check
   // "did the user already have results visible?" without making `mods` a
   // useCallback dep (that would self-trigger). Also doubles as the source
@@ -438,7 +454,7 @@ export default function Browse() {
     // we already loaded. Covers cache hydration on mount AND React
     // StrictMode's double-effect setup. Set BEFORE the network call so
     // a second setup hitting this line sees the stamp and returns.
-    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}`;
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}`;
     if (lastFetchedStampRef.current === stamp) return;
     lastFetchedStampRef.current = stamp;
 
@@ -509,6 +525,8 @@ export default function Browse() {
     heroCategoryId,
     nsfw,
     addedWithin,
+    customAddedFrom,
+    customAddedTo,
     useLocalSearch,
   ]);
 
@@ -516,7 +534,7 @@ export default function Browse() {
   const searchLocal = useCallback(async () => {
     // Same value-compare gate as fetchMods so the shared stamp prevents
     // re-fetching cached state and survives StrictMode double-mount.
-    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}`;
+    const stamp = `${page}|${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}`;
     if (lastFetchedStampRef.current === stamp) return;
     lastFetchedStampRef.current = stamp;
     // Same anti-flash logic as fetchMods: skeleton only on truly empty first
@@ -563,6 +581,8 @@ export default function Browse() {
         sortBy: sortMap[sort] || 'relevance',
         nsfw,
         addedWithin,
+        addedFrom: customAddedFrom,
+        addedTo: customAddedTo,
         limit: perPage,
         offset: (page - 1) * perPage,
       });
@@ -612,7 +632,7 @@ export default function Browse() {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, modCategories]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, modCategories]);
 
   // Value-compare gate for the filter-reset: remember what filters last
   // triggered a reset; only reset when the new combination is actually
@@ -620,10 +640,10 @@ export default function Browse() {
   // StrictMode's double-effect run (the second setup sees the same stamp
   // and short-circuits, instead of consuming a one-shot skip flag).
   const lastResetFiltersRef = useRef<string | null>(
-    `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${perPage}`
+    `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}`
   );
   useEffect(() => {
-    const current = `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${perPage}`;
+    const current = `${debouncedSearch}|${sort}|${section}|${effectiveCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}`;
     if (lastResetFiltersRef.current === current) return;
     lastResetFiltersRef.current = current;
     // Reset pagination when filters change but keep previous results visible
@@ -631,7 +651,7 @@ export default function Browse() {
     // skeleton flash on every keystroke pre-debounce.
     setPage(1);
     setHasMore(true);
-  }, [debouncedSearch, sort, section, effectiveCategoryId, nsfw, addedWithin, perPage]);
+  }, [debouncedSearch, sort, section, effectiveCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, perPage]);
 
   useEffect(() => {
     let active = true;
@@ -1459,6 +1479,8 @@ export default function Browse() {
                               setCategoryId('all');
                               setNsfw('all');
                               setAddedWithin('all');
+                              setAddedFrom('');
+                              setAddedTo('');
                             }}
                             className="text-xs text-text-secondary hover:text-accent cursor-pointer"
                           >
@@ -1532,9 +1554,10 @@ export default function Browse() {
                         )}
 
                         {hasLocalCache && (
-                          <label className="block">
+                          <div className="block">
                             <span className="block text-xs font-medium text-text-secondary mb-1.5">Added</span>
                             <select
+                              aria-label="Filter by date added"
                               value={addedWithin}
                               onChange={(e) => setAddedWithin(e.target.value as BrowseTimeRange)}
                               className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
@@ -1543,8 +1566,33 @@ export default function Browse() {
                               <option value="today">Today</option>
                               <option value="week">This week</option>
                               <option value="month">This month</option>
+                              <option value="custom">Custom range</option>
                             </select>
-                          </label>
+                            {addedWithin === 'custom' && (
+                              <div className="mt-2 grid grid-cols-2 gap-2">
+                                <label className="block">
+                                  <span className="block text-[11px] text-text-tertiary mb-1">From</span>
+                                  <input
+                                    type="date"
+                                    value={addedFrom}
+                                    max={addedTo || undefined}
+                                    onChange={(e) => setAddedFrom(e.target.value)}
+                                    className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                                  />
+                                </label>
+                                <label className="block">
+                                  <span className="block text-[11px] text-text-tertiary mb-1">To</span>
+                                  <input
+                                    type="date"
+                                    value={addedTo}
+                                    min={addedFrom || undefined}
+                                    onChange={(e) => setAddedTo(e.target.value)}
+                                    className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                                  />
+                                </label>
+                              </div>
+                            )}
+                          </div>
                         )}
                       </div>
                     </div>

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -18,11 +18,17 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 // query, view mode, and filters all reset when switching pages.
 export type BrowseSortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
 export type BrowseViewMode = 'grid' | 'compact' | 'dense' | 'list';
+export type BrowseNsfwFilter = 'all' | 'sfw' | 'nsfw';
+export type BrowseTimeRange = 'all' | 'today' | 'week' | 'month';
 export interface BrowseUiState {
   search: string;
   viewMode: BrowseViewMode;
   sort: BrowseSortOption;
   section: string;
+  // Content-rating filter and recency window. Both route browsing through the
+  // local catalog mirror (see useLocalSearch in Browse.tsx).
+  nsfw: BrowseNsfwFilter;
+  addedWithin: BrowseTimeRange;
   // 'none' is a Sound-only pseudo-hero: "show me sound mods whose title
   // doesn't resolve to any known hero" (item sounds, UI, music, etc.).
   // For Mod section it collapses to 'all' since every Skin lives under a hero.
@@ -69,6 +75,8 @@ const DEFAULT_BROWSE_UI: BrowseUiState = {
   viewMode: readPersistedViewMode(),
   sort: readPersistedSort(),
   section: 'Mod',
+  nsfw: 'all',
+  addedWithin: 'all',
   heroCategoryId: 'all',
   categoryId: 'all',
 };

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -19,16 +19,19 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 export type BrowseSortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
 export type BrowseViewMode = 'grid' | 'compact' | 'dense' | 'list';
 export type BrowseNsfwFilter = 'all' | 'sfw' | 'nsfw';
-export type BrowseTimeRange = 'all' | 'today' | 'week' | 'month';
+export type BrowseTimeRange = 'all' | 'today' | 'week' | 'month' | 'custom';
 export interface BrowseUiState {
   search: string;
   viewMode: BrowseViewMode;
   sort: BrowseSortOption;
   section: string;
   // Content-rating filter and recency window. Both route browsing through the
-  // local catalog mirror (see useLocalSearch in Browse.tsx).
+  // local catalog mirror (see useLocalSearch in Browse.tsx). addedFrom/addedTo
+  // are 'YYYY-MM-DD' inputs used only when addedWithin === 'custom'.
   nsfw: BrowseNsfwFilter;
   addedWithin: BrowseTimeRange;
+  addedFrom: string;
+  addedTo: string;
   // 'none' is a Sound-only pseudo-hero: "show me sound mods whose title
   // doesn't resolve to any known hero" (item sounds, UI, music, etc.).
   // For Mod section it collapses to 'all' since every Skin lives under a hero.
@@ -77,6 +80,8 @@ const DEFAULT_BROWSE_UI: BrowseUiState = {
   section: 'Mod',
   nsfw: 'all',
   addedWithin: 'all',
+  addedFrom: '',
+  addedTo: '',
   heroCategoryId: 'all',
   categoryId: 'all',
 };

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -203,7 +203,9 @@ export interface SearchLocalModsOptions {
     skinsCategoryId?: number;
     sortBy?: 'relevance' | 'likes' | 'date' | 'date_added' | 'views' | 'name';
     nsfw?: 'all' | 'sfw' | 'nsfw';
-    addedWithin?: 'all' | 'today' | 'week' | 'month';
+    addedWithin?: 'all' | 'today' | 'week' | 'month' | 'custom';
+    addedFrom?: number;
+    addedTo?: number;
     limit?: number;
     offset?: number;
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -202,6 +202,8 @@ export interface SearchLocalModsOptions {
     heroName?: string;
     skinsCategoryId?: number;
     sortBy?: 'relevance' | 'likes' | 'date' | 'date_added' | 'views' | 'name';
+    nsfw?: 'all' | 'sfw' | 'nsfw';
+    addedWithin?: 'all' | 'today' | 'week' | 'month';
     limit?: number;
     offset?: number;
 }


### PR DESCRIPTION
Follow-up to #92, addressing two more items from #91.

## What
- **Content filter** in the Browse > Filters popover: All / SFW only / NSFW only.
- **Added window**: Any time / Today / This week / This month (filters on `date_added`).

## How it routes
Both filters run against the local SQLite catalog mirror (`is_nsfw`, `date_added` columns), not the live GameBanana API. The API enriches NSFW *after* fetching a page (so it can't filter or paginate correctly) and doesn't support date windows. So `useLocalSearch` now also turns on when a content or recency filter is active; plain default browsing still uses the live API. Controls only appear once the local cache exists.

## Verification
- `tsc` clean on `tsconfig.app.json` + `tsconfig.node.json`; ESLint clean on changed files.
- Validated the SQL against the real cache DB: 4663 SFW / 305 NSFW / 4968 total, and the composite query (Mod + SFW + last 30 days + by likes) returns expected results.
- Ran in `pnpm dev`; renderer HMR + main-process restart clean.

## Files
`electron/main/services/searchService.ts`, `src/types/electron.d.ts`, `src/stores/appStore.ts`, `src/pages/Browse.tsx`

Still open on #91: parallel downloads, sidebar regrouping, Locker layout, Deadlocker aggregation.
