### PR TITLE
feat(installed,browse): card-size slider instead of fixed view presets

### DIFF
--- a/docs/locker-hero-card-apply.md
+++ b/docs/locker-hero-card-apply.md
@@ -139,13 +139,14 @@ swap, and revert are all just "edit the selection set, then rebuild".
 5. **Verify** (`verifyVpkOutput`) the temp output, then **swap it into the
    cosmetics slot atomically** (write to temp, reserve/replace the slot, rename
    in). Reuse `reserveOutputSlot` for the slot claim.
-6. **Slot to win:** keep the cosmetics VPK at a pakNN below every enabled
-   competitor that ships any included `panorama/images/heroes/<codename>_` path
-   (found via `parseVpkDirectoryCached`, as the prototype already prefilters).
-   With one stable VPK this is: if a competitor sits below it, `reorderMods` the
-   cosmetics VPK just under the lowest competitor; otherwise leave it. Usually
-   there are zero or one competitors per hero (the active skin bundle, an
-   enabled multi-hero icon pack).
+6. **Slot to win:** keep the cosmetics VPK pinned to the FRONT of the enabled
+   load order via `pinLockerVpksToFront` (`services/lockerVpk.ts`), shared with
+   the ability-sounds VPK. We pin unconditionally rather than only stepping ahead
+   of detected competitors: a source mod can ship its override at a layer/path
+   our exact-path check misses, and a competitor enabled LATER would otherwise
+   outrank an already-applied pick. The managed VPK only ships the exact
+   cosmetic paths the user chose (disjoint, additive), so sitting first can't
+   clobber anything it doesn't own. `reorderMods` no-ops when it's already first.
 7. **Stamp** `lockerCosmetics` with the (possibly pruned) selection set and
    `rebuiltAt`. Clean up temp files.
 
@@ -161,19 +162,32 @@ swap, and revert are all just "edit the selection set, then rebuild".
 ## Hiding the cosmetics VPK from other surfaces (cross-cutting cost)
 
 The cosmetics VPK is a real `pakNN_dir.vpk` in `addons/`, so without filtering
-it appears as a mystery mod. Treat "metadata has `lockerCosmetics`" as the hide
-signal and filter it out in:
+it appears as a mystery mod. "Metadata has `lockerCosmetics` or `lockerSounds`"
+is the hide signal, centralized as `isLockerManaged` in `services/lockerVpk.ts`.
+It is filtered out in:
 
-- `src/pages/Installed.tsx` (mod list)
-- `lockerUtils.ts` `isLockerManagedMod` / `isLockerManagedSound` (so it never
-  lands in a hero's skin/sound pile or the "Unassigned" bucket)
+- `electron/main/ipc/mods.ts` `get-mods` (managed VPKs never reach the renderer)
+- `src/pages/Installed.tsx` (mod list) and `lockerUtils.ts`
+  `isLockerManagedMod` / `isLockerManagedSound` (renderer defense in depth)
 - Conflicts scanning (`electron/main/services/conflicts.ts`)
-- Portable profile export (`modMerger.ts` `buildPortableForSources`,
-  `portableProfile.ts`) so it is not shared as if it were a mod
+- Profiles (`services/profiles.ts`): excluded from save AND never disabled on a
+  profile switch (the orphan-disable loop skips them, then re-pins). A profile
+  switch silently disabling the managed VPK was the original "sounds stopped
+  loading" root cause.
+- Portable profile export (`portableProfile.ts`) so it is not shared as a mod.
 
-Only ONE VPK to hide (vs one per card), but `merged` mods are NOT hidden today,
-so this is still new plumbing with no existing filter to piggyback on. This is
-the biggest part of the work and the main reason to design before coding.
+## Lifecycle guarantees (lockerVpk.ts)
+
+The managed VPKs are owned by Grimoire, never by the user:
+
+- **Always enabled + front:** `healLockerVpks` runs on app startup (after vanilla
+  stash recovery) and re-enables any managed VPK that ended up in `.disabled/`,
+  then pins all of them to the front. Skips while a vanilla launch is active so
+  it can't un-stash a live vanilla session.
+- **Never rebuilt into `.disabled/`:** the rebuild reuses an existing slot only
+  when that slot is enabled; a stale disabled copy is deleted and a fresh enabled
+  slot is minted. (Reusing a disabled path is exactly what stranded applied
+  sounds in `.disabled/` before.)
 
 ## Failure handling and edge cases
 

--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -12,6 +12,7 @@ import {
     type StopDeadlockResult,
 } from '../services/launch';
 import { readLaunchOptions, isSteamRunning } from '../services/launchOptions';
+import { healLockerVpks } from '../services/lockerVpk';
 import { getMainWindow } from '../index';
 
 function getActiveDeadlockPath(): string | null {
@@ -129,5 +130,15 @@ export async function runStartupRecovery(): Promise<void> {
         }
     } catch (err) {
         console.error('[launch] Startup recovery failed:', err);
+    }
+
+    // After any vanilla stash is restored, make sure the Locker-managed VPKs are
+    // enabled and pinned to the front. healLockerVpks no-ops while a stash is
+    // still active (recovery failed, game holding file locks), so this can't
+    // un-stash a live vanilla session.
+    try {
+        await healLockerVpks(deadlockPath);
+    } catch (err) {
+        console.error('[launch] Locker VPK heal failed:', err);
     }
 }

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -19,6 +19,7 @@ import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
 import { inferHeroFromVpk, classifyGlobalModFromVpk } from '../services/vpk';
 import { classifyAbilitySoundsFromVpk } from '../services/abilitySounds';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
+import { isLockerManaged } from '../services/lockerVpk';
 import { detectUnknownModFilters, type UnknownModFilterGuess } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
@@ -167,9 +168,16 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     // install's name/thumbnail/gameBananaId from the global metadata sidecar.
     const settings = loadSettings();
     if (!settings.devMode) {
+        // Prune against ALL scanned files (including managed VPKs) so we don't
+        // wipe their metadata before filtering them out of the list below.
         pruneOrphanMetadata(new Set(mods.map((m) => m.fileName)));
     }
-    return mods.map(enrichMod);
+    // Hide Grimoire-managed Locker VPKs (hero cards + ability sounds). They're
+    // driven solely through the Locker pickers and are auto-enabled + pinned to
+    // the front of the load order (services/lockerVpk.ts), so surfacing them in
+    // the Installed list would only let the user disable or reorder them and
+    // silently break their applied cosmetics.
+    return mods.filter((m) => !isLockerManaged(m.fileName)).map(enrichMod);
 });
 
 // enable-mod

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -24,7 +24,8 @@ import {
     verifyVpkOutput,
     reserveOutputSlot,
 } from './modMerger';
-import { scanMods, reorderMods, findNextAvailablePriority } from './mods';
+import { findNextAvailablePriority } from './mods';
+import { pinLockerVpksToFront } from './lockerVpk';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { codenamesForHero } from './heroPortraits';
@@ -216,15 +217,23 @@ async function rebuildLockerCosmetics(
         }
         await verifyVpkOutput(buildOut);
 
-        // Swap the freshly built VPK into place. Reuse the existing slot (keeps
-        // the load-order position + metadata) or reserve a new low slot.
+        // Swap the freshly built VPK into place. Reuse the existing slot ONLY when
+        // it's enabled (keeps the load-order position + metadata). A prior copy in
+        // .disabled/ must not be reused as the target: rebuilding into that path
+        // would leave the applied cards disabled and silent in game. Drop the stale
+        // disabled copy and reserve a fresh enabled slot instead.
         let destFileName: string;
         let destPath: string;
-        if (existing) {
+        if (existing && existing.ref.enabled) {
             destFileName = existing.ref.fileName;
             destPath = existing.ref.path;
             await fs.rename(buildOut, destPath);
         } else {
+            if (existing) {
+                await fs.unlink(existing.ref.path).catch(() => {});
+                removeModMetadata(existing.ref.fileName);
+                invalidateVpkParseCache(existing.ref.path);
+            }
             const slot = await findNextAvailablePriority(deadlockPath);
             destFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
             destPath = join(addonsPath, destFileName);
@@ -239,7 +248,7 @@ async function rebuildLockerCosmetics(
         // Locker's Global "Icon Packs" bucket (enrichMod skips classification).
         setModMetadata(destFileName, { modName: 'Locker Cards', lockerCosmetics: info, globalType: null });
 
-        await ensureCosmeticsWins(deadlockPath, destFileName, valid);
+        await pinLockerVpksToFront(deadlockPath);
         return { fileName: destFileName, missing };
     } finally {
         await Promise.all([
@@ -248,45 +257,6 @@ async function rebuildLockerCosmetics(
             fs.rm(planDir, { recursive: true, force: true }).catch(() => {}),
         ]);
     }
-}
-
-/**
- * Guarantee the cosmetics VPK outranks every enabled mod that ships any of its
- * heroes' card paths (lowest pakNN wins). Only reorders when an enabled
- * competitor currently sits below it, and only then moves the cosmetics VPK to
- * the front of the enabled load order. No competitor means it already wins.
- */
-async function ensureCosmeticsWins(
-    deadlockPath: string,
-    cosmeticsFileName: string,
-    cards: LockerCardSelection[]
-): Promise<void> {
-    const mods = await scanMods(deadlockPath);
-    const cosmetics = mods.find((m) => m.fileName === cosmeticsFileName);
-    if (!cosmetics || !cosmetics.enabled) return;
-
-    const prefixes = cards.flatMap((c) => heroCardPrefixes(c.heroName));
-    const competesForCards = (vpkPath: string): boolean => {
-        const tree = parseVpkDirectoryCached(vpkPath);
-        if (!tree) return false;
-        return tree.some((p) => {
-            const lower = p.toLowerCase();
-            return prefixes.some((pre) => lower.startsWith(pre));
-        });
-    };
-
-    const lowestCompetitor = mods
-        .filter((m) => m.enabled && m.id !== cosmetics.id && competesForCards(m.path))
-        .reduce((min, m) => Math.min(min, m.priority), Infinity);
-
-    if (cosmetics.priority <= lowestCompetitor) return; // already wins
-
-    const enabled = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
-    const ordered = [
-        cosmetics.fileName,
-        ...enabled.filter((m) => m.id !== cosmetics.id).map((m) => m.fileName),
-    ];
-    await reorderMods(deadlockPath, ordered);
 }
 
 /**

--- a/electron/main/services/heroSounds.ts
+++ b/electron/main/services/heroSounds.ts
@@ -22,9 +22,10 @@ import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
 import { getAddonsPath, getDisabledPath, getCitadelPath } from './deadlock';
-import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
+import { invalidateVpkParseCache } from './vpk';
 import { runVpkmerge, runVpkmergeStdout, vpkmergeBinaryPath, verifyVpkOutput, reserveOutputSlot } from './modMerger';
-import { scanMods, reorderMods, findNextAvailablePriority } from './mods';
+import { findNextAvailablePriority } from './mods';
+import { pinLockerVpksToFront } from './lockerVpk';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { soundCodenameForHero } from './heroSoundCodenames';
@@ -268,11 +269,23 @@ async function rebuildLockerSounds(
 
         let destFileName: string;
         let destPath: string;
-        if (existing) {
+        // Reuse the existing sound VPK in place ONLY when it's enabled. A prior
+        // copy parked in .disabled/ (e.g. left over from before the heal, or a
+        // half-finished vanilla stash) carries a free-form name in the disabled
+        // folder; rebuilding into that path would leave the freshly applied sounds
+        // disabled and silent in game (and pinLockerVpksToFront would skip it
+        // since it isn't enabled). Drop the stale disabled copy and mint a fresh
+        // enabled pakNN slot instead.
+        if (existing && existing.ref.enabled) {
             destFileName = existing.ref.fileName;
             destPath = existing.ref.path;
             await fs.rename(buildOut, destPath);
         } else {
+            if (existing) {
+                await fs.unlink(existing.ref.path).catch(() => {});
+                removeModMetadata(existing.ref.fileName);
+                invalidateVpkParseCache(existing.ref.path);
+            }
             const slot = await findNextAvailablePriority(deadlockPath);
             destFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
             destPath = join(addonsPath, destFileName);
@@ -295,7 +308,7 @@ async function rebuildLockerSounds(
             abilitySounds: null,
         });
 
-        await ensureSoundsWins(deadlockPath, destFileName, valid);
+        await pinLockerVpksToFront(deadlockPath);
         return { fileName: destFileName, missing };
     } finally {
         await Promise.all([
@@ -304,41 +317,6 @@ async function rebuildLockerSounds(
             fs.rm(planDir, { recursive: true, force: true }).catch(() => {}),
         ]);
     }
-}
-
-/**
- * Guarantee the sound VPK outranks every enabled mod that ships any of its
- * selected clips (lowest pakNN wins). Only reorders when an enabled competitor
- * currently sits below it.
- */
-async function ensureSoundsWins(
-    deadlockPath: string,
-    soundsFileName: string,
-    selections: LockerSoundSelection[],
-): Promise<void> {
-    const mods = await scanMods(deadlockPath);
-    const sounds = mods.find((m) => m.fileName === soundsFileName);
-    if (!sounds || !sounds.enabled) return;
-
-    const clips = new Set(selections.flatMap((s) => s.clipPaths.map((p) => p.toLowerCase())));
-    const competesForClips = (vpkPath: string): boolean => {
-        const tree = parseVpkDirectoryCached(vpkPath);
-        if (!tree) return false;
-        return tree.some((p) => clips.has(p.toLowerCase()));
-    };
-
-    const lowestCompetitor = mods
-        .filter((m) => m.enabled && m.id !== sounds.id && competesForClips(m.path))
-        .reduce((min, m) => Math.min(min, m.priority), Infinity);
-
-    if (sounds.priority <= lowestCompetitor) return;
-
-    const enabled = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
-    const ordered = [
-        sounds.fileName,
-        ...enabled.filter((m) => m.id !== sounds.id).map((m) => m.fileName),
-    ];
-    await reorderMods(deadlockPath, ordered);
 }
 
 /**

--- a/electron/main/services/lockerVpk.ts
+++ b/electron/main/services/lockerVpk.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared lifecycle for the Locker-managed override VPKs (hero cards + ability
+ * sounds). Both are built and owned by Grimoire, ship only the exact cosmetic
+ * paths the user picked (disjoint, additive), and must always sit at the FRONT
+ * of the load order so they win Deadlock's lowest-pakNN-wins collision.
+ *
+ * They are hidden from the Installed list (see ipc/mods.ts `get-mods`) and driven
+ * solely through the Locker pickers, so the user can't accidentally disable or
+ * reorder them. A stray disable silently killed applied sounds before this:
+ * the rebuilt VPK landed in .disabled/ and the game never mounted it.
+ */
+import { scanMods, enableMod, reorderMods } from './mods';
+import { getModMetadata } from './metadata';
+import { readStash } from './launch';
+
+/** A VPK is Locker-managed when its metadata carries a cards or sounds payload. */
+export function isLockerManaged(fileName: string): boolean {
+    const meta = getModMetadata(fileName);
+    return !!(meta?.lockerCosmetics || meta?.lockerSounds);
+}
+
+/**
+ * Stable relative order among the managed VPKs so repeated pins converge instead
+ * of ping-ponging the two front slots on each apply. Cosmetics ("icons") first,
+ * then sounds; both still beat every user mod by sitting at the front, and they
+ * touch disjoint paths so the order between them is cosmetic anyway.
+ */
+function lockerRank(fileName: string): number {
+    const meta = getModMetadata(fileName);
+    if (meta?.lockerCosmetics) return 0;
+    if (meta?.lockerSounds) return 1;
+    return 2;
+}
+
+/**
+ * Pin every enabled Locker-managed VPK to the front of the load order, in a
+ * stable relative order. No-ops when they already hold the front slots, so it's
+ * cheap to call after each apply/revert.
+ */
+export async function pinLockerVpksToFront(deadlockPath: string): Promise<void> {
+    const mods = await scanMods(deadlockPath);
+    const enabled = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
+    const managed = enabled
+        .filter((m) => isLockerManaged(m.fileName))
+        .sort((a, b) => lockerRank(a.fileName) - lockerRank(b.fileName));
+    if (managed.length === 0) return;
+
+    // Already at the front in the right order? Nothing to rename.
+    const front = enabled.slice(0, managed.length);
+    if (managed.every((m, i) => front[i]?.id === m.id)) return;
+
+    const rest = enabled.filter((m) => !isLockerManaged(m.fileName));
+    const ordered = [...managed, ...rest].map((m) => m.fileName);
+    await reorderMods(deadlockPath, ordered);
+}
+
+/**
+ * Self-heal: re-enable any Locker-managed VPK that ended up in .disabled/ (it
+ * must never sit disabled, since it's hidden from the Installed list and only
+ * the Locker controls it), then pin the managed VPKs to the front. Skips
+ * entirely while a vanilla launch is in progress so we don't undo the user's
+ * vanilla session by un-stashing the mods Launch Vanilla just parked.
+ */
+export async function healLockerVpks(deadlockPath: string): Promise<void> {
+    if (await readStash()) return; // vanilla session active; leave the stash intact
+
+    const mods = await scanMods(deadlockPath);
+    const disabledManaged = mods.filter((m) => !m.enabled && isLockerManaged(m.fileName));
+    for (const m of disabledManaged) {
+        try {
+            await enableMod(deadlockPath, m.id);
+        } catch (err) {
+            console.warn(`[lockerVpk] Failed to re-enable managed VPK ${m.fileName}:`, err);
+        }
+    }
+    await pinLockerVpksToFront(deadlockPath);
+}

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -3,6 +3,7 @@ import { gzipSync, gunzipSync, constants as zlibConstants } from 'zlib';
 import { addProfile, generateProfileId, loadProfiles, type Profile, type ProfileMod } from './profiles';
 import { scanMods } from './mods';
 import { getModMetadata } from './metadata';
+import { isLockerManaged } from './lockerVpk';
 import { fetchModDetails } from './gamebanana';
 import type {
     PortableProfile,
@@ -94,6 +95,10 @@ export async function buildPortableProfileFromInstalled(
     const warnings: string[] = [];
 
     for (const installedMod of installed) {
+        // Locker-managed VPKs (cards/sounds) are internal and have no GameBanana
+        // ref, so silently skip them rather than warning "Skipped local mod".
+        if (isLockerManaged(installedMod.fileName)) continue;
+
         const metadata = getModMetadata(installedMod.fileName);
         const gbId = metadata?.gameBananaId ?? installedMod.gameBananaId;
         const fileId = metadata?.gameBananaFileId ?? installedMod.gameBananaFileId;

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
 import { scanMods, enableMod, disableMod, reorderMods } from './mods';
 import { getModMetadata } from './metadata';
+import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
 
 export interface ProfileMod {
@@ -120,7 +121,10 @@ function saveProfiles(profiles: Profile[]): void {
  */
 export async function createProfile(deadlockPath: string, name: string, crosshairSettings?: ProfileCrosshairSettings): Promise<Profile> {
     const mods = await scanMods(deadlockPath);
-    const enabledMods = mods.filter(mod => mod.enabled);  // Only save enabled mods
+    // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
+    // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
+    // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
+    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.fileName));
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -223,7 +227,10 @@ export async function updateProfile(deadlockPath: string, profileId: string, cro
     }
 
     const mods = await scanMods(deadlockPath);
-    const enabledMods = mods.filter(mod => mod.enabled);  // Only save enabled mods
+    // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
+    // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
+    // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
+    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.fileName));
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -459,6 +466,11 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     // (was-enabled vs was-disabled), so the snapshot ids stay valid across both.
     for (const mod of currentMods) {
         if (!mod.enabled) continue;
+        // Locker-managed VPKs (hero cards + ability sounds) aren't part of any
+        // profile: they're hidden, auto-pinned, and owned by the Locker. Never
+        // disable them on a profile switch, or applied cosmetics would silently
+        // stop loading. They get re-pinned to the front after the reorder pass.
+        if (isLockerManaged(mod.fileName)) continue;
         const profileMod = profileModByCurrentId.get(mod.id);
         if (profileMod && profileMod.enabled) continue; // keep it enabled
         await disableMod(deadlockPath, mod.id);
@@ -523,6 +535,11 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     } else {
         console.log(`[profiles] reorder: nothing to reorder`);
     }
+
+    // Re-assert the Locker-managed VPKs at the front: the profile reorder only
+    // sequences the profile's own mods (managed VPKs are excluded), so pin them
+    // back to pak01.. so applied cards/sounds keep winning every collision.
+    await pinLockerVpksToFront(deadlockPath);
 
     // 2. Apply Autoexec & Crosshair
     const currentAutoexec = readAutoexec(deadlockPath);

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -10,7 +10,6 @@ import {
   RefreshCw,
   LayoutGrid,
   Grid3x3,
-  Grip,
   List,
   AlertTriangle,
   Clock,
@@ -38,8 +37,13 @@ import type {
   GameBananaCategoryNode,
 } from '../types/gamebanana';
 import { getModThumbnail, getSoundPreviewUrl, getPrimaryFile, formatDate, isModOutdated } from '../types/gamebanana';
-import { useAppStore } from '../stores/appStore';
-import type { BrowseNsfwFilter, BrowseTimeRange } from '../stores/appStore';
+import {
+  useAppStore,
+  BROWSE_CARD_SIZE_MIN,
+  BROWSE_CARD_SIZE_MAX,
+  BROWSE_COMPACT_CARD_THRESHOLD,
+} from '../stores/appStore';
+import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout } from '../stores/appStore';
 import ModThumbnail from '../components/ModThumbnail';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
@@ -53,7 +57,9 @@ import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition } from '../l
 
 const DEFAULT_PER_PAGE = 20;
 type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
-type ViewMode = 'grid' | 'compact' | 'dense' | 'list';
+// Effective render mode derived from layout + card size. 'compact' is no
+// longer a user choice: it's what small cards become below the size threshold.
+type ViewMode = 'grid' | 'compact' | 'list';
 const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
 // Persist filter UI inputs across page navigation. The store keeps these in
 // memory so visiting Installed and coming back doesn't blow away the user's
@@ -163,9 +169,14 @@ export default function Browse() {
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
-  const { search, viewMode, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId } = browseUi;
+  const { search, layout, cardSize, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId } = browseUi;
+  // Effective render mode: List is structural; otherwise small cards get the
+  // compact chrome automatically. ModCard/skeleton keep reading one ViewMode.
+  const viewMode: ViewMode =
+    layout === 'list' ? 'list' : cardSize < BROWSE_COMPACT_CARD_THRESHOLD ? 'compact' : 'grid';
   const setSearch = useCallback((v: string) => setBrowseUi({ search: v }), [setBrowseUi]);
-  const setViewMode = useCallback((v: ViewMode) => setBrowseUi({ viewMode: v }), [setBrowseUi]);
+  const setLayout = useCallback((v: BrowseLayout) => setBrowseUi({ layout: v }), [setBrowseUi]);
+  const setCardSize = useCallback((v: number) => setBrowseUi({ cardSize: v }), [setBrowseUi]);
   const setSort = useCallback((v: SortOption) => setBrowseUi({ sort: v }), [setBrowseUi]);
   const setSection = useCallback((v: string) => setBrowseUi({ section: v }), [setBrowseUi]);
   const setNsfw = useCallback((v: BrowseNsfwFilter) => setBrowseUi({ nsfw: v }), [setBrowseUi]);
@@ -1374,12 +1385,36 @@ export default function Browse() {
               )}
             </button>
 
-            {/* View Mode Toggle - Icon Only */}
+            {/* Card-size slider: only meaningful in grid layout, so it's
+                disabled (and dimmed) while List is active rather than hidden,
+                keeping the toolbar from reflowing as you switch. */}
+            <div
+              className={`flex items-center gap-2 h-10 rounded-lg border border-border bg-bg-secondary px-3 transition-opacity ${
+                layout === 'list' ? 'opacity-40' : ''
+              }`}
+              title="Card size"
+            >
+              <Grid3x3 className="w-4 h-4 flex-shrink-0 text-text-secondary" aria-hidden="true" />
+              <input
+                type="range"
+                min={BROWSE_CARD_SIZE_MIN}
+                max={BROWSE_CARD_SIZE_MAX}
+                step={5}
+                value={cardSize}
+                disabled={layout === 'list'}
+                onChange={(e) => setCardSize(Number(e.target.value))}
+                aria-label="Card size"
+                className="h-1.5 w-24 cursor-pointer accent-accent disabled:cursor-default"
+              />
+              <LayoutGrid className="w-5 h-5 flex-shrink-0 text-text-secondary" aria-hidden="true" />
+            </div>
+
+            {/* Layout Toggle - Grid vs List */}
             <div className="flex items-center h-10 rounded-lg border border-border bg-bg-secondary p-1">
               <button
                 type="button"
-                onClick={() => setViewMode('grid')}
-                className={`p-1.5 rounded-md transition-colors cursor-pointer ${viewMode === 'grid'
+                onClick={() => setLayout('grid')}
+                className={`p-1.5 rounded-md transition-colors cursor-pointer ${layout === 'grid'
                   ? 'bg-bg-tertiary text-text-primary'
                   : 'text-text-secondary hover:text-text-primary'
                   }`}
@@ -1389,30 +1424,8 @@ export default function Browse() {
               </button>
               <button
                 type="button"
-                onClick={() => setViewMode('compact')}
-                className={`p-2 rounded-md transition-colors cursor-pointer ${viewMode === 'compact'
-                  ? 'bg-bg-tertiary text-text-primary'
-                  : 'text-text-secondary hover:text-text-primary'
-                  }`}
-                title="Compact view"
-              >
-                <Grid3x3 className="w-5 h-5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setViewMode('dense')}
-                className={`p-2 rounded-md transition-colors cursor-pointer ${viewMode === 'dense'
-                  ? 'bg-bg-tertiary text-text-primary'
-                  : 'text-text-secondary hover:text-text-primary'
-                  }`}
-                title="Dense view"
-              >
-                <Grip className="w-5 h-5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setViewMode('list')}
-                className={`p-2 rounded-md transition-colors cursor-pointer ${viewMode === 'list'
+                onClick={() => setLayout('list')}
+                className={`p-2 rounded-md transition-colors cursor-pointer ${layout === 'list'
                   ? 'bg-bg-tertiary text-text-primary'
                   : 'text-text-secondary hover:text-text-primary'
                   }`}
@@ -1657,14 +1670,19 @@ export default function Browse() {
       {/* Main Content */}
       <div className="flex-1 p-4">
         {(() => {
+          // Column min-width is the slider value, so the grid template can't be
+          // a static Tailwind class (the JIT scanner never sees it). Drive it
+          // with an inline style; gap still tracks the compact threshold.
           const gridClass =
-            viewMode === 'list'
+            layout === 'list'
               ? 'flex flex-col gap-3'
-              : viewMode === 'dense'
-                ? 'grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-2'
-                : viewMode === 'compact'
-                  ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3'
-                  : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3';
+              : viewMode === 'compact'
+                ? 'grid gap-2'
+                : 'grid gap-3';
+          const gridStyle =
+            layout === 'list'
+              ? undefined
+              : { gridTemplateColumns: `repeat(auto-fill, minmax(${cardSize}px, 1fr))` };
           const hasActiveFilters =
             search.trim().length > 0 || heroCategoryId !== 'all' || categoryId !== 'all' || sort !== 'default';
 
@@ -1672,7 +1690,7 @@ export default function Browse() {
             // Match perPage so the skeleton grid fills roughly the same footprint
             // as the real results once they arrive.
             return (
-              <div className={gridClass} aria-busy="true" aria-live="polite">
+              <div className={gridClass} style={gridStyle} aria-busy="true" aria-live="polite">
                 {Array.from({ length: DEFAULT_PER_PAGE }).map((_, i) => (
                   <ModCardSkeleton key={i} viewMode={viewMode} />
                 ))}
@@ -1718,7 +1736,7 @@ export default function Browse() {
             );
           }
           return (
-            <div className={gridClass}>
+            <div className={gridClass} style={gridStyle}>
               {displayMods.map((mod) => {
                 const queueIndex = downloadQueue.findIndex(q => q.modId === mod.id);
                 const isQueued = queueIndex >= 0;
@@ -1854,7 +1872,7 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
       </div>
     );
   }
-  const aspect = viewMode === 'compact' || viewMode === 'dense' ? 'aspect-[4/3]' : 'aspect-[3/2]';
+  const aspect = viewMode === 'compact' ? 'aspect-[4/3]' : 'aspect-[3/2]';
   return (
     <div className={`relative bg-bg-tertiary border border-border rounded-lg overflow-hidden ${aspect}`}>
       <div className="absolute inset-0 skeleton-shimmer bg-bg-secondary" />
@@ -1869,9 +1887,9 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
 function ModCard({ mod, installed, installedDisabled, downloading, queuePosition, viewMode, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, onPlayingChange, onClick, onQuickDownload, onEnable }: ModCardProps) {
   const thumbnail = getModThumbnail(mod);
   const audioPreview = section === 'Sound' ? getSoundPreviewUrl(mod) : undefined;
-  // Dense reuses the compact card chrome (4:3 aspect, smaller text/padding); it
-  // only differs in how many columns the grid packs in.
-  const isCompact = viewMode === 'compact' || viewMode === 'dense';
+  // Compact chrome (4:3 aspect, smaller text/padding) kicks in for small cards;
+  // see the size-threshold derivation of viewMode in the Browse component.
+  const isCompact = viewMode === 'compact';
   const isList = viewMode === 'list';
   const isSoundSection = section === 'Sound';
   const hasAudioPreview = Boolean(audioPreview);

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -267,6 +267,16 @@ function buildCompactPriorityOrder(entries: ModEntry[]): Mod[] {
 const updateCheckCache = new Map<number, Set<number> | null>();
 let installedPageScrollTop = 0;
 
+// Card-size slider bounds (grid column min-width, in px). The slider replaces
+// the old fixed Cards/Compact presets: drag controls how wide each card gets,
+// and the layout reflows columns to fit. Below COMPACT_CARD_THRESHOLD cards
+// drop to the leaner "compact" treatment (fewer chips, shorter media frame),
+// so small sizes stay readable without a separate view mode.
+const CARD_SIZE_MIN = 190;
+const CARD_SIZE_MAX = 360;
+const CARD_SIZE_DEFAULT = 300;
+const COMPACT_CARD_THRESHOLD = 255;
+
 export default function Installed() {
   const navigate = useNavigate();
   const {
@@ -308,13 +318,33 @@ export default function Installed() {
   const visibleMods = mods.filter(
     (m) => !m.lockerCosmetics && !m.lockerSounds && !absorbedFileNames.has(m.fileName)
   );
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    const stored = localStorage.getItem('installedViewMode');
-    return stored === 'grid' || stored === 'compact' || stored === 'list' ? stored : 'grid';
+  // Layout = the user's structural choice (cards grid vs horizontal list).
+  // cardSize = grid column min-width driven by the size slider. The effective
+  // three-way `viewMode` below is derived from both so the rest of the page
+  // (and ModCard) keeps reading a single ViewMode unchanged.
+  const [layout, setLayout] = useState<'grid' | 'list'>(() => {
+    const stored = localStorage.getItem('installedLayout');
+    if (stored === 'grid' || stored === 'list') return stored;
+    // Migrate from the old three-mode key: only 'list' carried structure.
+    return localStorage.getItem('installedViewMode') === 'list' ? 'list' : 'grid';
+  });
+  const [cardSize, setCardSize] = useState<number>(() => {
+    const stored = Number(localStorage.getItem('installedCardSize'));
+    if (Number.isFinite(stored) && stored >= CARD_SIZE_MIN && stored <= CARD_SIZE_MAX) {
+      return stored;
+    }
+    // Migrate: the old 'compact' preset becomes a small card; anything else
+    // (including 'grid' and 'list') lands on the default size.
+    return localStorage.getItem('installedViewMode') === 'compact' ? 210 : CARD_SIZE_DEFAULT;
   });
   useEffect(() => {
-    localStorage.setItem('installedViewMode', viewMode);
-  }, [viewMode]);
+    localStorage.setItem('installedLayout', layout);
+  }, [layout]);
+  useEffect(() => {
+    localStorage.setItem('installedCardSize', String(cardSize));
+  }, [cardSize]);
+  const viewMode: ViewMode =
+    layout === 'list' ? 'list' : cardSize < COMPACT_CARD_THRESHOLD ? 'compact' : 'grid';
   const [search, setSearch] = useState('');
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
   // Raw pair count from detectConflicts. conflictMap.size / 2 only works when
@@ -1545,7 +1575,7 @@ export default function Installed() {
   }
 
   if (modsLoading) {
-    return <InstalledSkeleton viewMode={viewMode} />;
+    return <InstalledSkeleton viewMode={viewMode} cardSize={cardSize} />;
   }
 
   if (modsError) {
@@ -1925,11 +1955,15 @@ export default function Installed() {
     const activeEntry = draggingSection === section
       ? entries.find((entry) => entry.key === draggingKey)
       : undefined;
-    const gridClasses = viewMode === 'compact'
-      ? 'grid [grid-template-columns:repeat(auto-fill,minmax(210px,1fr))] gap-3'
-      : viewMode === 'grid'
-        ? 'grid [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))] gap-4'
-        : 'space-y-1.5';
+    // Grid column min-width is the slider value, so it can't be a static
+    // Tailwind arbitrary class (the JIT scanner never sees it). Drive it with
+    // an inline style instead. Gap still tracks the compact/grid threshold.
+    const gridClasses =
+      layout === 'list' ? 'space-y-1.5' : viewMode === 'compact' ? 'grid gap-3' : 'grid gap-4';
+    const gridStyle =
+      layout === 'list'
+        ? undefined
+        : { gridTemplateColumns: `repeat(auto-fill, minmax(${cardSize}px, 1fr))` };
 
     return (
       <DndContext
@@ -1943,9 +1977,9 @@ export default function Installed() {
       >
         <SortableContext
           items={entries.map((entry) => entry.key)}
-          strategy={viewMode === 'list' ? verticalListSortingStrategy : rectSortingStrategy}
+          strategy={layout === 'list' ? verticalListSortingStrategy : rectSortingStrategy}
         >
-          <div className={gridClasses}>
+          <div className={gridClasses} style={gridStyle}>
             {entries.map((entry) => (
               <SortableModEntry key={entry.key} id={entry.key} disabled={!sortableEnabled}>
                 {renderEntryCard(entry)}
@@ -2107,14 +2141,37 @@ export default function Installed() {
               title={selectMode ? 'Exit selection mode' : 'Select multiple mods for bulk delete, enable, or disable'}
             />
 
+            {/* Card-size slider: only meaningful in grid layout, so it's
+                disabled (and dimmed) while List is active rather than hidden,
+                keeping the toolbar from reflowing as you switch. */}
+            <div
+              className={`flex items-center gap-2 rounded-sm border border-border bg-bg-secondary px-2 py-1.5 transition-opacity ${
+                layout === 'list' ? 'opacity-40' : ''
+              }`}
+              title="Card size"
+            >
+              <Grid3x3 className="h-4 w-4 flex-shrink-0 text-text-secondary" aria-hidden="true" />
+              <input
+                type="range"
+                min={CARD_SIZE_MIN}
+                max={CARD_SIZE_MAX}
+                step={5}
+                value={cardSize}
+                disabled={layout === 'list'}
+                onChange={(e) => setCardSize(Number(e.target.value))}
+                aria-label="Card size"
+                className="h-1.5 w-24 cursor-pointer accent-accent disabled:cursor-default"
+              />
+              <LayoutGrid className="h-5 w-5 flex-shrink-0 text-text-secondary" aria-hidden="true" />
+            </div>
+
             <ViewModeToggle
-              value={viewMode}
+              value={layout}
               options={[
-                { value: 'grid', label: 'Cards view', icon: LayoutGrid },
-                { value: 'compact', label: 'Compact view', icon: Grid3x3 },
+                { value: 'grid', label: 'Grid view', icon: LayoutGrid },
                 { value: 'list', label: 'List view', icon: List },
               ]}
-              onChange={setViewMode}
+              onChange={(mode) => setLayout(mode === 'list' ? 'list' : 'grid')}
             />
           </div>
         </div>
@@ -2710,7 +2767,7 @@ export default function Installed() {
   );
 }
 
-function InstalledSkeleton({ viewMode }: { viewMode: ViewMode }) {
+function InstalledSkeleton({ viewMode, cardSize }: { viewMode: ViewMode; cardSize: number }) {
   const isGridLike = viewMode !== 'list';
   const rows = viewMode === 'compact' ? 12 : viewMode === 'grid' ? 8 : 6;
   return (
@@ -2725,11 +2782,12 @@ function InstalledSkeleton({ viewMode }: { viewMode: ViewMode }) {
       <div className="skeleton-shimmer bg-bg-tertiary/70 rounded h-3 w-20 mb-3" />
       <div
         className={
-          viewMode === 'compact'
-            ? 'grid [grid-template-columns:repeat(auto-fill,minmax(210px,1fr))] gap-3'
-            : viewMode === 'grid'
-              ? 'grid [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))] gap-4'
-              : 'space-y-2'
+          viewMode === 'list' ? 'space-y-2' : viewMode === 'compact' ? 'grid gap-3' : 'grid gap-4'
+        }
+        style={
+          isGridLike
+            ? { gridTemplateColumns: `repeat(auto-fill, minmax(${cardSize}px, 1fr))` }
+            : undefined
         }
       >
         {Array.from({ length: rows }).map((_, i) =>

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -17,12 +17,23 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 // survives navigation away from /browse and back — user complaint: search
 // query, view mode, and filters all reset when switching pages.
 export type BrowseSortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
-export type BrowseViewMode = 'grid' | 'compact' | 'dense' | 'list';
+export type BrowseLayout = 'grid' | 'list';
 export type BrowseNsfwFilter = 'all' | 'sfw' | 'nsfw';
+
+// Browse card-size slider bounds (grid column min-width, in px). The slider
+// replaced the old fixed Grid/Compact/Dense presets: one continuous control
+// over how wide each card gets, with the layout reflowing columns to fit.
+// Below BROWSE_COMPACT_CARD_THRESHOLD cards drop to the leaner "compact"
+// chrome (4:3 aspect, smaller text), so small sizes stay readable.
+export const BROWSE_CARD_SIZE_MIN = 140;
+export const BROWSE_CARD_SIZE_MAX = 340;
+export const BROWSE_CARD_SIZE_DEFAULT = 300;
+export const BROWSE_COMPACT_CARD_THRESHOLD = 250;
 export type BrowseTimeRange = 'all' | 'today' | 'week' | 'month' | 'custom';
 export interface BrowseUiState {
   search: string;
-  viewMode: BrowseViewMode;
+  layout: BrowseLayout;
+  cardSize: number;
   sort: BrowseSortOption;
   section: string;
   // Content-rating filter and recency window. Both route browsing through the
@@ -39,26 +50,51 @@ export interface BrowseUiState {
   categoryId: number | 'all';
 }
 
-// viewMode + sort behave like preferences (the user mentioned wanting their
-// "list vs blocks" choice remembered). Cache them in localStorage so they
-// survive app restarts. The rest of BrowseUiState is session-only — search
-// queries and filters shouldn't follow the user across launches.
-const VIEW_MODE_KEY = 'browseViewMode';
+// layout + cardSize + sort behave like preferences (the user mentioned wanting
+// their "list vs blocks" choice and card size remembered). Cache them in
+// localStorage so they survive app restarts. The rest of BrowseUiState is
+// session-only — search queries and filters shouldn't follow across launches.
+const LAYOUT_KEY = 'browseLayout';
+const CARD_SIZE_KEY = 'browseCardSize';
 const SORT_KEY = 'browseSort';
+// Pre-slider key holding 'grid' | 'compact' | 'dense' | 'list'. Read once for
+// migration so existing users keep a comparable layout and card size.
+const LEGACY_VIEW_MODE_KEY = 'browseViewMode';
 
-const VIEW_MODES: BrowseViewMode[] = ['grid', 'compact', 'dense', 'list'];
 const SORT_OPTIONS: BrowseSortOption[] = ['default', 'popular', 'recent', 'updated', 'views', 'name'];
 
-function readPersistedViewMode(): BrowseViewMode {
+function readPersistedLayout(): BrowseLayout {
   try {
-    const stored = localStorage.getItem(VIEW_MODE_KEY);
-    if (stored && (VIEW_MODES as string[]).includes(stored)) {
-      return stored as BrowseViewMode;
-    }
+    const stored = localStorage.getItem(LAYOUT_KEY);
+    if (stored === 'grid' || stored === 'list') return stored;
+    // Migrate from the old four-mode key: only 'list' carried structure.
+    if (localStorage.getItem(LEGACY_VIEW_MODE_KEY) === 'list') return 'list';
   } catch {
     // localStorage may be unavailable (e.g. SSR, restricted contexts).
   }
   return 'grid';
+}
+
+function readPersistedCardSize(): number {
+  try {
+    const raw = localStorage.getItem(CARD_SIZE_KEY);
+    if (raw !== null) {
+      const n = Number(raw);
+      if (Number.isFinite(n)) {
+        return Math.min(BROWSE_CARD_SIZE_MAX, Math.max(BROWSE_CARD_SIZE_MIN, n));
+      }
+    }
+    // Migrate the old density presets to comparable card widths.
+    switch (localStorage.getItem(LEGACY_VIEW_MODE_KEY)) {
+      case 'dense':
+        return 150;
+      case 'compact':
+        return 200;
+    }
+  } catch {
+    // localStorage may be unavailable.
+  }
+  return BROWSE_CARD_SIZE_DEFAULT;
 }
 
 function readPersistedSort(): BrowseSortOption {
@@ -75,7 +111,8 @@ function readPersistedSort(): BrowseSortOption {
 
 const DEFAULT_BROWSE_UI: BrowseUiState = {
   search: '',
-  viewMode: readPersistedViewMode(),
+  layout: readPersistedLayout(),
+  cardSize: readPersistedCardSize(),
   sort: readPersistedSort(),
   section: 'Mod',
   nsfw: 'all',
@@ -404,13 +441,16 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   // Patch Browse UI state. Use a partial so callers can update one field at
-  // a time without restating the rest. viewMode + sort also mirror to
+  // a time without restating the rest. layout + cardSize + sort also mirror to
   // localStorage so they persist across app restarts.
   setBrowseUi: (partial: Partial<BrowseUiState>) => {
     set({ browseUi: { ...get().browseUi, ...partial } });
     try {
-      if (partial.viewMode !== undefined) {
-        localStorage.setItem(VIEW_MODE_KEY, partial.viewMode);
+      if (partial.layout !== undefined) {
+        localStorage.setItem(LAYOUT_KEY, partial.layout);
+      }
+      if (partial.cardSize !== undefined) {
+        localStorage.setItem(CARD_SIZE_KEY, String(partial.cardSize));
       }
       if (partial.sort !== undefined) {
         localStorage.setItem(SORT_KEY, partial.sort);


### PR DESCRIPTION
## What

Replaces the hardcoded card-size view presets on the **Installed** and **Browse** tabs with one continuous **card-size slider**, plus a separate **Grid/List** toggle.

Before:
- Installed: `Cards` / `Compact` / `List`
- Browse: `Grid` / `Compact` / `Dense` / `List`

After (both tabs):
- A size slider that scales card width continuously, with columns reflowing to fit.
- A Grid/List toggle (List stays separate since it's a structurally different layout).

## How

- The slider drives the grid `gridTemplateColumns` via an **inline style** (`repeat(auto-fill, minmax(<size>px, 1fr))`), because Tailwind's JIT scanner can't see a runtime-interpolated arbitrary value.
- Cards **auto-simplify** to the leaner compact chrome below a width threshold (fewer chips / 4:3 aspect / smaller text), so small sizes stay readable without a dedicated mode. The effective three-way `viewMode` is *derived* from `layout` + `cardSize`, so `ModCard` and the skeletons needed no internal changes.
- The slider is shown but **disabled + dimmed** in List mode, so the toolbar doesn't reflow when switching layouts.

## Persistence & migration

`layout` + `cardSize` persist as preferences (localStorage), matching how the old view mode persisted.

- **Installed** migrates from `installedViewMode`: `compact` -> 210px, `list` -> List layout, else default 300px.
- **Browse** migrates from `browseViewMode` (in the store): `dense` -> 150px, `compact` -> 200px, `list` -> List layout, else default 300px.

## Notes

- Browse's grid previously used fixed responsive column counts (e.g. `xl:grid-cols-4`); it now flows by min-width like Installed. On very wide windows this yields more columns than the old 4/6/8 caps, the natural consequence of continuous sizing. Easy to cap later with a max-width wrapper if desired.
- No new deps. `tsc` (strict) and `eslint` both pass clean.

## Test plan

- [ ] Installed: drag slider, cards scale and reflow; below ~255px they switch to compact chrome; Grid/List toggle works; slider dims in List.
- [ ] Browse: same behaviors; sound/skin cards both look right at small + large sizes.
- [ ] Reload app: layout + card size are remembered on both tabs.
- [ ] Existing users (old `installedViewMode` / `browseViewMode` set) land on a comparable size on first launch.