### PR TITLE
fix(browse): queue multiple variant installs from the file list (#91)

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -44,6 +44,10 @@ interface ModDetailsModalProps {
    *  the local mod id of the disabled install. */
   onEnableFile?: (modId: string) => void;
   downloadingFileId: number | null;
+  /** GameBanana file ids for this mod that are queued behind the active
+   *  download. Their rows show a "Queued" state but other rows stay clickable,
+   *  so the user can line up several variants at once. */
+  queuedFileIds?: Set<number>;
   extracting: boolean;
   progress: { downloaded: number; total: number } | null;
   hideNsfwPreviews: boolean;
@@ -68,6 +72,7 @@ export default function ModDetailsModal({
   installedFileStates,
   onEnableFile,
   downloadingFileId,
+  queuedFileIds = new Set<number>(),
   extracting,
   progress,
   hideNsfwPreviews,
@@ -195,12 +200,17 @@ export default function ModDetailsModal({
     const isUpdate = !!updateAvailable && !isInstalled && !archived;
     const isActive = activeFileIds.has(file.id);
     const isDownloadingThis = downloadingFileId === file.id;
+    const isQueuedThis = queuedFileIds.has(file.id);
+    // Only this row's own download/queue state should lock its buttons. A
+    // download in progress on a *different* file must leave this row clickable
+    // so the user can queue several variants in one go.
+    const isBusyThis = isDownloadingThis || isQueuedThis;
     const installedFileState = installedFileStates?.get(file.id);
     const showEnablePill =
       !!installedFileState &&
       !installedFileState.enabled &&
       !!onEnableFile &&
-      !isDownloadingThis;
+      !isBusyThis;
     const pct = progress && progress.total > 0
       ? Math.round((progress.downloaded / progress.total) * 100)
       : null;
@@ -277,7 +287,7 @@ export default function ModDetailsModal({
         {showEnablePill && installedFileState && (
           <button
             onClick={() => onEnableFile!(installedFileState.modId)}
-            disabled={downloadingFileId !== null}
+            disabled={isBusyThis}
             title="Enable this mod"
             className="flex-shrink-0 flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium rounded-md transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-300 border border-yellow-500/40"
           >
@@ -287,7 +297,7 @@ export default function ModDetailsModal({
         )}
         <button
           onClick={() => onDownload(file.id, file.fileName)}
-          disabled={downloadingFileId !== null}
+          disabled={isBusyThis}
           className={`flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2 min-w-[110px] text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
             isUpdate
               ? 'bg-accent hover:bg-accent-hover text-white'
@@ -300,6 +310,11 @@ export default function ModDetailsModal({
             <>
               <Loader2 className="w-4 h-4 animate-spin" />
               {extracting ? 'Extracting...' : pct !== null ? `${pct}%` : 'Starting'}
+            </>
+          ) : isQueuedThis ? (
+            <>
+              <Clock className="w-4 h-4" />
+              Queued
             </>
           ) : (
             <>

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -958,17 +958,24 @@ export default function Browse() {
   const handleDownload = async (fileId: number, fileName: string) => {
     if (!selectedMod || !activeDeadlockPath) return;
 
-    setDownloading({ modId: selectedMod.id, fileId });
-    setDownloadProgress({ downloaded: 0, total: 0 });
-    setExtracting(false);
+    // The first file claims the active slot (shows progress); additional clicks
+    // queue behind it. The backend's download-queue-updated event is the source
+    // of truth for what's queued, so don't clobber the active progress UI here.
+    if (!downloading) {
+      setDownloading({ modId: selectedMod.id, fileId });
+      setDownloadProgress({ downloaded: 0, total: 0 });
+      setExtracting(false);
+    }
 
     try {
       await downloadMod(selectedMod.id, fileId, fileName, section, effectiveCategoryId);
     } catch (err) {
       setError(String(err));
-      setDownloading(null);
-      setDownloadProgress(null);
-      setExtracting(false);
+      // Reset the active UI only if the file that failed is the active one.
+      // Functional update reads fresh state, not this closure's snapshot.
+      setDownloading((cur) =>
+        cur && cur.modId === selectedMod.id && cur.fileId === fileId ? null : cur
+      );
     }
   };
 
@@ -1724,6 +1731,7 @@ export default function Browse() {
           installedFileStates={installedFileStates}
           onEnableFile={(modId) => toggleMod(modId)}
           downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
+          queuedFileIds={new Set(downloadQueue.filter((q) => q.modId === selectedMod.id).map((q) => q.fileId))}
           extracting={extracting}
           progress={downloadProgress}
           hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}


### PR DESCRIPTION
Addresses the "queue multiple downloads" item from #91.

## Problem
On a mod's file-variant list (e.g. a skin with white / pastel blue / wine red / ... files), clicking **Install** greyed out **every** Install button until the download finished, so you couldn't line up the other variants and had to wait and re-click each one.

## Cause
The backend download queue already supports lining up multiple files (`downloadQueue` + `processQueue` + `download-queue-updated`). The block was purely in the UI: `ModDetailsModal` disabled all Install buttons whenever `downloadingFileId !== null` and only modelled a single in-flight file.

## Fix (renderer only, backend untouched)
- `ModDetailsModal` takes a `queuedFileIds` set. Each row owns its state: the active file shows progress, clicked siblings show a **Queued** state (clock icon), and every other row stays clickable. Buttons disable per-row (`isBusyThis`), not globally.
- `Browse.handleDownload` only claims the active progress slot when nothing is downloading yet; additional clicks just enqueue (backend `download-queue-updated` is the source of truth). Error reset uses a functional state update so it doesn't clear the wrong file.

Downloads still run one at a time (the serial queue guards a VPK-priority race); this removes the manual wait, matching the reporter's ask. True simultaneous downloads would be a separate backend change.

## Verification
`tsc` (app) + ESLint clean. Tested in `pnpm dev`: queue several variants, active shows progress, others show Queued and install in turn.

## Files
`src/components/ModDetailsModal.tsx`, `src/pages/Browse.tsx`
