### PR TITLE
fix(installed): Fix Order no longer counts disabled mods toward the 99-slot cap

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -258,21 +258,22 @@ function entryFilesByEnabledState(entry: ModEntry, enabled: boolean): Mod[] {
   return entry.variants.filter((variant) => variant.enabled === enabled);
 }
 
+// Only enabled mods hold pakNN load-order slots; disabled mods live in
+// .disabled/ with free-form names and aren't loaded by the game. Compacting
+// must cover the enabled mods alone, otherwise the disabled ones inflate the
+// load order past the 99-slot cap and reorderMods rejects the whole operation.
 function buildCompactPriorityOrder(entries: ModEntry[]): Mod[] {
-  const compactState = (enabled: boolean) =>
-    entries
-      .map((entry) => {
-        const files = entryFilesByEnabledState(entry, enabled);
-        const priority = files.length > 0
-          ? Math.min(...files.map((file) => file.priority))
-          : Number.POSITIVE_INFINITY;
-        return { files, priority };
-      })
-      .filter(({ files }) => files.length > 0)
-      .sort((a, b) => a.priority - b.priority)
-      .flatMap(({ files }) => files);
-
-  return [...compactState(true), ...compactState(false)];
+  return entries
+    .map((entry) => {
+      const files = entryFilesByEnabledState(entry, true);
+      const priority = files.length > 0
+        ? Math.min(...files.map((file) => file.priority))
+        : Number.POSITIVE_INFINITY;
+      return { files, priority };
+    })
+    .filter(({ files }) => files.length > 0)
+    .sort((a, b) => a.priority - b.priority)
+    .flatMap(({ files }) => files);
 }
 
 /**
@@ -2295,7 +2296,7 @@ export default function Installed() {
               <button
                 type="button"
                 onClick={fixOrder}
-                title="Renumber all installed mods 1, 2, 3, ... to tidy priority slots"
+                title="Renumber enabled mods 1, 2, 3, ... to tidy priority slots"
                 className="text-[10px] uppercase tracking-wider px-2.5 py-1 border border-white/10 hover:border-accent/50 bg-white/[0.02] hover:bg-accent/10 text-text-secondary hover:text-text-primary rounded-full transition-colors cursor-pointer"
               >
                 Fix Order


### PR DESCRIPTION
## Summary

Fixes #96, the "You can have at most 99 mods enabled at once. Disable one to make room." error on **Fix Order** even when far fewer than 99 mods are actually enabled.

## Root cause

- `buildCompactPriorityOrder` (`src/pages/Installed.tsx`) built its compact list from **both** enabled and disabled mods (`[...compactState(true), ...compactState(false)]`) and handed the whole thing to `reorderMods`.
- `reorderMods` (`electron/main/services/mods.ts`) advances a load-order cursor per entry and throws once it passes slot 99.
- Disabled mods live in `.disabled/` with free-form names (`disableMod` -> `makeDisabledFileName`), so they hold no `pakNN` slot and the rename is a no-op for them, they were only consuming cursor budget.

Net effect: a library with more than 99 *total* installed mods tripped the cap during Fix Order regardless of how many were enabled. This matches the report, where dropping the total VPK count (enabled + disabled) to 99 made it work again.

## Fix

`buildCompactPriorityOrder` now compacts only the enabled mods, which aligns with the store contract ("the target enabled-list order"). The Fix Order tooltip wording is updated from "all installed mods" to "enabled mods".

## Test plan

- [ ] With >99 total installed mods but <99 enabled, press Fix Order and confirm no cap error and enabled mods renumber densely 1..N.
- [ ] Disabled mods are untouched (still free-form names in `.disabled/`).
- [ ] Drag-reorder of enabled mods still works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AfBHZ1FmB9RpAgRQGd3KvQ)_