### PR TITLE
fix(browse): correct Recently Updated and Name sort ordering

### DIFF
--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -560,12 +560,14 @@ export async function fetchSubmissions(
     options: GameBananaRequestOptions = {}
 ): Promise<GameBananaModsResponse> {
     let url: string;
-    // GameBanana v11 API only reliably supports likes/views sorting
-    // Default API order is already sorted by recent submissions, so 'new', 'recent', 'updated' don't need explicit sort
+    // The API's default order is already newest-submission-first, so 'recent'/'new'
+    // and 'default' need no explicit sort. 'updated' is distinct (date modified, not
+    // added) and must be requested explicitly or it silently mirrors 'recent'.
     const sortMap: Record<string, string> = {
         likes: 'Generic_MostLiked',
         popular: 'Generic_MostLiked',
         views: 'Generic_MostViewed',
+        updated: 'Generic_LatestModified',
     };
 
     // Fields to request from GameBanana API (including NSFW flag)

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1265,14 +1265,17 @@ export default function Browse() {
     // live API enriches NSFW after the fact and doesn't window by date, so route
     // those through local search (the cache is a full mirror of the index).
     const hasContentFilter = nsfw !== 'all' || addedWithin !== 'all';
-    return (hasSearchQuery || hasHeroFilter || hasContentFilter) && hasLocalCache && !localSearchFailed;
-  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, hasLocalCache, localSearchFailed]);
+    // The v11 API has no alphabetical sort token, so name ordering also has to
+    // come from the local mirror (which sorts name COLLATE NOCASE ASC).
+    const needsLocalSort = sort === 'name';
+    return (hasSearchQuery || hasHeroFilter || hasContentFilter || needsLocalSort) && hasLocalCache && !localSearchFailed;
+  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hasLocalCache, localSearchFailed]);
 
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
   useEffect(() => {
     setLocalSearchFailed(false);
-  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section]);
+  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section, sort]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search


### PR DESCRIPTION
## Summary
- **Recently Updated** showed identical results to **Recently Added**. In the unfiltered Browse view, results come from the GameBanana API (`fetchSubmissions`), whose sort map only covered likes/popular/views, so both `recent` and `updated` fell through to the API's default newest-added order. Now `updated` maps to `Generic_LatestModified` (verified against the live v11 API to order by `_tsDateModified` desc).
- **Name** sort had the same symptom but a different root cause: the v11 API has no alphabetical sort token at all (every candidate returns zero records, confirmed as the API's invalid-token behavior). Adding it to the API sort map would return an empty grid, so name ordering is routed through the local SQLite mirror instead (`name COLLATE NOCASE ASC`), matching the existing pattern for NSFW/recency filters the API can't satisfy.

## Notes
- Name sort requires a synced local cache. Without one it gracefully falls back to the API's default order (never an invalid token / empty grid).
- The local-cache path was already correct for `updated` (`date_modified DESC`); only the live-API path needed the fix.

## Test plan
- [ ] Browse (no search/filter) → toggle Recently Added vs Recently Updated: orderings now differ.
- [ ] Toggle Name sort: results are alphabetical (with a synced catalog).
- [ ] Name sort with no local cache: falls back to default order, not an empty grid.
- [ ] Popular / Most Viewed / Recently Added still behave as before.