### PR TITLE
feat(mods): lift 99-mod ceiling via multi-folder addon overflow

### DIFF
--- a/docs/multi-folder-addon-overflow.md
+++ b/docs/multi-folder-addon-overflow.md
@@ -1,0 +1,342 @@
+# Multi-folder addon overflow
+
+Status: implemented (W1-W10 landed); renderer polish (W11) optional
+Owner: Slush97
+Last updated: 2026-05-27
+
+## Goal
+
+Lift the effective 99-mod ceiling by overflowing enabled mods into sibling addon
+folders (`citadel/addons1`, `addons2`, ...), each carrying its own `pak01`-`pak99`
+namespace and each added as an additional `Game` search path in `gameinfo.gi`.
+Existing installs stay byte-identical until a user actually crosses 99.
+
+### Why the limit exists today
+
+The "99" is not a hard engine cap. It is purely the per-folder 2-digit `pakNN`
+naming convention (`pak01_dir.vpk` .. `pak99_dir.vpk`) applied to the single
+`citadel/addons` folder. Proof the engine mounts more than 99 VPKs already: the
+`citadel/grimoire` folder (Locker overrides, listed first in SearchPaths) mounts
+its own `pak01`/`pak02` alongside the 99 in `citadel/addons`, so a user can
+already have 101 VPKs loaded. Adding more `Game citadel/addonsN` search paths,
+each with its own `pak01`-`pak99`, multiplies the budget.
+
+## Core model
+
+**Folder list.** An ordered set of addon roots under `citadel/`: index 0 =
+`addons` (the existing one), index N = `addons{N}`. `.disabled/` stays a single
+shared parking lot under base `addons` (disabled mods carry no slot, so they
+never need overflow).
+
+**Asymmetric keying (the backwards-compat guarantee).**
+
+- Base `addons/` and `.disabled/` -> metadata key + id source = **bare filename**,
+  exactly as today.
+- Overflow `addons{N}/` -> key = **`addons{N}/<filename>`**.
+
+So every existing mod keeps its current `id` and metadata key; only
+never-before-seen overflow mods get namespaced keys. No migration of existing
+data. (The earlier "uniform relative path for everything" idea was rejected
+because it would re-key every existing user's metadata and force a one-time
+migration: mass data-loss risk for thousands of installs.)
+
+**Load-order model (Model A: folder dominates).** Global precedence = folder
+order in `SearchPaths`, then `pakNN` within the folder. A flat user-ordered list
+of length L maps to `folder = floor((pos-1)/99)`, `slot = ((pos-1) % 99) + 1`.
+Backed by the `citadel/grimoire` precedent (`lockerVpk.ts`: listed first,
+documented to "outrank every user mod by folder precedence"). See Gate 0.
+
+## Gate 0: precedence (RESOLVED 2026-05-27 - Model A confirmed)
+
+In-game test confirmed: **folder order in SearchPaths is the primary precedence
+key, then ascending pakNN within each folder** (pak01 is highest priority in a
+folder, and the earlier-listed folder outranks a later one). This is Model A.
+
+Global load-order position = `folderIndex * 99 + slot` (folderIndex 0 = base
+`citadel/addons`, slot in 1..99; LOWER position = higher priority, wins file
+collisions). So base `addons` holds positions 1-99, `addons1` holds 100-198
+(`addons1/pak01` = position 100), `addons2` holds 199-297, etc.
+
+Reverse mapping (flat user-ordered list -> disk):
+`folderIndex = floor((pos - 1) / 99)`, `slot = ((pos - 1) % 99) + 1`.
+
+Still unverified: whether the engine tolerates a listed SearchPath whose folder
+doesn't exist on disk. Sidestepped by lazy-listing (create the folder, THEN add
+its Game path), so we never list a missing folder. See open decisions.
+
+## Workstream 1: folder + key primitives (`deadlock.ts`) [foundational]
+
+- `getAddonFolderPaths(deadlockPath): string[]` - ordered absolute paths of
+  existing addon roots (base first). Base always included.
+- `overflowAddonsPath(deadlockPath, index): string` - `citadel/addons{index}`,
+  mkdir on demand (mirrors `getGrimoirePath` at `deadlock.ts:186`).
+- `metaKeyFor(absVpkPath, deadlockPath): string` - pure derivation: base
+  `addons/` and `.disabled/` -> bare filename; overflow -> `addons{N}/<file>`.
+  Single source of truth for the key rule.
+
+## Workstream 2: metadata keying `fileName` -> `metaKey` (wide, mechanical)
+
+Add `metaKey: string` to the `Mod` interface (`mods.ts:25`), set in `scanFolder`.
+Route every metadata call that currently keys off a **scanned mod's `fileName`**
+through `metaKey`:
+
+| File | Sites |
+|---|---|
+| `mods.ts` | `enableMod` (`:492`), `disableMod` (`:524`), `deleteMod` `removeModMetadata` (`:547`), `moveModToFolderAs` remember/migrate (`:392`,`:400`), `setModPriority` (`:596`-`599`), `reconcile` (`:304`) |
+| `conflicts.ts` | `getModMetadata(m.fileName)` (`:141`) |
+| `profiles.ts` | `toProfileMod` (`:158`), save (`:194`), apply index (`:304`) |
+| `portableProfile.ts` | (`:102`,`:183`) |
+| `lockerVpk.ts` | `isLockerManaged` (`:125`), `migrateManagedVpksToGrimoire` (`:102`), `lockerRank` (`:131`) |
+| `metadata.ts` | `pruneOrphanMetadata` valid-set built from **relative keys across all folders** (`:263`); sha256 backfill loop iterates **all** addon folders, not just `[addons, disabled]` (`:212`) |
+
+For raw-filename callers without a `Mod` (download staging, reconcile), use
+`metaKeyFor(path, ...)`. Base mods produce `metaKey === fileName`, so existing
+metadata still resolves.
+
+## Workstream 3: scan (`mods.ts`)
+
+- `scanMods` (`:255`): scan base + every overflow folder + `.disabled` (currently
+  just `[addons, disabled]` at `:256`-`264`). Set `metaKey` per mod.
+- `scanFolder` (`:210`): accept the folder's key-prefix so it can stamp `metaKey`.
+- `reconcileEnabledDisabledCollisions` (`:274`): scope to the base folder. The
+  enabled-vs-disabled same-name heal must not false-trigger across overflow
+  folders, where `pak01_dir.vpk` can legitimately exist in several.
+
+## Workstream 4: enable + slot allocation (`mods.ts`)
+
+- `folderPakNumbers` (`:172`) already folder-local: reuse per overflow folder.
+- `enableMod` (`:465`): walk folders in order; place in the first folder with a
+  free slot via `pickEnableSlot` (`:189`) against that folder's local `forbidden`
+  set. If all current folders are full, create the next overflow folder (and, if
+  lazy-listing, patch gameinfo to add its `Game` path). Destination path is now
+  folder-relative.
+- `findNextAvailablePriority`/`getUsedPriorities` (`:417`,`:445`): become
+  folder-scoped, or are replaced by the per-folder allocator. The cross-folder
+  id-collision guard in `forbidden` is no longer needed for overflow (prefixed
+  keys can't collide with bare); keep it within base addons.
+- Retire / re-message `ENABLE_LIMIT_MESSAGE` (`:20`). Renderer matches this
+  string for its toast (`src/pages/Installed.tsx`); update both together.
+
+## Workstream 5: reorder / setPriority / swap (`mods.ts`) [the gnarly one]
+
+- `reorderMods` (`:619`): the flat ordered list can now exceed 99. Map position
+  -> `(folder, slot)` per Model A. Files crossing a folder boundary **move
+  folders** (rename into a different dir) and **change key** (bare<->prefixed).
+  The two-phase rename (`:661`-`707`) currently computes paths via
+  `dirname(mod.path)` (the *source* dir, `:666`); change to the *target* folder.
+  `migrateModMetadata` (`:709`) must carry the bare<->prefixed key change.
+- `setModPriority` (`:562`) and `swapModPriority`/`directSwap` (`:720`,`:757`):
+  these assume same-folder pak renames. Either constrain them to within-folder
+  moves or route cross-folder cases through `reorderMods`.
+
+## Workstream 6: gameinfo writer (`system.ts`)
+
+- `SEARCH_PATHS_BLOCK` (`:6`): render N overflow `Game citadel/addons{N}` lines
+  (between `citadel/addons` and `Mod citadel`, preserving order = precedence).
+- **Keep `hasRequiredSearchPaths` (`:112`) requiring only `addons` + `grimoire`.**
+  Overflow paths are additive and must NOT gate "configured", or every existing
+  user reads as misconfigured on update.
+- `fixGameinfo` (`:208`) / `insertSearchPaths` (`:132`): emit whatever overflow
+  paths currently exist on disk.
+- Add `ensureOverflowFolderConfigured(deadlockPath, index)` (mirrors
+  `lockerVpk.ts:ensureGrimoireConfigured`) called from `enableMod` when a new
+  folder is minted. **Lazy-list** recommended (add a `Game` path only when its
+  folder is first created) so we never list a missing folder, pending Gate 0.
+
+## Workstream 7: conflict detection (`conflicts.ts`)
+
+- Priority-conflict grouping (`:157`-`180`) keys on `mod.priority` (the pak
+  number). Two mods at `pak05` in **different folders are not a real conflict.**
+  Group by `(folder, pakNN)` instead, and update the "Both use pak05" message.
+- File-conflict detection (VPK content overlap) is unaffected and correct, but
+  the implied "winner" now follows the cross-folder global order: surface that
+  consistently.
+
+## Workstream 8: cosmetic scanners (`heroCards.ts` / `heroSounds.ts` / `heroPortraits.ts`)
+
+`listAddonVpks` scans `[addons, disabled]` (`heroCards.ts:62`, `heroSounds.ts:57`,
+`heroPortraits.ts:118`). Add overflow folders so applied-cosmetic detection still
+sees a mod that overflowed.
+
+## Workstream 9: vanilla stash (`launch.ts`)
+
+`stashEnabledMods` (`:187`) and `restoreFromStash` (`:239`) only move base
+`addons/`. They must stash/restore **every** addon folder, preserving each file's
+origin folder in the stash record (`VanillaStash.mods` gains a folder field) so
+restore returns each VPK to the right folder.
+
+## Workstream 10: cleanup / merge / IPC
+
+- `cleanupAddons` (`system.ts:290`, called from `ipc/system.ts:357`) and the
+  addons uses at `ipc/system.ts:126,297`: extend to all folders.
+- `modMerger.ts` (`:253`,`:596`): merged-output placement and source scanning
+  must be folder-aware.
+- `ipc/mods.ts:620`: audit the addons-path use.
+- `download.ts`: **no change.** New mods install disabled with free-form names
+  (`:607`,`:540`); overflow is purely an enable-time concern. State this in the
+  PR so reviewers don't look for it.
+
+## Workstream 11: renderer (optional polish)
+
+- Update the enable-limit toast copy in `src/pages/Installed.tsx` (matches
+  `ENABLE_LIMIT_MESSAGE`).
+- Priority/order display assumes 1-99; decide whether to show a flat global index
+  or folder-grouped. Conflicts page (`src/pages/Conflicts.tsx`) "Both use pakNN"
+  string mirrors the backend change.
+
+## Backwards-compat guarantees
+
+1. Existing mods keep their exact `id` and metadata key (bare-filename keying for
+   the base folder is preserved).
+2. No migration runs; first launch after update is a no-op for anyone under 99.
+3. `gameinfo.gi` is untouched until a user overflows; `hasRequiredSearchPaths`
+   stays additive so nobody gets re-flagged.
+4. Downgrade caveat: an old build won't manage overflow folders and old
+   `fixGameinfo` would drop their paths (mods stay on disk, stop loading until
+   re-upgrade). Release-note it.
+
+## Open decisions before coding
+
+1. **Lazy-list vs pre-list** overflow paths in gameinfo - DECIDED: lazy. Create
+   `addons{N}` on demand and add its `Game` path in the same operation, so we
+   never list a folder that doesn't exist (avoids needing the missing-folder
+   tolerance answer). `hasRequiredSearchPaths` keeps requiring only base addons +
+   grimoire so existing users never read as misconfigured.
+2. **Effective cap** - DECIDED: `MAX_ADDON_FOLDERS = 10` total (base +
+   addons1..addons9 = 990 slots). A single constant in `deadlock.ts`, easy to
+   bump. Enabling past it throws the (reworded) enable-limit error.
+3. **Precedence model** - RESOLVED: Model A (see Gate 0 above).
+4. **reorder/swap interface** (new, surfaced in W2): `reorderMods` and
+   `swapModPriority` currently key the renderer-supplied order by `fileName`,
+   which collides across folders (pak01 in base and addons1). W5 must switch the
+   IPC contract + renderer drag-reorder to pass `metaKey` (or `id`) instead.
+
+## Implementation progress
+
+- **W1 (done):** `getAddonFolderPaths`, `overflowAddonsPath`, `metaKeyFor` added
+  to `deadlock.ts`.
+- **W3 (done):** `scanMods` scans every addon folder (base + overflow) plus
+  `.disabled`; `scanFolder` stamps `metaKey`; reconcile stays scoped to base.
+- **W2-core (done):** `metaKey` added to both the backend `Mod` (`mods.ts`) and
+  the renderer mirror (`src/types/mod.ts`); `generateModId` hashes `metaKey`; all
+  `mods.ts` file-move operations (move/enable/disable/delete/setPriority/reorder/
+  swap) key metadata by `metaKey`. Behavior is identical today because
+  `metaKey === fileName` for the base folder; no existing data is touched.
+- **W2-rest (done):** read-site conversions in `modMerger.ts`, `profiles.ts`,
+  `portableProfile.ts`, `conflicts.ts`, `heroCards.ts`, `heroSounds.ts`,
+  `heroPortraits.ts`, `ipc/mods.ts`, `download.ts` now key by `metaKey`.
+  `isLockerManaged(metaKey)` signature flipped; `VpkRef` in the hero scanners
+  carries `metaKey`. `pruneOrphanMetadata` valid-set is built from metaKeys, and
+  the `metadata.ts` sha256 backfill (`collectInstalledVpkPaths`) iterates all
+  addon folders keyed by metaKey. Bare-key writes that always target base addons
+  or `.disabled` (merge outputs, downloads, Mina presets, manual local-VPK add)
+  are intentionally left bare (`metaKey === fileName` there). Verified: zero new
+  type errors vs baseline; lint + full build clean.
+
+  W2-rest does NOT include moving the slot allocator, gameinfo writer, or
+  per-folder reorder/conflict grouping; those are W4-W7.
+- **W6 (done):** `deadlock.ts` gained `MAX_ADDON_FOLDERS = 10`,
+  `getOverflowFolderNames`, `createNextOverflowFolder`. `system.ts` gained
+  `buildSearchPathsBlock(overflow)` (inserts `Game citadel/addonsN` after
+  `citadel/addons`, Model A order; byte-identical to the old block when no
+  overflow) and a generic `hasActivePath` (token-matched, distinguishes
+  addons/addons1/addons10, ignores comments + DMM subfolders, both separators).
+  `fixGameinfo` rebuilds including current overflow folders and treats a missing
+  overflow path as fixable. `getGameinfoStatus`/`hasRequiredSearchPaths` still
+  check only base addons + grimoire, so existing users never read misconfigured.
+- **W4 (done):** `enableMod` fills base, then each existing overflow folder in
+  order (per-folder pak namespaces; base also avoids disabled pakNN ids), then
+  mints the next `addons{N}` and calls `fixGameinfo` to add its Game line BEFORE
+  moving the VPK in. Returns the enable-limit error at the cap.
+  `ENABLE_LIMIT_MESSAGE` reworded to 990; renderer match in `appStore.ts` is now
+  the cap-agnostic `/mods enabled at once/`.
+
+- **W5 (done):** `reorderMods` now takes an ordered list of mod **ids** and lays
+  the enabled mods out densely across folders per Model A (address generator:
+  base slots 1-99, then addons1, ...; skips reserved slots held by mods outside
+  the list + legacy disabled pakNN in base; creates overflow folders + runs
+  fixGameinfo before moving; two-phase cross-folder rename with metaKey
+  migration). `swapModPriority` sorts enabled mods by global position
+  (`folderIndex*100 + pakNN`) and reorders by id. `setModPriority`'s collision
+  check is folder-scoped. The `reorder-mods` IPC + `api`/`preload`/`electron.d.ts`
+  + store wrapper now pass ids, and the 4 renderer call sites send `m.id`.
+  Renderer ordering uses a new `modLoadOrder(mod)` (folder index from metaKey +
+  pakNN) for the display sort, compact, drag, and priority-editor reorder, and
+  `scanMods` returns mods in the same global order, so overflow-folder mods stay
+  after base ones instead of interleaving by pakNN. Verified: address generator
+  maps pos100 -> addons1/pak01, reserved slots skip, cap throws past 990; lint +
+  renderer tsc + electron diff (17=17) + full build all clean.
+
+  Remaining minor gap: the per-card priority badge still shows the per-folder
+  pakNN (so it restarts at 1 in each overflow folder); the list order is correct,
+  but the displayed number repeats. Cosmetic, can be a later polish.
+
+- **W7 (done):** `conflicts.ts` priority-collision grouping now keys on
+  `(folder, pakNN)` (folder derived from `metaKey`: bare = base addons,
+  `addonsN/` = overflow N) instead of raw `pakNN`, so base `pak05` and
+  `addons1/pak05` are no longer falsely reported as colliding. The "Both use
+  pakNN" message gains the folder for overflow (`Both use addons1/pak05`). File
+  (content-overlap) conflicts were already correct and are unchanged.
+
+- **W8 (done, Option A - folder-unique identity):** the cosmetics source identity
+  switched from the bare filename to the folder-relative `metaKey` end to end,
+  because once a user overflows the same `pakNN_dir.vpk` name exists in several
+  folders and the bare filename can no longer tell two sources apart (it would
+  apply the wrong same-slot mod, merge tiles, and mis-mark "Applied"). `metaKey`
+  is a superset (`=== fileName` for base mods), so this is migration-free and a
+  no-op for non-overflow users; persisted `LockerCardSelection/LockerSoundSelection
+  .source.fileName` now holds the metaKey (field name kept for back-compat; old
+  bare-filename entries still resolve as the base mod's metaKey). Changes:
+  `listAddonVpks` in heroCards/heroSounds/heroPortraits now scans every addon
+  folder (base + overflow) + `.disabled`; `getHeroPortraits.modFileName` emits the
+  metaKey (and its portrait cache dir is keyed by it, so two same-named sources
+  don't clobber); `locateSource`/apply/rebuild/`getActive*` resolve and store by
+  metaKey; `HeroSoundPicker` keys the active/busy/apply identity on `mod.metaKey`
+  (display still uses `mod.name`/`fileName`); `LockerOverridesModal`'s mod-join map
+  is keyed by `metaKey`. Type docs updated to record the metaKey semantics.
+
+- **W9 (done):** `launch.ts` vanilla stash now stashes/restores EVERY addon folder
+  (base + overflow), not just base. `VanillaStash.mods` gained an optional
+  `folder` (origin addon-root basename); base files still park flat in
+  `.disabled/` (byte-identical to the old format for non-overflow users) while
+  overflow files park in a per-folder `.disabled/addonsN/` subfolder so a repeated
+  pakNN name can't collide in the shared lot. Restore returns each VPK to its
+  origin folder (legacy stashes without `folder` default to base addons). So
+  "Launch Vanilla" now actually unloads overflow mods too.
+
+- **W10 (done):** folder-aware cleanup/merge/import.
+  - `cleanupAddons` (system.ts) iterates every addon folder + `.disabled`.
+  - New shared `allocateEnabledVpkPath` (mods.ts), extracted from `enableMod`'s
+    folder-walking allocator (base-first, spill to overflow, mint + patch
+    gameinfo at capacity, throw at the cap). `enableMod` now calls it too (no
+    behavior change). Used by:
+    - `modMerger.mergeMods` output placement (was base-only
+      `findNextAvailablePriority` + `getAddonsPath`; would fail once base was
+      full), keyed by `metaKeyFor(dest)`.
+    - `import-custom-mod` (ipc/mods.ts), which installs ENABLED and had the same
+      base-only failure; metadata now keyed by the destination metaKey.
+  - `modMerger` unmerge REBUILD now builds in place (a `.merge-rebuild-*` dotfile
+    in the merge's OWN folder, swapped into its exact slot) instead of grabbing a
+    fresh base slot and re-slotting via `setModPriority` - which was base-only and
+    would fail (or relocate the merge) for an overflow-resident merged mod. Keeps
+    the merge's folder + pakNN (and metaKey) stable.
+  - `set-mina-preset` (ipc/system.ts) routes through `enableMod` instead of a raw
+    `renameSync` into base addons: overflow-aware AND fixes a latent clobber (the
+    old hard-coded rename could overwrite a colliding base pakNN). The Mina preset
+    list rebuilds from a fresh scan and matches the active one by the `enabled`
+    flag + metadata, so the re-slot is transparent.
+  - Audited, intentionally unchanged: the "open addons folder" button
+    (ipc/system.ts) still opens base `citadel/addons` (the canonical mods folder;
+    overflow roots are siblings one level up). `apply-mina-variant` installs the
+    preset DISABLED (like `download.ts`), so overflow stays a pure enable-time
+    concern. `download.ts`: no change.
+
+  Verified: lint clean on all changed files; `tsc --noEmit` clean for both
+  tsconfig.node (electron) and tsconfig.app (renderer); full `electron-vite build`
+  succeeds.
+
+## Suggested sequencing
+
+Run Gate 0 first (10-minute in-game test); the precedence answer is load-bearing
+for Workstreams 5 and 6. Workstreams 1-3 (folder primitives + keying + scan) are
+precedence-independent and safe to land before the in-game test.

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { promises as fs, existsSync } from 'fs';
-import { extname, join } from 'path';
+import { extname } from 'path';
 import { loadSettings, saveSettings } from '../services/settings';
 import {
     scanMods,
@@ -10,10 +10,10 @@ import {
     setModPriority,
     reorderMods,
     swapModPriority,
-    findNextAvailablePriority,
+    allocateEnabledVpkPath,
     Mod,
 } from '../services/mods';
-import { getAddonsPath } from '../services/deadlock';
+import { metaKeyFor } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
 import { inferHeroFromVpk, classifyGlobalModFromVpk } from '../services/vpk';
@@ -48,7 +48,7 @@ function getActiveDeadlockPath(): string | null {
  * override path has a stable field to overwrite.
  */
 function enrichMod(mod: Mod): Mod {
-    const metadata = getModMetadata(mod.fileName);
+    const metadata = getModMetadata(mod.metaKey);
     const isUnknown =
         !metadata?.gameBananaId &&
         !(typeof metadata?.modName === 'string' && metadata.modName.trim().length > 0);
@@ -71,7 +71,7 @@ function enrichMod(mod: Mod): Mod {
                 }
             }
             if (inferred) {
-                setModMetadata(mod.fileName, { lockerHero: inferred, lockerHeroSource: inferredSource });
+                setModMetadata(mod.metaKey, { lockerHero: inferred, lockerHeroSource: inferredSource });
                 lockerHero = inferred;
                 lockerHeroSource = inferredSource;
             }
@@ -88,7 +88,7 @@ function enrichMod(mod: Mod): Mod {
             } catch (err) {
                 console.warn(`[enrichMod] VPK global-type classification failed for ${mod.fileName}:`, err);
             }
-            setModMetadata(mod.fileName, { globalType: classified });
+            setModMetadata(mod.metaKey, { globalType: classified });
             globalType = classified;
         }
         // Per-ability sound footprint. Same lazy + persist + null-sentinel
@@ -106,7 +106,7 @@ function enrichMod(mod: Mod): Mod {
             } catch (err) {
                 console.warn(`[enrichMod] VPK ability-sound classification failed for ${mod.fileName}:`, err);
             }
-            setModMetadata(mod.fileName, { abilitySounds: classified });
+            setModMetadata(mod.metaKey, { abilitySounds: classified });
             abilitySounds = classified;
         }
         return {
@@ -170,14 +170,14 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     if (!settings.devMode) {
         // Prune against ALL scanned files (including managed VPKs) so we don't
         // wipe their metadata before filtering them out of the list below.
-        pruneOrphanMetadata(new Set(mods.map((m) => m.fileName)));
+        pruneOrphanMetadata(new Set(mods.map((m) => m.metaKey)));
     }
     // Hide Grimoire-managed Locker VPKs (hero cards + ability sounds). They're
     // driven solely through the Locker pickers and are auto-enabled + pinned to
     // the front of the load order (services/lockerVpk.ts), so surfacing them in
     // the Installed list would only let the user disable or reorder them and
     // silently break their applied cosmetics.
-    return mods.filter((m) => !isLockerManaged(m.fileName)).map(enrichMod);
+    return mods.filter((m) => !isLockerManaged(m.metaKey)).map(enrichMod);
 });
 
 // enable-mod
@@ -325,7 +325,7 @@ ipcMain.handle(
             throw new Error(`Mod not found: ${modId}`);
         }
 
-        await setModMetadataWithHash(target.fileName, {
+        await setModMetadataWithHash(target.metaKey, {
             modName: args.name.trim(),
             thumbnailUrl: args.thumbnailDataUrl,
             nsfw: !!args.nsfw,
@@ -354,12 +354,12 @@ ipcMain.handle(
         if (!target) {
             throw new Error(`Mod not found: ${modId}`);
         }
-        const existing = getModMetadata(target.fileName) ?? {};
+        const existing = getModMetadata(target.metaKey) ?? {};
         if (typeof existing.gameBananaId === 'number' && existing.gameBananaId > 0) {
             throw new Error('Only local mods can be renamed');
         }
 
-        await setModMetadataWithHash(target.fileName, {
+        await setModMetadataWithHash(target.metaKey, {
             modName: trimmed,
             thumbnailUrl: args.thumbnailDataUrl,
             nsfw: !!args.nsfw,
@@ -386,7 +386,7 @@ ipcMain.handle(
             throw new Error(`Mod not found: ${modId}`);
         }
         const trimmed = label.trim();
-        setModMetadata(target.fileName, {
+        setModMetadata(target.metaKey, {
             variantLabel: trimmed.length > 0 ? trimmed : undefined,
         });
         return enrichMod(target);
@@ -410,7 +410,7 @@ ipcMain.handle(
             throw new Error(`Mod not found: ${modId}`);
         }
         const trimmed = heroName?.trim() ?? '';
-        setModMetadata(target.fileName, {
+        setModMetadata(target.metaKey, {
             lockerHero: trimmed.length > 0 ? trimmed : undefined,
             lockerHeroSource: trimmed.length > 0 ? 'manual' : undefined,
             ...(trimmed.length > 0 ? { globalType: undefined } : {}),
@@ -439,7 +439,7 @@ ipcMain.handle(
         if (!target) {
             throw new Error(`Mod not found: ${modId}`);
         }
-        setModMetadata(target.fileName, {
+        setModMetadata(target.metaKey, {
             globalType,
             // Assigning a global type moves the mod off the hero axis.
             ...(globalType ? { lockerHero: undefined, lockerHeroSource: undefined } : {}),
@@ -463,7 +463,7 @@ ipcMain.handle(
         if (!target) {
             throw new Error(`Mod not found: ${modId}`);
         }
-        setModMetadata(target.fileName, {
+        setModMetadata(target.metaKey, {
             ignoreUpdates: ignore ? true : undefined,
         });
         return enrichMod(target);
@@ -497,7 +497,7 @@ ipcMain.handle(
         if (!target) {
             throw new Error(`Mod not found: ${modId}`);
         }
-        const existing = getModMetadata(target.fileName) ?? {};
+        const existing = getModMetadata(target.metaKey) ?? {};
         const patch: Record<string, unknown> = { gameBananaFileId: payload.gameBananaFileId };
         if (payload.fileDescription && !existing.fileDescription) {
             patch.fileDescription = payload.fileDescription;
@@ -509,7 +509,7 @@ ipcMain.handle(
         if (payload.sourceFileName && (!existing.sourceFileName || placeholderName)) {
             patch.sourceFileName = payload.sourceFileName;
         }
-        setModMetadata(target.fileName, patch);
+        setModMetadata(target.metaKey, patch);
         return enrichMod(target);
     }
 );
@@ -531,13 +531,13 @@ ipcMain.handle(
 // reorder-mods
 ipcMain.handle(
     'reorder-mods',
-    async (_, orderedFileNames: string[]): Promise<Mod[]> => {
+    async (_, orderedIds: string[]): Promise<Mod[]> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) {
             throw new Error('No Deadlock path configured');
         }
         migrateIgnoredConflictKeysBeforeRenames(await scanMods(deadlockPath));
-        await reorderMods(deadlockPath, orderedFileNames);
+        await reorderMods(deadlockPath, orderedIds);
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);
     }
@@ -617,27 +617,26 @@ ipcMain.handle(
             throw new Error('A name is required');
         }
 
-        const addonsPath = getAddonsPath(deadlockPath);
-        if (!existsSync(addonsPath)) {
-            await fs.mkdir(addonsPath, { recursive: true });
-        }
+        // Imports install ENABLED, so reserve a slot via the overflow-aware
+        // allocator: it fills base addons first and spills into an overflow
+        // folder (creating one + patching gameinfo) when base is full, instead of
+        // failing once a >99 user has filled citadel/addons. Metadata is keyed by
+        // the destination's metaKey (folder-prefixed for an overflow slot).
+        const destPath = await allocateEnabledVpkPath(deadlockPath);
+        const destMetaKey = metaKeyFor(destPath);
 
-        const priority = await findNextAvailablePriority(deadlockPath);
-        const priorityStr = String(priority).padStart(2, '0');
-        const newDirFileName = `pak${priorityStr}_dir.vpk`;
-
-        await fs.copyFile(vpkPath, join(addonsPath, newDirFileName));
+        await fs.copyFile(vpkPath, destPath);
 
         // Scrub any orphan metadata at this slot before writing. setModMetadata
         // merges into the existing entry, so stale fields (gameBananaId,
         // categoryName, etc.) from a prior occupant would otherwise stick to
         // the new local mod and visually merge it with unrelated mods.
-        removeModMetadata(newDirFileName);
-        await setModMetadataWithHash(newDirFileName, {
+        removeModMetadata(destMetaKey);
+        await setModMetadataWithHash(destMetaKey, {
             modName: name.trim(),
             thumbnailUrl: thumbnailDataUrl,
             nsfw: !!nsfw,
-        }, join(addonsPath, newDirFileName));
+        }, destPath);
 
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -14,7 +14,6 @@ import {
     existsSync,
     readFileSync,
     readdirSync,
-    renameSync,
     copyFileSync,
     unlinkSync,
     mkdirSync,
@@ -28,6 +27,7 @@ import { fileURLToPath } from 'url';
 import https from 'https';
 import http from 'http';
 import { getAddonsPath, getDisabledPath, getCitadelPath } from '../services/deadlock';
+import { scanMods, enableMod } from '../services/mods';
 import { getUserDataPath } from '../utils/paths';
 import {
     getModMetadata,
@@ -294,34 +294,19 @@ ipcMain.handle('set-mina-preset', async (_, args: SetMinaPresetArgs): Promise<vo
         throw new Error('No Deadlock path configured');
     }
 
-    const addonsPath = getAddonsPath(deadlockPath);
-    const disabledPath = getDisabledPath(deadlockPath);
     const { presetFileName } = args;
 
-    // Find the preset file in either folder
-    let presetPath: string | null = null;
-    let isEnabled = false;
-
-    const addonsPreset = join(addonsPath, presetFileName);
-    const disabledPreset = join(disabledPath, presetFileName);
-
-    if (existsSync(addonsPreset)) {
-        presetPath = addonsPreset;
-        isEnabled = true;
-    } else if (existsSync(disabledPreset)) {
-        presetPath = disabledPreset;
-        isEnabled = false;
-    }
-
-    if (!presetPath) {
+    // Enable the preset through the normal enableMod path rather than a raw move
+    // into base addons: enableMod allocates a free slot across base + overflow
+    // folders (so it works for a >99 user with a full citadel/addons) and never
+    // clobbers an existing pakNN the way a hard-coded rename could.
+    const mods = await scanMods(deadlockPath);
+    const preset = mods.find((m) => m.fileName === presetFileName);
+    if (!preset) {
         throw new Error(`Preset file not found: ${presetFileName}`);
     }
-
-    // Move to addons if disabled
-    if (!isEnabled) {
-        const destPath = join(addonsPath, presetFileName);
-        renameSync(presetPath, destPath);
-    }
+    if (preset.enabled) return; // already active
+    await enableMod(deadlockPath, preset.id);
 });
 
 // list-mina-variants

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -61,8 +61,25 @@ function normalizeIdentityPart(value: string): string {
     return value.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+/** The addon folder an enabled mod lives in, derived from its metaKey: the bare
+ *  filename (no slash) means the base citadel/addons; `addonsN/<file>` means
+ *  overflow folder N. Used to scope pakNN priority-collision grouping per folder. */
+function folderOf(mod: Mod): string {
+    const slash = mod.metaKey.indexOf('/');
+    return slash === -1 ? 'addons' : mod.metaKey.slice(0, slash);
+}
+
+/** Message for a priority (same-slot) conflict. Two mods only reach here when
+ *  they share a folder AND a pakNN, so naming the slot (and the overflow folder,
+ *  when not base) is enough to tell the user which slot to change. */
+function priorityConflictDetail(mod: Mod): string {
+    const folder = folderOf(mod);
+    const pak = `pak${String(mod.priority).padStart(2, '0')}`;
+    return folder === 'addons' ? `Both use ${pak}` : `Both use ${folder}/${pak}`;
+}
+
 export function modConflictIdentity(mod: Mod): string {
-    const metadata = getModMetadata(mod.fileName);
+    const metadata = getModMetadata(mod.metaKey);
     if (typeof metadata?.gameBananaId === 'number' && metadata.gameBananaId > 0) {
         if (typeof metadata.gameBananaFileId === 'number' && metadata.gameBananaFileId > 0) {
             return `gb:${metadata.gameBananaId}:file:${metadata.gameBananaFileId}`;
@@ -138,7 +155,7 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     // wins), so they would otherwise report a file conflict against every
     // source. Exclude them.
     const enabledMods = mods.filter(m => {
-        const meta = getModMetadata(m.fileName);
+        const meta = getModMetadata(m.metaKey);
         return m.enabled && !meta?.lockerCosmetics && !meta?.lockerSounds;
     });
     const conflicts: ModConflict[] = [];
@@ -154,25 +171,27 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     const markReported = (a: Mod, b: Mod) => reportedPairs.add(conflictPairKey(a.id, b.id));
     const wasReported = (a: Mod, b: Mod) => reportedPairs.has(conflictPairKey(a.id, b.id));
 
-    const priorityMap = new Map<number, Mod[]>();
+    // A pakNN load-order slot only collides WITHIN a single addon folder: base
+    // citadel/addons/pak05 and an overflow citadel/addons1/pak05 are mounted via
+    // separate SearchPaths, so they are NOT a real priority conflict (each folder
+    // has its own pak01-pak99 namespace, Model A). Group by (folder, pakNN), not
+    // raw pakNN. The folder comes from metaKey: bare filename (no slash) = base
+    // addons, `addonsN/<file>` = overflow folder N.
+    const priorityMap = new Map<string, Mod[]>();
     for (const mod of enabledMods) {
-        const existing = priorityMap.get(mod.priority) || [];
+        const key = `${folderOf(mod)}#${mod.priority}`;
+        const existing = priorityMap.get(key) || [];
         existing.push(mod);
-        priorityMap.set(mod.priority, existing);
+        priorityMap.set(key, existing);
     }
 
-    for (const [priority, modsWithPriority] of priorityMap) {
+    for (const modsWithPriority of priorityMap.values()) {
         if (modsWithPriority.length > 1) {
             for (let i = 0; i < modsWithPriority.length; i++) {
                 for (let j = i + 1; j < modsWithPriority.length; j++) {
                     const a = modsWithPriority[i];
                     const b = modsWithPriority[j];
-                    conflicts.push(createConflict(
-                        a,
-                        b,
-                        'priority',
-                        `Both use pak${String(priority).padStart(2, '0')}`
-                    ));
+                    conflicts.push(createConflict(a, b, 'priority', priorityConflictDetail(a)));
                     markReported(a, b);
                 }
             }

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'fs';
+import { join, basename, dirname } from 'path';
 import { homedir } from 'os';
 import { execFileSync } from 'child_process';
 
@@ -191,6 +191,98 @@ export function getGrimoirePath(deadlockPath: string): string {
     }
 
     return grimoirePath;
+}
+
+/**
+ * Match an overflow addons folder name: addons1, addons2, ... (NOT the base
+ * "addons", which has no numeric suffix). Overflow folders hold mods that spill
+ * past the 99-slot pakNN budget of the base citadel/addons folder; each carries
+ * its own pak01-pak99 namespace and its own Game search path in gameinfo.gi.
+ */
+const OVERFLOW_FOLDER_RE = /^addons(\d+)$/i;
+
+/**
+ * Maximum number of addon root folders (base citadel/addons plus overflow
+ * addons1..addons9). Each holds a pak01-pak99 namespace, so 10 folders gives a
+ * 990-mod enabled ceiling. Bump this to raise the cap.
+ */
+export const MAX_ADDON_FOLDERS = 10;
+
+/**
+ * Ordered list of addon root folders the engine searches, base first, then
+ * overflow folders (addons1, addons2, ...) in numeric order. Only folders that
+ * exist on disk are returned; the base citadel/addons is always present (created
+ * if missing). Each entry is an absolute path.
+ */
+export function getAddonFolderPaths(deadlockPath: string): string[] {
+    const citadelPath = getCitadelPath(deadlockPath);
+    const folders = [getAddonsPath(deadlockPath)]; // base, created if missing
+    try {
+        const overflow = readdirSync(citadelPath, { withFileTypes: true })
+            .filter((e) => e.isDirectory() && OVERFLOW_FOLDER_RE.test(e.name))
+            .map((e) => ({ path: join(citadelPath, e.name), num: parseInt(e.name.match(OVERFLOW_FOLDER_RE)![1], 10) }))
+            .sort((a, b) => a.num - b.num)
+            .map((e) => e.path);
+        folders.push(...overflow);
+    } catch {
+        // citadel/ unreadable: base-only is the safe fallback.
+    }
+    return folders;
+}
+
+/**
+ * Get the Nth overflow addons folder path (citadel/addons{index}, index >= 1),
+ * creating it if necessary. These are the spill-over roots for mods past the
+ * base folder's 99-slot pakNN budget.
+ */
+export function overflowAddonsPath(deadlockPath: string, index: number): string {
+    const path = join(deadlockPath, 'game', 'citadel', `addons${index}`);
+    if (!existsSync(path)) {
+        mkdirSync(path, { recursive: true });
+    }
+    return path;
+}
+
+/** Overflow folder basenames (addons1, addons2, ...) that exist on disk, in
+ *  numeric order. Empty when no overflow folders have been created yet. */
+export function getOverflowFolderNames(deadlockPath: string): string[] {
+    return getAddonFolderPaths(deadlockPath)
+        .slice(1) // drop the base citadel/addons
+        .map((p) => basename(p));
+}
+
+/**
+ * Create and return the next overflow folder, reusing the lowest unused
+ * addons{N} index (so a deleted folder's slot is recycled). Returns null when
+ * the MAX_ADDON_FOLDERS cap is already reached, leaving the caller to surface
+ * the enable-limit error.
+ */
+export function createNextOverflowFolder(deadlockPath: string): string | null {
+    const used = new Set(
+        getOverflowFolderNames(deadlockPath).map((n) => parseInt(n.match(OVERFLOW_FOLDER_RE)![1], 10))
+    );
+    let index = 1;
+    while (used.has(index)) index++;
+    // index is the 1-based overflow slot; base counts as folder 0, so the cap is
+    // MAX_ADDON_FOLDERS - 1 overflow folders.
+    if (index > MAX_ADDON_FOLDERS - 1) return null;
+    return overflowAddonsPath(deadlockPath, index);
+}
+
+/**
+ * Derive the metadata/identity key for a VPK from its on-disk location.
+ *
+ * Mods in the base citadel/addons folder and in .disabled/ key to their BARE
+ * filename, exactly as they always have, so existing installs need no migration.
+ * Mods in an overflow folder key to `addons{N}/<filename>` so a pak01_dir.vpk in
+ * addons1 can't collide with the pak01_dir.vpk in the base folder. This is the
+ * single source of truth for the rule; metadata access and id generation both
+ * route through it.
+ */
+export function metaKeyFor(vpkPath: string): string {
+    const fileName = basename(vpkPath);
+    const parentName = basename(dirname(vpkPath));
+    return OVERFLOW_FOLDER_RE.test(parentName) ? `${parentName}/${fileName}` : fileName;
 }
 
 /**

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -854,7 +854,7 @@ async function executeDownload(
             const stalePeers = allMods.filter((m) => {
                 if (!m.enabled) return false;
                 if (installedSet.has(m.fileName)) return false;
-                const meta = getModMetadata(m.fileName);
+                const meta = getModMetadata(m.metaKey);
                 return (
                     meta?.gameBananaId === modId &&
                     meta?.gameBananaFileId !== fileId

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -16,7 +16,7 @@ import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
-import { getAddonsPath, getDisabledPath, getGrimoirePath } from './deadlock';
+import { getAddonFolderPaths, getDisabledPath, getGrimoirePath, metaKeyFor } from './deadlock';
 import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
 import {
     runVpkmerge,
@@ -53,14 +53,17 @@ function cardPrefix(codename: string): string {
 interface VpkRef {
     fileName: string;
     path: string;
+    metaKey: string;
     enabled: boolean;
 }
 
-/** Enabled addon VPKs plus the ones parked in `.disabled/`. */
+/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
+ *  overflow addonsN) plus the ones parked in `.disabled/`, so a card source that
+ *  overflowed past slot 99 is still found at apply/rebuild time. */
 async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
     const out: VpkRef[] = [];
     const folders: Array<[string, boolean]> = [
-        [getAddonsPath(deadlockPath), true],
+        ...getAddonFolderPaths(deadlockPath).map((p) => [p, true] as [string, boolean]),
         [getDisabledPath(deadlockPath), false],
     ];
     for (const [dir, enabled] of folders) {
@@ -72,7 +75,8 @@ async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
         }
         for (const entry of entries) {
             if (entry.toLowerCase().endsWith('_dir.vpk')) {
-                out.push({ fileName: entry, path: join(dir, entry), enabled });
+                const path = join(dir, entry);
+                out.push({ fileName: entry, path, metaKey: metaKeyFor(path), enabled });
             }
         }
     }
@@ -85,7 +89,7 @@ function findCosmeticsVpk(
     vpks: VpkRef[]
 ): { ref: VpkRef; info: LockerCosmeticsInfo } | null {
     for (const v of vpks) {
-        const info = getModMetadata(v.fileName)?.lockerCosmetics;
+        const info = getModMetadata(v.metaKey)?.lockerCosmetics;
         if (info) return { ref: v, info };
     }
     return null;
@@ -101,15 +105,19 @@ async function currentCardSelections(deadlockPath: string): Promise<LockerCardSe
     return findCosmeticsVpk(vpks)?.info.cards ?? [];
 }
 
-/** Locate a source VPK by filename, falling back to content hash if reconcile
- *  renamed it since apply time (same recovery unmergeMod uses). */
+/** Locate a source VPK by its folder-relative metaKey, falling back to content
+ *  hash if reconcile renamed or overflow moved it since apply time (same
+ *  recovery unmergeMod uses). Keying by metaKey (not the bare filename) keeps two
+ *  same-named sources in different addon folders distinct. Selections written
+ *  before overflow stored a bare filename, which is exactly the base mod's
+ *  metaKey, so they still resolve here. */
 async function locateSource(
     vpks: VpkRef[],
-    fileName: string,
+    sourceKey: string,
     sha256?: string
 ): Promise<VpkRef | null> {
-    const byName = vpks.find((v) => v.fileName === fileName);
-    if (byName) return byName;
+    const byKey = vpks.find((v) => v.metaKey === sourceKey);
+    if (byKey) return byKey;
     if (!sha256) return null;
     const wanted = sha256.toLowerCase();
     for (const v of vpks) {
@@ -186,7 +194,9 @@ async function rebuildLockerCosmetics(
             missing.push(sel.source.fileName);
             continue;
         }
-        valid.push({ ...sel, source: { ...sel.source, fileName: src.fileName } });
+        // Re-key to the located file's current metaKey so a source that moved
+        // folders (overflow) or was renamed (reconcile) stays addressable.
+        valid.push({ ...sel, source: { ...sel.source, fileName: src.metaKey } });
     }
 
     // Empty set: tear down the cosmetics VPK entirely.
@@ -208,7 +218,7 @@ async function rebuildLockerCosmetics(
         await fs.mkdir(planDir, { recursive: true });
         for (let i = 0; i < valid.length; i++) {
             const sel = valid[i];
-            const src = vpks.find((v) => v.fileName === sel.source.fileName)!;
+            const src = vpks.find((v) => v.metaKey === sel.source.fileName)!;
             const chunkPath = join(grimoireDir, `${tag}.chunk${i}.vpk`);
             const planPath = join(planDir, `plan${i}.json`);
             await fs.writeFile(
@@ -251,12 +261,14 @@ async function rebuildLockerCosmetics(
 }
 
 /**
- * Apply hero X's card from `sourceFileName`, replacing any prior choice for X.
+ * Apply hero X's card from the source identified by `sourceKey` (its
+ * folder-relative metaKey, as surfaced by getHeroPortraits.modFileName),
+ * replacing any prior choice for X.
  */
 export async function applyHeroCard(
     deadlockPath: string,
     heroName: string,
-    sourceFileName: string
+    sourceKey: string
 ): Promise<ApplyHeroCardResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
     ensureGrimoireConfigured(deadlockPath);
@@ -268,22 +280,22 @@ export async function applyHeroCard(
     await migrateManagedVpksToGrimoire(deadlockPath);
 
     const vpks = await listAddonVpks(deadlockPath);
-    const src = vpks.find((v) => v.fileName === sourceFileName);
-    if (!src) throw new Error(`Source mod not found: ${sourceFileName}`);
+    const src = vpks.find((v) => v.metaKey === sourceKey);
+    if (!src) throw new Error(`Source mod not found: ${sourceKey}`);
 
     const cardPaths = heroCardPaths(src.path, heroName);
     if (cardPaths.length === 0) {
-        throw new Error(`${basename(sourceFileName)} has no card art for ${heroName}.`);
+        throw new Error(`${basename(src.fileName)} has no card art for ${heroName}.`);
     }
 
     const fp = await fingerprintFile(src.path);
-    const srcMeta = getModMetadata(src.fileName);
+    const srcMeta = getModMetadata(src.metaKey);
     const selection: LockerCardSelection = {
         heroCodename: primaryCodename,
         heroName,
         variants: variantsFor(cardPaths, heroName),
         source: {
-            fileName: src.fileName,
+            fileName: src.metaKey,
             modName: srcMeta?.modName,
             gameBananaId: srcMeta?.gameBananaId,
             sha256AtApplyTime: fp.sha256,
@@ -295,7 +307,9 @@ export async function applyHeroCard(
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
     return {
-        activeSourceFileName: missing.includes(src.fileName) ? null : src.fileName,
+        // missing[] carries metaKeys (a selection's source key), so compare and
+        // report the metaKey, which the picker round-trips as the tile identity.
+        activeSourceFileName: missing.includes(src.metaKey) ? null : src.metaKey,
         missingSourceFileNames: missing,
     };
 }

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -14,7 +14,7 @@
 import { promises as fs } from 'fs';
 import { basename, join } from 'path';
 import { app } from 'electron';
-import { getAddonsPath } from './deadlock';
+import { getAddonFolderPaths, getDisabledPath, metaKeyFor } from './deadlock';
 import { parseVpkDirectoryCached } from './vpk';
 import { vpkmergeBinaryPath, runVpkmerge } from './modMerger';
 import { getModMetadata } from './metadata';
@@ -113,11 +113,12 @@ function sanitize(value: string): string {
     return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }
 
-/** Enabled addon VPKs plus the ones parked in `.disabled/`. */
+/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
+ *  overflow addonsN) plus the ones parked in `.disabled/`, so a source that
+ *  overflowed past slot 99 still surfaces in the picker. */
 async function listAddonVpks(deadlockPath: string): Promise<string[]> {
-    const addonsPath = getAddonsPath(deadlockPath);
     const vpks: string[] = [];
-    for (const dir of [addonsPath, join(addonsPath, '.disabled')]) {
+    for (const dir of [...getAddonFolderPaths(deadlockPath), getDisabledPath(deadlockPath)]) {
         let entries: string[];
         try {
             entries = await fs.readdir(dir);
@@ -163,12 +164,17 @@ export async function getHeroPortraits(
 
     const results: HeroPortrait[] = [];
     for (const vpk of vpks) {
+        // Identify the source by its folder-relative metaKey, not the bare
+        // filename: once a user overflows, the same pakNN_dir.vpk name exists in
+        // several folders, so the filename alone can't tell two sources apart
+        // (the picker round-trips this value straight back into applyHeroCard).
+        const metaKey = metaKeyFor(vpk);
         // Skip our own Locker-managed VPKs: the cosmetics VPK holds the
         // already-applied card, so decoding it would surface a duplicate tile of
         // whatever source it was built from (the source itself is still scanned
         // and stays the selectable, "Applied"-marked option). The sound VPK has
         // no card art, but is excluded on the same "managed artifact" grounds.
-        const portraitMeta = getModMetadata(basename(vpk));
+        const portraitMeta = getModMetadata(metaKey);
         if (portraitMeta?.lockerCosmetics || portraitMeta?.lockerSounds) continue;
 
         const tree = parseVpkDirectoryCached(vpk);
@@ -182,7 +188,9 @@ export async function getHeroPortraits(
         if (matched.length === 0) continue;
 
         for (const codename of matched) {
-            const outDir = join(cacheRoot, sanitize(basename(vpk)), codename);
+            // Cache dir keyed by the unique metaKey so two same-named sources in
+            // different folders don't clobber each other's decoded portraits.
+            const outDir = join(cacheRoot, sanitize(metaKey), codename);
             const manifestPath = join(outDir, 'manifest.json');
             try {
                 await runVpkmerge(
@@ -196,7 +204,7 @@ export async function getHeroPortraits(
                     if (!p.output_path) continue;
                     const png = await fs.readFile(p.output_path);
                     results.push({
-                        modFileName: basename(vpk),
+                        modFileName: metaKey,
                         variant: p.variant,
                         width: p.width,
                         height: p.height,

--- a/electron/main/services/heroSounds.ts
+++ b/electron/main/services/heroSounds.ts
@@ -21,7 +21,7 @@ import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
-import { getAddonsPath, getDisabledPath, getCitadelPath, getGrimoirePath } from './deadlock';
+import { getAddonFolderPaths, getDisabledPath, getCitadelPath, getGrimoirePath, metaKeyFor } from './deadlock';
 import { invalidateVpkParseCache } from './vpk';
 import { runVpkmerge, runVpkmergeStdout, vpkmergeBinaryPath, verifyVpkOutput } from './modMerger';
 import {
@@ -47,14 +47,17 @@ import type {
 interface VpkRef {
     fileName: string;
     path: string;
+    metaKey: string;
     enabled: boolean;
 }
 
-/** Enabled addon VPKs plus the ones parked in `.disabled/`. */
+/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
+ *  overflow addonsN) plus the ones parked in `.disabled/`, so a sound source that
+ *  overflowed past slot 99 is still found at apply/rebuild time. */
 async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
     const out: VpkRef[] = [];
     const folders: Array<[string, boolean]> = [
-        [getAddonsPath(deadlockPath), true],
+        ...getAddonFolderPaths(deadlockPath).map((p) => [p, true] as [string, boolean]),
         [getDisabledPath(deadlockPath), false],
     ];
     for (const [dir, enabled] of folders) {
@@ -66,7 +69,8 @@ async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
         }
         for (const entry of entries) {
             if (entry.toLowerCase().endsWith('_dir.vpk')) {
-                out.push({ fileName: entry, path: join(dir, entry), enabled });
+                const path = join(dir, entry);
+                out.push({ fileName: entry, path, metaKey: metaKeyFor(path), enabled });
             }
         }
     }
@@ -78,7 +82,7 @@ async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
  *  in grimoire with its selections under the synthetic key. */
 function findSoundsVpk(vpks: VpkRef[]): { ref: VpkRef; info: LockerSoundsInfo } | null {
     for (const v of vpks) {
-        const info = getModMetadata(v.fileName)?.lockerSounds;
+        const info = getModMetadata(v.metaKey)?.lockerSounds;
         if (info) return { ref: v, info };
     }
     return null;
@@ -94,15 +98,18 @@ async function currentSoundSelections(deadlockPath: string): Promise<LockerSound
     return findSoundsVpk(vpks)?.info.sounds ?? [];
 }
 
-/** Locate a source VPK by filename, falling back to content hash if reconcile
- *  renamed it since apply time. */
+/** Locate a source VPK by its folder-relative metaKey, falling back to content
+ *  hash if reconcile renamed or overflow moved it since apply time. Keying by
+ *  metaKey (not the bare filename) keeps two same-named sources in different
+ *  addon folders distinct; pre-overflow selections stored a bare filename, which
+ *  is exactly the base mod's metaKey, so they still resolve. */
 async function locateSource(
     vpks: VpkRef[],
-    fileName: string,
+    sourceKey: string,
     sha256?: string,
 ): Promise<VpkRef | null> {
-    const byName = vpks.find((v) => v.fileName === fileName);
-    if (byName) return byName;
+    const byKey = vpks.find((v) => v.metaKey === sourceKey);
+    if (byKey) return byKey;
     if (!sha256) return null;
     const wanted = sha256.toLowerCase();
     for (const v of vpks) {
@@ -215,7 +222,9 @@ async function rebuildLockerSounds(
             missing.push(sel.source.fileName);
             continue;
         }
-        valid.push({ ...sel, clipPaths, source: { ...sel.source, fileName: src.fileName } });
+        // Re-key to the located file's current metaKey so a source that moved
+        // folders (overflow) or was renamed (reconcile) stays addressable.
+        valid.push({ ...sel, clipPaths, source: { ...sel.source, fileName: src.metaKey } });
     }
 
     if (valid.length === 0) {
@@ -233,7 +242,7 @@ async function rebuildLockerSounds(
         await fs.mkdir(planDir, { recursive: true });
         for (let i = 0; i < valid.length; i++) {
             const sel = valid[i];
-            const src = vpks.find((v) => v.fileName === sel.source.fileName)!;
+            const src = vpks.find((v) => v.metaKey === sel.source.fileName)!;
             const chunkPath = join(grimoireDir, `${tag}.chunk${i}.vpk`);
             const planPath = join(planDir, `plan${i}.json`);
             // Each clip's full path used as an AnyPrefix predicate matches only
@@ -303,14 +312,15 @@ async function rebuildLockerSounds(
 }
 
 /**
- * Apply hero X's ability-`slot` sound from `sourceFileName`, replacing any prior
- * choice for that (hero, slot).
+ * Apply hero X's ability-`slot` sound from the source identified by `sourceKey`
+ * (its folder-relative metaKey, as carried by the renderer mod's metaKey),
+ * replacing any prior choice for that (hero, slot).
  */
 export async function applyHeroSound(
     deadlockPath: string,
     heroName: string,
     slot: AbilitySlot,
-    sourceFileName: string,
+    sourceKey: string,
     params?: AbilitySoundParams,
 ): Promise<ApplyHeroSoundResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
@@ -322,16 +332,16 @@ export async function applyHeroSound(
     await migrateManagedVpksToGrimoire(deadlockPath);
 
     const vpks = await listAddonVpks(deadlockPath);
-    const src = vpks.find((v) => v.fileName === sourceFileName);
-    if (!src) throw new Error(`Source mod not found: ${sourceFileName}`);
+    const src = vpks.find((v) => v.metaKey === sourceKey);
+    if (!src) throw new Error(`Source mod not found: ${sourceKey}`);
 
     const clipPaths = abilitySoundClipsForSlot(src.path, heroName, slot);
     if (clipPaths.length === 0) {
-        throw new Error(`${basename(sourceFileName)} has no ability ${slot} sound for ${heroName}.`);
+        throw new Error(`${basename(src.fileName)} has no ability ${slot} sound for ${heroName}.`);
     }
 
     const fp = await fingerprintFile(src.path);
-    const srcMeta = getModMetadata(src.fileName);
+    const srcMeta = getModMetadata(src.metaKey);
     const selection: LockerSoundSelection = {
         heroName,
         heroCodename: codename,
@@ -341,7 +351,7 @@ export async function applyHeroSound(
         // all-neutral pick stays a pure clip selection (and reverts cleanly).
         ...(hasParams(params) ? { params } : {}),
         source: {
-            fileName: src.fileName,
+            fileName: src.metaKey,
             modName: srcMeta?.modName,
             gameBananaId: srcMeta?.gameBananaId,
             sha256AtApplyTime: fp.sha256,
@@ -356,7 +366,9 @@ export async function applyHeroSound(
     ];
     const { missing } = await rebuildLockerSounds(deadlockPath, next);
     return {
-        activeSourceFileName: missing.includes(src.fileName) ? null : src.fileName,
+        // missing[] carries metaKeys (a selection's source key); compare and
+        // report the metaKey, which the picker round-trips as the source identity.
+        activeSourceFileName: missing.includes(src.metaKey) ? null : src.metaKey,
         missingSourceFileNames: missing,
     };
 }

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -1,9 +1,9 @@
 import { promises as fs, existsSync } from 'fs';
-import { join } from 'path';
+import { join, basename, dirname } from 'path';
 import { spawn } from 'child_process';
 import { shell } from 'electron';
 import { getUserDataPath } from '../utils/paths';
-import { getAddonsPath, getDisabledPath } from './deadlock';
+import { getAddonsPath, getDisabledPath, getAddonFolderPaths, getCitadelPath } from './deadlock';
 import { loadSettings } from './settings';
 import { writeLaunchOptions, readLaunchOptions, isSteamRunning } from './launchOptions';
 
@@ -39,7 +39,32 @@ export interface VanillaStash {
     version: 1;
     status: 'pending' | 'active';
     startedAt: string;
-    mods: Array<{ fileName: string }>;
+    /** Each stashed VPK plus the addon folder it came from, so restore returns
+     *  it to the right place. `folder` is the addon root basename: "addons" for
+     *  the base folder, "addonsN" for an overflow folder. Absent on stashes
+     *  written before multi-folder overflow existed; those are all base addons. */
+    mods: Array<{ fileName: string; folder?: string }>;
+}
+
+/** Absolute path of an addon root folder from the basename recorded in the
+ *  stash ("addons" -> base citadel/addons, "addonsN" -> citadel/addonsN). */
+function originFolderPath(deadlockPath: string, folder: string): string {
+    return folder === 'addons'
+        ? getAddonsPath(deadlockPath)
+        : join(getCitadelPath(deadlockPath), folder);
+}
+
+/**
+ * Where a stashed VPK lives while parked. Base-addons files stay flat in
+ * `.disabled/` (byte-identical to the pre-overflow stash format, so a
+ * non-overflow user's vanilla launch is unchanged). Overflow addonsN files go in
+ * a per-folder subfolder of `.disabled/` so a pakNN name (which legitimately
+ * repeats across folders) can't collide in the shared parking lot.
+ */
+function stashSlotPath(disabledPath: string, folder: string, fileName: string): string {
+    return folder === 'addons'
+        ? join(disabledPath, fileName)
+        : join(disabledPath, folder, fileName);
 }
 
 function getStashPath(): string {
@@ -176,39 +201,57 @@ export async function stopDeadlockGame(): Promise<StopDeadlockResult> {
 }
 
 /**
- * Stash every VPK currently in the addons folder: record them to the stash
- * file first (so a crash mid-move leaves a recoverable breadcrumb), then move
- * the files into disabled/. Mark the stash 'active' only once all moves succeed.
+ * Stash every VPK across every addon folder (base citadel/addons plus any
+ * overflow addonsN): record them to the stash file first (so a crash mid-move
+ * leaves a recoverable breadcrumb that knows each file's origin folder), then
+ * move the files into disabled/. Mark the stash 'active' only once all moves
+ * succeed.
  *
  * If a move fails mid-operation, we leave the stash at 'pending' and rethrow.
  * The caller (or next app startup) can then invoke restoreFromStash to
  * reassemble whatever state made it to disk.
  */
 async function stashEnabledMods(deadlockPath: string): Promise<VanillaStash> {
-    const addonsPath = getAddonsPath(deadlockPath);
     const disabledPath = getDisabledPath(deadlockPath);
 
-    const entries = await fs.readdir(addonsPath);
-    // Stash only VPK files (addons folder may contain other junk).
-    const vpks = entries.filter((e) => e.toLowerCase().endsWith('.vpk'));
+    // Enumerate every addon root (base citadel/addons first, then overflow
+    // addons1, addons2, ...) and record each enabled VPK with its origin folder
+    // BEFORE moving anything, so a crash mid-move leaves a recoverable breadcrumb
+    // that knows where each file belongs.
+    const mods: Array<{ fileName: string; folder: string }> = [];
+    for (const folder of getAddonFolderPaths(deadlockPath)) {
+        const name = basename(folder);
+        let entries: string[];
+        try {
+            entries = await fs.readdir(folder);
+        } catch {
+            continue;
+        }
+        // Stash only VPK files (addon folders may contain other junk).
+        for (const fileName of entries) {
+            if (fileName.toLowerCase().endsWith('.vpk')) mods.push({ fileName, folder: name });
+        }
+    }
 
     const stash: VanillaStash = {
         version: 1,
         status: 'pending',
         startedAt: new Date().toISOString(),
-        mods: vpks.map((fileName) => ({ fileName })),
+        mods,
     };
     await writeStash(stash);
 
-    for (const fileName of vpks) {
-        const from = join(addonsPath, fileName);
-        const to = join(disabledPath, fileName);
+    for (const { fileName, folder } of mods) {
+        const from = join(originFolderPath(deadlockPath, folder), fileName);
+        const to = stashSlotPath(disabledPath, folder, fileName);
         if (existsSync(to)) {
-            // Disabled folder already has a file with this name. This shouldn't
-            // happen in normal operation (enable/disable handles collisions),
-            // but be safe: skip rather than overwrite the disabled copy.
+            // Parking spot already taken. This shouldn't happen in normal
+            // operation (enable/disable handles collisions, and overflow files
+            // get a per-folder subfolder), but be safe: skip rather than
+            // overwrite the parked copy.
             continue;
         }
+        await fs.mkdir(dirname(to), { recursive: true });
         await fs.rename(from, to);
     }
 
@@ -224,32 +267,36 @@ export interface RestoreResult {
 }
 
 /**
- * Move stashed VPKs from disabled/ back to addons/, with retries for transient
- * Windows file locks. Deletes the stash only if every file is accounted for.
+ * Move stashed VPKs from disabled/ back to each one's origin addon folder (base
+ * addons or an overflow addonsN, per the stash record), with retries for
+ * transient Windows file locks. Deletes the stash only if every file is
+ * accounted for.
  *
  * Hazard notes:
  * - If the game is still running and holds a handle on the _dir.vpk, Windows
  *   will fail the rename with EBUSY/EPERM. We retry a few times then give up
  *   and leave the stash in place so the user can hit "Restore now" after they
  *   quit the game.
- * - If a stashed file is already back in addons/ (user manually moved it),
- *   we skip rather than clobber.
+ * - If a stashed file is already back in its origin folder (user manually moved
+ *   it), we skip rather than clobber.
  * - If the stashed file vanished from disabled/ (user deleted it), we skip.
  */
 export async function restoreFromStash(
     deadlockPath: string,
     stash: VanillaStash
 ): Promise<RestoreResult> {
-    const addonsPath = getAddonsPath(deadlockPath);
     const disabledPath = getDisabledPath(deadlockPath);
 
     let restored = 0;
     let skipped = 0;
     const failed: string[] = [];
 
-    for (const { fileName } of stash.mods) {
-        const from = join(disabledPath, fileName);
-        const to = join(addonsPath, fileName);
+    for (const { fileName, folder } of stash.mods) {
+        // Legacy stashes (pre-overflow) carry no folder; they're all base addons.
+        const originFolder = folder ?? 'addons';
+        const from = stashSlotPath(disabledPath, originFolder, fileName);
+        const targetDir = originFolderPath(deadlockPath, originFolder);
+        const to = join(targetDir, fileName);
 
         if (!existsSync(from)) {
             skipped++;
@@ -260,6 +307,10 @@ export async function restoreFromStash(
             skipped++;
             continue;
         }
+
+        // The origin folder may have been emptied (overflow) but should still
+        // exist; recreate it defensively so the rename lands.
+        await fs.mkdir(targetDir, { recursive: true });
 
         let ok = false;
         let lastErr: unknown;

--- a/electron/main/services/lockerVpk.ts
+++ b/electron/main/services/lockerVpk.ts
@@ -99,14 +99,14 @@ async function relocateManaged(
 export async function migrateManagedVpksToGrimoire(deadlockPath: string): Promise<void> {
     const mods = await scanMods(deadlockPath);
     for (const m of mods) {
-        const meta = getModMetadata(m.fileName);
+        const meta = getModMetadata(m.metaKey);
         if (meta?.lockerCosmetics) {
-            await relocateManaged(m.path, m.fileName, lockerCardsVpkPath(deadlockPath), LOCKER_CARDS_KEY, {
+            await relocateManaged(m.path, m.metaKey, lockerCardsVpkPath(deadlockPath), LOCKER_CARDS_KEY, {
                 modName: 'Locker Cards',
                 lockerCosmetics: meta.lockerCosmetics,
             });
         } else if (meta?.lockerSounds) {
-            await relocateManaged(m.path, m.fileName, lockerSoundsVpkPath(deadlockPath), LOCKER_SOUNDS_KEY, {
+            await relocateManaged(m.path, m.metaKey, lockerSoundsVpkPath(deadlockPath), LOCKER_SOUNDS_KEY, {
                 modName: 'Locker Sounds',
                 lockerSounds: meta.lockerSounds,
             });
@@ -121,14 +121,14 @@ export async function migrateManagedVpksToGrimoire(deadlockPath: string): Promis
  * scanned. Used by addons-scanning surfaces (get-mods, conflicts, profiles) to
  * hide a not-yet-migrated managed VPK.
  */
-export function isLockerManaged(fileName: string): boolean {
-    const meta = getModMetadata(fileName);
+export function isLockerManaged(metaKey: string): boolean {
+    const meta = getModMetadata(metaKey);
     return !!(meta?.lockerCosmetics || meta?.lockerSounds);
 }
 
 /** Stable relative order among in-addons managed VPKs (fallback path only). */
-function lockerRank(fileName: string): number {
-    const meta = getModMetadata(fileName);
+function lockerRank(metaKey: string): number {
+    const meta = getModMetadata(metaKey);
     if (meta?.lockerCosmetics) return 0;
     if (meta?.lockerSounds) return 1;
     return 2;
@@ -144,15 +144,15 @@ export async function pinLockerVpksToFront(deadlockPath: string): Promise<void> 
     const mods = await scanMods(deadlockPath);
     const enabled = mods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
     const managed = enabled
-        .filter((m) => isLockerManaged(m.fileName))
-        .sort((a, b) => lockerRank(a.fileName) - lockerRank(b.fileName));
+        .filter((m) => isLockerManaged(m.metaKey))
+        .sort((a, b) => lockerRank(a.metaKey) - lockerRank(b.metaKey));
     if (managed.length === 0) return;
 
     const front = enabled.slice(0, managed.length);
     if (managed.every((m, i) => front[i]?.id === m.id)) return;
 
-    const rest = enabled.filter((m) => !isLockerManaged(m.fileName));
-    const ordered = [...managed, ...rest].map((m) => m.fileName);
+    const rest = enabled.filter((m) => !isLockerManaged(m.metaKey));
+    const ordered = [...managed, ...rest].map((m) => m.id);
     await reorderMods(deadlockPath, ordered);
 }
 
@@ -174,7 +174,7 @@ export async function healLockerVpks(deadlockPath: string): Promise<void> {
     // grimoire not configured yet: re-enable any managed VPK parked in .disabled/
     // and pin it to the front of addons so applied cosmetics keep loading.
     const mods = await scanMods(deadlockPath);
-    const disabledManaged = mods.filter((m) => !m.enabled && isLockerManaged(m.fileName));
+    const disabledManaged = mods.filter((m) => !m.enabled && isLockerManaged(m.metaKey));
     for (const m of disabledManaged) {
         try {
             await enableMod(deadlockPath, m.id);

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, statSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getAddonsPath, getDisabledPath } from './deadlock';
+import { getAddonFolderPaths, getDisabledPath, metaKeyFor } from './deadlock';
 import { getMetadataPath } from '../utils/paths';
 
 export interface ModMetadata {
@@ -184,18 +184,18 @@ export async function backfillMissingMetadataHashes(deadlockPath: string): Promi
     const missing = Object.entries(metadata).filter(([, data]) => !isValidSha256(data.sha256));
     if (missing.length === 0) return 0;
 
-    const filesByName = await collectInstalledVpkPaths(deadlockPath);
+    const filesByKey = await collectInstalledVpkPaths(deadlockPath);
     let updated = 0;
 
-    for (const [fileName, data] of missing) {
-        const filePath = filesByName.get(fileName.toLowerCase());
+    for (const [key, data] of missing) {
+        const filePath = filesByKey.get(key.toLowerCase());
         if (!filePath) continue;
 
         try {
             data.sha256 = await hashFileSha256(filePath);
             updated++;
         } catch (error) {
-            console.warn(`[Metadata] Failed to backfill SHA-256 for ${fileName}:`, error);
+            console.warn(`[Metadata] Failed to backfill SHA-256 for ${key}:`, error);
         }
     }
 
@@ -206,19 +206,23 @@ export async function backfillMissingMetadataHashes(deadlockPath: string): Promi
     return updated;
 }
 
+// Map every installed VPK to its absolute path, keyed by metaKey (lowercased) so
+// it lines up with the metaKey-keyed metadata entries. Scans every addon folder
+// (base + overflow) plus .disabled; for base/.disabled the key is the bare
+// filename, for overflow it's addons{N}/<file>.
 async function collectInstalledVpkPaths(deadlockPath: string): Promise<Map<string, string>> {
-    const filesByName = new Map<string, string>();
+    const filesByKey = new Map<string, string>();
 
-    for (const folder of [getAddonsPath(deadlockPath), getDisabledPath(deadlockPath)]) {
+    for (const folder of [...getAddonFolderPaths(deadlockPath), getDisabledPath(deadlockPath)]) {
         for (const entry of await fs.readdir(folder, { withFileTypes: true }).catch(() => [])) {
-            const key = entry.name.toLowerCase();
-            if (entry.isFile() && key.endsWith('_dir.vpk') && !filesByName.has(key)) {
-                filesByName.set(key, join(folder, entry.name));
-            }
+            if (!entry.isFile() || !entry.name.toLowerCase().endsWith('_dir.vpk')) continue;
+            const full = join(folder, entry.name);
+            const key = metaKeyFor(full).toLowerCase();
+            if (!filesByKey.has(key)) filesByKey.set(key, full);
         }
     }
 
-    return filesByName;
+    return filesByKey;
 }
 
 function isValidSha256(value: string | undefined): boolean {
@@ -254,19 +258,19 @@ export const deleteModMetadata = removeModMetadata;
  * Drop metadata entries whose VPK no longer exists on disk.
  *
  * Older versions of deleteMod removed the .vpk file but left metadata behind,
- * keyed by fileName. When the next mod was assigned the same pakNN_dir.vpk
+ * keyed by the mod's metaKey. When the next mod was assigned the same pakNN_dir.vpk
  * slot, setModMetadata's merge behavior leaked the dead mod's gameBananaId,
  * categoryName, thumbnail, etc. onto the new install (issue #26). Callers
- * pass the current valid set so users with pre-existing orphans self-heal
- * the next time the mods list is scanned.
+ * pass the current valid set (metaKeys) so users with pre-existing orphans
+ * self-heal the next time the mods list is scanned.
  */
-export function pruneOrphanMetadata(validFileNames: Set<string>): void {
+export function pruneOrphanMetadata(validKeys: Set<string>): void {
     const metadata = loadMetadata();
     // Synthetic `locker:*` keys hold the Locker-managed selection sets (cards /
     // sounds), which live in citadel/grimoire and are NOT scanned filenames, so
     // they must never be treated as orphans.
     const orphans = Object.keys(metadata).filter(
-        (key) => !key.startsWith('locker:') && !validFileNames.has(key),
+        (key) => !key.startsWith('locker:') && !validKeys.has(key),
     );
     if (orphans.length === 0) return;
 

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -1,10 +1,10 @@
 import { promises as fs, existsSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
-import { getAddonsPath } from './deadlock';
-import { scanMods, disableMod, enableMod, setModPriority, findNextAvailablePriority, type Mod } from './mods';
+import { metaKeyFor } from './deadlock';
+import { scanMods, disableMod, enableMod, allocateEnabledVpkPath, type Mod } from './mods';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { encodeShareCode } from './portableProfile';
@@ -172,8 +172,8 @@ export async function verifyVpkOutput(path: string): Promise<void> {
 /**
  * Exclusively create an empty file at `path` so the priority slot is
  * reserved on disk before we hand it to vpkmerge. Closes the TOCTOU
- * window between findNextAvailablePriority() and runVpkmerge() where a
- * concurrent download or 1-Click install could otherwise claim the slot.
+ * window between slot allocation (allocateEnabledVpkPath) and runVpkmerge()
+ * where a concurrent download or 1-Click install could otherwise claim the slot.
  * Throws a friendly error if the slot was lost to a race.
  */
 export async function reserveOutputSlot(path: string): Promise<void> {
@@ -221,7 +221,7 @@ export async function mergeMods(
     for (const id of modIds) {
         const found = installed.find((m) => m.id === id);
         if (!found) throw new Error(`Selected mod not found (id: ${id}).`);
-        const meta = getModMetadata(found.fileName);
+        const meta = getModMetadata(found.metaKey);
         if (meta?.merged) {
             throw new Error(
                 `"${meta.modName || found.name}" is already a merged mod. Unmerge it first.`
@@ -247,11 +247,13 @@ export async function mergeMods(
     const portable = buildPortableForSources(sources, trimmedName);
     const shareCode = encodeShareCode(JSON.stringify(portable));
 
-    const priority = await findNextAvailablePriority(deadlockPath);
-    const priorityStr = String(priority).padStart(2, '0');
-    const mergedFileName = `pak${priorityStr}_dir.vpk`;
-    const addonsPath = getAddonsPath(deadlockPath);
-    const mergedPath = join(addonsPath, mergedFileName);
+    // The merged VPK installs ENABLED, so reserve a slot via the overflow-aware
+    // allocator: it fills base addons first and spills into an overflow folder
+    // (creating one + patching gameinfo) when base is full, so a merge still
+    // works for a >99 user whose citadel/addons is already saturated. The
+    // metadata key is the destination's metaKey (folder-prefixed for overflow).
+    const mergedPath = await allocateEnabledVpkPath(deadlockPath);
+    const mergedMetaKey = metaKeyFor(mergedPath);
 
     // Reserve the slot on disk before spawning vpkmerge so a concurrent
     // download or 1-Click install can't claim it mid-spawn. wx errors with
@@ -272,7 +274,7 @@ export async function mergeMods(
     }
 
     const preDisableSnapshot: MergedModSource[] = sources.map((src, i) => {
-        const meta = getModMetadata(src.fileName);
+        const meta = getModMetadata(src.metaKey);
         return {
             fileName: src.fileName,
             modName: meta?.modName || src.name,
@@ -300,8 +302,8 @@ export async function mergeMods(
     // fileName fields here are pre-disable; they're updated after each
     // successful disable so the contents-modal UI shows the actual on-disk
     // name. Scrub any orphan metadata from a prior occupant first.
-    removeModMetadata(mergedFileName);
-    setModMetadata(mergedFileName, {
+    removeModMetadata(mergedMetaKey);
+    setModMetadata(mergedMetaKey, {
         modName: trimmedName,
         thumbnailUrl: options.thumbnailDataUrl,
         sha256,
@@ -322,7 +324,7 @@ export async function mergeMods(
             const after = await disableMod(deadlockPath, src.id);
             disabledSources.push(after);
             preDisableSnapshot[i].fileName = after.fileName;
-            setModMetadata(mergedFileName, {
+            setModMetadata(mergedMetaKey, {
                 modName: trimmedName,
                 thumbnailUrl: options.thumbnailDataUrl,
                 sha256,
@@ -334,7 +336,7 @@ export async function mergeMods(
     }
 
     const finalMods = await scanMods(deadlockPath);
-    const newMod = finalMods.find((m) => m.fileName === mergedFileName);
+    const newMod = finalMods.find((m) => m.metaKey === mergedMetaKey);
     if (!newMod) {
         throw new Error('Merged mod was created on disk but could not be located in the rescan.');
     }
@@ -344,7 +346,7 @@ export async function mergeMods(
 function buildPortableForSources(sources: Mod[], profileName: string): PortableProfile {
     const mods: PortableModEntry[] = [];
     for (const src of sources) {
-        const meta = getModMetadata(src.fileName);
+        const meta = getModMetadata(src.metaKey);
         const gbId = meta?.gameBananaId ?? src.gameBananaId;
         const fileId = meta?.gameBananaFileId ?? src.gameBananaFileId;
         if (!gbId || !fileId) continue; // local mod — fast-path unmerge still works
@@ -404,17 +406,17 @@ function makeSourceLocator(candidates: Mod[]): SourceLocator {
 
     const hashCache = new Map<string, string>();
     const getHash = async (mod: Mod): Promise<string> => {
-        const cached = hashCache.get(mod.fileName);
+        const cached = hashCache.get(mod.metaKey);
         if (cached) return cached;
-        const fromMeta = getModMetadata(mod.fileName)?.sha256;
+        const fromMeta = getModMetadata(mod.metaKey)?.sha256;
         if (fromMeta) {
             const lower = fromMeta.toLowerCase();
-            hashCache.set(mod.fileName, lower);
+            hashCache.set(mod.metaKey, lower);
             return lower;
         }
         const fp = await fingerprintFile(mod.path);
         const lower = fp.sha256.toLowerCase();
-        hashCache.set(mod.fileName, lower);
+        hashCache.set(mod.metaKey, lower);
         return lower;
     };
 
@@ -458,7 +460,7 @@ export async function unmergeMod(
     const target = installed.find((m) => m.id === mergedModId);
     if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
 
-    const meta = getModMetadata(target.fileName);
+    const meta = getModMetadata(target.metaKey);
     if (!meta?.merged) {
         throw new Error(`"${meta?.modName || target.name}" is not a merged mod.`);
     }
@@ -485,7 +487,7 @@ export async function unmergeMod(
     }
 
     await fs.unlink(target.path);
-    removeModMetadata(target.fileName);
+    removeModMetadata(target.metaKey);
 
     return {
         recovered,
@@ -513,7 +515,7 @@ export async function extractMergeSource(
     const target = installed.find((m) => m.id === mergedModId);
     if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
 
-    const meta = getModMetadata(target.fileName);
+    const meta = getModMetadata(target.metaKey);
     if (!meta?.merged) {
         throw new Error(`"${meta?.modName || target.name}" is not a merged mod.`);
     }
@@ -560,7 +562,7 @@ export async function extractMergeSource(
             }
         }
         await fs.unlink(target.path);
-        removeModMetadata(target.fileName);
+        removeModMetadata(target.metaKey);
         await restoreExtracted();
         return { collapsed: true, merged: null, restored };
     }
@@ -591,19 +593,24 @@ export async function extractMergeSource(
         .sort((a, b) => b.priority - a.priority)
         .map((p) => p.mod);
 
-    const rebuildPriority = await findNextAvailablePriority(deadlockPath);
-    const rebuildFileName = `pak${String(rebuildPriority).padStart(2, '0')}_dir.vpk`;
-    const addonsPath = getAddonsPath(deadlockPath);
-    const rebuildPath = join(addonsPath, rebuildFileName);
-
-    await reserveOutputSlot(rebuildPath);
+    // Rebuild IN PLACE: build to a dotfile in the merged mod's OWN folder (a
+    // non-`_dir.vpk` name, so it isn't scanned as a mod or counted as a slot),
+    // then swap it into the target's exact path. Staying in-folder keeps the
+    // merge at its original load-order position (folder + pakNN) and needs no free
+    // slot elsewhere, which matters once the merge lives in an overflow folder:
+    // the old findNextAvailablePriority + setModPriority path is base-only and
+    // would wrongly fail (or move the merge to base) for an overflowed merge.
+    const targetDir = dirname(target.path);
+    const buildPath = join(targetDir, `.merge-rebuild-${randomUUID()}.vpk`);
     try {
-        await runVpkmerge([rebuildPath, ...ordered.map((m) => m.path)]);
-        await verifyVpkOutput(rebuildPath);
+        await runVpkmerge([buildPath, ...ordered.map((m) => m.path)]);
+        await verifyVpkOutput(buildPath);
     } catch (err) {
-        try { await fs.unlink(rebuildPath); } catch { /* ignore partial-output cleanup */ }
+        try { await fs.unlink(buildPath); } catch { /* ignore partial-output cleanup */ }
         throw err;
     }
+
+    const sha256 = await hashFile(buildPath);
 
     // Fresh manifest: keep the surviving source snapshots (still accurate),
     // regenerate the share code from the on-disk survivors, preserve createdAt.
@@ -614,33 +621,28 @@ export async function extractMergeSource(
         shareCode: encodeShareCode(JSON.stringify(portable)),
         sources: remainingSnapshots,
     };
-    const sha256 = await hashFile(rebuildPath);
-    removeModMetadata(rebuildFileName); // scrub any orphan from a prior slot occupant
-    setModMetadata(rebuildFileName, {
+
+    // Swap: drop the old merged VPK, then move the freshly built one into its
+    // exact path. Same folder + pakNN means the metaKey (and load order) is
+    // preserved, so the metadata re-stamps under the unchanged key.
+    await fs.unlink(target.path);
+    removeModMetadata(target.metaKey);
+    await fs.rename(buildPath, target.path);
+    setModMetadata(target.metaKey, {
         modName: meta.modName,
         thumbnailUrl: meta.thumbnailUrl,
         sha256,
         merged: newManifest,
     });
 
-    // Delete the old merged VPK to free its slot, then move the rebuilt VPK
-    // back into that slot so the merge keeps its load-order position.
-    const originalPriority = target.priority;
-    await fs.unlink(target.path);
-    removeModMetadata(target.fileName);
-
-    const afterBuild = await scanMods(deadlockPath);
-    const rebuilt = afterBuild.find((m) => m.fileName === rebuildFileName);
-    if (!rebuilt) {
-        throw new Error('Rebuilt merged VPK was created but could not be located in the rescan.');
-    }
-    const reslotted = await setModPriority(deadlockPath, rebuilt.id, originalPriority);
-
     await restoreExtracted();
 
-    // Re-read so the returned merged mod reflects its final on-disk filename
-    // (setModPriority renamed it); the IPC layer enriches it with the manifest.
+    // Re-read so the returned merged mod reflects on-disk state; the IPC layer
+    // enriches it with the manifest. The slot/metaKey is unchanged by the swap.
     const finalScan = await scanMods(deadlockPath);
-    const finalMerged = finalScan.find((m) => m.fileName === reslotted.fileName) ?? reslotted;
+    const finalMerged = finalScan.find((m) => m.metaKey === target.metaKey);
+    if (!finalMerged) {
+        throw new Error('Rebuilt merged VPK was created but could not be located in the rescan.');
+    }
     return { collapsed: false, merged: finalMerged, restored };
 }

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { createHash, randomBytes } from 'crypto';
-import { getAddonsPath, getDisabledPath } from './deadlock';
+import { getAddonsPath, getDisabledPath, getAddonFolderPaths, createNextOverflowFolder, overflowAddonsPath, MAX_ADDON_FOLDERS, metaKeyFor } from './deadlock';
+import { fixGameinfo } from './system';
 import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
 import { compareFileContents, fingerprintFile } from './fileMatch';
 
@@ -13,12 +14,13 @@ const MAX_VPK_PRIORITY = 99;
 /** Default priority for mods without pak## prefix */
 const DEFAULT_MOD_PRIORITY = 50;
 /**
- * Thrown by enableMod when all 99 enabled (pakNN) slots are taken. The renderer
- * matches on the "99 mods enabled" phrase to surface this as a non-fatal toast
- * instead of the full-page error screen, so keep that substring stable.
+ * Thrown by enableMod when every addon folder (base + overflow, up to
+ * MAX_ADDON_FOLDERS) is full. The renderer matches on the "mods enabled at once"
+ * phrase to surface this as a non-fatal toast instead of the full-page error
+ * screen, so keep that substring stable across cap changes.
  */
 export const ENABLE_LIMIT_MESSAGE =
-    'You can have at most 99 mods enabled at once. Disable one to make room.';
+    'You can have at most 990 mods enabled at once. Disable one to make room.';
 
 type CollisionMetadataOwner = 'enabled' | 'disabled';
 
@@ -27,6 +29,12 @@ export interface Mod {
     name: string;
     fileName: string;
     path: string;
+    /** Metadata/identity key for this VPK, derived from its folder location.
+     *  Bare filename for the base addons folder + .disabled (unchanged for
+     *  existing installs); `addons{N}/<file>` for overflow folders. Use this,
+     *  not fileName, as the key for getModMetadata/setModMetadata and as the
+     *  generateModId input, so a pakNN_dir.vpk can't collide across folders. */
+    metaKey: string;
     enabled: boolean;
     priority: number;
     size: number;
@@ -85,11 +93,13 @@ function parseVpkPriority(filename: string): number | null {
 }
 
 /**
- * Generate a mod ID from the file name (hash)
- * Uses fileName instead of full path so ID stays stable when mod moves between folders
+ * Generate a mod ID by hashing its metadata key (see metaKeyFor). The key is the
+ * bare filename for base-addons + .disabled mods (so existing IDs are unchanged)
+ * and `addons{N}/<file>` for overflow mods, which keeps IDs unique when the same
+ * pakNN_dir.vpk name exists in more than one addon folder.
  */
-function generateModId(fileName: string): string {
-    return createHash('md5').update(fileName).digest('hex').slice(0, 16);
+function generateModId(metaKey: string): string {
+    return createHash('md5').update(metaKey).digest('hex').slice(0, 16);
 }
 
 /**
@@ -166,6 +176,16 @@ function slugify(value: string): string {
 }
 
 /**
+ * Folder index of an addon VPK from its on-disk path: 0 for the base
+ * citadel/addons, N for an overflow citadel/addonsN. Anything else (e.g. a
+ * .disabled file) reports 0; callers that care gate on mod.enabled first.
+ */
+function addonFolderIndex(vpkPath: string): number {
+    const match = basename(dirname(vpkPath)).match(/^addons(\d+)$/i);
+    return match ? parseInt(match[1], 10) : 0;
+}
+
+/**
  * The set of pakNN load-order numbers currently used by files in one folder.
  * Free-form (disabled) filenames don't parse as pakNN, so they're excluded.
  */
@@ -226,12 +246,14 @@ async function scanFolder(folder: string, enabled: boolean): Promise<Mod[]> {
             if (!isDeadlockModVpk(entry)) continue;
 
             const priority = parseVpkPriority(entry) ?? DEFAULT_MOD_PRIORITY;
+            const metaKey = metaKeyFor(fullPath);
 
             mods.push({
-                id: generateModId(entry),
+                id: generateModId(metaKey),
                 name: extractModName(entry),
                 fileName: entry,
                 path: fullPath,
+                metaKey,
                 enabled,
                 priority,
                 size: stats.size,
@@ -258,15 +280,23 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
 
     await reconcileEnabledDisabledCollisions(deadlockPath, addonsPath, disabledPath);
 
-    const [enabledMods, disabledMods] = await Promise.all([
-        scanFolder(addonsPath, true),
+    // Scan every enabled addon folder (base citadel/addons plus any overflow
+    // addons1, addons2, ...) and the single shared .disabled parking lot. Each
+    // mod's metaKey is stamped in scanFolder from its folder location.
+    const enabledFolders = getAddonFolderPaths(deadlockPath);
+    const scanned = await Promise.all([
+        ...enabledFolders.map((folder) => scanFolder(folder, true)),
         scanFolder(disabledPath, false),
     ]);
 
-    const mods = [...enabledMods, ...disabledMods];
+    const mods = scanned.flat();
 
-    // Sort by priority
-    mods.sort((a, b) => a.priority - b.priority);
+    // Sort by global load order: folder first (base, then addons1, addons2, ...),
+    // then pakNN within a folder, so the list reflects real load priority.
+    mods.sort(
+        (a, b) =>
+            addonFolderIndex(a.path) * 100 + a.priority - (addonFolderIndex(b.path) * 100 + b.priority)
+    );
 
     return mods;
 }
@@ -389,21 +419,23 @@ async function moveModToFolderAs(
     rememberPriority?: number
 ): Promise<Mod> {
     if (rememberPriority != null) {
-        setModMetadata(targetMod.fileName, { lastPriority: rememberPriority });
+        setModMetadata(targetMod.metaKey, { lastPriority: rememberPriority });
     }
 
     await fs.mkdir(destinationFolder, { recursive: true });
     const destinationPath = join(destinationFolder, destinationFileName);
     await fs.rename(targetMod.path, destinationPath);
+    const destMetaKey = metaKeyFor(destinationPath);
 
-    if (destinationFileName !== targetMod.fileName) {
-        migrateModMetadata([{ from: targetMod.fileName, to: destinationFileName }]);
+    if (destMetaKey !== targetMod.metaKey) {
+        migrateModMetadata([{ from: targetMod.metaKey, to: destMetaKey }]);
     }
 
     return {
         ...targetMod,
-        id: generateModId(destinationFileName),
+        id: generateModId(destMetaKey),
         fileName: destinationFileName,
+        metaKey: destMetaKey,
         enabled,
         priority: parseVpkPriority(destinationFileName) ?? targetMod.priority,
         path: destinationPath,
@@ -459,6 +491,79 @@ export async function findNextAvailablePriority(deadlockPath: string, startFrom 
     return priority;
 }
 
+interface AllocatedSlot {
+    /** Absolute path of the chosen addon folder (base citadel/addons or an
+     *  overflow citadel/addonsN). */
+    folder: string;
+    /** pakNN_dir.vpk name for the chosen free slot in that folder. */
+    fileName: string;
+}
+
+/**
+ * Find a free enabled (pakNN) slot, walking the base addons folder first then
+ * each existing overflow folder in order, minting a new overflow folder (and
+ * patching gameinfo.gi to add its Game path) only when all are full. Per Model A
+ * the earlier folder is higher priority, so filling base-first keeps the densest
+ * load order. Throws ENABLE_LIMIT_MESSAGE at the MAX_ADDON_FOLDERS cap.
+ *
+ * `preferred` slot numbers (a remembered last-priority, a mod's own legacy pakNN)
+ * are honored only in the base folder. `disabledForbidden` are pakNN held by
+ * .disabled files; the base folder must avoid them because base + .disabled share
+ * the bare-filename id namespace (overflow folders are folder-namespaced, so they
+ * don't). Shared by enableMod and allocateEnabledVpkPath.
+ */
+async function allocateSlot(
+    deadlockPath: string,
+    opts: { disabledForbidden: Set<number>; preferred: Array<number | undefined> }
+): Promise<AllocatedSlot> {
+    const folders = getAddonFolderPaths(deadlockPath);
+    for (let i = 0; i < folders.length; i++) {
+        const folder = folders[i];
+        const used = await folderPakNumbers(folder);
+        const forbidden = i === 0 ? new Set<number>([...used, ...opts.disabledForbidden]) : used;
+        const preferred = i === 0 ? opts.preferred : [];
+        let slot: number;
+        try {
+            slot = pickEnableSlot(forbidden, preferred);
+        } catch {
+            continue; // this folder is full; try the next
+        }
+        return { folder, fileName: `pak${String(slot).padStart(2, '0')}_dir.vpk` };
+    }
+
+    // Every existing folder is full: spill into a fresh overflow folder. Add it
+    // to gameinfo BEFORE the caller writes a VPK in, or the engine won't load it.
+    // createNextOverflowFolder returns null once the MAX_ADDON_FOLDERS cap is hit.
+    const overflowFolder = createNextOverflowFolder(deadlockPath);
+    if (!overflowFolder) {
+        throw new Error(ENABLE_LIMIT_MESSAGE);
+    }
+    const status = fixGameinfo(deadlockPath);
+    if (!status.configured) {
+        throw new Error(
+            `Couldn't add the overflow mod folder to gameinfo.gi${status.message ? `: ${status.message}` : ''}. ` +
+                'Open Settings and use Fix Configuration, then try again.'
+        );
+    }
+    return { folder: overflowFolder, fileName: `pak${String(MIN_VPK_PRIORITY).padStart(2, '0')}_dir.vpk` };
+}
+
+/**
+ * Absolute path a brand-new ENABLED VPK should be written to (custom local
+ * import, merge output), honoring the multi-folder overflow model so the create
+ * still succeeds when the base addons folder is full. Unlike
+ * findNextAvailablePriority (base + .disabled only), this spills into overflow
+ * folders and mints a new one at capacity. Throws ENABLE_LIMIT_MESSAGE at the cap.
+ *
+ * The caller writes the VPK to this path and then keys its metadata by
+ * metaKeyFor(path), since an overflow destination uses a folder-prefixed key.
+ */
+export async function allocateEnabledVpkPath(deadlockPath: string): Promise<string> {
+    const disabledForbidden = await folderPakNumbers(getDisabledPath(deadlockPath));
+    const { folder, fileName } = await allocateSlot(deadlockPath, { disabledForbidden, preferred: [] });
+    return join(folder, fileName);
+}
+
 /**
  * Enable a mod by moving it from disabled to addons folder (async)
  */
@@ -474,26 +579,26 @@ export async function enableMod(deadlockPath: string, modId: string): Promise<Mo
         return targetMod;
     }
 
-    const addonsPath = getAddonsPath(deadlockPath);
     const disabledPath = getDisabledPath(deadlockPath);
 
-    // The destination slot must avoid every number already enabled, plus every
-    // OTHER disabled mod that still carries a legacy pakNN name (so the enabled
-    // copy can't share an id with a still-disabled file). The mod we're moving
-    // out is excluded from that disabled set.
-    const addonsUsed = await folderPakNumbers(addonsPath);
+    // A still-disabled mod with a legacy pakNN name shares the bare-filename id
+    // namespace with a base-folder file, so the base folder must avoid those
+    // numbers (an overflow file's id is namespaced by its folder, so disabled
+    // names can't collide there). The mod we're moving out is excluded.
     const disabledUsed = await folderPakNumbers(disabledPath);
     const ownNumber = parseVpkPriority(targetMod.fileName);
     if (ownNumber !== null) disabledUsed.delete(ownNumber);
-    const forbidden = new Set<number>([...addonsUsed, ...disabledUsed]);
 
     // Prefer the slot the mod last held, then its own legacy number, so a
     // re-enable returns it to roughly its old load-order position when free.
-    const meta = getModMetadata(targetMod.fileName);
-    const slot = pickEnableSlot(forbidden, [meta?.lastPriority, ownNumber ?? undefined]);
-    const destinationFileName = `pak${String(slot).padStart(2, '0')}_dir.vpk`;
-
-    return moveModToFolderAs(targetMod, addonsPath, destinationFileName, true);
+    // allocateSlot fills the base addons folder first, then each overflow folder
+    // in order, minting a new one (and patching gameinfo) only when all are full.
+    const meta = getModMetadata(targetMod.metaKey);
+    const { folder, fileName } = await allocateSlot(deadlockPath, {
+        disabledForbidden: disabledUsed,
+        preferred: [meta?.lastPriority, ownNumber ?? undefined],
+    });
+    return moveModToFolderAs(targetMod, folder, fileName, true);
 }
 
 /**
@@ -521,7 +626,7 @@ export async function disableMod(deadlockPath: string, modId: string): Promise<M
         : new Set<string>();
     // Name the disabled file after the mod's display name (an enabled mod's own
     // filename is a bare pakNN with nothing readable to keep).
-    const meta = getModMetadata(targetMod.fileName);
+    const meta = getModMetadata(targetMod.metaKey);
     const preferredName = meta?.modName ?? meta?.sourceFileName ?? meta?.variantLabel;
     const destinationFileName = makeDisabledFileName(targetMod.fileName, taken, preferredName);
 
@@ -541,10 +646,10 @@ export async function deleteMod(deadlockPath: string, modId: string): Promise<vo
 
     await fs.unlink(targetMod.path);
 
-    // Metadata is keyed by fileName. If we leave it behind, the next mod that
-    // is assigned the same pakNN_dir.vpk slot will inherit the deleted mod's
-    // gameBananaId, thumbnail, category, etc. via setModMetadata's merge.
-    removeModMetadata(targetMod.fileName);
+    // Metadata is keyed by metaKey. If we leave it behind, the next mod that
+    // is assigned the same slot will inherit the deleted mod's gameBananaId,
+    // thumbnail, category, etc. via setModMetadata's merge.
+    removeModMetadata(targetMod.metaKey);
 }
 
 /**
@@ -578,98 +683,142 @@ export async function setModPriority(
         return targetMod;
     }
 
-    // Check BOTH folders, not just parentDir. Otherwise the user could
-    // promote an enabled mod into a priority slot held by a disabled mod
-    // (e.g. an absorbed merge source), reconcile would then rename the
-    // disabled file on next scan, and any merged-mod manifest pointing at
-    // that disabled fileName would silently lose its source.
-    const addonsPath = getAddonsPath(deadlockPath);
-    const disabledPath = getDisabledPath(deadlockPath);
-    if (
-        existsSync(join(addonsPath, newFileName)) ||
-        existsSync(join(disabledPath, newFileName))
-    ) {
+    // Reject a slot already taken in the mod's OWN folder. For a base-folder mod
+    // also reject one held by a disabled file: the two share the bare-filename id
+    // namespace, so reconcile would otherwise rename the disabled file on the next
+    // scan and a merged-mod manifest pointing at it would lose its source.
+    // (Overflow folders have a folder-prefixed id namespace, so disabled names
+    // can't collide there.)
+    const collides =
+        existsSync(join(parentDir, newFileName)) ||
+        (addonFolderIndex(targetMod.path) === 0 &&
+            existsSync(join(getDisabledPath(deadlockPath), newFileName)));
+    if (collides) {
         throw new Error(`Priority ${newPriority} is already in use`);
     }
-    await fs.rename(join(parentDir, targetMod.fileName), join(parentDir, newFileName));
+    const newPath = join(parentDir, newFileName);
+    await fs.rename(join(parentDir, targetMod.fileName), newPath);
+    const newMetaKey = metaKeyFor(newPath);
 
-    const oldMeta = getModMetadata(targetMod.fileName);
+    const oldMeta = getModMetadata(targetMod.metaKey);
     if (oldMeta) {
-        setModMetadata(newFileName, oldMeta);
-        removeModMetadata(targetMod.fileName);
+        setModMetadata(newMetaKey, oldMeta);
+        removeModMetadata(targetMod.metaKey);
     }
 
     return {
         ...targetMod,
         priority: newPriority,
         fileName: newFileName,
-        path: join(parentDir, newFileName),
-        id: generateModId(newFileName),
+        metaKey: newMetaKey,
+        path: newPath,
+        id: generateModId(newMetaKey),
     };
 }
 
 /**
- * Reorder mods by rewriting their pak## priorities to match the given order (async).
- * - Assigns priorities 1, 2, 3, … to orderedFileNames, skipping priority numbers
- *   already held by mods NOT in the list (so disabled mods keep their slots).
- * - Uses two-phase rename (temp prefix → final) so collisions between target
- *   priorities can't happen mid-operation.
- * - Migrates metadata for every renamed _dir.vpk.
+ * Reorder the enabled mods to match the given order (async).
+ *
+ * `orderedIds` is the desired order of enabled mods (by id). They're laid out
+ * densely across addon folders per Model A: the first 99 fill the base
+ * citadel/addons (pak01..pak99), the next 99 fill addons1, then addons2, etc.
+ * So flat position P maps to folderIndex floor((P-1)/99), slot ((P-1)%99)+1;
+ * lower position = higher load-order priority.
+ *
+ * Slots held by mods NOT in the list are reserved so they're not overwritten: an
+ * enabled mod keeps its slot in its own folder, and a legacy disabled pakNN
+ * reserves that number in the BASE folder (it shares the bare-filename id
+ * namespace). Disabled ids in the list are ignored - reordering never pulls a mod
+ * out of .disabled (matches the old free-form-name no-op).
+ *
+ * Overflow folders are created and added to gameinfo before any file moves. A
+ * two-phase rename (source -> temp in the target folder -> final) keeps
+ * cross-folder moves and slot swaps collision-free; metadata migrates with each.
  */
 export async function reorderMods(
     deadlockPath: string,
-    orderedFileNames: string[]
+    orderedIds: string[]
 ): Promise<void> {
     const allMods = await scanMods(deadlockPath);
-    const modByFileName = new Map(allMods.map((m) => [m.fileName, m]));
+    const modById = new Map(allMods.map((m) => [m.id, m]));
 
-    for (const fn of orderedFileNames) {
-        if (!modByFileName.has(fn)) {
-            throw new Error(`Mod not in list: ${fn}`);
-        }
+    const targets: Mod[] = [];
+    for (const id of orderedIds) {
+        const mod = modById.get(id);
+        if (!mod) throw new Error(`Mod not in list: ${id}`);
+        if (mod.enabled) targets.push(mod);
     }
+    if (targets.length === 0) return;
+    const targetIds = new Set(targets.map((m) => m.id));
 
-    const targetSet = new Set(orderedFileNames);
-    // Reserve only genuine pakNN slots held by mods outside the reorder list:
-    // enabled mods not being moved, plus any legacy disabled mod still named
-    // pakNN. Free-form disabled mods carry no slot (their parsed priority is
-    // null and they only report DEFAULT_MOD_PRIORITY), so they reserve nothing.
-    const reserved = new Set<number>();
+    // Reserve slots held by mods NOT being reordered, per folder index.
+    const reservedByIndex = new Map<number, Set<number>>();
+    const reserve = (idx: number, slot: number) => {
+        const set = reservedByIndex.get(idx) ?? new Set<number>();
+        set.add(slot);
+        reservedByIndex.set(idx, set);
+    };
     for (const m of allMods) {
-        if (targetSet.has(m.fileName)) continue;
+        if (targetIds.has(m.id)) continue;
         const slot = parseVpkPriority(m.fileName);
-        if (slot !== null) reserved.add(slot);
+        if (slot === null) continue; // free-form disabled: reserves nothing
+        if (m.enabled) reserve(addonFolderIndex(m.path), slot);
+        else reserve(0, slot); // legacy disabled pakNN blocks the base slot
     }
 
-    const assignments: { mod: Mod; newPriority: number; newFileName: string }[] = [];
-    let cursor = MIN_VPK_PRIORITY;
-    for (const fileName of orderedFileNames) {
-        while (reserved.has(cursor) && cursor <= MAX_VPK_PRIORITY) cursor++;
-        if (cursor > MAX_VPK_PRIORITY) {
-            throw new Error(ENABLE_LIMIT_MESSAGE);
+    // Generate dense (folderIndex, slot) addresses in priority order, skipping
+    // reserved slots and advancing to the next folder when one fills.
+    const addresses: Array<{ idx: number; slot: number }> = [];
+    let idx = 0;
+    let slot = MIN_VPK_PRIORITY;
+    while (addresses.length < targets.length) {
+        if (slot > MAX_VPK_PRIORITY) {
+            idx++;
+            slot = MIN_VPK_PRIORITY;
+            if (idx > MAX_ADDON_FOLDERS - 1) throw new Error(ENABLE_LIMIT_MESSAGE);
+            continue;
         }
-        const mod = modByFileName.get(fileName)!;
-        const newFileName = renameWithPriority(fileName, cursor);
-        if (mod.priority !== cursor || newFileName !== fileName) {
-            assignments.push({ mod, newPriority: cursor, newFileName });
-        }
-        cursor++;
+        if (!reservedByIndex.get(idx)?.has(slot)) addresses.push({ idx, slot });
+        slot++;
     }
 
+    // Create the overflow folders the layout needs and make gameinfo list them
+    // before moving any files in (or the engine won't load them).
+    const maxIdx = addresses.reduce((mx, a) => Math.max(mx, a.idx), 0);
+    if (maxIdx >= 1) {
+        for (let k = 1; k <= maxIdx; k++) overflowAddonsPath(deadlockPath, k);
+        const status = fixGameinfo(deadlockPath);
+        if (!status.configured) {
+            throw new Error(
+                `Couldn't add the overflow mod folders to gameinfo.gi${status.message ? `: ${status.message}` : ''}. ` +
+                    'Open Settings and use Fix Configuration, then try again.'
+            );
+        }
+    }
+
+    type Assignment = { mod: Mod; toFolder: string; toFileName: string; toMetaKey: string };
+    const assignments: Assignment[] = [];
+    for (let i = 0; i < targets.length; i++) {
+        const mod = targets[i];
+        const { idx: toIdx, slot: toSlot } = addresses[i];
+        const toFolder = toIdx === 0 ? getAddonsPath(deadlockPath) : overflowAddonsPath(deadlockPath, toIdx);
+        const toFileName = `pak${String(toSlot).padStart(2, '0')}_dir.vpk`;
+        const toPath = join(toFolder, toFileName);
+        if (mod.path !== toPath) {
+            assignments.push({ mod, toFolder, toFileName, toMetaKey: metaKeyFor(toPath) });
+        }
+    }
     if (assignments.length === 0) return;
 
+    // Two-phase rename: source -> temp (in the TARGET folder) -> final. Unique
+    // temp names make cross-folder moves and same-folder slot swaps collision-free.
     const tmpId = randomBytes(4).toString('hex');
     type RenameStep = { fromPath: string; tmpPath: string; finalPath: string };
-    const steps: RenameStep[] = [];
-
-    for (const { mod, newFileName } of assignments) {
-        const parentDir = dirname(mod.path);
-        steps.push({
-            fromPath: join(parentDir, mod.fileName),
-            tmpPath: join(parentDir, `tmp${tmpId}_${mod.fileName}`),
-            finalPath: join(parentDir, newFileName),
-        });
-    }
+    const steps: RenameStep[] = assignments.map(({ mod, toFolder, toFileName }, i) => ({
+        fromPath: mod.path,
+        tmpPath: join(toFolder, `tmp${tmpId}_${i}_${toFileName}`),
+        finalPath: join(toFolder, toFileName),
+    }));
 
     const phase1Done: RenameStep[] = [];
     try {
@@ -707,10 +856,7 @@ export async function reorderMods(
     }
 
     migrateModMetadata(
-        assignments.map(({ mod, newFileName }) => ({
-            from: mod.fileName,
-            to: newFileName,
-        }))
+        assignments.map(({ mod, toMetaKey }) => ({ from: mod.metaKey, to: toMetaKey }))
     );
 }
 
@@ -733,9 +879,11 @@ export async function swapModPriority(
         throw new Error('Cannot swap mods with identical priorities');
     }
 
-    // Build a new ordered list where A and B's positions are swapped.
-    // We only reorder enabled mods to avoid touching disabled-mod priorities.
-    const enabled = mods.filter((m) => m.enabled).sort((x, y) => x.priority - y.priority);
+    // Build the enabled mods in global load order (folder first, then pakNN),
+    // swap A and B's positions, and hand the id order to reorderMods. We only
+    // reorder enabled mods to avoid touching disabled-mod priorities.
+    const globalPos = (m: Mod) => addonFolderIndex(m.path) * 100 + m.priority;
+    const enabled = mods.filter((m) => m.enabled).sort((x, y) => globalPos(x) - globalPos(y));
     const aIdx = enabled.findIndex((m) => m.id === modIdA);
     const bIdx = enabled.findIndex((m) => m.id === modIdB);
 
@@ -745,9 +893,9 @@ export async function swapModPriority(
         return;
     }
 
-    const orderedFileNames = enabled.map((m) => m.fileName);
-    [orderedFileNames[aIdx], orderedFileNames[bIdx]] = [orderedFileNames[bIdx], orderedFileNames[aIdx]];
-    await reorderMods(deadlockPath, orderedFileNames);
+    const orderedIds = enabled.map((m) => m.id);
+    [orderedIds[aIdx], orderedIds[bIdx]] = [orderedIds[bIdx], orderedIds[aIdx]];
+    await reorderMods(deadlockPath, orderedIds);
 }
 
 /**
@@ -775,7 +923,7 @@ async function directSwap(a: Mod, b: Mod): Promise<void> {
     for (const step of steps) await fs.rename(step.tmp, step.final);
 
     migrateModMetadata([
-        { from: a.fileName, to: renameWithPriority(a.fileName, b.priority) },
-        { from: b.fileName, to: renameWithPriority(b.fileName, a.priority) },
+        { from: a.metaKey, to: metaKeyFor(steps[0].final) },
+        { from: b.metaKey, to: metaKeyFor(steps[1].final) },
     ]);
 }

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -97,9 +97,9 @@ export async function buildPortableProfileFromInstalled(
     for (const installedMod of installed) {
         // Locker-managed VPKs (cards/sounds) are internal and have no GameBanana
         // ref, so silently skip them rather than warning "Skipped local mod".
-        if (isLockerManaged(installedMod.fileName)) continue;
+        if (isLockerManaged(installedMod.metaKey)) continue;
 
-        const metadata = getModMetadata(installedMod.fileName);
+        const metadata = getModMetadata(installedMod.metaKey);
         const gbId = metadata?.gameBananaId ?? installedMod.gameBananaId;
         const fileId = metadata?.gameBananaFileId ?? installedMod.gameBananaFileId;
 
@@ -180,7 +180,7 @@ export async function buildPortableProfile(
     // installs.
     const modByGbFile = new Map<string, typeof installed[number]>();
     for (const m of installed) {
-        const meta = getModMetadata(m.fileName);
+        const meta = getModMetadata(m.metaKey);
         if (typeof meta?.gameBananaId === 'number' && typeof meta?.gameBananaFileId === 'number') {
             const key = `${meta.gameBananaId}:${meta.gameBananaFileId}`;
             if (!modByGbFile.has(key)) modByGbFile.set(key, m);
@@ -199,8 +199,8 @@ export async function buildPortableProfile(
         const installedMod =
             (stableKey ? modByGbFile.get(stableKey) : undefined) ??
             modByFileName.get(profileMod.fileName);
-        const metadataFileName = installedMod?.fileName ?? profileMod.fileName;
-        const metadata = getModMetadata(metadataFileName);
+        const metadataKey = installedMod?.metaKey ?? profileMod.fileName;
+        const metadata = getModMetadata(metadataKey);
         const gbId =
             profileMod.gameBananaId ??
             metadata?.gameBananaId ??
@@ -417,7 +417,7 @@ async function buildInstalledIndex(deadlockPath: string): Promise<InstalledIndex
     const byVariant = new Map<string, string>();
     const byArchive = new Map<string, string>();
     for (const mod of installed) {
-        const meta = getModMetadata(mod.fileName);
+        const meta = getModMetadata(mod.metaKey);
         if (meta?.gameBananaId === undefined || meta?.gameBananaFileId === undefined) continue;
         const archiveKey = `${meta.gameBananaId}:${meta.gameBananaFileId}`;
         if (!byArchive.has(archiveKey)) byArchive.set(archiveKey, mod.fileName);

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -124,7 +124,7 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
     // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
     // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
     // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
-    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.fileName));
+    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey));
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -154,8 +154,8 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
  * ids are what `applyProfile` resolves against so a mod can still be found
  * after its fileName has changed (reorder, collision-rename, multi-vpk pick).
  */
-function toProfileMod(mod: { fileName: string; priority: number }, enabled: boolean): ProfileMod {
-    const meta = getModMetadata(mod.fileName);
+function toProfileMod(mod: { fileName: string; metaKey: string; priority: number }, enabled: boolean): ProfileMod {
+    const meta = getModMetadata(mod.metaKey);
     const out: ProfileMod = {
         fileName: mod.fileName,
         enabled,
@@ -191,7 +191,7 @@ export async function createProfileFromGameBananaIds(
     // it up per-mod here. Without this the filter never matches and the
     // profile saves zero mods.
     const matching = mods.filter((mod) => {
-        const metadata = getModMetadata(mod.fileName);
+        const metadata = getModMetadata(mod.metaKey);
         return metadata?.gameBananaId !== undefined && idSet.has(metadata.gameBananaId);
     });
 
@@ -230,7 +230,7 @@ export async function updateProfile(deadlockPath: string, profileId: string, cro
     // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
     // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
     // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
-    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.fileName));
+    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey));
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -301,7 +301,7 @@ function buildProfileModResolver(
     const metaByFileName = new Map<string, ReturnType<typeof getModMetadata>>();
     for (const mod of currentMods) {
         byFileName.set(mod.fileName, mod);
-        const meta = getModMetadata(mod.fileName);
+        const meta = getModMetadata(mod.metaKey);
         metaByFileName.set(mod.fileName, meta);
         const gbId = meta?.gameBananaId;
         const fileId = meta?.gameBananaFileId;
@@ -470,7 +470,7 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
         // profile: they're hidden, auto-pinned, and owned by the Locker. Never
         // disable them on a profile switch, or applied cosmetics would silently
         // stop loading. They get re-pinned to the front after the reorder pass.
-        if (isLockerManaged(mod.fileName)) continue;
+        if (isLockerManaged(mod.metaKey)) continue;
         const profileMod = profileModByCurrentId.get(mod.id);
         if (profileMod && profileMod.enabled) continue; // keep it enabled
         await disableMod(deadlockPath, mod.id);
@@ -507,7 +507,7 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     // id-to-mod (and fileName) mapping is stale.
     const refreshedMods = await scanMods(deadlockPath);
     const resolveAgainstRefreshed = buildProfileModResolver(refreshedMods);
-    const orderedFileNames: string[] = [];
+    const orderedIds: string[] = [];
     const seen = new Set<string>();
     let reorderSkippedDisabled = 0;
     let reorderSkippedUnmatched = 0;
@@ -522,16 +522,16 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
             reorderSkippedDisabled++;
             continue;
         }
-        if (seen.has(resolution.mod.fileName)) continue;
-        seen.add(resolution.mod.fileName);
-        orderedFileNames.push(resolution.mod.fileName);
+        if (seen.has(resolution.mod.id)) continue;
+        seen.add(resolution.mod.id);
+        orderedIds.push(resolution.mod.id);
     }
-    if (orderedFileNames.length > 0) {
+    if (orderedIds.length > 0) {
         console.log(
-            `[profiles] reorder: ${orderedFileNames.length} mods -> pak01..pak${orderedFileNames.length} ` +
+            `[profiles] reorder: ${orderedIds.length} mods laid out densely across addon folders ` +
             `(skipped ${reorderSkippedUnmatched} unmatched, ${reorderSkippedDisabled} disabled)`
         );
-        await reorderMods(deadlockPath, orderedFileNames);
+        await reorderMods(deadlockPath, orderedIds);
     } else {
         console.log(`[profiles] reorder: nothing to reorder`);
     }

--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join, extname } from 'path';
-import { getGameinfoPath, getAddonsPath, getDisabledPath, getCitadelPath, getGrimoirePath } from './deadlock';
+import { getGameinfoPath, getDisabledPath, getCitadelPath, getGrimoirePath, getOverflowFolderNames, getAddonFolderPaths } from './deadlock';
 
 // The canonical SearchPaths block for Deadlock with mod support
 const SEARCH_PATHS_BLOCK = `SearchPaths
@@ -16,6 +16,20 @@ const SEARCH_PATHS_BLOCK = `SearchPaths
 		AddonRoot			citadel_addons
 		OfficialAddonRoot		citadel_community_addons
 	}`;
+
+// The canonical block with one extra `Game citadel/addonsN` line per overflow
+// folder, inserted right after the base citadel/addons line and reusing its
+// indentation. Per Model A precedence (earlier line wins), base addons outranks
+// addons1 outranks addons2, etc. With no overflow folders this is byte-identical
+// to SEARCH_PATHS_BLOCK, so existing installs are unaffected.
+function buildSearchPathsBlock(overflowFolderNames: string[]): string {
+    if (overflowFolderNames.length === 0) return SEARCH_PATHS_BLOCK;
+    return SEARCH_PATHS_BLOCK.replace(
+        /^([^\S\n]*Game[^\S\n]+)citadel\/addons[^\S\n]*$/m,
+        (line, prefix: string) =>
+            [line, ...overflowFolderNames.map((name) => `${prefix}citadel/${name}`)].join('\n')
+    );
+}
 
 export interface GameinfoStatus {
     configured: boolean;
@@ -77,32 +91,26 @@ function findSearchPathsBlock(
 }
 
 // True when the SearchPaths body has an active (non-commented) entry pointing the
-// engine at citadel/addons. Checking inside the block and ignoring // comments
-// means a stray "citadel/addons" in a comment or elsewhere in the file no longer
-// reads as configured: that false positive is what let a DLM-mangled gameinfo.gi
-// look healthy while mods silently failed to load.
-function hasActiveAddonPath(searchPathsBody: string): boolean {
-    return searchPathsBody.split(/\r?\n/).some((line) => {
-        const code = line.split('//')[0]; // drop any trailing line comment
-        // Match citadel/addons only as a complete path token. A subfolder path
-        // like citadel/addons/profile_default (which Deadlock Mod Manager writes
-        // in its profile mode) must NOT count as configured: the engine would
-        // search that subfolder, not the addons root where Grimoire drops its
-        // VPKs. The bare substring check this replaces treated that prefix as
-        // healthy, so Grimoire reported "configured" while no mods loaded.
-        return /citadel[\\/]+addons(?![\\/\w])/i.test(code);
-    });
+// engine at the given citadel-relative folder. Matched as a COMPLETE path token,
+// ignoring // comments, so: a stray path in a comment doesn't read as configured
+// (the false positive that let a DLM-mangled gameinfo.gi look healthy); a
+// subfolder like citadel/addons/profile_default (Deadlock Mod Manager's profile
+// mode) does NOT satisfy citadel/addons; and citadel/addons does NOT satisfy a
+// query for citadel/addons1 (or vice versa).
+function hasActivePath(searchPathsBody: string, relPath: string): boolean {
+    const pattern = relPath.replace(/[/\\]/g, '[\\\\/]+');
+    const re = new RegExp(`${pattern}(?![\\\\/\\w])`, 'i');
+    return searchPathsBody.split(/\r?\n/).some((line) => re.test(line.split('//')[0]));
 }
 
-// True when the SearchPaths body has an active entry pointing the engine at
-// citadel/grimoire, the Grimoire-managed override folder (Locker cards + ability
-// sounds). Listed first in the canonical block so it outranks every user mod;
-// matched as a complete token, ignoring comments, same as the addons check.
+function hasActiveAddonPath(searchPathsBody: string): boolean {
+    return hasActivePath(searchPathsBody, 'citadel/addons');
+}
+
+// citadel/grimoire is the Grimoire-managed override folder (Locker cards +
+// ability sounds), listed first in the canonical block so it outranks every mod.
 function hasActiveGrimoirePath(searchPathsBody: string): boolean {
-    return searchPathsBody.split(/\r?\n/).some((line) => {
-        const code = line.split('//')[0];
-        return /citadel[\\/]+grimoire(?![\\/\w])/i.test(code);
-    });
+    return hasActivePath(searchPathsBody, 'citadel/grimoire');
 }
 
 // Both required search paths are present and active. The grimoire path is what
@@ -129,11 +137,11 @@ function backupGameinfoOnce(gameinfoPath: string, original: string): void {
 // Insert the canonical SearchPaths block just inside the FileSystem section, for
 // the case where another tool stripped SearchPaths out entirely. Returns null if
 // there's no FileSystem block to repair (don't guess at an unknown structure).
-function insertSearchPaths(content: string): string | null {
+function insertSearchPaths(content: string, block: string): string | null {
     const match = /FileSystem\s*\{/.exec(content);
     if (!match) return null;
     const insertAt = match.index + match[0].length;
-    return `${content.slice(0, insertAt)}\n\t\t${SEARCH_PATHS_BLOCK}${content.slice(insertAt)}`;
+    return `${content.slice(0, insertAt)}\n\t\t${block}${content.slice(insertAt)}`;
 }
 
 export interface CleanupResult {
@@ -164,10 +172,28 @@ export function getGameinfoStatus(deadlockPath: string): GameinfoStatus {
         const block = findSearchPathsBlock(content);
 
         if (block && hasRequiredSearchPaths(block.body)) {
+            // Required base paths are present. Also require a Game line for every
+            // overflow folder that exists on disk: a >99 user whose gameinfo.gi
+            // lost its overflow paths (a game update reset the file, or an old
+            // build's fixGameinfo dropped them) would otherwise read as configured
+            // while those mods silently stop loading. Vacuously true - and a no-op
+            // - for the common install with no overflow folders, so non-overflow
+            // users are never re-flagged.
+            const missingOverflow = getOverflowFolderNames(deadlockPath).filter(
+                (name) => !hasActivePath(block.body, `citadel/${name}`)
+            );
+            if (missingOverflow.length === 0) {
+                return {
+                    configured: true,
+                    missing: false,
+                    message: 'Addon search paths are configured correctly',
+                    candidates: [],
+                };
+            }
             return {
-                configured: true,
+                configured: false,
                 missing: false,
-                message: 'Addon search paths are configured correctly',
+                message: `Overflow mod folders are missing from gameinfo.gi (${missingOverflow.join(', ')}). Use Fix Configuration to restore them.`,
                 candidates: [],
             };
         }
@@ -221,8 +247,18 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         const content = readFileSync(gameinfoPath, 'utf-8');
         const block = findSearchPathsBlock(content);
 
-        // Already correct: an active addon path inside a real SearchPaths block.
-        if (block && hasRequiredSearchPaths(block.body)) {
+        // The canonical block includes a Game line for every overflow folder that
+        // currently exists on disk, so a user-triggered repair restores them too.
+        const overflow = getOverflowFolderNames(deadlockPath);
+        const canonical = buildSearchPathsBlock(overflow);
+
+        // Already correct: a real SearchPaths block with the required base paths
+        // AND every existing overflow folder's Game line present.
+        if (
+            block &&
+            hasRequiredSearchPaths(block.body) &&
+            overflow.every((name) => hasActivePath(block.body, `citadel/${name}`))
+        ) {
             return {
                 configured: true,
                 missing: false,
@@ -235,11 +271,11 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
         if (block) {
             // Canonicalize: swap whatever SearchPaths block is present (including
             // one a different mod manager rewrote) for our known-good version.
-            next = content.slice(0, block.start) + SEARCH_PATHS_BLOCK + content.slice(block.end);
+            next = content.slice(0, block.start) + canonical + content.slice(block.end);
         } else if (!/SearchPaths/.test(content)) {
             // Another tool stripped SearchPaths out entirely. Rebuild it inside the
             // FileSystem section so mods load again without a game reinstall.
-            const rebuilt = insertSearchPaths(content);
+            const rebuilt = insertSearchPaths(content, canonical);
             if (!rebuilt) {
                 return {
                     configured: false,
@@ -296,11 +332,12 @@ export function cleanupAddons(deadlockPath: string): CleanupResult {
         skippedMinaTextures: 0,
     };
 
-    const addonsPath = getAddonsPath(deadlockPath);
     const disabledPath = getDisabledPath(deadlockPath);
 
-    // Process both enabled and disabled folders
-    for (const folder of [addonsPath, disabledPath]) {
+    // Process every enabled addon folder (base citadel/addons plus any overflow
+    // addonsN) and the shared .disabled parking lot, so leftover archives and
+    // Mina files are normalized wherever a mod ended up.
+    for (const folder of [...getAddonFolderPaths(deadlockPath), disabledPath]) {
         if (!existsSync(folder)) continue;
 
         const files = readdirSync(folder);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -64,7 +64,7 @@ export interface ElectronAPI {
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
     ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
-    reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
+    reorderMods: (orderedIds: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
@@ -815,8 +815,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ) => ipcRenderer.invoke('backfill-gamebanana-file-id', modId, payload),
     setModPriority: (modId: string, priority: number) =>
         ipcRenderer.invoke('set-mod-priority', modId, priority),
-    reorderMods: (orderedFileNames: string[]) =>
-        ipcRenderer.invoke('reorder-mods', orderedFileNames),
+    reorderMods: (orderedIds: string[]) =>
+        ipcRenderer.invoke('reorder-mods', orderedIds),
     swapModPriority: (modIdA: string, modIdB: string) =>
         ipcRenderer.invoke('swap-mod-priority', modIdA, modIdB),
     importCustomMod: (args: ImportCustomModArgs) =>

--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -176,9 +176,13 @@ export function LockerOverridesModal({
     const [thumbsLoading, setThumbsLoading] = useState(false);
     const commitTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
+    // Keyed by metaKey (folder-relative), because an override's sourceFileName is
+    // now that key, not the bare filename: once a user overflows, the same
+    // pakNN_dir.vpk name repeats across addon folders. metaKey === fileName for
+    // base-folder mods, so this is unchanged for non-overflow users.
     const modByFile = useMemo(() => {
         const m = new Map<string, Mod>();
-        for (const mod of mods) m.set(mod.fileName, mod);
+        for (const mod of mods) m.set(mod.metaKey, mod);
         return m;
     }, [mods]);
 

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -1,37 +1,37 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { setModPriority } from '../lib/api';
-import { useAppStore } from '../stores/appStore';
 
 interface Props {
-  modId: string;
   modName: string;
-  priority: number;
+  /** The number shown on the chip and seeded into the editor: the mod's
+   *  1-based global load-order position (1 = loads first). */
+  value: number;
+  /** Highest selectable position (the count of enabled mods). The editor
+   *  rejects anything outside 1..max. */
+  max: number;
   variant?: 'overlay' | 'inline';
-  /** Override the default single-rename commit path. Provided by Installed.tsx
-   *  so collisions with same-section mods rebuild the order via reorderMods
-   *  (insert-and-shift) instead of throwing "already in use". */
-  onCommit?: (newPriority: number) => Promise<void>;
+  /** Commit a new load-order position. Installed.tsx repositions the mod in the
+   *  global enabled order and reorders the pakNN slots on disk to match. */
+  onCommit?: (newPosition: number) => Promise<void>;
 }
 
 /**
- * Click-to-edit load order chip. Opens a small popover so users can retype
- * a priority instead of dragging through
- * a long list. Right-click is supported too because some users reach for
- * a context menu first — we suppress the native menu in that case.
+ * Click-to-edit load order chip. Opens a small popover so users can retype a
+ * position instead of dragging through a long list. Right-click is supported
+ * too because some users reach for a context menu first (we suppress the native
+ * menu in that case).
  *
- * Enter / blur commit; Escape cancels. Validation mirrors the underlying
- * setModPriority IPC (1-99), and the IPC's "already in use" error surfaces
- * inline so the user can pick another number without leaving the field.
+ * The number is the mod's global load-order position (1 = loads first). Enter /
+ * blur commit; Escape cancels. Valid range is 1..max (the enabled-mod count);
+ * onCommit repositions the mod and reorders the pakNN slots on disk to match.
  */
 export default function PriorityEditor({
-  modId,
   modName,
-  priority,
+  value,
+  max,
   variant = 'inline',
   onCommit,
 }: Props) {
-  const loadMods = useAppStore((s) => s.loadMods);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export default function PriorityEditor({
   const startEdit = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
     if ('preventDefault' in e) e.preventDefault();
-    setDraft(String(priority));
+    setDraft(String(value));
     setEditing(true);
     setError(null);
     const rect = chipRef.current?.getBoundingClientRect();
@@ -69,19 +69,15 @@ export default function PriorityEditor({
     const trimmed = draft.trim();
     if (trimmed === '') return cancel();
     const n = parseInt(trimmed, 10);
-    if (!Number.isFinite(n) || n < 1 || n > 99) {
-      setError('Use 1-99');
+    if (!Number.isFinite(n) || n < 1 || n > max) {
+      setError(`Use 1-${max}`);
       return;
     }
-    if (n === priority) return cancel();
+    if (n === value) return cancel();
+    if (!onCommit) return cancel();
     setBusy(true);
     try {
-      if (onCommit) {
-        await onCommit(n);
-      } else {
-        await setModPriority(modId, n);
-        await loadMods();
-      }
+      await onCommit(n);
       setEditing(false);
       setError(null);
       setPopoverPos(null);
@@ -112,7 +108,7 @@ export default function PriorityEditor({
         }
       }}
       className="group/order-chip relative inline-flex min-h-7 min-w-7 cursor-pointer items-center justify-center rounded-md focus:outline-none"
-      aria-label={`Load order ${priority}. Click to change.`}
+      aria-label={`Load order ${value}. Click to change.`}
     >
       <span
         // White number on a neutral dark scrim (overlay) or the standard input
@@ -127,7 +123,7 @@ export default function PriorityEditor({
             : 'bg-bg-tertiary'
         }`}
       >
-        #{priority}
+        #{value}
       </span>
       {!editing && (
         <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-bg-primary/95 px-2 py-1 text-[11px] font-medium text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 group-hover/order-chip:opacity-100 group-focus-visible/order-chip:opacity-100">
@@ -150,7 +146,7 @@ export default function PriorityEditor({
               inputMode="numeric"
               value={draft}
               disabled={busy}
-              onChange={(e) => setDraft(e.target.value.replace(/\D/g, '').slice(0, 2))}
+              onChange={(e) => setDraft(e.target.value.replace(/\D/g, '').slice(0, 3))}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault();

--- a/src/components/locker/HeroSoundPicker.tsx
+++ b/src/components/locker/HeroSoundPicker.tsx
@@ -360,10 +360,14 @@ export default function HeroSoundPicker({ heroName, soundList, onSelect }: HeroS
 
   const handlePick = async (slot: AbilitySlot, mod: Mod) => {
     if (busyKey || savingSlot !== null) return;
-    setBusyKey(`${slot}:${mod.fileName}`);
+    // Identify the source by its folder-unique metaKey, not the bare filename:
+    // once a user overflows, the same pakNN_dir.vpk name exists in several addon
+    // folders, so the filename can't tell two sources apart. (metaKey === fileName
+    // for base-folder mods, so nothing changes for non-overflow users.)
+    setBusyKey(`${slot}:${mod.metaKey}`);
     setActionError(null);
     try {
-      if (activeBySlot.get(slot) === mod.fileName) {
+      if (activeBySlot.get(slot) === mod.metaKey) {
         await revertHeroSound(heroName, slot);
         setActiveBySlot((prev) => {
           const next = new Map(prev);
@@ -371,7 +375,7 @@ export default function HeroSoundPicker({ heroName, soundList, onSelect }: HeroS
           return next;
         });
       } else {
-        const result = await applyHeroSound(heroName, slot, mod.fileName);
+        const result = await applyHeroSound(heroName, slot, mod.metaKey);
         setActiveBySlot((prev) => {
           const next = new Map(prev);
           if (result.activeSourceFileName) next.set(slot, result.activeSourceFileName);
@@ -549,8 +553,8 @@ export default function HeroSoundPicker({ heroName, soundList, onSelect }: HeroS
                         mod={mod}
                         heroName={heroName}
                         slot={slot.slot}
-                        isActive={activeSource === mod.fileName}
-                        isBusy={busyKey === `${slot.slot}:${mod.fileName}`}
+                        isActive={activeSource === mod.metaKey}
+                        isBusy={busyKey === `${slot.slot}:${mod.metaKey}`}
                         anyBusy={anyBusy}
                         params={paramsBySlot.get(slot.slot) ?? {}}
                         saving={savingSlot === slot.slot}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -175,8 +175,8 @@ export async function setModPriority(modId: string, priority: number): Promise<M
   return window.electronAPI.setModPriority(modId, priority);
 }
 
-export async function reorderMods(orderedFileNames: string[]): Promise<Mod[]> {
-  return window.electronAPI.reorderMods(orderedFileNames);
+export async function reorderMods(orderedIds: string[]): Promise<Mod[]> {
+  return window.electronAPI.reorderMods(orderedIds);
 }
 
 export async function swapModPriority(modIdA: string, modIdB: string): Promise<Mod[]> {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -56,7 +56,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, extractMergeSource, setModPriority as apiSetModPriority, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, cancelUnknownModDetection, applyUnknownModMatch, applyUnknownCustomMod, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModFilterGuess, MergedModSource } from '../types/mod';
@@ -183,8 +183,18 @@ function isEntryEnabled(entry: ModEntry): boolean {
 /** Sort key for ordering enabled/disabled sections. Uses the primary's
  *  priority for groups so reorder math stays consistent with the existing
  *  per-mod priority system. */
+/** Global load-order rank of a mod: lower = higher priority. With overflow
+ *  folders the pakNN (mod.priority) repeats per folder, so we fold in the folder
+ *  index from metaKey (addons{N}/...) to get a single monotonic order. Base
+ *  citadel/addons (and disabled) is folder 0, addons1 is 1, etc. */
+function modLoadOrder(mod: Mod): number {
+  const match = mod.metaKey.match(/^addons(\d+)\//);
+  const folderIndex = match ? parseInt(match[1], 10) : 0;
+  return folderIndex * 100 + mod.priority;
+}
+
 function entrySortPriority(entry: ModEntry): number {
-  return entry.kind === 'single' ? entry.mod.priority : entry.primary.priority;
+  return modLoadOrder(entry.kind === 'single' ? entry.mod : entry.primary);
 }
 
 /** Searchable display name for an entry (the visible card title). */
@@ -305,14 +315,14 @@ function entryFilesByEnabledState(entry: ModEntry, enabled: boolean): Mod[] {
 
 // Only enabled mods hold pakNN load-order slots; disabled mods live in
 // .disabled/ with free-form names and aren't loaded by the game. Compacting
-// must cover the enabled mods alone, otherwise the disabled ones inflate the
-// load order past the 99-slot cap and reorderMods rejects the whole operation.
+// covers the enabled mods alone (reorderMods ignores disabled ids anyway) and
+// orders them by global load order so overflow-folder mods stay after base ones.
 function buildCompactPriorityOrder(entries: ModEntry[]): Mod[] {
   return entries
     .map((entry) => {
       const files = entryFilesByEnabledState(entry, true);
       const priority = files.length > 0
-        ? Math.min(...files.map((file) => file.priority))
+        ? Math.min(...files.map(modLoadOrder))
         : Number.POSITIVE_INFINITY;
       return { files, priority };
     })
@@ -1512,7 +1522,7 @@ export default function Installed() {
     // Use `visibleMods` so absorbed merge sources aren't passed to
     // reorderMods — their fileNames are recorded in the merged mod's
     // manifest, and a rename would silently break unmerge recovery.
-    const enabledMods = visibleMods.filter((m) => m.enabled).sort((a, b) => a.priority - b.priority);
+    const enabledMods = visibleMods.filter((m) => m.enabled).sort((a, b) => modLoadOrder(a) - modLoadOrder(b));
     const disabledMods = visibleMods.filter((m) => !m.enabled).sort((a, b) => a.priority - b.priority);
     const section = source.enabled ? enabledMods : disabledMods;
     const next = section.slice();
@@ -1529,7 +1539,7 @@ export default function Installed() {
     const full = source.enabled
       ? [...next, ...disabledMods]
       : [...enabledMods, ...next];
-    await reorderMods(full.map((m) => m.fileName));
+    await reorderMods(full.map((m) => m.id));
   };
 
   /**
@@ -1788,6 +1798,17 @@ export default function Installed() {
   const enabledCount = enabledEntries.length;
   const disabledCount = disabledEntries.length;
 
+  // Global load-order position (1..N) of each enabled mod, in true load order
+  // (modLoadOrder folds in the addon-folder index, so overflow-folder mods rank
+  // after base ones instead of restarting their pakNN at 1). Drives the
+  // load-order badge so the displayed number never repeats across folders, and
+  // commitLoadPosition repositions within this same ordering.
+  const enabledByLoadOrder = visibleMods
+    .filter((m) => m.enabled)
+    .sort((a, b) => modLoadOrder(a) - modLoadOrder(b));
+  const enabledModCount = enabledByLoadOrder.length;
+  const loadPositionById = new Map(enabledByLoadOrder.map((m, i) => [m.id, i + 1] as const));
+
   // Filter by search query (substring on name), source (GameBanana vs local
   // import), and mod type, then optionally re-sort. Status (enabled/disabled) is
   // applied per-section below. Drag-and-drop reorder is disabled whenever any of
@@ -1961,61 +1982,38 @@ export default function Installed() {
     const unchanged = next.every((m, i) => m.id === prev[i]?.id);
     if (unchanged) return false;
 
-    await reorderMods(next.map((m) => m.fileName));
+    await reorderMods(next.map((m) => m.id));
     return true;
   };
 
   const fixOrder = () => {
     if (compactOrder.length === 0) return;
-    reorderMods(compactOrder.map((m) => m.fileName));
+    reorderMods(compactOrder.map((m) => m.id));
   };
 
   /**
-   * Commit a typed priority from the right-click Load editor. When the target
-   * slot is held by another enabled mod we can't just rename (the file would
-   * collide), so we rebuild the enabled-section order around the collider and
-   * hand it to reorderMods. When moving down, the collider shifts up after the
-   * moved mod is removed, so we insert after it; when moving up, we insert
-   * before it. That preserves "type N, end at N" semantics.
+   * Commit a typed load-order position from the Load editor. The number is a
+   * 1-based global position over the enabled mods (1 = loads first), so we move
+   * the mod to that index in the global enabled order and hand the full id list
+   * to reorderMods, which lays the slots out densely across addon folders. This
+   * replaces the old pakNN-rename path, which restarted its number per overflow
+   * folder and could collide; repositioning can never "already be in use".
    *
    * Calls the API directly (not the store wrappers) so errors propagate back
    * to PriorityEditor for inline display instead of being swallowed into
    * modsError.
    */
-  const commitPriorityForMod = async (modId: string, newPriority: number): Promise<void> => {
-    const mod = mods.find((m) => m.id === modId);
-    if (!mod) throw new Error('Mod not found');
-    if (mod.priority === newPriority) return;
-
-    const collider = mods.find(
-      (m) => m.id !== modId && m.enabled && m.priority === newPriority
-    );
-
-    if (!collider) {
-      await apiSetModPriority(modId, newPriority);
-      await loadMods();
-      return;
-    }
-
-    const enabled = mods
-      .filter((m) => m.enabled)
-      .sort((a, b) => a.priority - b.priority);
-    const withoutMoved = enabled.filter((m) => m.id !== modId);
-    const insertIdx = withoutMoved.findIndex((m) => m.id === collider.id);
-    if (insertIdx === -1) {
-      // Defensive: collider must be enabled, so this shouldn't trigger.
-      // Fall back to the single rename so the user still gets feedback.
-      await apiSetModPriority(modId, newPriority);
-      await loadMods();
-      return;
-    }
-    const insertAt = mod.priority < newPriority ? insertIdx + 1 : insertIdx;
-    const reordered = [
-      ...withoutMoved.slice(0, insertAt),
-      mod,
-      ...withoutMoved.slice(insertAt),
-    ];
-    await apiReorderMods(reordered.map((m) => m.fileName));
+  const commitLoadPosition = async (modId: string, newPosition: number): Promise<void> => {
+    const ordered = enabledByLoadOrder.slice();
+    const fromIdx = ordered.findIndex((m) => m.id === modId);
+    if (fromIdx === -1) throw new Error('Mod not found');
+    // The editor validates 1..N, but a stale render could submit out of range;
+    // clamp to a real slot so we never index past the ends.
+    const toIdx = Math.min(Math.max(newPosition - 1, 0), ordered.length - 1);
+    if (toIdx === fromIdx) return;
+    const [moved] = ordered.splice(fromIdx, 1);
+    ordered.splice(toIdx, 0, moved);
+    await apiReorderMods(ordered.map((m) => m.id));
     await loadMods();
   };
 
@@ -2067,7 +2065,9 @@ export default function Installed() {
           }}
           onFixUnknown={mod.isUnknown ? () => openUnknownModFix(mod, 'single') : undefined}
           fixingUnknown={unknownFilterPendingIds.has(mod.id)}
-          onCommitPriority={(p) => commitPriorityForMod(mod.id, p)}
+          loadPosition={loadPositionById.get(mod.id)}
+          loadCount={enabledModCount}
+          onCommitPriority={(p) => commitLoadPosition(mod.id, p)}
           onUnmerge={mod.merged ? () => setUnmergeTarget(mod) : undefined}
           onCopyShareCode={mod.merged ? () => void handleCopyShareCode(mod) : undefined}
           selectMode={selectMode}
@@ -2128,7 +2128,9 @@ export default function Installed() {
             await setModGlobalType(variant.id, globalType);
           }
         }}
-        onCommitPriority={(p) => commitPriorityForMod(entry.primary.id, p)}
+        loadPosition={loadPositionById.get(entry.primary.id)}
+        loadCount={enabledModCount}
+        onCommitPriority={(p) => commitLoadPosition(entry.primary.id, p)}
         selectMode={selectMode}
         selected={entrySelected}
         onSelectToggle={() => toggleEntrySelection(entry)}
@@ -3822,9 +3824,13 @@ interface ModCardProps {
   onTagGlobal?: (globalType: GlobalModType | null) => void | Promise<void>;
   onFixUnknown?: () => void;
   fixingUnknown?: boolean;
-  /** Collision-tolerant priority commit. Passed through to PriorityEditor so
-   *  retyping an already-used slot insert-shifts instead of throwing. */
-  onCommitPriority?: (newPriority: number) => Promise<void>;
+  /** Reposition commit. Passed through to PriorityEditor; the argument is a
+   *  1-based global load-order position, applied via a dense reorder. */
+  onCommitPriority?: (newPosition: number) => Promise<void>;
+  /** This mod's 1-based global load-order position, shown on the badge. */
+  loadPosition?: number;
+  /** Count of enabled mods (the badge editor's max position). */
+  loadCount?: number;
   /** Open the unmerge confirm flow. Only meaningful when `mod.merged` is set. */
   onUnmerge?: () => void;
   /** Copy the merged mod's share code to the clipboard. */
@@ -4017,7 +4023,9 @@ interface ModListRowContentProps {
   hideNsfwPreviews: boolean;
   soundVolume: number;
   onOpenDetails?: () => void;
-  onCommitPriority?: (newPriority: number) => Promise<void>;
+  onCommitPriority?: (newPosition: number) => Promise<void>;
+  loadPosition?: number;
+  loadCount?: number;
   isGroupCard: boolean;
   group?: ModCardProps['group'];
   variantStatusLabel: string | null;
@@ -4154,6 +4162,8 @@ function ModListRowContent({
   soundVolume,
   onOpenDetails,
   onCommitPriority,
+  loadPosition,
+  loadCount,
   isGroupCard,
   group,
   variantStatusLabel,
@@ -4180,12 +4190,12 @@ function ModListRowContent({
         {mod.enabled ? (
           <span data-card-action="true">
             <PriorityEditor
-              modId={mod.id}
               modName={mod.name}
-            priority={mod.priority}
-            variant="inline"
-            onCommit={onCommitPriority}
-          />
+              value={loadPosition ?? mod.priority}
+              max={loadCount ?? 99}
+              variant="inline"
+              onCommit={onCommitPriority}
+            />
           </span>
         ) : (
           <span className="inline-flex h-5 items-center rounded border border-white/[0.06] bg-bg-tertiary/60 px-1.5 text-[11px] font-semibold text-text-secondary/70">
@@ -4318,6 +4328,8 @@ function ModCard({
   onFixUnknown,
   fixingUnknown,
   onCommitPriority,
+  loadPosition,
+  loadCount,
   onUnmerge,
   onCopyShareCode,
   selectMode,
@@ -4776,6 +4788,8 @@ function ModCard({
             soundVolume={soundVolume}
             onOpenDetails={onOpenDetails}
             onCommitPriority={onCommitPriority}
+            loadPosition={loadPosition}
+            loadCount={loadCount}
             isGroupCard={isGroupCard}
             group={group}
             variantStatusLabel={variantStatusLabel}
@@ -4810,9 +4824,9 @@ function ModCard({
             {mod.enabled && !selectMode && (
               <div className="absolute top-2 left-2 z-10 flex h-5 items-start" data-card-action="true">
                 <PriorityEditor
-                  modId={mod.id}
                   modName={mod.name}
-                  priority={mod.priority}
+                  value={loadPosition ?? mod.priority}
+                  max={loadCount ?? 99}
                   variant="overlay"
                   onCommit={onCommitPriority}
                 />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -198,7 +198,7 @@ interface AppState {
   deleteMod: (modId: string) => Promise<void>;
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
-  reorderMods: (orderedFileNames: string[]) => Promise<void>;
+  reorderMods: (orderedIds: string[]) => Promise<void>;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
   setVariantLabel: (modId: string, label: string) => Promise<void>;
@@ -221,12 +221,13 @@ interface AppState {
   setInstalledScrollTop: (scrollTop: number) => void;
 }
 
-// The main process throws this exact phrase from every "can't add a 100th
-// active mod" path (enable, reorder/compact, local import, merge). We surface
-// it as a transient toast instead of the full-page modsError screen.
+// The main process throws this exact phrase from every "out of enabled slots"
+// path (enable, reorder/compact, local import, merge). We surface it as a
+// transient toast instead of the full-page modsError screen. Match on the
+// cap-agnostic tail so a future MAX_ADDON_FOLDERS bump doesn't break detection.
 const ENABLE_CAP_NOTICE =
-  'You can have at most 99 mods enabled at once. Disable one to make room.';
-const isEnableCapError = (err: unknown): boolean => /99 mods enabled/.test(String(err));
+  'You can have at most 990 mods enabled at once. Disable one to make room.';
+const isEnableCapError = (err: unknown): boolean => /mods enabled at once/.test(String(err));
 
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
@@ -379,11 +380,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  // Reorder mods via drag-and-drop. Accepts the target enabled-list order as filenames.
+  // Reorder mods via drag-and-drop. Accepts the target enabled-list order as mod ids.
   // Rolls back to a fresh scan on error so the UI can't desync from disk.
-  reorderMods: async (orderedFileNames: string[]) => {
+  reorderMods: async (orderedIds: string[]) => {
     try {
-      const updated = await api.reorderMods(orderedFileNames);
+      const updated = await api.reorderMods(orderedIds);
       set({ mods: updated });
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -332,7 +332,7 @@ export interface ElectronAPI {
       payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }
     ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
-    reorderMods: (orderedFileNames: string[]) => Promise<Mod[]>;
+    reorderMods: (orderedIds: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     readImageDataUrl: (imagePath: string) => Promise<string>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -49,8 +49,12 @@ export interface LockerCardSelection {
    *  Informational: the split takes the whole per-hero panorama prefix. */
   variants: string[];
   source: {
-    /** Source VPK filename at apply time. May drift if reconcile renames it;
-     *  `sha256AtApplyTime` is the content-identity fallback for relocation. */
+    /** Folder-relative metaKey of the source VPK (bare filename for a base
+     *  citadel/addons mod, "addonsN/<file>" for an overflow mod). Named
+     *  `fileName` for back-compat: pre-overflow selections stored the bare
+     *  filename, which IS the base mod's metaKey, so they still resolve. May
+     *  drift if reconcile renames or overflow moves it; `sha256AtApplyTime` is
+     *  the content-identity fallback for relocation. */
     fileName: string;
     modName?: string;
     gameBananaId?: number;
@@ -73,9 +77,10 @@ export interface LockerCosmeticsInfo {
 }
 
 export interface ApplyHeroCardResult {
-  /** Source VPK filename now providing this hero's card, or null if reverted. */
+  /** Source identity (folder-relative metaKey; == filename for base mods) now
+   *  providing this hero's card, or null if reverted. */
   activeSourceFileName: string | null;
-  /** Selections dropped because their source VPK was gone at rebuild time. */
+  /** Source identities (metaKeys) dropped because their VPK was gone at rebuild. */
   missingSourceFileNames: string[];
 }
 
@@ -110,8 +115,10 @@ export interface LockerSoundSelection {
   /** Optional volume/pitch retune for this ability (see AbilitySoundParams). */
   params?: AbilitySoundParams;
   source: {
-    /** Source VPK filename at apply time; `sha256AtApplyTime` relocates it if
-     *  reconcile renamed it (same recovery heroCards uses). */
+    /** Folder-relative metaKey of the source VPK (bare filename for base
+     *  citadel/addons, "addonsN/<file>" for overflow). Named `fileName` for
+     *  back-compat (see LockerCardSelection.source.fileName). `sha256AtApplyTime`
+     *  relocates it if reconcile renamed or overflow moved it. */
     fileName: string;
     modName?: string;
     gameBananaId?: number;
@@ -133,17 +140,19 @@ export interface LockerSoundsInfo {
 }
 
 export interface ApplyHeroSoundResult {
-  /** Source VPK filename now providing this ability's sound, or null if reverted. */
+  /** Source identity (folder-relative metaKey; == filename for base mods) now
+   *  providing this ability's sound, or null if reverted. */
   activeSourceFileName: string | null;
-  /** Selections dropped because their source VPK was gone at rebuild time. */
+  /** Source identities (metaKeys) dropped because their VPK was gone at rebuild. */
   missingSourceFileNames: string[];
 }
 
 /** One applied hero-card override, summarized for the Locker Overrides popup. */
 export interface LockerOverviewCard {
   heroName: string;
-  /** Source VPK filename whose card art is applied. Joins to the installed mod
-   *  for its thumbnail/name; the revert itself is keyed by heroName. */
+  /** Source identity (folder-relative metaKey; == filename for base mods) whose
+   *  card art is applied. Joins to the installed mod by metaKey for its
+   *  thumbnail/name; the revert itself is keyed by heroName. */
   sourceFileName: string;
   modName?: string;
 }
@@ -152,8 +161,9 @@ export interface LockerOverviewCard {
 export interface LockerOverviewSound {
   heroName: string;
   slot: AbilitySlot;
-  /** Source VPK filename providing this ability's clip. Joins to the installed
-   *  mod for its preview audio/name; the revert is keyed by (heroName, slot). */
+  /** Source identity (folder-relative metaKey; == filename for base mods)
+   *  providing this ability's clip. Joins to the installed mod by metaKey for its
+   *  preview audio/name; the revert is keyed by (heroName, slot). */
   sourceFileName: string;
   modName?: string;
   /** True when this slot carries a non-neutral volume/pitch retune. */
@@ -185,6 +195,8 @@ export interface LockerCardThumbnail {
  *  back so the picker can reflect the active pick + slider positions. */
 export interface ActiveHeroSound {
   slot: AbilitySlot;
+  /** Source identity (folder-relative metaKey; == filename for base mods). The
+   *  sound picker compares this against each mod's metaKey to mark the active row. */
   sourceFileName: string;
   params?: AbilitySoundParams;
 }
@@ -267,6 +279,10 @@ export interface Mod {
   name: string;
   fileName: string;
   path: string;
+  /** Metadata/identity key derived from the VPK's addon folder. Bare filename
+   *  for the base addons folder + .disabled; `addons{N}/<file>` for overflow
+   *  folders. Mirrors the backend field so the IPC Mod stays in sync. */
+  metaKey: string;
   enabled: boolean;
   priority: number;
   size: number;

--- a/src/types/portrait.ts
+++ b/src/types/portrait.ts
@@ -5,7 +5,12 @@
  * process; the renderer only ever sees the ready-to-display data URL.
  */
 export interface HeroPortrait {
-  /** File name of the mod VPK this portrait came from (e.g. "pak42_dir.vpk"). */
+  /** Folder-relative identity key of the source mod VPK this portrait came from:
+   *  the bare filename for a base citadel/addons mod (e.g. "pak42_dir.vpk"), or
+   *  "addonsN/pak42_dir.vpk" for an overflow-folder mod. Equals the filename for
+   *  base mods (so it stays human-readable and unchanged for non-overflow users)
+   *  but stays unique across folders, which the bare filename does not once a
+   *  user overflows. Round-tripped verbatim back into applyHeroCard. */
   modFileName: string;
   /** card | vertical | minimap | small | card_critical | card_gloat | other */
   variant: string;


### PR DESCRIPTION
## Summary
- Lifts the effective 99-mod ceiling by overflowing enabled mods into sibling `citadel/addonsN` folders, each with its own `pak01`-`pak99` namespace and its own `Game` search path in `gameinfo.gi`. Precedence is Model A: folder order is the primary key, then `pakNN` within a folder. Cap is `MAX_ADDON_FOLDERS = 10` (990 slots).
- **Backwards-compatible.** Base-folder and `.disabled` mods keep their bare-filename metadata keys + ids, `gameinfo.gi` is untouched, and no migration runs until a user actually crosses 99, so existing installs stay byte-identical. (Caveat: downgrading *after* overflowing drops the overflow `Game` lines until re-upgrade; release-note item.)
- Load-order badge now shows a flat global position (1..N) instead of a per-folder `pakNN` that repeats across folders; editing it repositions the mod densely via reorder.
- `getGameinfoStatus` flags missing overflow `Game` lines when those folders exist on disk (so a game-update reset prompts Fix Configuration); non-overflow installs are never re-flagged.

Workstreams: folder/key primitives + scan + slot allocation, reorder/swap (two-phase cross-folder rename with metaKey migration), gameinfo writer, folder-scoped conflict grouping, per-folder vanilla stash/restore, overflow-aware merge/import/cleanup. Design doc: `docs/multi-folder-addon-overflow.md`.

## Test plan
- [x] `tsc` clean (tsconfig.node + tsconfig.app), ESLint clean on changed files, `electron-vite build` succeeds
- [x] Under-99 install: `gameinfo.gi` + `metadata.json` unchanged after update; mod ids/metadata stable
- [x] Cross 99: `addons1` created, `Game citadel/addons1` appended after `citadel/addons`, mod loads in-game
- [x] Precedence: base `pak99` beats `addons1/pak01` on a shared-file collision in-game
- [x] Reorder across the folder boundary; disable/re-enable from an overflow folder
- [x] Launch Vanilla with >99 enabled (all folders empty, then restore to origin folders)
- [x] Merge / custom import at capacity spills into overflow
- [x] Conflict grouping: base `pak05` + `addons1/pak05` is not a false conflict
- [x] Cap at 990 surfaces the reworded enable-limit toast