### PR TITLE
Locker Overrides popup + Installed/Browse QOL fixes

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -55,10 +55,11 @@ import './ipc/social';
 import './ipc/diagnostics';
 import './ipc/portraits';
 import './ipc/abilitySounds';
+import './ipc/locker';
 
 import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';
-import { loadSettings } from './services/settings';
+import { loadSettings, saveSettings } from './services/settings';
 import { backfillMissingMetadataHashes } from './services/metadata';
 
 let mainWindow: BrowserWindow | null = null;
@@ -162,6 +163,38 @@ function createWindow(): void {
     // Debug: log renderer errors
     mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
         console.error('[Main] Renderer failed to load:', errorCode, errorDescription);
+    });
+
+    // --- UI zoom (Ctrl +/-/0), persisted across launches. The renderer is dense
+    // and on hi-DPI laptops everything renders tiny, so let the user scale the
+    // whole UI. Driven through webContents.setZoomFactor via before-input-event
+    // (the menu bar is auto-hidden, so there's no View > Zoom to lean on).
+    const ZOOM_MIN = 0.5;
+    const ZOOM_MAX = 3.0;
+    const ZOOM_STEP = 0.1;
+    const clampZoom = (z: number) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 10) / 10));
+    const persistZoom = (z: number) => {
+        try {
+            saveSettings({ ...loadSettings(), zoomFactor: z });
+        } catch (err) {
+            console.warn('[Main] Failed to persist zoom factor:', err);
+        }
+    };
+    // Zoom factor resets to 1 on every load, so re-apply the saved value each time.
+    mainWindow.webContents.on('did-finish-load', () => {
+        mainWindow?.webContents.setZoomFactor(clampZoom(loadSettings().zoomFactor ?? 1));
+    });
+    mainWindow.webContents.on('before-input-event', (event, input) => {
+        if (input.type !== 'keyDown' || !input.control || input.alt || input.meta || !mainWindow) return;
+        const wc = mainWindow.webContents;
+        let next: number | null = null;
+        if (input.key === '=' || input.key === '+' || input.key === 'Add') next = clampZoom(wc.getZoomFactor() + ZOOM_STEP);
+        else if (input.key === '-' || input.key === 'Subtract') next = clampZoom(wc.getZoomFactor() - ZOOM_STEP);
+        else if (input.key === '0') next = 1;
+        if (next === null) return;
+        event.preventDefault();
+        wc.setZoomFactor(next);
+        persistZoom(next);
     });
 
     // Load the renderer

--- a/electron/main/ipc/locker.ts
+++ b/electron/main/ipc/locker.ts
@@ -1,0 +1,46 @@
+import { ipcMain } from 'electron';
+import { loadSettings } from '../services/settings';
+import { listAppliedCards, clearAllHeroCards, getAppliedCardThumbnails } from '../services/heroCards';
+import { listAppliedSounds, clearAllHeroSounds } from '../services/heroSounds';
+import type { LockerCardThumbnail, LockerClearScope, LockerOverview } from '../../../src/types/mod';
+
+/** Active Deadlock install path (dev override wins, same as the other locker IPC). */
+function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+// Cross-cutting Locker IPC: a summary of everything the Locker is currently
+// overriding (cards + ability sounds), plus a bulk clear. Drives the
+// Installed-tab "Locker Overrides" popup (toolbar Wand2 icon).
+ipcMain.handle('get-locker-overview', async (): Promise<LockerOverview> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) return { cards: [], sounds: [] };
+    const [cards, sounds] = await Promise.all([
+        listAppliedCards(deadlockPath),
+        listAppliedSounds(deadlockPath),
+    ]);
+    return { cards, sounds };
+});
+
+// Lazy companion to the overview: decode the real applied card art into one
+// thumbnail per hero. Heavier (shells out to vpkmerge), so the popup fetches it
+// separately and only when it opens, keeping the overview/count cheap.
+ipcMain.handle('get-locker-card-thumbnails', async (): Promise<LockerCardThumbnail[]> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) return [];
+    return getAppliedCardThumbnails(deadlockPath);
+});
+
+ipcMain.handle(
+    'clear-locker-overrides',
+    async (_, scope: LockerClearScope): Promise<void> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        if (scope === 'cards' || scope === 'all') await clearAllHeroCards(deadlockPath);
+        if (scope === 'sounds' || scope === 'all') await clearAllHeroSounds(deadlockPath);
+    },
+);

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -9,6 +9,7 @@ import {
     CleanupResult,
 } from '../services/system';
 import { listArchiveContents } from '../services/extract';
+import { healLockerVpks } from '../services/lockerVpk';
 import {
     existsSync,
     readdirSync,
@@ -144,7 +145,7 @@ ipcMain.handle('get-always-on-top', (): boolean => {
 });
 
 // fix-gameinfo
-ipcMain.handle('fix-gameinfo', (): GameinfoStatus => {
+ipcMain.handle('fix-gameinfo', async (): Promise<GameinfoStatus> => {
     const deadlockPath = getActiveDeadlockPath();
     if (!deadlockPath) {
         return {
@@ -154,7 +155,18 @@ ipcMain.handle('fix-gameinfo', (): GameinfoStatus => {
             candidates: [],
         };
     }
-    return fixGameinfo(deadlockPath);
+    const status = fixGameinfo(deadlockPath);
+    // Now that the grimoire search path is in place, migrate any Locker-managed
+    // VPKs out of addons into citadel/grimoire immediately, so applied cards /
+    // sounds relocate without needing an app restart.
+    if (status.configured) {
+        try {
+            await healLockerVpks(deadlockPath);
+        } catch (err) {
+            console.error('[system] Locker migration after fix-gameinfo failed:', err);
+        }
+    }
+    return status;
 });
 
 // download-mina-variations

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -176,6 +176,24 @@ export function getDisabledPath(deadlockPath: string): string {
 }
 
 /**
+ * Get the Grimoire-managed addon folder path, creating it if necessary.
+ *
+ * This is a SECOND addon search path (sibling of citadel/addons), listed FIRST
+ * in gameinfo.gi's SearchPaths so it outranks every user mod. It holds only the
+ * Locker-managed override VPKs (hero cards + ability sounds), keeping them off
+ * the user's 99-slot citadel/addons budget while still winning every collision.
+ */
+export function getGrimoirePath(deadlockPath: string): string {
+    const grimoirePath = join(deadlockPath, 'game', 'citadel', 'grimoire');
+
+    if (!existsSync(grimoirePath)) {
+        mkdirSync(grimoirePath, { recursive: true });
+    }
+
+    return grimoirePath;
+}
+
+/**
  * Get the gameinfo.gi file path
  */
 export function getGameinfoPath(deadlockPath: string): string {

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -16,16 +16,19 @@ import { promises as fs } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
-import { getAddonsPath, getDisabledPath } from './deadlock';
+import { getAddonsPath, getDisabledPath, getGrimoirePath } from './deadlock';
 import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
 import {
     runVpkmerge,
     vpkmergeBinaryPath,
     verifyVpkOutput,
-    reserveOutputSlot,
 } from './modMerger';
-import { findNextAvailablePriority } from './mods';
-import { pinLockerVpksToFront } from './lockerVpk';
+import {
+    LOCKER_CARDS_KEY,
+    lockerCardsVpkPath,
+    ensureGrimoireConfigured,
+    migrateManagedVpksToGrimoire,
+} from './lockerVpk';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { codenamesForHero } from './heroPortraits';
@@ -84,6 +87,16 @@ function findCosmeticsVpk(
         if (info) return { ref: v, info };
     }
     return null;
+}
+
+/** The current card selection set, read from the synthetic key (post-migration)
+ *  or, as a fallback during the pre-migration window, from an in-addons managed
+ *  VPK. */
+async function currentCardSelections(deadlockPath: string): Promise<LockerCardSelection[]> {
+    const synth = getModMetadata(LOCKER_CARDS_KEY)?.lockerCosmetics?.cards;
+    if (synth) return synth;
+    const vpks = await listAddonVpks(deadlockPath);
+    return findCosmeticsVpk(vpks)?.info.cards ?? [];
 }
 
 /** Locate a source VPK by filename, falling back to content hash if reconcile
@@ -157,9 +170,9 @@ async function rebuildLockerCosmetics(
     deadlockPath: string,
     desired: LockerCardSelection[]
 ): Promise<RebuildResult> {
-    const addonsPath = getAddonsPath(deadlockPath);
+    const grimoireDir = getGrimoirePath(deadlockPath);
+    const destPath = lockerCardsVpkPath(deadlockPath);
     const vpks = await listAddonVpks(deadlockPath);
-    const existing = findCosmeticsVpk(vpks);
 
     // Resolve each selection's source (relocating by hash if renamed) and
     // confirm it still ships this hero's cards. Anything unresolved is dropped.
@@ -176,27 +189,25 @@ async function rebuildLockerCosmetics(
 
     // Empty set: tear down the cosmetics VPK entirely.
     if (valid.length === 0) {
-        if (existing) {
-            await fs.unlink(existing.ref.path).catch(() => {});
-            removeModMetadata(existing.ref.fileName);
-            invalidateVpkParseCache(existing.ref.path);
-        }
+        await fs.unlink(destPath).catch(() => {});
+        removeModMetadata(LOCKER_CARDS_KEY);
+        invalidateVpkParseCache(destPath);
         return { fileName: null, missing };
     }
 
-    // Build artifacts live in the addons dir as dotfiles (not `_dir.vpk`, so
-    // scanMods ignores them) to keep every rename same-filesystem. Plans go to
-    // userData. Everything here is cleaned up in the finally block.
+    // Build artifacts live in the grimoire dir as dotfiles (not `_dir.vpk`) to
+    // keep every rename same-filesystem. Plans go to userData. Everything here is
+    // cleaned up in the finally block.
     const tag = `.locker-cards-build-${randomUUID()}`;
     const planDir = join(app.getPath('userData'), 'locker-cosmetics-build', randomUUID());
-    const buildOut = join(addonsPath, `${tag}.out.vpk`);
+    const buildOut = join(grimoireDir, `${tag}.out.vpk`);
     const chunkPaths: string[] = [];
     try {
         await fs.mkdir(planDir, { recursive: true });
         for (let i = 0; i < valid.length; i++) {
             const sel = valid[i];
             const src = vpks.find((v) => v.fileName === sel.source.fileName)!;
-            const chunkPath = join(addonsPath, `${tag}.chunk${i}.vpk`);
+            const chunkPath = join(grimoireDir, `${tag}.chunk${i}.vpk`);
             const planPath = join(planDir, `plan${i}.json`);
             await fs.writeFile(
                 planPath,
@@ -217,39 +228,17 @@ async function rebuildLockerCosmetics(
         }
         await verifyVpkOutput(buildOut);
 
-        // Swap the freshly built VPK into place. Reuse the existing slot ONLY when
-        // it's enabled (keeps the load-order position + metadata). A prior copy in
-        // .disabled/ must not be reused as the target: rebuilding into that path
-        // would leave the applied cards disabled and silent in game. Drop the stale
-        // disabled copy and reserve a fresh enabled slot instead.
-        let destFileName: string;
-        let destPath: string;
-        if (existing && existing.ref.enabled) {
-            destFileName = existing.ref.fileName;
-            destPath = existing.ref.path;
-            await fs.rename(buildOut, destPath);
-        } else {
-            if (existing) {
-                await fs.unlink(existing.ref.path).catch(() => {});
-                removeModMetadata(existing.ref.fileName);
-                invalidateVpkParseCache(existing.ref.path);
-            }
-            const slot = await findNextAvailablePriority(deadlockPath);
-            destFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
-            destPath = join(addonsPath, destFileName);
-            await reserveOutputSlot(destPath);
-            await fs.rename(buildOut, destPath);
-            removeModMetadata(destFileName); // scrub any orphan from a prior occupant
-        }
+        // Swap into the FIXED grimoire slot (overwrite). The grimoire folder wins
+        // by SearchPaths precedence, so no load-order pinning is needed and the
+        // selection set lives under the synthetic key, not the VPK filename.
+        await fs.unlink(destPath).catch(() => {});
+        await fs.rename(buildOut, destPath);
         invalidateVpkParseCache(destPath);
 
         const info: LockerCosmeticsInfo = { cards: valid, rebuiltAt: new Date().toISOString() };
-        // globalType: null keeps the multi-hero panorama payload out of the
-        // Locker's Global "Icon Packs" bucket (enrichMod skips classification).
-        setModMetadata(destFileName, { modName: 'Locker Cards', lockerCosmetics: info, globalType: null });
+        setModMetadata(LOCKER_CARDS_KEY, { modName: 'Locker Cards', lockerCosmetics: info });
 
-        await pinLockerVpksToFront(deadlockPath);
-        return { fileName: destFileName, missing };
+        return { fileName: destPath, missing };
     } finally {
         await Promise.all([
             ...chunkPaths.map((p) => fs.unlink(p).catch(() => {})),
@@ -268,9 +257,13 @@ export async function applyHeroCard(
     sourceFileName: string
 ): Promise<ApplyHeroCardResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    ensureGrimoireConfigured(deadlockPath);
     const codenames = codenamesForHero(heroName);
     if (codenames.length === 0) throw new Error(`Unknown hero: ${heroName}`);
     const primaryCodename = codenames[0];
+    // Idempotent: relocates any not-yet-migrated managed VPK so `current` reads
+    // from the synthetic key even if config was fixed mid-session.
+    await migrateManagedVpksToGrimoire(deadlockPath);
 
     const vpks = await listAddonVpks(deadlockPath);
     const src = vpks.find((v) => v.fileName === sourceFileName);
@@ -296,7 +289,7 @@ export async function applyHeroCard(
         addedAt: new Date().toISOString(),
     };
 
-    const current = findCosmeticsVpk(vpks)?.info.cards ?? [];
+    const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return {
@@ -313,12 +306,13 @@ export async function revertHeroCard(
     const codenames = codenamesForHero(heroName);
     if (codenames.length === 0) throw new Error(`Unknown hero: ${heroName}`);
     const primaryCodename = codenames[0];
+    ensureGrimoireConfigured(deadlockPath);
+    await migrateManagedVpksToGrimoire(deadlockPath);
 
-    const vpks = await listAddonVpks(deadlockPath);
-    const existing = findCosmeticsVpk(vpks);
-    if (!existing) return { activeSourceFileName: null, missingSourceFileNames: [] };
+    const current = await currentCardSelections(deadlockPath);
+    if (current.length === 0) return { activeSourceFileName: null, missingSourceFileNames: [] };
 
-    const next = existing.info.cards.filter((c) => c.heroCodename !== primaryCodename);
+    const next = current.filter((c) => c.heroCodename !== primaryCodename);
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return { activeSourceFileName: null, missingSourceFileNames: missing };
 }
@@ -331,7 +325,7 @@ export async function getActiveHeroCard(
     const codenames = codenamesForHero(heroName);
     if (codenames.length === 0) return null;
     const primaryCodename = codenames[0];
-    const vpks = await listAddonVpks(deadlockPath);
-    const card = findCosmeticsVpk(vpks)?.info.cards.find((c) => c.heroCodename === primaryCodename);
+    const cards = await currentCardSelections(deadlockPath);
+    const card = cards.find((c) => c.heroCodename === primaryCodename);
     return card ? { sourceFileName: card.source.fileName, variants: card.variants } : null;
 }

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -12,7 +12,7 @@
  * `.vtex_c` the game loads). Decoding to PNG (`vpkmerge portrait`) is only for
  * the preview grid in heroPortraits.ts.
  */
-import { promises as fs } from 'fs';
+import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
@@ -35,7 +35,9 @@ import { codenamesForHero } from './heroPortraits';
 import type {
     ApplyHeroCardResult,
     LockerCardSelection,
+    LockerCardThumbnail,
     LockerCosmeticsInfo,
+    LockerOverviewCard,
 } from '../../../src/types/mod';
 
 const PANORAMA_HERO_PREFIX = 'panorama/images/heroes/';
@@ -315,6 +317,92 @@ export async function revertHeroCard(
     const next = current.filter((c) => c.heroCodename !== primaryCodename);
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return { activeSourceFileName: null, missingSourceFileNames: missing };
+}
+
+/** Applied hero cards, summarized for the Installed-tab Locker Overrides card. */
+export async function listAppliedCards(deadlockPath: string): Promise<LockerOverviewCard[]> {
+    const cards = await currentCardSelections(deadlockPath);
+    return cards.map((c) => ({
+        heroName: c.heroName,
+        sourceFileName: c.source.fileName,
+        modName: c.source.modName,
+    }));
+}
+
+/** Clear every applied card (rebuild to empty, which deletes the cards VPK). */
+export async function clearAllHeroCards(deadlockPath: string): Promise<void> {
+    await rebuildLockerCosmetics(deadlockPath, []);
+}
+
+interface PortraitManifest {
+    portraits: Array<{
+        variant: string;
+        width: number;
+        height: number;
+        format_name: string;
+        output_path: string | null;
+    }>;
+}
+
+/** Which applied variant best represents a hero in a small tile: the full card
+ *  cover first, then the rest by prominence; anything unlisted sorts last. */
+const THUMB_VARIANT_ORDER = ['card', 'vertical', 'card_critical', 'card_gloat', 'minimap', 'small'];
+
+function thumbVariantRank(variant: string): number {
+    const i = THUMB_VARIANT_ORDER.indexOf(variant);
+    return i === -1 ? THUMB_VARIANT_ORDER.length : i;
+}
+
+/**
+ * Decode the ACTUAL applied card art into one representative thumbnail per hero,
+ * for the Locker Overrides popup. Reads straight from the managed cosmetics VPK
+ * (which holds exactly the applied cards) rather than the source mod's
+ * GameBanana cover, and picks the most cover-like variant per hero.
+ *
+ * Separate from the (cheap) overview/count on purpose: this shells out to
+ * `vpkmerge portrait` per applied hero, so it's fetched lazily only when the
+ * popup opens. A hero whose art fails to decode is simply omitted (the popup
+ * falls back to a placeholder), so one bad entry never sinks the rest.
+ */
+export async function getAppliedCardThumbnails(
+    deadlockPath: string
+): Promise<LockerCardThumbnail[]> {
+    const selections = await currentCardSelections(deadlockPath);
+    if (selections.length === 0) return [];
+    const vpkPath = lockerCardsVpkPath(deadlockPath);
+    if (!existsSync(vpkPath)) return [];
+    vpkmergeBinaryPath(); // clear early error if the binary is missing/old
+
+    const cacheRoot = join(app.getPath('userData'), 'locker-card-thumbs');
+    const out: LockerCardThumbnail[] = [];
+    for (const sel of selections) {
+        // The split folds in the whole per-hero prefix, so the art may sit under
+        // a legacy alias codename, not the primary. Try each and keep the best.
+        let best: { rank: number; outputPath: string } | null = null;
+        for (const codename of codenamesForHero(sel.heroName)) {
+            const outDir = join(cacheRoot, codename);
+            const manifestPath = join(outDir, 'manifest.json');
+            try {
+                await runVpkmerge(
+                    ['portrait', vpkPath, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
+                    60000
+                );
+                const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8')) as PortraitManifest;
+                for (const p of manifest.portraits) {
+                    if (!p.output_path) continue;
+                    const rank = thumbVariantRank(p.variant);
+                    if (!best || rank < best.rank) best = { rank, outputPath: p.output_path };
+                }
+            } catch (err) {
+                console.warn(`[heroCards] thumb decode failed for ${sel.heroName} (${codename}): ${String(err)}`);
+            }
+        }
+        if (best) {
+            const png = await fs.readFile(best.outputPath);
+            out.push({ heroName: sel.heroName, dataUrl: `data:image/png;base64,${png.toString('base64')}` });
+        }
+    }
+    return out;
 }
 
 /** The card currently applied for a hero (to reflect selection in the picker). */

--- a/electron/main/services/heroSounds.ts
+++ b/electron/main/services/heroSounds.ts
@@ -21,11 +21,15 @@ import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
-import { getAddonsPath, getDisabledPath, getCitadelPath } from './deadlock';
+import { getAddonsPath, getDisabledPath, getCitadelPath, getGrimoirePath } from './deadlock';
 import { invalidateVpkParseCache } from './vpk';
-import { runVpkmerge, runVpkmergeStdout, vpkmergeBinaryPath, verifyVpkOutput, reserveOutputSlot } from './modMerger';
-import { findNextAvailablePriority } from './mods';
-import { pinLockerVpksToFront } from './lockerVpk';
+import { runVpkmerge, runVpkmergeStdout, vpkmergeBinaryPath, verifyVpkOutput } from './modMerger';
+import {
+    LOCKER_SOUNDS_KEY,
+    lockerSoundsVpkPath,
+    ensureGrimoireConfigured,
+    migrateManagedVpksToGrimoire,
+} from './lockerVpk';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { soundCodenameForHero } from './heroSoundCodenames';
@@ -68,13 +72,25 @@ async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
     return out;
 }
 
-/** The single Locker sound VPK (metadata carries `lockerSounds`), or null. */
+/** The single Locker sound VPK (metadata carries `lockerSounds`), or null. Only
+ *  finds a PRE-migration copy still in addons/.disabled; the migrated copy lives
+ *  in grimoire with its selections under the synthetic key. */
 function findSoundsVpk(vpks: VpkRef[]): { ref: VpkRef; info: LockerSoundsInfo } | null {
     for (const v of vpks) {
         const info = getModMetadata(v.fileName)?.lockerSounds;
         if (info) return { ref: v, info };
     }
     return null;
+}
+
+/** The current sound selection set, read from the synthetic key (post-migration)
+ *  or, as a fallback during the pre-migration window, from an in-addons managed
+ *  VPK. */
+async function currentSoundSelections(deadlockPath: string): Promise<LockerSoundSelection[]> {
+    const synth = getModMetadata(LOCKER_SOUNDS_KEY)?.lockerSounds?.sounds;
+    if (synth) return synth;
+    const vpks = await listAddonVpks(deadlockPath);
+    return findSoundsVpk(vpks)?.info.sounds ?? [];
 }
 
 /** Locate a source VPK by filename, falling back to content hash if reconcile
@@ -183,9 +199,9 @@ async function rebuildLockerSounds(
     deadlockPath: string,
     desired: LockerSoundSelection[],
 ): Promise<RebuildResult> {
-    const addonsPath = getAddonsPath(deadlockPath);
+    const grimoireDir = getGrimoirePath(deadlockPath);
+    const destPath = lockerSoundsVpkPath(deadlockPath);
     const vpks = await listAddonVpks(deadlockPath);
-    const existing = findSoundsVpk(vpks);
 
     // Resolve each selection's source (relocating by hash) and re-derive the
     // clips it still ships for that (hero, slot). Anything unresolved is dropped.
@@ -202,24 +218,22 @@ async function rebuildLockerSounds(
     }
 
     if (valid.length === 0) {
-        if (existing) {
-            await fs.unlink(existing.ref.path).catch(() => {});
-            removeModMetadata(existing.ref.fileName);
-            invalidateVpkParseCache(existing.ref.path);
-        }
+        await fs.unlink(destPath).catch(() => {});
+        removeModMetadata(LOCKER_SOUNDS_KEY);
+        invalidateVpkParseCache(destPath);
         return { fileName: null, missing };
     }
 
     const tag = `.locker-sounds-build-${randomUUID()}`;
     const planDir = join(app.getPath('userData'), 'locker-sounds-build', randomUUID());
-    const buildOut = join(addonsPath, `${tag}.out.vpk`);
+    const buildOut = join(grimoireDir, `${tag}.out.vpk`);
     const chunkPaths: string[] = [];
     try {
         await fs.mkdir(planDir, { recursive: true });
         for (let i = 0; i < valid.length; i++) {
             const sel = valid[i];
             const src = vpks.find((v) => v.fileName === sel.source.fileName)!;
-            const chunkPath = join(addonsPath, `${tag}.chunk${i}.vpk`);
+            const chunkPath = join(grimoireDir, `${tag}.chunk${i}.vpk`);
             const planPath = join(planDir, `plan${i}.json`);
             // Each clip's full path used as an AnyPrefix predicate matches only
             // that file, so the chunk is exactly this (hero, slot)'s clips.
@@ -246,7 +260,7 @@ async function rebuildLockerSounds(
         }
         let sndIdx = 0;
         for (const [codename, sels] of paramByHero) {
-            const chunkPath = join(addonsPath, `${tag}.snd${sndIdx++}.vpk`);
+            const chunkPath = join(grimoireDir, `${tag}.snd${sndIdx++}.vpk`);
             try {
                 if (await synthesizeHeroSoundeventsChunk(deadlockPath, codename, sels, chunkPath)) {
                     chunkPaths.push(chunkPath);
@@ -267,49 +281,17 @@ async function rebuildLockerSounds(
         }
         await verifyVpkOutput(buildOut);
 
-        let destFileName: string;
-        let destPath: string;
-        // Reuse the existing sound VPK in place ONLY when it's enabled. A prior
-        // copy parked in .disabled/ (e.g. left over from before the heal, or a
-        // half-finished vanilla stash) carries a free-form name in the disabled
-        // folder; rebuilding into that path would leave the freshly applied sounds
-        // disabled and silent in game (and pinLockerVpksToFront would skip it
-        // since it isn't enabled). Drop the stale disabled copy and mint a fresh
-        // enabled pakNN slot instead.
-        if (existing && existing.ref.enabled) {
-            destFileName = existing.ref.fileName;
-            destPath = existing.ref.path;
-            await fs.rename(buildOut, destPath);
-        } else {
-            if (existing) {
-                await fs.unlink(existing.ref.path).catch(() => {});
-                removeModMetadata(existing.ref.fileName);
-                invalidateVpkParseCache(existing.ref.path);
-            }
-            const slot = await findNextAvailablePriority(deadlockPath);
-            destFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
-            destPath = join(addonsPath, destFileName);
-            await reserveOutputSlot(destPath);
-            await fs.rename(buildOut, destPath);
-            removeModMetadata(destFileName);
-        }
+        // Swap into the FIXED grimoire slot (overwrite). The grimoire folder wins
+        // by SearchPaths precedence, so no load-order pinning is needed and the
+        // selection set lives under the synthetic key, not the VPK filename.
+        await fs.unlink(destPath).catch(() => {});
+        await fs.rename(buildOut, destPath);
         invalidateVpkParseCache(destPath);
 
         const info: LockerSoundsInfo = { sounds: valid, rebuiltAt: new Date().toISOString() };
-        // globalType: null keeps it off the Locker Global axis, and
-        // abilitySounds: null keeps this VPK out of the sound picker's own source
-        // list (it ships ability clips, so without the sentinel enrichMod would
-        // classify it and re-offer it as a selectable source). enrichMod skips
-        // both classifications when metadata already carries a result.
-        setModMetadata(destFileName, {
-            modName: 'Locker Sounds',
-            lockerSounds: info,
-            globalType: null,
-            abilitySounds: null,
-        });
+        setModMetadata(LOCKER_SOUNDS_KEY, { modName: 'Locker Sounds', lockerSounds: info });
 
-        await pinLockerVpksToFront(deadlockPath);
-        return { fileName: destFileName, missing };
+        return { fileName: destPath, missing };
     } finally {
         await Promise.all([
             ...chunkPaths.map((p) => fs.unlink(p).catch(() => {})),
@@ -331,8 +313,12 @@ export async function applyHeroSound(
     params?: AbilitySoundParams,
 ): Promise<ApplyHeroSoundResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    ensureGrimoireConfigured(deadlockPath);
     const codename = soundCodenameForHero(heroName);
     if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+    // Idempotent: relocates any not-yet-migrated managed VPK so `current` reads
+    // from the synthetic key even if config was fixed mid-session.
+    await migrateManagedVpksToGrimoire(deadlockPath);
 
     const vpks = await listAddonVpks(deadlockPath);
     const src = vpks.find((v) => v.fileName === sourceFileName);
@@ -362,7 +348,7 @@ export async function applyHeroSound(
         addedAt: new Date().toISOString(),
     };
 
-    const current = findSoundsVpk(vpks)?.info.sounds ?? [];
+    const current = await currentSoundSelections(deadlockPath);
     const next = [
         ...current.filter((s) => !(s.heroCodename === codename && s.slot === slot)),
         selection,
@@ -382,12 +368,13 @@ export async function revertHeroSound(
 ): Promise<ApplyHeroSoundResult> {
     const codename = soundCodenameForHero(heroName);
     if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+    ensureGrimoireConfigured(deadlockPath);
+    await migrateManagedVpksToGrimoire(deadlockPath);
 
-    const vpks = await listAddonVpks(deadlockPath);
-    const existing = findSoundsVpk(vpks);
-    if (!existing) return { activeSourceFileName: null, missingSourceFileNames: [] };
+    const current = await currentSoundSelections(deadlockPath);
+    if (current.length === 0) return { activeSourceFileName: null, missingSourceFileNames: [] };
 
-    const next = existing.info.sounds.filter(
+    const next = current.filter(
         (s) => !(s.heroCodename === codename && s.slot === slot),
     );
     const { missing } = await rebuildLockerSounds(deadlockPath, next);
@@ -402,10 +389,8 @@ export async function getActiveHeroSounds(
 ): Promise<ActiveHeroSound[]> {
     const codename = soundCodenameForHero(heroName);
     if (!codename) return [];
-    const vpks = await listAddonVpks(deadlockPath);
-    const info = findSoundsVpk(vpks)?.info;
-    if (!info) return [];
-    return info.sounds
+    const sounds = await currentSoundSelections(deadlockPath);
+    return sounds
         .filter((s) => s.heroCodename === codename)
         .map((s) => ({ slot: s.slot, sourceFileName: s.source.fileName, params: s.params }));
 }

--- a/electron/main/services/heroSounds.ts
+++ b/electron/main/services/heroSounds.ts
@@ -39,6 +39,7 @@ import type {
     AbilitySoundParams,
     ActiveHeroSound,
     ApplyHeroSoundResult,
+    LockerOverviewSound,
     LockerSoundSelection,
     LockerSoundsInfo,
 } from '../../../src/types/mod';
@@ -379,6 +380,24 @@ export async function revertHeroSound(
     );
     const { missing } = await rebuildLockerSounds(deadlockPath, next);
     return { activeSourceFileName: null, missingSourceFileNames: missing };
+}
+
+/** Applied ability sounds, summarized for the Installed-tab Locker Overrides card. */
+export async function listAppliedSounds(deadlockPath: string): Promise<LockerOverviewSound[]> {
+    const sounds = await currentSoundSelections(deadlockPath);
+    return sounds.map((s) => ({
+        heroName: s.heroName,
+        slot: s.slot,
+        sourceFileName: s.source.fileName,
+        modName: s.source.modName,
+        tuned: !!s.params,
+        params: s.params,
+    }));
+}
+
+/** Clear every applied sound (rebuild to empty, which deletes the sounds VPK). */
+export async function clearAllHeroSounds(deadlockPath: string): Promise<void> {
+    await rebuildLockerSounds(deadlockPath, []);
 }
 
 /** The source (and any volume/pitch retune) applied for each of a hero's ability

--- a/electron/main/services/lockerVpk.ts
+++ b/electron/main/services/lockerVpk.ts
@@ -1,30 +1,132 @@
 /**
- * Shared lifecycle for the Locker-managed override VPKs (hero cards + ability
- * sounds). Both are built and owned by Grimoire, ship only the exact cosmetic
- * paths the user picked (disjoint, additive), and must always sit at the FRONT
- * of the load order so they win Deadlock's lowest-pakNN-wins collision.
+ * Lifecycle for the Locker-managed override VPKs (hero cards + ability sounds).
  *
- * They are hidden from the Installed list (see ipc/mods.ts `get-mods`) and driven
- * solely through the Locker pickers, so the user can't accidentally disable or
- * reorder them. A stray disable silently killed applied sounds before this:
- * the rebuilt VPK landed in .disabled/ and the game never mounted it.
+ * They live in their OWN addon folder, citadel/grimoire, listed first in
+ * gameinfo.gi's SearchPaths so they outrank every user mod by folder precedence.
+ * That keeps them off the user's 99-slot citadel/addons budget entirely (the
+ * grimoire folder is never scanned by scanMods), while still winning every
+ * cosmetic collision. Each has a FIXED filename in grimoire (pak01=cards,
+ * pak02=sounds; disjoint paths, so the order between them is cosmetic), and its
+ * selection set is stored under a synthetic metadata key (`locker:cards` /
+ * `locker:sounds`) rather than the VPK's filename, so it can never collide with
+ * a user mod that later takes the freed addons/pak01 slot.
+ *
+ * Migration: 1.13.x users have their cards VPK in citadel/addons. Once the
+ * grimoire search path is configured (via the existing Fix Configuration flow),
+ * `migrateManagedVpksToGrimoire` relocates it and moves its selections to the
+ * synthetic key. Until then, `healLockerVpks` keeps it enabled + pinned in
+ * addons so applied cards keep loading through the transition.
  */
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { getGrimoirePath } from './deadlock';
+import { getGameinfoStatus, fixGameinfo } from './system';
 import { scanMods, enableMod, reorderMods } from './mods';
-import { getModMetadata } from './metadata';
+import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import { invalidateVpkParseCache } from './vpk';
 import { readStash } from './launch';
 
-/** A VPK is Locker-managed when its metadata carries a cards or sounds payload. */
+/** Synthetic metadata keys for the managed selection sets (decoupled from the
+ *  VPK filename so they never collide with a user mod). */
+export const LOCKER_CARDS_KEY = 'locker:cards';
+export const LOCKER_SOUNDS_KEY = 'locker:sounds';
+
+/** Fixed filenames inside citadel/grimoire. */
+const GRIMOIRE_CARDS_FILE = 'pak01_dir.vpk';
+const GRIMOIRE_SOUNDS_FILE = 'pak02_dir.vpk';
+
+/** Absolute path to the managed cards VPK in citadel/grimoire. */
+export function lockerCardsVpkPath(deadlockPath: string): string {
+    return join(getGrimoirePath(deadlockPath), GRIMOIRE_CARDS_FILE);
+}
+
+/** Absolute path to the managed sounds VPK in citadel/grimoire. */
+export function lockerSoundsVpkPath(deadlockPath: string): string {
+    return join(getGrimoirePath(deadlockPath), GRIMOIRE_SOUNDS_FILE);
+}
+
+/** Whether the grimoire search path (and addons) is active in gameinfo.gi. The
+ *  managed VPKs only load once it is, so apply gates on this. */
+export function isGrimoireConfigured(deadlockPath: string): boolean {
+    return getGameinfoStatus(deadlockPath).configured;
+}
+
+/**
+ * Ensure the grimoire search path is active in gameinfo.gi, running the same
+ * fixGameinfo repair the Settings button uses if it's missing. A managed VPK
+ * written to grimoire wouldn't load without it. Called on a deliberate apply (not
+ * at launch), so this isn't a silent launch-time write. Throws only when the
+ * repair can't succeed (gameinfo absent or unparseable), where the user must
+ * recover the file via Settings first.
+ */
+export function ensureGrimoireConfigured(deadlockPath: string): void {
+    if (isGrimoireConfigured(deadlockPath)) return;
+    const status = fixGameinfo(deadlockPath);
+    if (!status.configured) {
+        throw new Error(
+            `Couldn't configure the mod folders${status.message ? `: ${status.message}` : ''}. ` +
+                'Open Settings and use Fix Configuration, then try again.',
+        );
+    }
+}
+
+/**
+ * Relocate a managed VPK currently in citadel/addons (or .disabled) into
+ * citadel/grimoire under its fixed name, moving its selection set from the old
+ * filename-keyed metadata to the synthetic key. Idempotent: a no-op once the
+ * source is gone.
+ */
+async function relocateManaged(
+    fromPath: string,
+    fromKey: string,
+    toPath: string,
+    toKey: string,
+    metaToWrite: Parameters<typeof setModMetadata>[1],
+): Promise<void> {
+    await fs.unlink(toPath).catch(() => {}); // overwrite any partial prior migration
+    await fs.rename(fromPath, toPath);
+    setModMetadata(toKey, metaToWrite);
+    removeModMetadata(fromKey);
+    invalidateVpkParseCache(fromPath);
+    invalidateVpkParseCache(toPath);
+}
+
+/**
+ * Move any Locker-managed VPK still living in citadel/addons (enabled or
+ * disabled) into citadel/grimoire, and migrate its selections to the synthetic
+ * key. Run once the grimoire search path is configured. Idempotent.
+ */
+export async function migrateManagedVpksToGrimoire(deadlockPath: string): Promise<void> {
+    const mods = await scanMods(deadlockPath);
+    for (const m of mods) {
+        const meta = getModMetadata(m.fileName);
+        if (meta?.lockerCosmetics) {
+            await relocateManaged(m.path, m.fileName, lockerCardsVpkPath(deadlockPath), LOCKER_CARDS_KEY, {
+                modName: 'Locker Cards',
+                lockerCosmetics: meta.lockerCosmetics,
+            });
+        } else if (meta?.lockerSounds) {
+            await relocateManaged(m.path, m.fileName, lockerSoundsVpkPath(deadlockPath), LOCKER_SOUNDS_KEY, {
+                modName: 'Locker Sounds',
+                lockerSounds: meta.lockerSounds,
+            });
+        }
+    }
+}
+
+/**
+ * A VPK is Locker-managed when its (filename-keyed) metadata carries a cards or
+ * sounds payload. Only true for the pre-migration in-addons copy: once migrated,
+ * the selections live under the synthetic keys and the grimoire VPK is never
+ * scanned. Used by addons-scanning surfaces (get-mods, conflicts, profiles) to
+ * hide a not-yet-migrated managed VPK.
+ */
 export function isLockerManaged(fileName: string): boolean {
     const meta = getModMetadata(fileName);
     return !!(meta?.lockerCosmetics || meta?.lockerSounds);
 }
 
-/**
- * Stable relative order among the managed VPKs so repeated pins converge instead
- * of ping-ponging the two front slots on each apply. Cosmetics ("icons") first,
- * then sounds; both still beat every user mod by sitting at the front, and they
- * touch disjoint paths so the order between them is cosmetic anyway.
- */
+/** Stable relative order among in-addons managed VPKs (fallback path only). */
 function lockerRank(fileName: string): number {
     const meta = getModMetadata(fileName);
     if (meta?.lockerCosmetics) return 0;
@@ -33,9 +135,10 @@ function lockerRank(fileName: string): number {
 }
 
 /**
- * Pin every enabled Locker-managed VPK to the front of the load order, in a
- * stable relative order. No-ops when they already hold the front slots, so it's
- * cheap to call after each apply/revert.
+ * FALLBACK (pre-migration only): keep any managed VPK still in citadel/addons
+ * enabled and pinned to the front, so applied cosmetics keep loading until the
+ * grimoire search path is configured and they migrate out. No-ops once the
+ * managed VPKs have moved to grimoire (nothing managed left in addons).
  */
 export async function pinLockerVpksToFront(deadlockPath: string): Promise<void> {
     const mods = await scanMods(deadlockPath);
@@ -45,7 +148,6 @@ export async function pinLockerVpksToFront(deadlockPath: string): Promise<void> 
         .sort((a, b) => lockerRank(a.fileName) - lockerRank(b.fileName));
     if (managed.length === 0) return;
 
-    // Already at the front in the right order? Nothing to rename.
     const front = enabled.slice(0, managed.length);
     if (managed.every((m, i) => front[i]?.id === m.id)) return;
 
@@ -55,15 +157,22 @@ export async function pinLockerVpksToFront(deadlockPath: string): Promise<void> 
 }
 
 /**
- * Self-heal: re-enable any Locker-managed VPK that ended up in .disabled/ (it
- * must never sit disabled, since it's hidden from the Installed list and only
- * the Locker controls it), then pin the managed VPKs to the front. Skips
- * entirely while a vanilla launch is in progress so we don't undo the user's
- * vanilla session by un-stashing the mods Launch Vanilla just parked.
+ * Startup self-heal. When the grimoire search path is configured, migrate any
+ * managed VPK out of addons into grimoire. When it isn't yet (a fresh 1.13.x
+ * update before Fix Configuration), keep the in-addons managed VPKs enabled and
+ * pinned so applied cosmetics still load. Skips entirely during a vanilla launch
+ * so it can't un-stash the mods Launch Vanilla just parked.
  */
 export async function healLockerVpks(deadlockPath: string): Promise<void> {
     if (await readStash()) return; // vanilla session active; leave the stash intact
 
+    if (isGrimoireConfigured(deadlockPath)) {
+        await migrateManagedVpksToGrimoire(deadlockPath);
+        return;
+    }
+
+    // grimoire not configured yet: re-enable any managed VPK parked in .disabled/
+    // and pin it to the front of addons so applied cosmetics keep loading.
     const mods = await scanMods(deadlockPath);
     const disabledManaged = mods.filter((m) => !m.enabled && isLockerManaged(m.fileName));
     for (const m of disabledManaged) {

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -262,7 +262,12 @@ export const deleteModMetadata = removeModMetadata;
  */
 export function pruneOrphanMetadata(validFileNames: Set<string>): void {
     const metadata = loadMetadata();
-    const orphans = Object.keys(metadata).filter((key) => !validFileNames.has(key));
+    // Synthetic `locker:*` keys hold the Locker-managed selection sets (cards /
+    // sounds), which live in citadel/grimoire and are NOT scanned filenames, so
+    // they must never be treated as orphans.
+    const orphans = Object.keys(metadata).filter(
+        (key) => !key.startsWith('locker:') && !validFileNames.has(key),
+    );
     if (orphans.length === 0) return;
 
     for (const key of orphans) {

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -36,6 +36,10 @@ export interface AppSettings {
     accentColor: string;
     /** Order used to render absolute dates (mod/file upload + update dates). */
     dateFormat: 'MM/DD/YYYY' | 'DD/MM/YYYY';
+    /** UI zoom factor (webContents.setZoomFactor). Driven by Ctrl +/-/0 and
+     *  persisted so hi-DPI laptops keep their preferred scale across launches.
+     *  1 = 100%. */
+    zoomFactor?: number;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -57,6 +61,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     ignoreConflictsByDefault: false,
     accentColor: '#f97316',
     dateFormat: 'MM/DD/YYYY',
+    zoomFactor: 1,
 };
 
 /**

--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -1,10 +1,11 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join, extname } from 'path';
-import { getGameinfoPath, getAddonsPath, getDisabledPath, getCitadelPath } from './deadlock';
+import { getGameinfoPath, getAddonsPath, getDisabledPath, getCitadelPath, getGrimoirePath } from './deadlock';
 
 // The canonical SearchPaths block for Deadlock with mod support
 const SEARCH_PATHS_BLOCK = `SearchPaths
 	{
+		Game				citadel/grimoire
 		Game				citadel/addons
 		Mod				citadel
 		Write				citadel
@@ -93,6 +94,25 @@ function hasActiveAddonPath(searchPathsBody: string): boolean {
     });
 }
 
+// True when the SearchPaths body has an active entry pointing the engine at
+// citadel/grimoire, the Grimoire-managed override folder (Locker cards + ability
+// sounds). Listed first in the canonical block so it outranks every user mod;
+// matched as a complete token, ignoring comments, same as the addons check.
+function hasActiveGrimoirePath(searchPathsBody: string): boolean {
+    return searchPathsBody.split(/\r?\n/).some((line) => {
+        const code = line.split('//')[0];
+        return /citadel[\\/]+grimoire(?![\\/\w])/i.test(code);
+    });
+}
+
+// Both required search paths are present and active. The grimoire path is what
+// makes applied Locker cards/sounds win, so an install missing it (e.g. a
+// pre-grimoire 1.13.x user, or a game update that reset gameinfo.gi) reads as
+// not-yet-configured and Fix Configuration rewrites the canonical block.
+function hasRequiredSearchPaths(searchPathsBody: string): boolean {
+    return hasActiveAddonPath(searchPathsBody) && hasActiveGrimoirePath(searchPathsBody);
+}
+
 // Preserve the first version we touch. Never overwrites an existing backup so the
 // oldest (closest-to-original) copy is kept. Best-effort: a failed backup must
 // not block the repair itself.
@@ -143,7 +163,7 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
         const content = readFileSync(gameinfoPath, 'utf-8');
         const block = findSearchPathsBlock(content);
 
-        if (block && hasActiveAddonPath(block.body)) {
+        if (block && hasRequiredSearchPaths(block.body)) {
             return {
                 configured: true,
                 missing: false,
@@ -202,7 +222,7 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         const block = findSearchPathsBlock(content);
 
         // Already correct: an active addon path inside a real SearchPaths block.
-        if (block && hasActiveAddonPath(block.body)) {
+        if (block && hasRequiredSearchPaths(block.body)) {
             return {
                 configured: true,
                 missing: false,
@@ -243,6 +263,10 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         // Keep a one-time recovery copy before the first write.
         backupGameinfoOnce(gameinfoPath, content);
         writeFileSync(gameinfoPath, next, 'utf-8');
+
+        // Ensure the grimoire override folder exists so its (now-active) search
+        // path points at a real directory rather than a missing one.
+        getGrimoirePath(deadlockPath);
 
         return {
             configured: true,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -15,6 +15,7 @@ import type {
     ApplyUnknownModMatchArgs,
     GlobalModType,
     EditLocalModArgs,
+    LockerClearScope,
     MergeModsArgs,
     Mod,
     ModConflict,
@@ -797,6 +798,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('revert-hero-sound', heroName, slot),
     getActiveHeroSounds: (heroName: string) =>
         ipcRenderer.invoke('get-active-hero-sounds', heroName),
+    getLockerOverview: () =>
+        ipcRenderer.invoke('get-locker-overview'),
+    getLockerCardThumbnails: () =>
+        ipcRenderer.invoke('get-locker-card-thumbnails'),
+    clearLockerOverrides: (scope: LockerClearScope) =>
+        ipcRenderer.invoke('clear-locker-overrides', scope),
     setModGlobalType: (modId: string, globalType: GlobalModType | null) =>
         ipcRenderer.invoke('set-mod-global-type', modId, globalType),
     setModIgnoreUpdates: (modId: string, ignore: boolean) =>

--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -1,0 +1,640 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+    X,
+    Image as ImageIcon,
+    Volume2,
+    Wand2,
+    RotateCcw,
+    RefreshCw,
+    SlidersHorizontal,
+    ExternalLink,
+    Loader2,
+} from 'lucide-react';
+import { Button } from './common/ui';
+import AudioPreviewPlayer from './AudioPreviewPlayer';
+import {
+    getLockerOverview,
+    getLockerCardThumbnails,
+    clearLockerOverrides,
+    revertHeroCard,
+    revertHeroSound,
+    applyHeroSound,
+    getGameRunningStatus,
+} from '../lib/api';
+import { useAppStore } from '../stores/appStore';
+import { getHeroChipIconPath } from '../lib/lockerUtils';
+import type {
+    AbilitySlot,
+    AbilitySoundParams,
+    LockerOverview,
+    Mod,
+} from '../types/mod';
+
+const VOLUME_MIN = -12;
+const VOLUME_MAX = 12;
+const PITCH_MIN = 0.5;
+const PITCH_MAX = 2;
+/** Re-apply (rebuild the sound VPK) this long after the last slider move. */
+const PARAM_COMMIT_DELAY_MS = 600;
+
+type Tab = 'cards' | 'sounds';
+
+function abilityLabel(slot: AbilitySlot): string {
+    return slot === 4 ? 'Ultimate' : `Ability ${slot}`;
+}
+
+/** Strip the `_dir.vpk` tail for a friendlier source label. */
+function sourceLabel(modName: string | undefined, fileName: string): string {
+    return modName || fileName.replace(/_dir\.vpk$/, '');
+}
+
+/** Hero face icon for the sounds list, with a 2-letter fallback if the bundled
+ *  chip icon is missing for this hero. */
+function HeroIcon({ heroName }: { heroName: string }) {
+    const [failed, setFailed] = useState(false);
+    if (failed) {
+        return (
+            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-bg-tertiary text-[10px] font-semibold uppercase text-text-secondary">
+                {heroName.slice(0, 2)}
+            </span>
+        );
+    }
+    return (
+        <img
+            src={getHeroChipIconPath(heroName)}
+            alt=""
+            className="h-9 w-9 flex-shrink-0 rounded-full bg-bg-tertiary object-cover"
+            onError={() => setFailed(true)}
+        />
+    );
+}
+
+/** Volume (dB) + pitch sliders for one applied ability sound. Mirrors the
+ *  per-hero picker's controls so retuning works the same from here. */
+function ParamSliders({
+    params,
+    saving,
+    disabled,
+    onChange,
+}: {
+    params: AbilitySoundParams;
+    saving: boolean;
+    disabled: boolean;
+    onChange: (next: AbilitySoundParams) => void;
+}) {
+    const volumeDb = params.volumeDb ?? 0;
+    const pitch = params.pitch ?? 1;
+    const dirty = volumeDb !== 0 || pitch !== 1;
+    return (
+        <div className="space-y-2 border-t border-border/50 px-3 py-2">
+            <div className="flex items-center gap-2">
+                <span className="w-10 text-[10px] uppercase tracking-wide text-text-secondary">Volume</span>
+                <input
+                    type="range"
+                    min={VOLUME_MIN}
+                    max={VOLUME_MAX}
+                    step={1}
+                    value={volumeDb}
+                    disabled={disabled}
+                    onChange={(e) => onChange({ ...params, volumeDb: Number(e.target.value) })}
+                    className="h-1 flex-1 cursor-pointer accent-accent disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-right text-[10px] tabular-nums text-text-secondary">
+                    {volumeDb > 0 ? `+${volumeDb}` : volumeDb} dB
+                </span>
+            </div>
+            <div className="flex items-center gap-2">
+                <span className="w-10 text-[10px] uppercase tracking-wide text-text-secondary">Pitch</span>
+                <input
+                    type="range"
+                    min={PITCH_MIN}
+                    max={PITCH_MAX}
+                    step={0.05}
+                    value={pitch}
+                    disabled={disabled}
+                    onChange={(e) => onChange({ ...params, pitch: Number(e.target.value) })}
+                    className="h-1 flex-1 cursor-pointer accent-accent disabled:cursor-not-allowed"
+                />
+                <span className="w-12 text-right text-[10px] tabular-nums text-text-secondary">
+                    {pitch.toFixed(2)}x
+                </span>
+            </div>
+            <div className="flex items-center justify-between">
+                <span className="text-[9px] text-text-secondary/70">
+                    {saving ? 'Saving...' : 'Applies on release'}
+                </span>
+                {dirty && !disabled && (
+                    <button
+                        type="button"
+                        onClick={() => onChange({ volumeDb: 0, pitch: 1 })}
+                        className="text-[9px] font-semibold uppercase tracking-wide text-accent hover:underline"
+                    >
+                        Reset
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Cross-hero management popup for the Grimoire-managed Locker overrides (hero
+ * cards + per-ability sounds). They live in citadel/grimoire, off the mod list
+ * and the 99-slot budget, so this is the one place to review everything that's
+ * applied, preview it, retune sounds, and remove individual overrides.
+ *
+ * "Remove" reverts a single override (rebuild the managed VPK from the
+ * remaining selections); it never deletes the source mod, hence Remove not
+ * Delete. To ADD a new override you pick from a hero's mods in the Locker.
+ */
+export function LockerOverridesModal({
+    onClose,
+    onChanged,
+}: {
+    onClose: () => void;
+    onChanged?: () => void;
+}) {
+    const navigate = useNavigate();
+    const mods = useAppStore((s) => s.mods);
+    const loadMods = useAppStore((s) => s.loadMods);
+
+    const [overview, setOverview] = useState<LockerOverview | null>(null);
+    const [tab, setTab] = useState<Tab>('cards');
+    // `card:<hero>` or `sound:<hero>:<slot>` of the row mid-remove.
+    const [removing, setRemoving] = useState<string | null>(null);
+    const [clearing, setClearing] = useState<Tab | null>(null);
+    // Slider positions per `<hero>:<slot>` (seeded from applied params).
+    const [paramsByKey, setParamsByKey] = useState<Map<string, AbilitySoundParams>>(new Map());
+    const [savingKey, setSavingKey] = useState<string | null>(null);
+    const [gameRunning, setGameRunning] = useState(false);
+    const [actionError, setActionError] = useState<string | null>(null);
+    // Real applied card art, decoded per hero from the managed cosmetics VPK
+    // (heroName -> PNG data URL). Fetched lazily; the GameBanana cover is only a
+    // fallback while this loads or if a decode fails.
+    const [cardThumbs, setCardThumbs] = useState<Map<string, string>>(new Map());
+    const [thumbsLoading, setThumbsLoading] = useState(false);
+    const commitTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+    const modByFile = useMemo(() => {
+        const m = new Map<string, Mod>();
+        for (const mod of mods) m.set(mod.fileName, mod);
+        return m;
+    }, [mods]);
+
+    const refresh = useCallback(async () => {
+        try {
+            const next = await getLockerOverview();
+            setOverview(next);
+            // Reseed slider positions from what's actually applied.
+            setParamsByKey(
+                new Map(
+                    next.sounds
+                        .filter((s) => s.params)
+                        .map((s) => [`${s.heroName}:${s.slot}`, s.params as AbilitySoundParams]),
+                ),
+            );
+        } catch (err) {
+            setActionError(String(err));
+        }
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+        getGameRunningStatus()
+            .then((s) => setGameRunning(s.running))
+            .catch(() => setGameRunning(false));
+    }, [refresh]);
+
+    // Default to the tab that actually has content on open.
+    useEffect(() => {
+        if (!overview) return;
+        if (overview.cards.length === 0 && overview.sounds.length > 0) setTab('sounds');
+    }, [overview]);
+
+    // Decode the real applied card art whenever the applied-card SET changes
+    // (an add or remove). Keyed on hero+source so retuning a sound doesn't
+    // trigger a redundant re-decode.
+    const cardSetKey = useMemo(
+        () => (overview?.cards ?? []).map((c) => `${c.heroName}:${c.sourceFileName}`).join('|'),
+        [overview],
+    );
+    useEffect(() => {
+        if (cardSetKey === '') {
+            setCardThumbs(new Map());
+            return;
+        }
+        let active = true;
+        setThumbsLoading(true);
+        getLockerCardThumbnails()
+            .then((thumbs) => {
+                if (active) setCardThumbs(new Map(thumbs.map((t) => [t.heroName, t.dataUrl])));
+            })
+            .catch(() => {
+                if (active) setCardThumbs(new Map());
+            })
+            .finally(() => {
+                if (active) setThumbsLoading(false);
+            });
+        return () => {
+            active = false;
+        };
+    }, [cardSetKey]);
+
+    const busy = removing !== null || clearing !== null || savingKey !== null;
+
+    // Escape closes, but not mid-operation (don't abandon a rebuild visually).
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && !busy) onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [busy, onClose]);
+
+    useEffect(() => {
+        const timers = commitTimers.current;
+        return () => {
+            for (const t of timers.values()) clearTimeout(t);
+            timers.clear();
+        };
+    }, []);
+
+    const afterChange = useCallback(async () => {
+        await refresh();
+        await loadMods({ silent: true });
+        onChanged?.();
+    }, [refresh, loadMods, onChanged]);
+
+    const removeCard = async (heroName: string) => {
+        if (busy) return;
+        setRemoving(`card:${heroName}`);
+        setActionError(null);
+        try {
+            await revertHeroCard(heroName);
+            await afterChange();
+        } catch (err) {
+            setActionError(String(err));
+        } finally {
+            setRemoving(null);
+        }
+    };
+
+    const removeSound = async (heroName: string, slot: AbilitySlot) => {
+        if (busy) return;
+        setRemoving(`sound:${heroName}:${slot}`);
+        setActionError(null);
+        try {
+            await revertHeroSound(heroName, slot);
+            await afterChange();
+        } catch (err) {
+            setActionError(String(err));
+        } finally {
+            setRemoving(null);
+        }
+    };
+
+    const clearTab = async (which: Tab) => {
+        if (busy) return;
+        setClearing(which);
+        setActionError(null);
+        try {
+            await clearLockerOverrides(which);
+            await afterChange();
+        } catch (err) {
+            setActionError(String(err));
+        } finally {
+            setClearing(null);
+        }
+    };
+
+    // Re-apply the active source for (hero, slot) with the latest slider params.
+    // The rebuild is heavy, so the caller debounces.
+    const commitParams = async (
+        heroName: string,
+        slot: AbilitySlot,
+        sourceFileName: string,
+        params: AbilitySoundParams,
+    ) => {
+        const key = `${heroName}:${slot}`;
+        setSavingKey(key);
+        setActionError(null);
+        try {
+            await applyHeroSound(heroName, slot, sourceFileName, params);
+            await afterChange();
+        } catch (err) {
+            setActionError(String(err));
+        } finally {
+            setSavingKey((prev) => (prev === key ? null : prev));
+        }
+    };
+
+    const handleParamChange = (
+        heroName: string,
+        slot: AbilitySlot,
+        sourceFileName: string,
+        next: AbilitySoundParams,
+    ) => {
+        const key = `${heroName}:${slot}`;
+        setParamsByKey((prev) => new Map(prev).set(key, next));
+        const timers = commitTimers.current;
+        const pending = timers.get(key);
+        if (pending) clearTimeout(pending);
+        timers.set(
+            key,
+            setTimeout(() => {
+                timers.delete(key);
+                void commitParams(heroName, slot, sourceFileName, next);
+            }, PARAM_COMMIT_DELAY_MS),
+        );
+    };
+
+    const cards = overview?.cards ?? [];
+    const sounds = overview?.sounds ?? [];
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 animate-fade-in"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Locker overrides"
+            onMouseDown={(e) => {
+                if (e.target === e.currentTarget && !busy) onClose();
+            }}
+        >
+            <div className="flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border bg-bg-secondary shadow-2xl">
+                {/* Header */}
+                <div className="flex items-start justify-between gap-3 border-b border-border px-5 py-4">
+                    <div className="flex items-center gap-2.5">
+                        <Wand2 className="h-5 w-5 text-accent" />
+                        <div>
+                            <h2 className="text-base font-semibold text-text-primary">Locker Overrides</h2>
+                            <p className="text-xs text-text-secondary">
+                                Always-on cosmetics, separate from your mod load order and the 99-slot cap.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => !busy && onClose()}
+                        disabled={busy}
+                        aria-label="Close"
+                        className="rounded-md p-1 text-text-secondary hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    >
+                        <X className="h-5 w-5" />
+                    </button>
+                </div>
+
+                {/* Tabs */}
+                <div className="flex items-center gap-1 border-b border-border px-3 pt-2">
+                    {([
+                        { id: 'cards' as const, label: 'Hero Cards', icon: ImageIcon, count: cards.length },
+                        { id: 'sounds' as const, label: 'Ability Sounds', icon: Volume2, count: sounds.length },
+                    ]).map(({ id, label, icon: Icon, count }) => (
+                        <button
+                            key={id}
+                            type="button"
+                            onClick={() => setTab(id)}
+                            className={`flex items-center gap-1.5 rounded-t-md border-b-2 px-3 py-2 text-sm transition-colors cursor-pointer ${
+                                tab === id
+                                    ? 'border-accent text-text-primary'
+                                    : 'border-transparent text-text-secondary hover:text-text-primary'
+                            }`}
+                        >
+                            <Icon className="h-4 w-4" />
+                            {label}
+                            <span className="rounded-full bg-bg-tertiary px-1.5 text-[11px] tabular-nums text-text-secondary">
+                                {count}
+                            </span>
+                        </button>
+                    ))}
+                </div>
+
+                {/* Body */}
+                <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+                    {actionError && (
+                        <div className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+                            {actionError}
+                        </div>
+                    )}
+
+                    {tab === 'cards' && (
+                        cards.length === 0 ? (
+                            <EmptyState
+                                kind="cards"
+                                onOpenLocker={() => {
+                                    onClose();
+                                    navigate('/locker');
+                                }}
+                            />
+                        ) : (
+                            <div className="grid grid-cols-2 gap-3">
+                                {cards.map((card) => {
+                                    const mod = modByFile.get(card.sourceFileName);
+                                    const key = `card:${card.heroName}`;
+                                    const art = cardThumbs.get(card.heroName);
+                                    const isRemoving = removing === key;
+                                    return (
+                                        <div
+                                            key={key}
+                                            className="overflow-hidden rounded-md border border-border bg-bg-secondary"
+                                        >
+                                            {/* Media: the applied art, clean (no text over it). */}
+                                            <div className="relative aspect-square bg-bg-primary/50">
+                                                {art ? (
+                                                    // The real applied card art, decoded from the
+                                                    // managed VPK.
+                                                    <img src={art} alt="" className="h-full w-full object-cover" />
+                                                ) : thumbsLoading ? (
+                                                    <div className="flex h-full w-full items-center justify-center">
+                                                        <Loader2 className="h-5 w-5 animate-spin text-text-secondary/60" />
+                                                    </div>
+                                                ) : mod?.thumbnailUrl ? (
+                                                    // Fallback: the source mod's GameBanana cover.
+                                                    <img src={mod.thumbnailUrl} alt="" className="h-full w-full object-cover" />
+                                                ) : (
+                                                    <div className="flex h-full w-full items-center justify-center">
+                                                        <ImageIcon className="h-7 w-7 text-text-secondary/50" />
+                                                    </div>
+                                                )}
+
+                                                {/* Remove overlay (revert to default). Circular, with a
+                                                    hover-red X: the standard "remove this tile" affordance. */}
+                                                <button
+                                                    type="button"
+                                                    onClick={() => removeCard(card.heroName)}
+                                                    disabled={busy}
+                                                    title={`Remove ${card.heroName} card`}
+                                                    aria-label={`Remove ${card.heroName} card`}
+                                                    className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/85 ring-1 ring-white/15 backdrop-blur-sm transition-all hover:bg-red-500 hover:text-white hover:ring-red-400 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                                                >
+                                                    {isRemoving ? (
+                                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                    ) : (
+                                                        <X className="h-4 w-4" />
+                                                    )}
+                                                </button>
+                                            </div>
+
+                                            {/* Body: hero icon + name + source, below the image. */}
+                                            <div className="flex items-center gap-2 px-2.5 py-2">
+                                                <HeroIcon heroName={card.heroName} />
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="truncate text-sm font-semibold text-text-primary">
+                                                        {card.heroName}
+                                                    </div>
+                                                    <div className="truncate text-[11px] text-text-secondary">
+                                                        {sourceLabel(card.modName ?? mod?.name, card.sourceFileName)}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )
+                    )}
+
+                    {tab === 'sounds' && (
+                        sounds.length === 0 ? (
+                            <EmptyState
+                                kind="sounds"
+                                onOpenLocker={() => {
+                                    onClose();
+                                    navigate('/locker');
+                                }}
+                            />
+                        ) : (
+                            <div className="space-y-3">
+                                {gameRunning && (
+                                    <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+                                        <RefreshCw className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                                        <span>
+                                            Restart Deadlock for sound changes to take effect (addons mount at game start).
+                                        </span>
+                                    </div>
+                                )}
+                                {sounds.map((sound) => {
+                                    const mod = modByFile.get(sound.sourceFileName);
+                                    const key = `sound:${sound.heroName}:${sound.slot}`;
+                                    const paramKey = `${sound.heroName}:${sound.slot}`;
+                                    const params = paramsByKey.get(paramKey) ?? sound.params ?? {};
+                                    return (
+                                        <div
+                                            key={key}
+                                            className="overflow-hidden rounded-md border border-border bg-bg-tertiary/40"
+                                        >
+                                            <div className="flex items-center gap-3 p-2.5">
+                                                <HeroIcon heroName={sound.heroName} />
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="flex items-center gap-1.5">
+                                                        <span className="truncate text-sm font-medium text-text-primary">
+                                                            {sound.heroName}
+                                                        </span>
+                                                        <span className="flex-shrink-0 rounded-full bg-bg-tertiary px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-secondary">
+                                                            {abilityLabel(sound.slot)}
+                                                        </span>
+                                                        {sound.tuned && (
+                                                            <SlidersHorizontal
+                                                                className="h-3 w-3 text-accent"
+                                                                aria-label="volume/pitch tuned"
+                                                            />
+                                                        )}
+                                                    </div>
+                                                    <div className="truncate text-xs text-text-secondary">
+                                                        {sourceLabel(sound.modName ?? mod?.name, sound.sourceFileName)}
+                                                    </div>
+                                                </div>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    icon={removing === key ? undefined : RotateCcw}
+                                                    isLoading={removing === key}
+                                                    disabled={busy}
+                                                    onClick={() => removeSound(sound.heroName, sound.slot)}
+                                                >
+                                                    Remove
+                                                </Button>
+                                            </div>
+                                            {mod?.audioUrl && (
+                                                <div className="px-2.5 pb-2">
+                                                    <AudioPreviewPlayer
+                                                        src={mod.audioUrl}
+                                                        compact
+                                                        variant="inline"
+                                                    />
+                                                </div>
+                                            )}
+                                            <ParamSliders
+                                                params={params}
+                                                saving={savingKey === paramKey}
+                                                disabled={busy && savingKey !== paramKey}
+                                                onChange={(next) =>
+                                                    handleParamChange(
+                                                        sound.heroName,
+                                                        sound.slot,
+                                                        sound.sourceFileName,
+                                                        next,
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )
+                    )}
+                </div>
+
+                {/* Footer: per-tab clear-all + a link to add more in the Locker. */}
+                <div className="flex items-center justify-between gap-3 border-t border-border px-5 py-3">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onClose();
+                            navigate('/locker');
+                        }}
+                        className="flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary cursor-pointer"
+                    >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        Add or change in the Locker
+                    </button>
+                    {((tab === 'cards' && cards.length > 0) || (tab === 'sounds' && sounds.length > 0)) && (
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            icon={RotateCcw}
+                            isLoading={clearing === tab}
+                            disabled={busy}
+                            onClick={() => clearTab(tab)}
+                        >
+                            Remove all {tab === 'cards' ? 'cards' : 'sounds'}
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Per-tab empty state with a nudge toward the Locker, where overrides are added. */
+function EmptyState({
+    kind,
+    onOpenLocker,
+}: {
+    kind: Tab;
+    onOpenLocker: () => void;
+}) {
+    const Icon = kind === 'cards' ? ImageIcon : Volume2;
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+            <Icon className="h-8 w-8 text-text-secondary/50" />
+            <p className="text-sm text-text-secondary">
+                No {kind === 'cards' ? 'hero card' : 'ability sound'} overrides applied yet.
+            </p>
+            <Button variant="secondary" size="sm" icon={ExternalLink} onClick={onOpenLocker}>
+                Open the Locker
+            </Button>
+        </div>
+    );
+}

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -115,8 +115,12 @@ export default function PriorityEditor({
       aria-label={`Load order ${priority}. Click to change.`}
     >
       <span
-        className={`inline-flex h-[22px] min-w-[30px] items-center justify-center rounded-md border border-accent/55 bg-[rgba(10,20,24,0.72)] px-2 text-[11px] font-bold leading-none tabular-nums text-accent shadow-none transition-colors duration-150 group-hover/order-chip:border-accent/85 group-hover/order-chip:bg-accent/10 group-focus-visible/order-chip:outline group-focus-visible/order-chip:outline-2 group-focus-visible/order-chip:outline-accent/35 ${
-          variant === 'overlay' ? 'backdrop-blur-sm' : ''
+        // White number on a neutral dark scrim (overlay) or the standard input
+        // surface (inline), with a subtle grey border so it reads as a quiet
+        // card chip rather than an accent-highlighted control. Neutral greys keep
+        // it on-theme regardless of the user's accent hue.
+        className={`inline-flex h-[22px] min-w-[30px] items-center justify-center rounded-md border border-white/20 px-2 text-[11px] font-bold leading-none tabular-nums text-text-primary shadow-none transition-colors duration-150 group-hover/order-chip:border-white/35 group-hover/order-chip:bg-white/10 group-focus-visible/order-chip:outline group-focus-visible/order-chip:outline-2 group-focus-visible/order-chip:outline-white/40 ${
+          variant === 'overlay' ? 'bg-black/55 backdrop-blur-sm' : 'bg-bg-tertiary'
         }`}
       >
         #{priority}
@@ -128,13 +132,13 @@ export default function PriorityEditor({
       )}
       {editing && popoverPos && createPortal(
         <div
-          className="fixed z-[9999] w-40 rounded-lg border border-white/10 bg-bg-primary/95 p-2.5 text-left shadow-xl"
+          className="fixed z-[9999] w-40 rounded-lg border border-border bg-bg-secondary p-2.5 text-left shadow-xl"
           style={{ top: popoverPos.top, left: popoverPos.left }}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >
           <span className="mb-2 block text-xs font-semibold text-text-primary">Load order</span>
-          <span className="inline-flex h-8 w-full items-center rounded-md border border-accent/55 bg-bg-tertiary/80 px-2 text-sm text-text-primary">
+          <span className="inline-flex h-9 w-full items-center rounded-md border border-border bg-bg-tertiary px-2.5 text-sm text-text-primary transition-colors focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/30">
             <span className="mr-1 text-text-secondary">#</span>
             <input
               ref={inputRef}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
 import type { HeroPortrait } from '../types/portrait';
 import type {
   GameBananaModsResponse,
@@ -136,6 +136,18 @@ export async function revertHeroSound(
 
 export async function getActiveHeroSounds(heroName: string): Promise<ActiveHeroSound[]> {
   return window.electronAPI.getActiveHeroSounds(heroName);
+}
+
+export async function getLockerOverview(): Promise<LockerOverview> {
+  return window.electronAPI.getLockerOverview();
+}
+
+export async function getLockerCardThumbnails(): Promise<LockerCardThumbnail[]> {
+  return window.electronAPI.getLockerCardThumbnails();
+}
+
+export async function clearLockerOverrides(scope: LockerClearScope): Promise<void> {
+  return window.electronAPI.clearLockerOverrides(scope);
 }
 
 export async function setModGlobalType(

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -2084,7 +2084,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
               }
             : {
                 background:
-                  'linear-gradient(to top, rgba(0,0,0,0.95) 0%, rgba(0,0,0,0.7) 22%, rgba(0,0,0,0.25) 55%, transparent 80%)',
+                  'linear-gradient(to top, rgba(0,0,0,0.97) 0%, rgba(0,0,0,0.86) 30%, rgba(0,0,0,0.5) 55%, rgba(0,0,0,0.12) 78%, transparent 100%)',
               }
         }
       />
@@ -2127,7 +2127,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
           </div>
         </div>
       ) : (
-        <div className={`absolute bottom-0 left-0 right-0 ${isCompact ? 'p-2.5' : 'p-3'}`}>
+        <div className={`absolute bottom-0 left-0 right-0 ${isCompact ? 'p-2.5 pr-11' : 'p-3 pr-12'}`}>
           <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
           <div className={`flex items-center gap-3 text-white/90 mt-1 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] flex-wrap ${isCompact ? 'text-xs' : 'text-sm'}`}>
             <span className="flex items-center gap-1"><ThumbsUp className={isCompact ? 'w-3 h-3' : 'w-3.5 h-3.5'} />{formatCount(mod.likeCount)}</span>
@@ -2212,8 +2212,10 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
         </div>
       )}
 
-      {/* Download / Enable button overlay — top right with backdrop */}
-      <div className="absolute top-2 right-2">
+      {/* Download / Enable button overlay. Anchored bottom-right alongside the
+          title (where the eye already lands); sound cards with an audio player
+          keep it top-right so it doesn't collide with the pinned player. */}
+      <div className={`absolute right-2 ${isSoundSection && hasAudioPreview ? 'top-2' : 'bottom-2'}`}>
         {installed && installedDisabled && onEnable ? (
           // Mod just installed but still in the disabled folder. Surface an
           // inline Enable affordance right where the user's eye is rather

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -27,6 +27,7 @@ import {
   AlertTriangle,
   FolderOpen,
   FilePlus,
+  Files,
   X,
   ImagePlus,
   Search,
@@ -3664,7 +3665,6 @@ interface ModListRowContentProps {
   manualTagChipClasses: string;
   inferredTagChipClasses: string;
   dangerInlineChipClasses: string;
-  accentInlineChipClasses: string;
   tagIconClassName: string;
   technicalMetaClasses: string;
   actions: ReactNode;
@@ -3714,12 +3714,23 @@ function CategoryChip({
   label,
   className,
   iconClassName = 'h-4 w-4',
+  iconOnly = false,
 }: {
   label: string;
   className: string;
   iconClassName?: string;
+  /** When the category is a hero, collapse to the bare face icon (no frame, no
+   *  truncated name) to match the locker-hero chip in cards. */
+  iconOnly?: boolean;
 }) {
   const heroName = heroNameForLabel(label);
+  if (heroName && iconOnly) {
+    return (
+      <span className="inline-flex flex-shrink-0 items-center" title={label}>
+        <HeroTagLabel heroName={heroName} iconClassName={iconClassName} iconOnly />
+      </span>
+    );
+  }
   return (
     <span className={className} title={label}>
       {heroName ? (
@@ -3790,7 +3801,6 @@ function ModListRowContent({
   manualTagChipClasses,
   inferredTagChipClasses,
   dangerInlineChipClasses,
-  accentInlineChipClasses,
   tagIconClassName,
   technicalMetaClasses,
   actions,
@@ -3890,11 +3900,13 @@ function ModListRowContent({
             {formatRelativeDate(mod.installedAt)}
           </span>
           {group && (
-            <MetaTextChip
-              label={`${variantStatusLabel} files`}
-              className={accentInlineChipClasses}
+            <span
+              className="inline-flex flex-shrink-0 items-center gap-1 tabular-nums text-text-secondary"
               title={variantStatusTitle}
-            />
+            >
+              <Files className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              {variantStatusLabel}
+            </span>
           )}
           {!group && (
             <span className={technicalMetaClasses} title={mod.fileName}>
@@ -4078,7 +4090,6 @@ function ModCard({
   const manualTagChipClasses = `${baseChipClasses} border border-accent/30 bg-accent/10 text-accent`;
   const inferredTagChipClasses = `${baseChipClasses} border border-sky-400/35 bg-sky-500/15 text-sky-100`;
   const dangerInlineChipClasses = `${baseChipClasses} flex-shrink-0 border border-state-danger/40 bg-state-danger/10 text-state-danger`;
-  const accentInlineChipClasses = `${baseChipClasses} flex-shrink-0 border border-accent/30 bg-accent/10 text-accent tabular-nums`;
   const technicalMetaClasses = 'min-w-0 truncate font-mono text-[11px] text-text-secondary/55 hover:text-text-secondary cursor-help';
   const utilityActionClasses = 'inline-flex h-7 w-7 items-center justify-center rounded-md text-text-secondary transition-all duration-200 hover:bg-bg-tertiary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 cursor-pointer disabled:opacity-60';
   const menuItemClasses = 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary focus:outline-none focus-visible:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50';
@@ -4410,7 +4421,6 @@ function ModCard({
             manualTagChipClasses={manualTagChipClasses}
             inferredTagChipClasses={inferredTagChipClasses}
             dangerInlineChipClasses={dangerInlineChipClasses}
-            accentInlineChipClasses={accentInlineChipClasses}
             tagIconClassName={tagIconClassName}
             technicalMetaClasses={technicalMetaClasses}
             actions={actions}
@@ -4533,22 +4543,27 @@ function ModCard({
                 iconClassName={tagIconClassName}
                 iconOnly
               />
-              {showCategoryChip && mod.categoryName && (
+              {showCategoryChip && mod.categoryName && heroNameForLabel(mod.categoryName) !== mod.lockerHero && (
                 <CategoryChip
                   label={mod.categoryName}
                   className={metaChipClasses}
                   iconClassName={tagIconClassName}
+                  iconOnly
                 />
               )}
               {showNsfwChip && (
                 <MetaTextChip label="18+" className={dangerInlineChipClasses} />
               )}
               {showGroupChip && (
-                <MetaTextChip
-                  label={`${variantStatusLabel} files`}
-                  className={accentInlineChipClasses}
+                // Enabled/total variant count as a quiet icon + number (no accent,
+                // no border, no "files" label) so it reads as metadata, not a tag.
+                <span
+                  className="inline-flex flex-shrink-0 items-center gap-1 text-[11px] tabular-nums text-text-secondary"
                   title={variantStatusTitle}
-                />
+                >
+                  <Files className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                  {variantStatusLabel}
+                </span>
               )}
               {!isCompact && (
                 <span

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -48,11 +48,12 @@ import {
   Tag as TagIcon,
   Pencil,
   MoreHorizontal,
+  Wand2,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, extractMergeSource, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, extractMergeSource, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModFilterGuess, MergedModSource } from '../types/mod';
@@ -68,6 +69,7 @@ import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChip
 import { setModGlobalType } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
+import { LockerOverridesModal } from '../components/LockerOverridesModal';
 import { ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
 
 function formatBytes(bytes: number): string {
@@ -223,7 +225,11 @@ function SortableModEntry({
   return (
     <div
       ref={setNodeRef}
-      className={disabled ? undefined : 'cursor-grab active:cursor-grabbing'}
+      // Each card carries a transform (its own stacking context), so a card's
+      // open action menu can only paint within that card. When the menu opens
+      // downward it would land behind the next card; lift this wrapper above its
+      // siblings whenever it contains an open menu so the dropdown stays on top.
+      className={`has-[[data-card-menu-open]]:z-20 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       style={style}
       {...attributes}
       {...listeners}
@@ -345,6 +351,23 @@ export default function Installed() {
   }, [cardSize]);
   const viewMode: ViewMode =
     layout === 'list' ? 'list' : cardSize < COMPACT_CARD_THRESHOLD ? 'compact' : 'grid';
+  // Locker overrides (hero cards + ability sounds) live off the mod list in
+  // citadel/grimoire. The toolbar icon opens the manage popup; the badge shows
+  // how many are applied. Count is fetched on mount (covers changes made over
+  // in the Locker) and refreshed from the popup's onChanged.
+  const [lockerOverridesOpen, setLockerOverridesOpen] = useState(false);
+  const [lockerOverrideCount, setLockerOverrideCount] = useState(0);
+  const refreshLockerOverrideCount = useCallback(async () => {
+    try {
+      const ov = await getLockerOverview();
+      setLockerOverrideCount(ov.cards.length + ov.sounds.length);
+    } catch {
+      setLockerOverrideCount(0);
+    }
+  }, []);
+  useEffect(() => {
+    void refreshLockerOverrideCount();
+  }, [refreshLockerOverrideCount]);
   const [search, setSearch] = useState('');
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
   // Raw pair count from detectConflicts. conflictMap.size / 2 only works when
@@ -1040,6 +1063,20 @@ export default function Installed() {
     setSelectMode(false);
     setSelectedIds(new Set());
   };
+
+  // ESC leaves bulk-select mode (same as the toolbar toggle / X). Guarded so it
+  // doesn't fire mid bulk-operation or steal ESC from the delete-confirm modal.
+  useEffect(() => {
+    if (!selectMode) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !bulkProgress && !modToDelete) {
+        setSelectMode(false);
+        setSelectedIds(new Set());
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectMode, bulkProgress, modToDelete]);
 
   const handleDeleteConfirm = async () => {
     if (!modToDelete) return;
@@ -2141,6 +2178,25 @@ export default function Installed() {
               title={selectMode ? 'Exit selection mode' : 'Select multiple mods for bulk delete, enable, or disable'}
             />
 
+            {/* Locker overrides: hero cards + ability sounds applied off the
+                mod list. The badge shows how many are active; the popup reviews,
+                previews, and removes them. */}
+            <div className="relative">
+              <Button
+                variant="secondary"
+                onClick={() => setLockerOverridesOpen(true)}
+                icon={Wand2}
+                className="!px-2.5"
+                aria-label="Locker overrides"
+                title="Locker overrides: review and remove applied hero cards and ability sounds"
+              />
+              {lockerOverrideCount > 0 && (
+                <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-bg-primary">
+                  {lockerOverrideCount}
+                </span>
+              )}
+            </div>
+
             {/* Card-size slider: only meaningful in grid layout, so it's
                 disabled (and dimmed) while List is active rather than hidden,
                 keeping the toolbar from reflowing as you switch. */}
@@ -2176,6 +2232,16 @@ export default function Installed() {
           </div>
         </div>
       </div>
+
+      {lockerOverridesOpen && (
+        <LockerOverridesModal
+          onClose={() => setLockerOverridesOpen(false)}
+          onChanged={() => {
+            void refreshLockerOverrideCount();
+            loadMods({ silent: true });
+          }}
+        />
+      )}
 
       {searchNeedle && totalMatches === 0 && (
         <div className="flex flex-col items-center justify-center py-16 text-text-secondary">
@@ -3623,7 +3689,7 @@ function ChipText({ children }: { children: ReactNode }) {
   return <span className="relative top-[1.5px] min-w-0 truncate leading-[14px]">{children}</span>;
 }
 
-function HeroTagLabel({ heroName, iconClassName = 'h-4 w-4' }: { heroName: string; iconClassName?: string }) {
+function HeroTagLabel({ heroName, iconClassName = 'h-4 w-4', iconOnly = false }: { heroName: string; iconClassName?: string; iconOnly?: boolean }) {
   return (
     <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 align-middle leading-none">
       <img
@@ -3633,7 +3699,7 @@ function HeroTagLabel({ heroName, iconClassName = 'h-4 w-4' }: { heroName: strin
         className={`${iconClassName} block flex-shrink-0 rounded-full object-cover`}
         loading="lazy"
       />
-      <ChipText>{heroName}</ChipText>
+      {!iconOnly && <ChipText>{heroName}</ChipText>}
     </span>
   );
 }
@@ -3678,18 +3744,32 @@ function LockerHeroChip({
   manualTagChipClasses,
   inferredTagChipClasses,
   iconClassName = 'h-4 w-4',
+  iconOnly = false,
 }: {
   mod: { lockerHero?: string; lockerHeroSource?: Mod['lockerHeroSource'] };
   manualTagChipClasses: string;
   inferredTagChipClasses: string;
   iconClassName?: string;
+  /** Drop the hero name and show just the face icon. Used in the card grid,
+   *  where a narrow chip otherwise truncates the name to a useless "L." */
+  iconOnly?: boolean;
 }) {
   if (!mod.lockerHero) return null;
   const isManual = mod.lockerHeroSource === 'manual';
+  const title = `${lockerHeroSourceLabel(mod.lockerHeroSource)}: ${mod.lockerHero}`;
+  // Icon-only (card grid): just the bare face icon, no accent chip frame — the
+  // colored manual/inferred border reads as a highlight that fights the theme.
+  if (iconOnly) {
+    return (
+      <span className="inline-flex flex-shrink-0 items-center" title={title}>
+        <HeroTagLabel heroName={mod.lockerHero} iconClassName={iconClassName} iconOnly />
+      </span>
+    );
+  }
   return (
     <span
       className={isManual ? manualTagChipClasses : inferredTagChipClasses}
-      title={`${lockerHeroSourceLabel(mod.lockerHeroSource)}: ${mod.lockerHero}`}
+      title={title}
     >
       <HeroTagLabel heroName={mod.lockerHero} iconClassName={iconClassName} />
     </span>
@@ -3882,6 +3962,10 @@ function ModCard({
   const [tagPickerOpen, setTagPickerOpen] = useState(false);
   const [menuBusy, setMenuBusy] = useState(false);
   const [menuError, setMenuError] = useState<string | null>(null);
+  // The menu (and its tall tag picker) opens upward by default, but for cards
+  // near the top of the scroll area that clips it. Flip downward when there's
+  // little room above. Measured from the trigger on open.
+  const [menuPlacement, setMenuPlacement] = useState<'up' | 'down'>('up');
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -4027,7 +4111,9 @@ function ModCard({
   const titleClasses = isCompact
     ? 'text-[14px] font-semibold leading-[18px] truncate'
     : 'text-[15px] font-medium leading-[19px] truncate';
-  const gridTagsClasses = viewMode === 'compact' ? 'h-[26px] flex-nowrap' : 'h-7 flex-nowrap';
+  // Compact cards stay single-line (too small to wrap nicely); standard grid
+  // cards wrap so a hero + category + 18+ + files chip never clips mid-chip.
+  const gridTagsClasses = viewMode === 'compact' ? 'h-[26px] flex-nowrap' : 'min-h-7 flex-wrap';
   const showCategoryChip = viewMode !== 'compact' || !mod.lockerHero;
   const compactBaseChipCount =
     (mod.lockerHero ? 1 : 0) + (showCategoryChip && mod.categoryName ? 1 : 0);
@@ -4040,7 +4126,18 @@ function ModCard({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            setMenuOpen((open) => !open);
+            setMenuOpen((open) => {
+              const willOpen = !open;
+              if (willOpen && menuRef.current) {
+                const rect = menuRef.current.getBoundingClientRect();
+                // The menu can grow tall (tag picker). Prefer opening upward,
+                // but flip down when there's clearly more room below.
+                const spaceAbove = rect.top;
+                const spaceBelow = window.innerHeight - rect.bottom;
+                setMenuPlacement(spaceAbove < 340 && spaceBelow > spaceAbove ? 'down' : 'up');
+              }
+              return willOpen;
+            });
             setTagPickerOpen(false);
             setMenuError(null);
           }}
@@ -4055,7 +4152,10 @@ function ModCard({
         {menuOpen && (
           <div
             role="menu"
-            className="absolute bottom-full right-0 z-[70] mb-2 w-56 rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
+            data-card-menu-open
+            className={`absolute right-0 z-[70] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in ${
+              menuPlacement === 'up' ? 'bottom-full mb-2' : 'top-full mt-2'
+            }`}
           >
             {menuError && (
               <div className="mb-1 rounded-md border border-state-danger/30 bg-state-danger/10 px-2 py-1.5 text-xs text-state-danger">
@@ -4431,6 +4531,7 @@ function ModCard({
                 manualTagChipClasses={manualTagChipClasses}
                 inferredTagChipClasses={inferredTagChipClasses}
                 iconClassName={tagIconClassName}
+                iconOnly
               />
               {showCategoryChip && mod.categoryName && (
                 <CategoryChip

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -13,6 +13,14 @@ interface CacheEntry<T> {
 // TTL for download counts cache (1 hour in ms)
 const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 
+// Monotonic generation guard for the mods list. loadMods claims a generation
+// before its (async) scan and only writes if it's still current; mutations that
+// replace the list (e.g. custom-mod import) bump it. This stops a slow silent
+// reload — notably the focus refresh fired when the OS file picker closes — from
+// resolving late and clobbering a just-completed mutation with a stale scan
+// (the "added a custom mod but can't act on it until I refresh" bug).
+let modsGeneration = 0;
+
 // Browse-page UI state. Kept in the store (not local component state) so it
 // survives navigation away from /browse and back — user complaint: search
 // query, view mode, and filters all reset when switching pages.
@@ -278,12 +286,23 @@ export const useAppStore = create<AppState>((set, get) => ({
   // doesn't flash the skeleton over already-rendered content.
   loadMods: async (opts) => {
     const silent = !!opts?.silent;
+    const gen = ++modsGeneration;
     if (!silent) set({ modsLoading: true, modsError: null });
     try {
       const mods = await api.getMods();
-      set(silent ? { mods, modsLoaded: true, modsError: null } : { mods, modsLoaded: true, modsLoading: false });
+      if (gen === modsGeneration) {
+        set(silent ? { mods, modsLoaded: true, modsError: null } : { mods, modsLoaded: true, modsLoading: false });
+      } else if (!silent) {
+        // Superseded by a newer load/mutation: drop the stale list, but still
+        // clear our own spinner so the page doesn't hang on it.
+        set({ modsLoading: false });
+      }
     } catch (err) {
-      set(silent ? { modsError: String(err) } : { modsError: String(err), modsLoading: false });
+      if (gen === modsGeneration) {
+        set(silent ? { modsError: String(err) } : { modsError: String(err), modsLoading: false });
+      } else if (!silent) {
+        set({ modsLoading: false });
+      }
     }
   },
 
@@ -401,6 +420,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   importCustomMod: async (args) => {
     try {
       const updated = await api.importCustomMod(args);
+      // Bump the generation so any in-flight silent reload (e.g. the focus
+      // refresh from the just-closed file picker) can't overwrite this with a
+      // scan taken before the new VPK landed.
+      modsGeneration++;
       set({ mods: updated });
     } catch (err) {
       // At the 99-active cap, importing (which lands enabled) can't claim a

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -16,6 +16,9 @@ import type {
     AbilitySoundParams,
     ActiveHeroSound,
     ApplyHeroSoundResult,
+    LockerOverview,
+    LockerCardThumbnail,
+    LockerClearScope,
 } from './mod';
 import type {
     GameBananaModsResponse,
@@ -319,6 +322,9 @@ export interface ElectronAPI {
     ) => Promise<ApplyHeroSoundResult>;
     revertHeroSound: (heroName: string, slot: AbilitySlot) => Promise<ApplyHeroSoundResult>;
     getActiveHeroSounds: (heroName: string) => Promise<ActiveHeroSound[]>;
+    getLockerOverview: () => Promise<LockerOverview>;
+    getLockerCardThumbnails: () => Promise<LockerCardThumbnail[]>;
+    clearLockerOverrides: (scope: LockerClearScope) => Promise<void>;
     setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<Mod>;
     setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -139,6 +139,48 @@ export interface ApplyHeroSoundResult {
   missingSourceFileNames: string[];
 }
 
+/** One applied hero-card override, summarized for the Locker Overrides popup. */
+export interface LockerOverviewCard {
+  heroName: string;
+  /** Source VPK filename whose card art is applied. Joins to the installed mod
+   *  for its thumbnail/name; the revert itself is keyed by heroName. */
+  sourceFileName: string;
+  modName?: string;
+}
+
+/** One applied ability-sound override, summarized for the popup. */
+export interface LockerOverviewSound {
+  heroName: string;
+  slot: AbilitySlot;
+  /** Source VPK filename providing this ability's clip. Joins to the installed
+   *  mod for its preview audio/name; the revert is keyed by (heroName, slot). */
+  sourceFileName: string;
+  modName?: string;
+  /** True when this slot carries a non-neutral volume/pitch retune. */
+  tuned: boolean;
+  /** The applied volume/pitch retune, so the popup's sliders reflect it. */
+  params?: AbilitySoundParams;
+}
+
+/** Everything the Locker is currently overriding, for the Locker Overrides popup. */
+export interface LockerOverview {
+  cards: LockerOverviewCard[];
+  sounds: LockerOverviewSound[];
+}
+
+/** Which slice of Locker overrides to clear. */
+export type LockerClearScope = 'all' | 'cards' | 'sounds';
+
+/** One applied hero card decoded to a preview thumbnail, for the popup. Decoded
+ *  on demand from the managed cosmetics VPK (the real applied art, not the
+ *  source mod's GameBanana cover), so it's a separate call from the cheap
+ *  overview/count. */
+export interface LockerCardThumbnail {
+  heroName: string;
+  /** PNG data URL of the most representative applied variant (card cover first). */
+  dataUrl: string;
+}
+
 /** The source (and any volume/pitch retune) applied for one ability slot, read
  *  back so the picker can reflect the active pick + slider positions. */
 export interface ActiveHeroSound {
@@ -416,4 +458,6 @@ export interface AppSettings {
   accentColor: string;
   /** Order used to render absolute dates (mod/file upload + update dates). */
   dateFormat: 'MM/DD/YYYY' | 'DD/MM/YYYY';
+  /** UI zoom factor (Ctrl +/-/0), persisted across launches. 1 = 100%. */
+  zoomFactor?: number;
 }


### PR DESCRIPTION
## Summary

Builds on the Grimoire-managed `citadel/grimoire` folder to add a global **Locker Overrides** manager, plus a batch of Installed/Browse quality-of-life fixes from #91.

### Locker Overrides
- Global toolbar icon on the Installed tab (with a count badge) opens a two-tab popup: **Hero Cards** and **Ability Sounds**, replacing the old Installed status card.
- Per override: preview audio, retune volume/pitch (sounds), and **Remove** (reverts to default, never deletes the source mod). Per-tab clear-all.
- Cards show the **real applied art** decoded from the managed cosmetics VPK (lazy IPC, kept off the cheap badge-count path), laid out like Installed cards. Sound rows show hero face icons.

### Installed / Browse QOL (#91)
- **Zoom**: Ctrl `+` / `-` / `0` scales the UI (persisted across launches) for hi-DPI laptops.
- **Stale-until-refresh fix**: a generation guard in `loadMods` so a late focus-triggered reload cannot clobber a just-completed mutation (the 'added a custom mod but cannot act on it' report).
- Actions/tag menu **flips down** instead of clipping at the top of the list, with a stacking-context z-order fix.
- Tag chips **wrap** instead of clipping when a card has many tags; locker-hero chip is **icon-only** in cards.
- Browse card: **stronger title gradient** plus download button moved **beside the title**.
- Priority `#` badge recolored to neutral grey; load-order input modernized; **ESC exits bulk-select**.

### Not in this PR (larger, deferred)
From #91, these need their own design pass and are not included: sidebar IA redesign (combine Browse/Discover, Library grouping, top tabs), Installed sort options, multi-download queue, category-to-dropdown, aggregate from Deadlocker, NSFW-only toggle, smaller browse blocks.

## Testing
- TypeScript strict (`tsc` for app + main) and ESLint pass.
- No test framework in this repo; verified by typecheck/lint and manual review. Zoom is a main-process change (needs an app restart to load).

Addresses #91 (partial).