### PR TITLE
fix(locker): alphabetize and de-dupe hero list in Installed tag menu

### DIFF
--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -93,6 +93,34 @@ export const HERO_NAMES = SHARED_HERO_NAMES;
 export const HERO_ALIASES = SHARED_HERO_ALIASES;
 
 /**
+ * Display-name aliases that collapse roster duplicates to one canonical label.
+ * The shared roster carries both "Doorman" (GameBanana's category name, the one
+ * wired into every client-side map: face position, stats id, sound codename)
+ * and "The Doorman" (the deadlock-api roster name, appended later with the
+ * "Old Gods, New Blood" batch). They are the same hero, so the tag menu shows a
+ * single "Doorman". Kept client-side only: the shared roster and server-side
+ * inference are untouched.
+ */
+const HERO_DISPLAY_ALIASES: Readonly<Record<string, string>> = {
+  'The Doorman': 'Doorman',
+};
+
+/** Canonical display name for a hero, collapsing roster duplicates (see above). */
+export function canonicalHeroName(name: string | undefined | null): string {
+  if (!name) return '';
+  return HERO_DISPLAY_ALIASES[name] ?? name;
+}
+
+/**
+ * The hero roster for tag-menu display: canonicalized (duplicates collapsed),
+ * de-duplicated, and alphabetized. The Locker tag menu sorts its own roster
+ * (built from GameBanana categories), so the Installed menu uses this to match.
+ */
+export const HERO_NAMES_SORTED: readonly string[] = Array.from(
+  new Set(SHARED_HERO_NAMES.map(canonicalHeroName))
+).sort((a, b) => a.localeCompare(b));
+
+/**
  * Infer the Deadlock hero associated with a mod title. Re-exported from the
  * shared package; see @grimoire/social-types/heroes for the matcher details.
  */

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -69,7 +69,7 @@ import VariantPickerModal from '../components/VariantPickerModal';
 import MergeModsModal from '../components/MergeModsModal';
 import MergedContentsModal from '../components/MergedContentsModal';
 import PriorityEditor from '../components/PriorityEditor';
-import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
+import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
 import { setModGlobalType } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
@@ -3155,7 +3155,7 @@ export default function Installed() {
                     <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
                       Hero
                     </div>
-                    {HERO_NAMES.map((name) => (
+                    {HERO_NAMES_SORTED.map((name) => (
                       <button
                         key={name}
                         type="button"
@@ -4634,7 +4634,9 @@ function ModCard({
                     <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
                       Hero
                     </div>
-                    {HERO_NAMES.map((heroName) => (
+                    {HERO_NAMES_SORTED.map((heroName) => {
+                      const tagged = canonicalHeroName(mod.lockerHero) === heroName;
+                      return (
                       <button
                         key={heroName}
                         type="button"
@@ -4644,7 +4646,7 @@ function ModCard({
                         }}
                         disabled={menuBusy}
                         className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50 ${
-                          mod.lockerHero === heroName
+                          tagged
                             ? mod.lockerHeroSource === 'manual'
                               ? 'text-accent'
                               : 'text-sky-200'
@@ -4652,9 +4654,10 @@ function ModCard({
                         }`}
                       >
                         <HeroTagLabel heroName={heroName} />
-                        {mod.lockerHero === heroName && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
+                        {tagged && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
                       </button>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </>


### PR DESCRIPTION
## What

The Installed **Set Locker tag** menu (both per-card and bulk) now shows the hero roster fully alphabetized and de-duplicated, matching the Locker tag menu.

## Why

The Installed menu mapped the raw `HERO_NAMES` array, which:
- appends newer ("Old Gods, New Blood") heroes at the end, out of order, and
- contains the same hero twice: `Doorman` (GameBanana category name, wired into every client-side map) and `The Doorman` (deadlock-api roster name, appended later).

The Locker tag menu sorts its own roster (built from GameBanana categories), so the two views disagreed. Reported by users.

## How

- Add `canonicalHeroName()` and a sorted, de-duped `HERO_NAMES_SORTED` to `src/lib/lockerUtils.ts`. `The Doorman` collapses to `Doorman`.
- Use `HERO_NAMES_SORTED` in both tag menus in `src/pages/Installed.tsx`.
- Canonicalize the tag-state comparison so a mod already tagged `The Doorman` still shows its checkmark under `Doorman`.

Client display only: the shared `@grimoire/social-types` roster and server-side inference are untouched, so published-profile data is unaffected.

## Test

Open the Installed Set Locker tag menu: list is alphabetical with a single `Doorman`. A mod previously tagged `The Doorman` still shows its check under `Doorman`. Parity with the Locker tag menu.