### PR TITLE
feat(locker): 3D soul-container previews in the Global view

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,7 +1,18 @@
-import { app, BrowserWindow, shell, session } from 'electron';
+import { app, BrowserWindow, shell, session, protocol } from 'electron';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
+import { SOUL_MODEL_SCHEME, registerSoulModelProtocol } from './services/soulContainerModels';
+
+// The `grimoire-soul:` scheme serves per-mod soul-container GLBs out of the
+// user's library to the renderer's 3D viewer. Must be declared privileged
+// before app-ready so fetch/streaming work under the renderer's file:// origin.
+protocol.registerSchemesAsPrivileged([
+    {
+        scheme: SOUL_MODEL_SCHEME,
+        privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true },
+    },
+]);
 
 // Initialize the file logger before anything else so console.* calls in IPC
 // and service modules (imported below) flow into the rolling log file from
@@ -259,6 +270,9 @@ if (!gotTheLock) {
     app.whenReady().then(() => {
         // Set app user model id for windows
         electronApp.setAppUserModelId('com.grimoire.modmanager');
+
+        // Serve per-mod soul-container GLBs from the user's library.
+        registerSoulModelProtocol();
 
         // Default open or close DevTools by F12 in development
         app.on('browser-window-created', (_, window) => {

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -65,10 +65,10 @@ ipcMain.handle(
 
 ipcMain.handle(
     'export-soul-model',
-    async (_, fileName: string): Promise<SoulModelInfo> => {
+    async (_, metaKey: string): Promise<SoulModelInfo> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return exportSoulModel(deadlockPath, fileName);
+        return exportSoulModel(deadlockPath, metaKey);
     }
 );
 

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -2,6 +2,12 @@ import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import { getHeroPortraits } from '../services/heroPortraits';
 import { applyHeroCard, revertHeroCard, getActiveHeroCard } from '../services/heroCards';
+import {
+    getSoulModelInfo,
+    exportSoulModel,
+    clearSoulModel,
+    type SoulModelInfo,
+} from '../services/soulContainerModels';
 import type { HeroPortrait } from '../../../src/types/portrait';
 import type { ApplyHeroCardResult } from '../../../src/types/mod';
 
@@ -47,5 +53,28 @@ ipcMain.handle(
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) return null;
         return getActiveHeroCard(deadlockPath, heroName);
+    }
+);
+
+ipcMain.handle(
+    'get-soul-model-info',
+    async (_, key: string): Promise<SoulModelInfo> => {
+        return getSoulModelInfo(key);
+    }
+);
+
+ipcMain.handle(
+    'export-soul-model',
+    async (_, fileName: string): Promise<SoulModelInfo> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return exportSoulModel(deadlockPath, fileName);
+    }
+);
+
+ipcMain.handle(
+    'clear-soul-model',
+    async (_, key: string): Promise<void> => {
+        return clearSoulModel(key);
     }
 );

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -1,0 +1,199 @@
+/**
+ * Per-mod soul-container model store.
+ *
+ * Soul containers are a global (non-hero) Deadlock cosmetic: a small static
+ * prop. The Locker's Global view shows them as flat GameBanana thumbnails,
+ * which are often poor. This service produces a clean `.glb` per installed
+ * soul-container mod via the bundled `vpkmerge model export`, so the Locker can
+ * render the actual model.
+ *
+ * Keyed per-mod by the VPK file name. Uses an explicit `--entry` (soul
+ * containers are props, not heroes, so there is no `--hero` discovery).
+ *
+ * Layout: userData/soul-models/<key>/model.glb
+ *
+ * The renderer can't read userData files directly under file:// + webSecurity,
+ * so they're served through the registered `grimoire-soul:` scheme
+ * (see registerSoulModelProtocol).
+ */
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { app, protocol, net } from 'electron';
+import { runVpkmerge } from './modMerger';
+import { getCitadelPath, getAddonsPath } from './deadlock';
+
+export const SOUL_MODEL_SCHEME = 'grimoire-soul';
+
+/**
+ * Canonical soul-container model entry. Present in the base pak01 and in the
+ * soul-container mods inspected so far. A texture-only mod ships no model, so
+ * this resolves from --base while the mod's overriding textures still win. A
+ * mod that replaces the mesh under a different entry name (e.g. only
+ * `_noskins`) would fall back to the base mesh; robust per-mod entry discovery
+ * is a later refinement.
+ */
+const SOUL_CONTAINER_ENTRY = 'models/props_gameplay/soul_container/soul_container.vmdl_c';
+
+function sanitize(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
+}
+
+function modelDir(key: string): string {
+    // The key is both the storage name and the `grimoire-soul:` URL host.
+    // Chromium lowercases the host of a registered scheme, so canonicalize to
+    // lowercase here; VPK file names are unique case-insensitively.
+    return join(app.getPath('userData'), 'soul-models', sanitize(key.toLowerCase()));
+}
+
+function modelFile(key: string): string {
+    return join(modelDir(key), 'model.glb');
+}
+
+/** Resolve a mod VPK file name to its on-disk path (enabled or disabled). */
+async function resolveModVpk(deadlockPath: string, fileName: string): Promise<string | null> {
+    const addons = getAddonsPath(deadlockPath);
+    for (const candidate of [join(addons, fileName), join(addons, '.disabled', fileName)]) {
+        try {
+            await fs.access(candidate);
+            return candidate;
+        } catch {
+            /* try next */
+        }
+    }
+    return null;
+}
+
+const GLB_MAGIC = 0x46546c67; // 'glTF'
+const GLB_JSON_CHUNK = 0x4e4f534a; // 'JSON'
+
+/**
+ * Strip skins from a GLB.
+ *
+ * morphic attaches a degenerate single-joint skin to these static props but
+ * emits no JOINTS_0/WEIGHTS_0 on the mesh. three.js then builds a SkinnedMesh
+ * and crashes in normalizeSkinWeights (reads `geometry.attributes.skinWeight.count`
+ * on an undefined attribute). Soul containers are static, so dropping the skin
+ * (and each node's `skin` ref) turns them into plain meshes with no visual
+ * change. Only the JSON chunk is rewritten; the BIN chunk is preserved verbatim
+ * and accessors/bufferViews are left untouched (the now-unreferenced inverse-bind
+ * accessor is harmless).
+ *
+ * Returns the patched bytes, or the input unchanged when there are no skins or
+ * the container can't be parsed as a GLB.
+ */
+function stripGlbSkins(glb: Buffer): Buffer {
+    if (glb.length < 20 || glb.readUInt32LE(0) !== GLB_MAGIC) return glb;
+    const jsonLen = glb.readUInt32LE(12);
+    if (glb.readUInt32LE(16) !== GLB_JSON_CHUNK) return glb;
+    const jsonStart = 20;
+    const jsonEnd = jsonStart + jsonLen;
+    if (jsonEnd > glb.length) return glb;
+
+    let json: { skins?: unknown[]; nodes?: Array<{ skin?: number }> };
+    try {
+        json = JSON.parse(glb.toString('utf8', jsonStart, jsonEnd));
+    } catch {
+        return glb;
+    }
+    if (!json.skins || json.skins.length === 0) return glb;
+
+    delete json.skins;
+    for (const node of json.nodes ?? []) delete node.skin;
+
+    // Re-serialize and pad the JSON chunk to a 4-byte boundary with spaces.
+    let jsonBuf = Buffer.from(JSON.stringify(json), 'utf8');
+    const pad = (4 - (jsonBuf.length % 4)) % 4;
+    if (pad) jsonBuf = Buffer.concat([jsonBuf, Buffer.alloc(pad, 0x20)]);
+
+    const rest = glb.subarray(jsonEnd);
+    const header = Buffer.alloc(20);
+    header.writeUInt32LE(GLB_MAGIC, 0);
+    header.writeUInt32LE(2, 4); // glTF version
+    header.writeUInt32LE(20 + jsonBuf.length + rest.length, 8); // total length
+    header.writeUInt32LE(jsonBuf.length, 12); // JSON chunk length
+    header.writeUInt32LE(GLB_JSON_CHUNK, 16);
+    return Buffer.concat([header, jsonBuf, rest]);
+}
+
+export interface SoulModelInfo {
+    hasModel: boolean;
+    /** mtime of the stored GLB, used to cache-bust the renderer URL on re-export. */
+    mtimeMs: number | null;
+}
+
+/** Whether a soul-container mod has an exported model, plus its mtime. */
+export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
+    try {
+        const stat = await fs.stat(modelFile(key));
+        return { hasModel: true, mtimeMs: stat.mtimeMs };
+    } catch {
+        return { hasModel: false, mtimeMs: null };
+    }
+}
+
+/**
+ * Export a soul-container mod's model to a `.glb` by running the bundled
+ * `vpkmerge model export` against the mod's VPK (mesh + textures) with the base
+ * pak as the fallback resolver. Keyed by the mod's VPK file name.
+ */
+export async function exportSoulModel(
+    deadlockPath: string,
+    fileName: string
+): Promise<SoulModelInfo> {
+    const vpk = await resolveModVpk(deadlockPath, fileName);
+    if (!vpk) {
+        throw new Error(`Soul-container VPK not found: ${fileName}`);
+    }
+    const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+
+    const dir = modelDir(fileName);
+    await fs.mkdir(dir, { recursive: true });
+    const out = modelFile(fileName);
+
+    await runVpkmerge([
+        'model',
+        'export',
+        '--vpk',
+        vpk,
+        '--entry',
+        SOUL_CONTAINER_ENTRY,
+        '--base',
+        pak01,
+        '--out',
+        out,
+    ]);
+
+    // Drop the degenerate skin morphic emits on these static props so three.js
+    // loads them as plain meshes (see stripGlbSkins).
+    const raw = await fs.readFile(out);
+    const patched = stripGlbSkins(raw);
+    if (patched !== raw) await fs.writeFile(out, patched);
+
+    return getSoulModelInfo(fileName);
+}
+
+/** Delete a soul-container mod's exported model. */
+export async function clearSoulModel(key: string): Promise<void> {
+    await fs.rm(modelDir(key), { recursive: true, force: true });
+}
+
+/**
+ * Register the `grimoire-soul:` scheme handler. URLs look like
+ * `grimoire-soul://<key>/model.glb` (the `?v=` cache-buster is ignored). Must
+ * be paired with a registerSchemesAsPrivileged({ scheme, privileges }) call
+ * before app-ready (done in index.ts).
+ */
+export function registerSoulModelProtocol(): void {
+    protocol.handle(SOUL_MODEL_SCHEME, async (request) => {
+        try {
+            const url = new URL(request.url);
+            const key = decodeURIComponent(url.hostname);
+            const file = modelFile(key);
+            await fs.access(file);
+            return net.fetch(pathToFileURL(file).toString());
+        } catch {
+            return new Response(null, { status: 404 });
+        }
+    });
+}

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -7,8 +7,10 @@
  * soul-container mod via the bundled `vpkmerge model export`, so the Locker can
  * render the actual model.
  *
- * Keyed per-mod by the VPK file name. Uses an explicit `--entry` (soul
- * containers are props, not heroes, so there is no `--hero` discovery).
+ * Keyed per-mod by the mod's metaKey (folder-qualified for overflow mods, so a
+ * `pakNN_dir.vpk` name that recurs across addon folders stays distinct). Uses an
+ * explicit `--entry` (soul containers are props, not heroes, so there is no
+ * `--hero` discovery).
  *
  * Layout: userData/soul-models/<key>/model.glb
  *
@@ -21,7 +23,7 @@ import { join } from 'path';
 import { pathToFileURL } from 'url';
 import { app, protocol, net } from 'electron';
 import { runVpkmerge } from './modMerger';
-import { getCitadelPath, getAddonsPath } from './deadlock';
+import { getCitadelPath, getAddonsPath, getDisabledPath } from './deadlock';
 
 export const SOUL_MODEL_SCHEME = 'grimoire-soul';
 
@@ -40,9 +42,9 @@ function sanitize(value: string): string {
 }
 
 function modelDir(key: string): string {
-    // The key is both the storage name and the `grimoire-soul:` URL host.
-    // Chromium lowercases the host of a registered scheme, so canonicalize to
-    // lowercase here; VPK file names are unique case-insensitively.
+    // The key (a mod metaKey) is the storage name; sanitize it to a single flat
+    // directory segment. Lowercased because VPK file names are unique
+    // case-insensitively and the read path may differ in case.
     return join(app.getPath('userData'), 'soul-models', sanitize(key.toLowerCase()));
 }
 
@@ -50,10 +52,21 @@ function modelFile(key: string): string {
     return join(modelDir(key), 'model.glb');
 }
 
-/** Resolve a mod VPK file name to its on-disk path (enabled or disabled). */
-async function resolveModVpk(deadlockPath: string, fileName: string): Promise<string | null> {
-    const addons = getAddonsPath(deadlockPath);
-    for (const candidate of [join(addons, fileName), join(addons, '.disabled', fileName)]) {
+/**
+ * Resolve a mod's metaKey (see metaKeyFor) to its on-disk VPK path. An overflow
+ * mod's key is folder-qualified (`addons{N}/<file>`); a base-addons or .disabled
+ * mod's key is a bare filename. Resolving by metaKey (not a bare filename) is
+ * required because each addon folder carries its own pak01-99 namespace, so the
+ * same `pakNN_dir.vpk` name can exist in several folders at once.
+ */
+async function resolveModVpk(deadlockPath: string, metaKey: string): Promise<string | null> {
+    const candidates = metaKey.includes('/')
+        ? [join(getCitadelPath(deadlockPath), metaKey)] // enabled overflow folder
+        : [
+              join(getAddonsPath(deadlockPath), metaKey), // enabled base addons
+              join(getDisabledPath(deadlockPath), metaKey), // disabled (single shared parking lot)
+          ];
+    for (const candidate of candidates) {
         try {
             await fs.access(candidate);
             return candidate;
@@ -135,21 +148,21 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
 /**
  * Export a soul-container mod's model to a `.glb` by running the bundled
  * `vpkmerge model export` against the mod's VPK (mesh + textures) with the base
- * pak as the fallback resolver. Keyed by the mod's VPK file name.
+ * pak as the fallback resolver. Keyed by the mod's metaKey.
  */
 export async function exportSoulModel(
     deadlockPath: string,
-    fileName: string
+    metaKey: string
 ): Promise<SoulModelInfo> {
-    const vpk = await resolveModVpk(deadlockPath, fileName);
+    const vpk = await resolveModVpk(deadlockPath, metaKey);
     if (!vpk) {
-        throw new Error(`Soul-container VPK not found: ${fileName}`);
+        throw new Error(`Soul-container VPK not found: ${metaKey}`);
     }
     const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
 
-    const dir = modelDir(fileName);
+    const dir = modelDir(metaKey);
     await fs.mkdir(dir, { recursive: true });
-    const out = modelFile(fileName);
+    const out = modelFile(metaKey);
 
     await runVpkmerge([
         'model',
@@ -170,7 +183,7 @@ export async function exportSoulModel(
     const patched = stripGlbSkins(raw);
     if (patched !== raw) await fs.writeFile(out, patched);
 
-    return getSoulModelInfo(fileName);
+    return getSoulModelInfo(metaKey);
 }
 
 /** Delete a soul-container mod's exported model. */
@@ -180,15 +193,21 @@ export async function clearSoulModel(key: string): Promise<void> {
 
 /**
  * Register the `grimoire-soul:` scheme handler. URLs look like
- * `grimoire-soul://<key>/model.glb` (the `?v=` cache-buster is ignored). Must
- * be paired with a registerSchemesAsPrivileged({ scheme, privileges }) call
- * before app-ready (done in index.ts).
+ * `grimoire-soul://m/<encoded-metaKey>/model.glb` (the `?v=` cache-buster is
+ * ignored). The key rides in the path under a fixed `m` host, not in the host
+ * itself: it's a mod metaKey, which for overflow mods contains a `/` that a
+ * standard scheme's host parser forbids. Must be paired with a
+ * registerSchemesAsPrivileged({ scheme, privileges }) call before app-ready
+ * (done in index.ts).
  */
 export function registerSoulModelProtocol(): void {
     protocol.handle(SOUL_MODEL_SCHEME, async (request) => {
         try {
             const url = new URL(request.url);
-            const key = decodeURIComponent(url.hostname);
+            // Path is /<encodeURIComponent(metaKey)>/model.glb; the first
+            // segment is the (still-encoded) key.
+            const segment = url.pathname.split('/').filter(Boolean)[0] ?? '';
+            const key = decodeURIComponent(segment);
             const file = modelFile(key);
             await fs.access(file);
             return net.fetch(pathToFileURL(file).toString());

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -793,6 +793,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('revert-hero-card', heroName),
     getActiveHeroCard: (heroName: string) =>
         ipcRenderer.invoke('get-active-hero-card', heroName),
+    getSoulModelInfo: (key: string) =>
+        ipcRenderer.invoke('get-soul-model-info', key),
+    exportSoulModel: (fileName: string) =>
+        ipcRenderer.invoke('export-soul-model', fileName),
+    clearSoulModel: (key: string) =>
+        ipcRenderer.invoke('clear-soul-model', key),
     applyHeroSound: (heroName: string, slot: AbilitySlot, sourceFileName: string, params?: AbilitySoundParams) =>
         ipcRenderer.invoke('apply-hero-sound', heroName, slot, sourceFileName, params),
     revertHeroSound: (heroName: string, slot: AbilitySlot) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -795,8 +795,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('get-active-hero-card', heroName),
     getSoulModelInfo: (key: string) =>
         ipcRenderer.invoke('get-soul-model-info', key),
-    exportSoulModel: (fileName: string) =>
-        ipcRenderer.invoke('export-soul-model', fileName),
+    exportSoulModel: (metaKey: string) =>
+        ipcRenderer.invoke('export-soul-model', metaKey),
     clearSoulModel: (key: string) =>
         ipcRenderer.invoke('clear-soul-model', key),
     applyHeroSound: (heroName: string, slot: AbilitySlot, sourceFileName: string, params?: AbilitySoundParams) =>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@grimoire/social-types": "workspace:*",
     "@radix-ui/react-context-menu": "^2.2.16",
+    "@react-three/fiber": "^9.6.1",
     "@tanstack/react-virtual": "^3.13.26",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.5.0",
@@ -50,6 +51,7 @@
     "react-colorful": "^5.7.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.11.0",
+    "three": "^0.184.0",
     "zod": "^3.23.0",
     "zustand": "^5.0.9"
   },
@@ -64,6 +66,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^5.1.1",
     "asar": "^3.2.0",
     "electron": "^35.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,13 @@ importers:
         version: 3.2.2(react@19.2.3)
       '@grimoire/social-types':
         specifier: workspace:*
-        version: link:../grimoire-social/packages/social-types
+        version: link:../../../../grimoire-social/packages/social-types
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-three/fiber':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0)
       '@tanstack/react-virtual':
         specifier: ^3.13.26
         version: 3.13.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -68,12 +71,15 @@ importers:
       react-router-dom:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
       zod:
         specifier: ^3.23.0
         version: 3.25.76
       zustand:
         specifier: ^5.0.9
-        version: 5.0.9(@types/react@19.2.7)(react@19.2.3)
+        version: 5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
@@ -105,6 +111,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      '@types/three':
+        specifier: ^0.184.1
+        version: 0.184.1
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.1.2(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -145,7 +154,7 @@ importers:
         specifier: ^6.3.0
         version: 6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  ../grimoire-social/packages/social-types:
+  ../../../../grimoire-social/packages/social-types:
     dependencies:
       zod:
         specifier: ^3.23.0
@@ -233,6 +242,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -251,6 +264,9 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -886,6 +902,31 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -1125,6 +1166,9 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
@@ -1192,17 +1236,31 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1426,6 +1484,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builder-util-runtime@9.3.1:
     resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
@@ -1840,6 +1901,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2128,6 +2192,11 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -2336,6 +2405,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2709,6 +2781,15 @@ packages:
       '@types/react':
         optional: true
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -2910,6 +2991,11 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
@@ -2938,6 +3024,9 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -3049,6 +3138,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -3286,6 +3380,8 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -3315,6 +3411,8 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
     dependencies:
@@ -3944,6 +4042,26 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-three/fiber@9.6.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-use-measure: 2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.3)
+      three: 0.184.0
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      zustand: 5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
@@ -4096,6 +4214,8 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/adm-zip@0.5.7':
     dependencies:
       '@types/node': 24.10.4
@@ -4185,6 +4305,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.7
 
+  '@types/react-reconciler@0.28.9(@types/react@19.2.7)':
+    dependencies:
+      '@types/react': 19.2.7
+
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
@@ -4193,11 +4317,24 @@ snapshots:
     dependencies:
       '@types/node': 24.10.4
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/trusted-types@2.0.7':
     optional: true
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/webxr@0.5.24': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -4477,6 +4614,11 @@ snapshots:
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -5037,6 +5179,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -5349,6 +5493,13 @@ snapshots:
 
   isexe@3.1.1: {}
 
+  its-fine@2.0.0(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.7)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - '@types/react'
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -5545,6 +5696,8 @@ snapshots:
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  meshoptimizer@1.1.1: {}
 
   mime-db@1.52.0: {}
 
@@ -5898,6 +6051,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  react-use-measure@2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+
   react@19.2.3: {}
 
   read-binary-file-arch@1.0.6:
@@ -6119,6 +6278,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  suspend-react@0.1.3(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
@@ -6164,6 +6327,8 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  three@0.184.0: {}
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -6265,6 +6430,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
@@ -6353,7 +6522,8 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zustand@5.0.9(@types/react@19.2.7)(react@19.2.3):
+  zustand@5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:
       '@types/react': 19.2.7
       react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.4.0';
+const VPKMERGE_VERSION = 'v0.5.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '6860a989335afec0aa19544cf30cbebac9dc6b88af3f3a8d9c3340a6435fa045' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '54f9edf5f1b7c5486beed23c42e7d187f422bc0c14f6f6422b65285ada91a96e' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'cad55988bafbc357f50fa3209b9cc53e2da95f9a7fa0e8ce326f91f084e36a16' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'e2de105fe59d9ec058bff86dd886bdab437dbc0efc16c1cabaceabc2e9ff386f' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '825f6e02be6410d726ec07e1a25cf11981abaf246be356e3cfb9a624ad2ccc26' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'bd198f50de2c5fb89b7a0d1a4a7e7a803b7dbde7f19bbe999e0b5c012c53107f' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/src/components/locker/SoulContainerViewer.tsx
+++ b/src/components/locker/SoulContainerViewer.tsx
@@ -26,7 +26,10 @@ import { getSoulModelInfo, exportSoulModel } from '../../lib/api';
 const SOUL_MODEL_SCHEME = 'grimoire-soul';
 
 function meshUrlFor(key: string, mtimeMs: number | null): string {
-  return `${SOUL_MODEL_SCHEME}://${encodeURIComponent(key)}/model.glb?v=${mtimeMs ?? 0}`;
+  // The key is a mod metaKey (overflow mods carry a '/', which a standard
+  // scheme forbids in the host), so carry it as a single encoded path segment
+  // under a fixed `m` host.
+  return `${SOUL_MODEL_SCHEME}://m/${encodeURIComponent(key)}/model.glb?v=${mtimeMs ?? 0}`;
 }
 
 /** Free a loaded scene's GPU resources (geometry, materials, textures). */
@@ -78,21 +81,19 @@ function OrbitingModel({ scene }: { scene: THREE.Object3D }) {
 
 export default function SoulContainerViewer({
   modKey,
-  fileName,
 }: {
-  /** Storage/URL key for this mod's model (the VPK file name). */
+  /** The mod's metaKey: the collision-safe storage/URL key and the source the
+   *  main process resolves and exports from. Folder-qualified for overflow
+   *  mods (`addons{N}/<file>`), a bare filename for base-addons/.disabled. */
   modKey: string;
-  /** VPK file name to export from (same as modKey today; passed explicitly so
-   *  the export source is unambiguous). */
-  fileName: string;
 }) {
   const [scene, setScene] = useState<THREE.Object3D | null>(null);
   const [generating, setGenerating] = useState(false);
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
-    // Each Locker card mounts its own viewer (keyed by mod), so modKey/fileName
-    // are stable for an instance and initial state needs no reset here.
+    // Each Locker card mounts its own viewer (keyed by mod), so modKey is
+    // stable for an instance and initial state needs no reset here.
     let cancelled = false;
     let loaded: THREE.Object3D | null = null;
 
@@ -102,7 +103,7 @@ export default function SoulContainerViewer({
         if (!info.hasModel) {
           if (cancelled) return;
           setGenerating(true);
-          info = await exportSoulModel(fileName);
+          info = await exportSoulModel(modKey);
           if (cancelled) return;
           setGenerating(false);
         }
@@ -132,7 +133,7 @@ export default function SoulContainerViewer({
       cancelled = true;
       if (loaded) disposeScene(loaded);
     };
-  }, [modKey, fileName]);
+  }, [modKey]);
 
   // Failure: render nothing so the card's clear window shows.
   if (failed) return null;

--- a/src/components/locker/SoulContainerViewer.tsx
+++ b/src/components/locker/SoulContainerViewer.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { Loader2 } from 'lucide-react';
+import { getSoulModelInfo, exportSoulModel } from '../../lib/api';
+
+/**
+ * Live 3D preview of a soul-container mod, for the Locker's Global view.
+ *
+ * Soul containers are small static props; this is a deliberately minimal,
+ * non-interactive auto-orbit viewer. The GLB is produced on demand by the
+ * bundled `vpkmerge model export` (exportSoulModel) and served from the user's
+ * library via the privileged `grimoire-soul:` scheme.
+ *
+ * Loading uses three's GLTFLoader directly (no @react-three/drei): each card
+ * loads its own GLB once, so there is no shared cache to clone around and the
+ * scene is disposed on unmount. This keeps the slice's dependencies to `three`
+ * + `@react-three/fiber`.
+ *
+ * The whole Locker card is the enable/disable control, so this overlay is
+ * pointer-events-none; clicks pass through to toggle the mod. On any failure it
+ * renders nothing, leaving the card's clear window.
+ */
+
+const SOUL_MODEL_SCHEME = 'grimoire-soul';
+
+function meshUrlFor(key: string, mtimeMs: number | null): string {
+  return `${SOUL_MODEL_SCHEME}://${encodeURIComponent(key)}/model.glb?v=${mtimeMs ?? 0}`;
+}
+
+/** Free a loaded scene's GPU resources (geometry, materials, textures). */
+function disposeScene(root: THREE.Object3D): void {
+  root.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    mesh.geometry?.dispose();
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    for (const m of mats) {
+      const sm = m as THREE.MeshStandardMaterial;
+      [sm.map, sm.normalMap, sm.roughnessMap, sm.metalnessMap, sm.emissiveMap, sm.aoMap].forEach(
+        (t) => t?.dispose()
+      );
+      m?.dispose();
+    }
+  });
+}
+
+/** The static prop, normalized to a unit size and centered, slowly spinning. */
+function OrbitingModel({ scene }: { scene: THREE.Object3D }) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  // Normalize by the largest dimension so tall and wide props both fit the
+  // small card frame, and recenter on the origin.
+  const norm = useMemo(() => {
+    const box = new THREE.Box3().setFromObject(scene);
+    const size = new THREE.Vector3();
+    const center = new THREE.Vector3();
+    box.getSize(size);
+    box.getCenter(center);
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const scale = maxDim > 0 ? 1.7 / maxDim : 1;
+    return { scale, center };
+  }, [scene]);
+
+  useFrame((_, delta) => {
+    if (groupRef.current) groupRef.current.rotation.y += delta * 0.5;
+  });
+
+  return (
+    <group ref={groupRef} scale={norm.scale}>
+      <group position={[-norm.center.x, -norm.center.y, -norm.center.z]}>
+        <primitive object={scene} />
+      </group>
+    </group>
+  );
+}
+
+export default function SoulContainerViewer({
+  modKey,
+  fileName,
+}: {
+  /** Storage/URL key for this mod's model (the VPK file name). */
+  modKey: string;
+  /** VPK file name to export from (same as modKey today; passed explicitly so
+   *  the export source is unambiguous). */
+  fileName: string;
+}) {
+  const [scene, setScene] = useState<THREE.Object3D | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    // Each Locker card mounts its own viewer (keyed by mod), so modKey/fileName
+    // are stable for an instance and initial state needs no reset here.
+    let cancelled = false;
+    let loaded: THREE.Object3D | null = null;
+
+    (async () => {
+      try {
+        let info = await getSoulModelInfo(modKey);
+        if (!info.hasModel) {
+          if (cancelled) return;
+          setGenerating(true);
+          info = await exportSoulModel(fileName);
+          if (cancelled) return;
+          setGenerating(false);
+        }
+        if (!info.hasModel) {
+          if (!cancelled) setFailed(true);
+          return;
+        }
+        const url = meshUrlFor(modKey, info.mtimeMs);
+        const gltf = await new Promise<GLTF>((resolve, reject) => {
+          new GLTFLoader().load(url, resolve, undefined, reject);
+        });
+        if (cancelled) {
+          disposeScene(gltf.scene);
+          return;
+        }
+        loaded = gltf.scene;
+        setScene(gltf.scene);
+      } catch {
+        if (!cancelled) {
+          setGenerating(false);
+          setFailed(true);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (loaded) disposeScene(loaded);
+    };
+  }, [modKey, fileName]);
+
+  // Failure: render nothing so the card's clear window shows.
+  if (failed) return null;
+
+  if (!scene) {
+    // Exporting (or first stat): a subtle spinner.
+    return generating ? (
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
+        <Loader2 className="h-5 w-5 animate-spin text-white/80" />
+      </div>
+    ) : null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0">
+      <Canvas camera={{ position: [0, 0.35, 3], fov: 35 }} dpr={1} gl={{ alpha: true }}>
+        <ambientLight intensity={0.75} />
+        <directionalLight position={[3, 5, 2]} intensity={1.3} />
+        <directionalLight position={[-3, 2, -2]} intensity={0.5} />
+        <OrbitingModel scene={scene} />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -123,9 +123,10 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
   return window.electronAPI.getSoulModelInfo(key);
 }
 
-/** Export a soul-container mod's model via the bundled vpkmerge exporter. */
-export async function exportSoulModel(fileName: string): Promise<SoulModelInfo> {
-  return window.electronAPI.exportSoulModel(fileName);
+/** Export a soul-container mod's model via the bundled vpkmerge exporter.
+ *  Keyed by the mod's metaKey (folder-qualified for overflow mods). */
+export async function exportSoulModel(metaKey: string): Promise<SoulModelInfo> {
+  return window.electronAPI.exportSoulModel(metaKey);
 }
 
 /** Delete a soul-container mod's exported model. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
-import type { HeroPortrait } from '../types/portrait';
+import type { HeroPortrait, SoulModelInfo } from '../types/portrait';
 import type {
   GameBananaModsResponse,
   GameBananaModDetails,
@@ -116,6 +116,21 @@ export async function getActiveHeroCard(
   heroName: string
 ): Promise<{ sourceFileName: string; variants: string[] } | null> {
   return window.electronAPI.getActiveHeroCard(heroName);
+}
+
+/** Whether a soul-container mod has an exported model in the user's library (+ mtime). */
+export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
+  return window.electronAPI.getSoulModelInfo(key);
+}
+
+/** Export a soul-container mod's model via the bundled vpkmerge exporter. */
+export async function exportSoulModel(fileName: string): Promise<SoulModelInfo> {
+  return window.electronAPI.exportSoulModel(fileName);
+}
+
+/** Delete a soul-container mod's exported model. */
+export async function clearSoulModel(key: string): Promise<void> {
+  return window.electronAPI.clearSoulModel(key);
 }
 
 export async function applyHeroSound(

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1080,7 +1080,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                             GameBanana thumbnail. */}
                         {activeType === 'soul-container' ? (
                           <Suspense fallback={null}>
-                            <SoulContainerViewer modKey={mod.fileName} fileName={mod.fileName} />
+                            <SoulContainerViewer modKey={mod.metaKey} />
                           </Suspense>
                         ) : (
                           <div

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, Layers, MoreVertical, Music, PowerOff, Shield, Shirt, Star } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
@@ -15,6 +15,9 @@ import { getAssetPath } from '../lib/assetPath';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import { LockerHeroView } from './LockerHero';
 import ModThumbnail from '../components/ModThumbnail';
+
+// Heavy (three.js): only pulled in when the soul-container type is viewed.
+const SoulContainerViewer = lazy(() => import('../components/locker/SoulContainerViewer'));
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { GlobalModType, Mod } from '../types/mod';
@@ -1045,8 +1048,9 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                     >
                       {/* Glass backdrop: a blurred copy of the cover art bleeds
                           behind the card so it's tinted by its own thumbnail,
-                          matching the Installed grid cards. */}
-                      {glassBackdropUrl && (
+                          matching the Installed grid cards. Soul containers show
+                          a 3D model on a clear window, so they skip it. */}
+                      {glassBackdropUrl && activeType !== 'soul-container' && (
                         <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[10px]">
                           <img
                             src={glassBackdropUrl}
@@ -1061,27 +1065,44 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                         </div>
                       )}
 
-                      {/* Media: aspect-video cover. */}
-                      <div className="relative mb-2 aspect-video w-full overflow-hidden rounded-lg border border-white/[0.08] bg-bg-tertiary">
-                        <div
-                          className={`h-full w-full transition-[filter,opacity] duration-200 ${
-                            mod.enabled ? '' : 'grayscale-[0.6] opacity-[0.7]'
-                          }`}
-                        >
-                          <ModThumbnail
-                            src={mod.thumbnailUrl}
-                            alt={mod.name}
-                            nsfw={mod.nsfw}
-                            hideNsfw={hideNsfw}
-                            className="h-full w-full"
-                            imageClassName="origin-center transform-gpu will-change-transform transition-transform duration-200 group-hover/card:scale-[1.03]"
-                            fallback={
-                              <div className="flex h-full w-full items-center justify-center text-xs text-text-secondary">
-                                No preview
-                              </div>
-                            }
-                          />
-                        </div>
+                      {/* Media: aspect-video cover. Soul containers float their
+                          3D model over a frosted-glass panel so the environment
+                          background shows through; other types keep a solid bg. */}
+                      <div
+                        className={`relative mb-2 aspect-video w-full overflow-hidden rounded-lg border border-white/[0.08] ${
+                          activeType === 'soul-container'
+                            ? 'bg-white/[0.04] backdrop-blur-md'
+                            : 'bg-bg-tertiary'
+                        }`}
+                      >
+                        {/* Soul containers show a live 3D model on a clear window
+                            (no 2D thumbnail behind it); other types show their
+                            GameBanana thumbnail. */}
+                        {activeType === 'soul-container' ? (
+                          <Suspense fallback={null}>
+                            <SoulContainerViewer modKey={mod.fileName} fileName={mod.fileName} />
+                          </Suspense>
+                        ) : (
+                          <div
+                            className={`h-full w-full transition-[filter,opacity] duration-200 ${
+                              mod.enabled ? '' : 'grayscale-[0.6] opacity-[0.7]'
+                            }`}
+                          >
+                            <ModThumbnail
+                              src={mod.thumbnailUrl}
+                              alt={mod.name}
+                              nsfw={mod.nsfw}
+                              hideNsfw={hideNsfw}
+                              className="h-full w-full"
+                              imageClassName="origin-center transform-gpu will-change-transform transition-transform duration-200 group-hover/card:scale-[1.03]"
+                              fallback={
+                                <div className="flex h-full w-full items-center justify-center text-xs text-text-secondary">
+                                  No preview
+                                </div>
+                              }
+                            />
+                          </div>
+                        )}
                         <div className="pointer-events-none absolute inset-0 bg-bg-primary/0 transition-colors duration-200 group-hover/card:bg-bg-primary/20" />
                         {!mod.enabled && (
                           <div className="pointer-events-none absolute left-2 top-2 z-10 flex h-5 items-start">

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -315,7 +315,7 @@ export interface ElectronAPI {
         heroName: string
     ) => Promise<{ sourceFileName: string; variants: string[] } | null>;
     getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
-    exportSoulModel: (fileName: string) => Promise<SoulModelInfo>;
+    exportSoulModel: (metaKey: string) => Promise<SoulModelInfo>;
     clearSoulModel: (key: string) => Promise<void>;
     applyHeroSound: (
         heroName: string,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -29,7 +29,7 @@ import type {
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
 } from './gamebanana';
-import type { HeroPortrait } from './portrait';
+import type { HeroPortrait, SoulModelInfo } from './portrait';
 
 export interface BrowseModsArgs {
     page: number;
@@ -314,6 +314,9 @@ export interface ElectronAPI {
     getActiveHeroCard: (
         heroName: string
     ) => Promise<{ sourceFileName: string; variants: string[] } | null>;
+    getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
+    exportSoulModel: (fileName: string) => Promise<SoulModelInfo>;
+    clearSoulModel: (key: string) => Promise<void>;
     applyHeroSound: (
         heroName: string,
         slot: AbilitySlot,

--- a/src/types/portrait.ts
+++ b/src/types/portrait.ts
@@ -21,3 +21,14 @@ export interface HeroPortrait {
   /** Decoded PNG as a data URL, ready to drop into an <img src>. */
   dataUrl: string;
 }
+
+/**
+ * Whether a soul-container mod has an exported 3D model in the user's library,
+ * and its mtime (used to cache-bust the `grimoire-soul:` URL after a re-export).
+ * Keyed per-mod by the VPK file name. The GLB itself never reaches the renderer
+ * as bytes; it's served through the privileged scheme.
+ */
+export interface SoulModelInfo {
+  hasModel: boolean;
+  mtimeMs: number | null;
+}


### PR DESCRIPTION
## Summary

A minimal, self-contained slice of the 3D pipeline, branched clean off `main`: in the Locker's **Global -> Soul Containers** view, each installed soul-container mod renders as a live auto-orbiting 3D model instead of a flat GameBanana thumbnail.

- The GLB is produced on demand by the bundled `vpkmerge model export --entry models/props_gameplay/soul_container/soul_container.vmdl_c` and served from the user's library via a new privileged `grimoire-soul:` Electron scheme.
- `SoulContainerViewer.tsx` is a deliberately minimal static viewer using three's `GLTFLoader` directly (no `@react-three/drei`), so the only new runtime deps are **`three` + `@react-three/fiber`**.
- three.js loads in a **lazy chunk**, only when the soul view opens; verified `0` three.js in the startup bundle, all of it (~388 KB gz) in the on-demand soul chunk.
- Bumps the bundled vpkmerge **v0.4.0 -> v0.5.0** (v0.4.0 has no `model export` at all).
- Soul cards render on a frosted-glass panel so the environment background shows through.

### Why the skin-strip

morphic attaches a degenerate single-joint skin (no `JOINTS_0`/`WEIGHTS_0`) to these static props. three then builds a `SkinnedMesh` and crashes in `normalizeSkinWeights` (`reading 'count'` on a missing attribute). The exporter strips the skin from the GLB so it loads as a plain mesh, with no visual change.

### Footprint

- **Ships:** vpkmerge binary ~4.9 MB (one per platform, fetched at install) + the lazy three chunk (~388 KB gz, on-demand). Startup bundle unchanged.
- **Dev:** `three` + `@react-three/fiber` (+ `@types/three`). No drei, so none of the mediapipe/hls transitive tail.
- New code: `soulContainerModels.ts` + `SoulContainerViewer.tsx` + small additive wiring (IPC/preload/types/api/index/Locker).

Reuses what's already on `main`: the soul-container classification, the Locker Global view, `runVpkmerge`/`vpkmergeBinaryPath`, `getActiveDeadlockPath`, `getCitadelPath`.

## Test plan

- [ ] `pnpm install` (fetches the v0.5.0 binary; note: `better-sqlite3` may need `pnpm exec electron-rebuild -f -w better-sqlite3` as usual)
- [ ] `pnpm dev` -> Locker -> Global -> Soul Containers: each card shows a slowly orbiting 3D model (cold card shows a brief spinner, then the model)
- [ ] Clicking a card still toggles enable/disable (the canvas is pointer-events-none)
- [ ] A texture-only soul mod still renders (mesh resolved from the base pak)
- [ ] `pnpm exec tsc -p tsconfig.app.json --noEmit && pnpm exec tsc -p tsconfig.node.json --noEmit && pnpm lint && pnpm build` all clean

## Known follow-ups (out of scope)

- Exclusive single-select (soul containers all write the same path; enabling two conflicts by load order).
- Robust per-mod entry discovery (currently hardcodes `soul_container.vmdl_c`, falling back to the base mesh for oddly-named meshes).