### PR TITLE
Locker + Conflicts UX batch: 5 user-reported fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          # Match the local pnpm that generates pnpm-lock.yaml (v10). pnpm 9
+          # mis-links the out-of-root @grimoire/social-types workspace package
+          # (../grimoire-social/packages/*), which makes tsc report it as an
+          # unresolved module and every social import cascades to implicit-any.
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
+          # Match the local pnpm that generates pnpm-lock.yaml (v10); see ci.yml.
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,6 +3,19 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
 
+// Resolve the shared @grimoire/social-types workspace package straight from the
+// sibling checkout. pnpm's symlink for this out-of-root package
+// (../grimoire-social/packages/*) resolves to the wrong depth in CI's nested
+// directory layout, leaving it dangling so bundling fails. These aliases (which
+// mirror the tsconfig `paths`) make resolution deterministic in CI and local
+// dev for both the main and renderer builds. The /heroes entry must precede the
+// bare one so the more specific subpath matches first.
+const SOCIAL_TYPES_ROOT = resolve(__dirname, '../grimoire-social/packages/social-types/src');
+const socialTypesAlias = {
+    '@grimoire/social-types/heroes': resolve(SOCIAL_TYPES_ROOT, 'heroes.ts'),
+    '@grimoire/social-types': resolve(SOCIAL_TYPES_ROOT, 'schemas.ts'),
+};
+
 // Bake the social Worker URL at build time. Dev runs (electron-vite dev) fall
 // back to wrangler's local port. Production builds (electron-vite build, used
 // by all package:* scripts) REQUIRE GRIMOIRE_SOCIAL_BASE_URL to be set —
@@ -34,6 +47,7 @@ export default defineConfig(({ mode }) => {
     const SOCIAL_BASE_URL = resolveSocialBaseUrl(mode);
     return {
     main: {
+        resolve: { alias: socialTypesAlias },
         plugins: [
             externalizeDepsPlugin({
                 // @grimoire/social-types is a workspace package whose entrypoint is a
@@ -76,6 +90,7 @@ export default defineConfig(({ mode }) => {
         },
     },
     renderer: {
+        resolve: { alias: socialTypesAlias },
         root: '.',
         base: './',
         build: {

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -16,7 +16,7 @@ import {
 import { metaKeyFor } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
-import { inferHeroFromVpk, classifyGlobalModFromVpk } from '../services/vpk';
+import { inferHeroFromVpk, classifyGlobalModFromVpk, GLOBAL_CLASSIFIER_VERSION } from '../services/vpk';
 import { classifyAbilitySoundsFromVpk } from '../services/abilitySounds';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 import { isLockerManaged } from '../services/lockerVpk';
@@ -47,11 +47,47 @@ function getActiveDeadlockPath(): string | null {
  * hero) but writing back means follow-up scans skip the work and the manual
  * override path has a stable field to overwrite.
  */
+/**
+ * Resolve a mod's Locker global type, classifying from the VPK tree when it has
+ * not been classified yet OR when an older classifier version produced a stale
+ * `null` ("not global") result. A positive type is left untouched: it may be a
+ * manual override, and re-running can't improve a confident hit. Runs for mods
+ * with no metadata row too (a VPK dropped straight into citadel/addons), so
+ * locally added HUD / Soul Container mods get tagged like downloaded ones.
+ * Persists the result + classifier version so later scans skip the re-parse.
+ */
+function resolveGlobalType(
+    mod: Mod,
+    metadata: ReturnType<typeof getModMetadata>
+): import('../../../src/types/mod').GlobalModType | null {
+    const current = metadata?.globalType;
+    const stamped = metadata?.globalTypeClassifierVersion ?? 0;
+    const needsClassify =
+        current === undefined || (current === null && stamped < GLOBAL_CLASSIFIER_VERSION);
+    if (!needsClassify) return current;
+    let classified: ReturnType<typeof classifyGlobalModFromVpk> = null;
+    try {
+        classified = classifyGlobalModFromVpk(mod.path);
+    } catch (err) {
+        console.warn(`[enrichMod] VPK global-type classification failed for ${mod.fileName}:`, err);
+    }
+    setModMetadata(mod.metaKey, {
+        globalType: classified,
+        globalTypeClassifierVersion: GLOBAL_CLASSIFIER_VERSION,
+    });
+    return classified;
+}
+
 function enrichMod(mod: Mod): Mod {
     const metadata = getModMetadata(mod.metaKey);
     const isUnknown =
         !metadata?.gameBananaId &&
         !(typeof metadata?.modName === 'string' && metadata.modName.trim().length > 0);
+    // Classify the global (non-hero) cosmetic type for EVERY scanned VPK, even
+    // ones with no metadata row, so locally added mods get tagged like
+    // downloaded ones. resolveGlobalType persists the result + classifier
+    // version so subsequent scans skip the parse.
+    const globalType = resolveGlobalType(mod, metadata);
     if (metadata) {
         let lockerHero = metadata.lockerHero;
         let lockerHeroSource = metadata.lockerHeroSource;
@@ -75,21 +111,6 @@ function enrichMod(mod: Mod): Mod {
                 lockerHero = inferred;
                 lockerHeroSource = inferredSource;
             }
-        }
-        // Global (non-hero) cosmetic type. Classified once from the VPK tree
-        // then persisted (including the null "checked, not global" result) so
-        // later scans skip the parse. The classifier guards out hero payloads,
-        // so a real skin resolves to null and stays on the hero axis.
-        let globalType = metadata.globalType;
-        if (globalType === undefined) {
-            let classified: ReturnType<typeof classifyGlobalModFromVpk> = null;
-            try {
-                classified = classifyGlobalModFromVpk(mod.path);
-            } catch (err) {
-                console.warn(`[enrichMod] VPK global-type classification failed for ${mod.fileName}:`, err);
-            }
-            setModMetadata(mod.metaKey, { globalType: classified });
-            globalType = classified;
         }
         // Per-ability sound footprint. Same lazy + persist + null-sentinel
         // pattern as globalType, and it shares the cached VPK parse, so the two
@@ -137,7 +158,7 @@ function enrichMod(mod: Mod): Mod {
             ignoreUpdates: metadata.ignoreUpdates,
         };
     }
-    return { ...mod, isUnknown };
+    return { ...mod, isUnknown, globalType: globalType ?? undefined };
 }
 
 function sameKeys(a: string[], b: string[]): boolean {
@@ -424,9 +445,10 @@ ipcMain.handle(
 // under the wrong type. Pass a GlobalModType to assign it (this also clears any
 // hero tag, since a mod lives on either the hero axis or the global axis, never
 // both). Pass null to force it OFF the global axis: we persist the explicit null
-// so the classifier doesn't just re-add it on the next scan. The stored value
-// wins over auto-classification because enrichMod only classifies when
-// globalType is undefined.
+// so the classifier doesn't just re-add it on the next scan. A positive type
+// always wins over auto-classification (enrichMod never re-runs a positive
+// result); the null is stamped with the current classifier version so a stale
+// null re-run can't override this deliberate "not global" choice.
 ipcMain.handle(
     'set-mod-global-type',
     async (_, modId: string, globalType: GlobalModType | null): Promise<Mod> => {
@@ -441,6 +463,7 @@ ipcMain.handle(
         }
         setModMetadata(target.metaKey, {
             globalType,
+            globalTypeClassifierVersion: GLOBAL_CLASSIFIER_VERSION,
             // Assigning a global type moves the mod off the hero axis.
             ...(globalType ? { lockerHero: undefined, lockerHeroSource: undefined } : {}),
         });

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -38,6 +38,11 @@ export interface ModMetadata {
      *  has not been classified yet. The null sentinel lets enrichMod skip
      *  re-parsing every skin's VPK on subsequent scans. */
     globalType?: import('../../../src/types/mod').GlobalModType | null;
+    /** Classifier version that produced `globalType`. Lets enrichMod re-run a
+     *  stale `null` result when the classifier patterns improve (see
+     *  GLOBAL_CLASSIFIER_VERSION in vpk.ts). Absent on pre-stamp metadata,
+     *  treated as version 0. */
+    globalTypeClassifierVersion?: number;
     /** Set when this VPK was produced by mergeMods. The share code +
      *  source list are the unroll payload. */
     merged?: import('../../../src/types/mod').MergedModInfo;

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -385,6 +385,14 @@ function heroImageCodenames(paths: string[]): Set<string> {
  * card (often shipped alongside a skin) and belongs on the hero axis — so we
  * return null and let the per-hero grouping claim it.
  */
+/**
+ * Bump when the global-type patterns above change. enrichMod re-runs
+ * classification for mods whose stored result was a stale `null` stamped with
+ * an older version, so pattern improvements (e.g. new HUD paths) reach
+ * already-installed mods without a manual retag or a metadata migration.
+ */
+export const GLOBAL_CLASSIFIER_VERSION = 1;
+
 export function classifyGlobalModType(paths: string[]): GlobalModType | null {
     if (paths.length === 0) return null;
     // Hero skin / ability payload wins outright: those belong on the hero axis.

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -149,8 +149,36 @@ export default function ModDetailsModal({
         if (e.key === 'ArrowRight') goToNext();
       }
     };
+    // Side mouse buttons (3 = back, 4 = forward) would otherwise let Chromium
+    // walk the router history out from under an open modal/lightbox. While this
+    // modal is mounted, repurpose both to close the topmost overlay (same
+    // precedence as Escape) and suppress the navigation. The physical
+    // back/forward mapping varies by mouse, so handle either button.
+    const isSideButton = (e: MouseEvent) => e.button === 3 || e.button === 4;
+    const suppressNav = (e: MouseEvent) => {
+      if (isSideButton(e)) e.preventDefault();
+    };
+    const handleMouseUp = (e: MouseEvent) => {
+      if (!isSideButton(e)) return;
+      e.preventDefault();
+      if (lightboxOpen) {
+        setLightboxOpen(false);
+      } else {
+        onClose();
+      }
+    };
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    // mousedown/auxclick are the gesture's cancelable phases; preventing default
+    // on them is what actually blocks the history navigation in Chromium.
+    window.addEventListener('mousedown', suppressNav);
+    window.addEventListener('auxclick', suppressNav);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('mousedown', suppressNav);
+      window.removeEventListener('auxclick', suppressNav);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose, images.length, lightboxOpen]);
 

--- a/src/components/conflicts/ConflictReorderActions.tsx
+++ b/src/components/conflicts/ConflictReorderActions.tsx
@@ -1,0 +1,90 @@
+import { ArrowDownUp, Crown } from 'lucide-react';
+import type { ModConflict } from '../../lib/api';
+
+interface ConflictModRef {
+  id: string;
+  name: string;
+}
+
+interface ConflictReorderActionsProps {
+  conflict: ModConflict;
+  modA: ConflictModRef;
+  modB: ConflictModRef;
+  /** Enabled mod ids in true load order (index 0 loads first). */
+  orderedEnabledIds: string[];
+  /** True while a reorder for this pair is in flight. */
+  busy: boolean;
+  /** Reorder so `winnerId` loads immediately after `loserId` (later = wins). */
+  onSetWinner: (winnerId: string, loserId: string) => void;
+}
+
+/**
+ * Inline load-order control for a conflict card. The mod that loads later wins
+ * overlapping files, so "wins" places the chosen mod immediately after the
+ * other in load order. For a priority conflict (shared pak slot) the reorder
+ * also separates the two into distinct slots, clearing the conflict; for a file
+ * overlap the pair stays flagged but the winner is now deterministic.
+ */
+export default function ConflictReorderActions({
+  conflict,
+  modA,
+  modB,
+  orderedEnabledIds,
+  busy,
+  onSetWinner,
+}: ConflictReorderActionsProps) {
+  const aIdx = orderedEnabledIds.indexOf(modA.id);
+  const bIdx = orderedEnabledIds.indexOf(modB.id);
+  // Reordering only moves mods that hold a load-order slot. A disabled mod has
+  // none, so guard the control until both sides are enabled.
+  const bothEnabled = aIdx !== -1 && bIdx !== -1;
+  const aWins = bothEnabled && aIdx > bIdx;
+  const bWins = bothEnabled && bIdx > aIdx;
+
+  const label =
+    conflict.conflictType === 'file' ? 'Wins shared files' : 'Resolve by load order';
+  const hint = bothEnabled
+    ? 'The mod that loads later overrides shared files. This sets the pair adjacent in load order.'
+    : 'Enable both mods to set their load order.';
+
+  const renderButton = (mod: ConflictModRef, other: ConflictModRef, isWinner: boolean) => (
+    <button
+      type="button"
+      onClick={() => onSetWinner(mod.id, other.id)}
+      disabled={busy || !bothEnabled || isWinner}
+      title={
+        !bothEnabled
+          ? 'Enable both mods to set their load order.'
+          : isWinner
+            ? `${mod.name} already wins this conflict`
+            : `Make ${mod.name} win (load it after ${other.name})`
+      }
+      className={`flex min-w-0 items-center justify-center gap-1.5 rounded-lg border px-2 py-1.5 text-xs font-medium transition-colors ${
+        isWinner
+          ? 'border-accent/40 bg-accent/15 text-accent cursor-default'
+          : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary hover:border-text-tertiary cursor-pointer'
+      } disabled:cursor-not-allowed ${!bothEnabled ? 'opacity-50' : ''}`}
+    >
+      {isWinner && <Crown className="w-3.5 h-3.5 flex-shrink-0" />}
+      <span className="truncate" title={mod.name}>
+        {mod.name}
+      </span>
+    </button>
+  );
+
+  return (
+    <div className="px-4 pb-4">
+      <div
+        className="mb-1.5 flex items-center justify-center gap-1.5 text-[11px] text-text-tertiary"
+        title={hint}
+      >
+        <ArrowDownUp className="w-3 h-3 flex-shrink-0" />
+        {label}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {renderButton(modA, modB, aWins)}
+        {renderButton(modB, modA, bWins)}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -348,7 +348,11 @@ const KILLSTREAK_MUSIC_CATEGORY = 'killstreak music';
  * type on the Global card rather than per-hero sounds. Used by
  * getEffectiveGlobalType; kept narrow (category only) on purpose.
  */
-export function isKillstreakMusicSound(mod: Mod): boolean {
+/** Minimal mod shape the global-type helpers read. Lets card components pass a
+ *  structural subset of Mod (e.g. ModCardProps['mod']) without the full type. */
+type GlobalTypeModFields = Pick<Mod, 'globalType' | 'lockerHero' | 'sourceSection' | 'categoryName'>;
+
+export function isKillstreakMusicSound(mod: GlobalTypeModFields): boolean {
   return (
     mod.sourceSection === 'Sound' &&
     mod.categoryName?.trim().toLowerCase() === KILLSTREAK_MUSIC_CATEGORY
@@ -366,7 +370,7 @@ const ANNOUNCER_CATEGORY = 'announcer';
  * Lock, `sounds/mods/`) already carry a 'announcer' globalType from the
  * main-process classifier; this rescues the sound-only packs that don't.
  */
-export function isAnnouncerSound(mod: Mod): boolean {
+export function isAnnouncerSound(mod: GlobalTypeModFields): boolean {
   return (
     mod.sourceSection === 'Sound' &&
     mod.categoryName?.trim().toLowerCase() === ANNOUNCER_CATEGORY
@@ -384,7 +388,7 @@ export function isAnnouncerSound(mod: Mod): boolean {
  * category existed, with no metadata migration. A manual override still wins,
  * since `mod.globalType` is checked first.
  */
-export function getEffectiveGlobalType(mod: Mod): GlobalModType | undefined {
+export function getEffectiveGlobalType(mod: GlobalTypeModFields): GlobalModType | undefined {
   if (mod.globalType) return mod.globalType;
   if (isKillstreakMusicSound(mod)) return 'killstreak-music';
   // A hero tag wins: hero-tied SFX belong on that hero's Sounds tab, not here.

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -93,6 +93,34 @@ export const HERO_NAMES = SHARED_HERO_NAMES;
 export const HERO_ALIASES = SHARED_HERO_ALIASES;
 
 /**
+ * Display-name aliases that collapse roster duplicates to one canonical label.
+ * The shared roster carries both "Doorman" (GameBanana's category name, the one
+ * wired into every client-side map: face position, stats id, sound codename)
+ * and "The Doorman" (the deadlock-api roster name, appended later with the
+ * "Old Gods, New Blood" batch). They are the same hero, so the tag menu shows a
+ * single "Doorman". Kept client-side only: the shared roster and server-side
+ * inference are untouched.
+ */
+const HERO_DISPLAY_ALIASES: Readonly<Record<string, string>> = {
+  'The Doorman': 'Doorman',
+};
+
+/** Canonical display name for a hero, collapsing roster duplicates (see above). */
+export function canonicalHeroName(name: string | undefined | null): string {
+  if (!name) return '';
+  return HERO_DISPLAY_ALIASES[name] ?? name;
+}
+
+/**
+ * The hero roster for tag-menu display: canonicalized (duplicates collapsed),
+ * de-duplicated, and alphabetized. The Locker tag menu sorts its own roster
+ * (built from GameBanana categories), so the Installed menu uses this to match.
+ */
+export const HERO_NAMES_SORTED: readonly string[] = Array.from(
+  new Set(SHARED_HERO_NAMES.map(canonicalHeroName))
+).sort((a, b) => a.localeCompare(b));
+
+/**
  * Infer the Deadlock hero associated with a mod title. Re-exported from the
  * shared package; see @grimoire/social-types/heroes for the matcher details.
  */

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -8,12 +8,24 @@ import {
   ignoreConflict,
   unignoreConflict,
   conflictPairKey,
+  reorderMods,
 } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import { Button } from '../components/common/ui';
 import { PageHeader, EmptyState, ConfirmModal } from '../components/common/PageComponents';
+import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
+
+/** Global load-order rank of a mod: lower = loads first. The pakNN (mod.priority)
+ *  repeats per overflow folder, so fold in the folder index from metaKey
+ *  (addons{N}/...) for a single monotonic order. Mirrors modLoadOrder in
+ *  Installed.tsx so the conflict reorder matches the load-order list. */
+function modLoadOrder(mod: Mod): number {
+  const match = mod.metaKey.match(/^addons(\d+)\//);
+  const folderIndex = match ? parseInt(match[1], 10) : 0;
+  return folderIndex * 100 + mod.priority;
+}
 interface ModWithThumbnail {
   id: string;
   name: string;
@@ -100,6 +112,9 @@ function ConflictsSkeleton() {
 export default function Conflicts() {
   const [conflicts, setConflicts] = useState<ModConflict[]>([]);
   const [modsMap, setModsMap] = useState<Map<string, ModWithThumbnail>>(new Map());
+  // Enabled mod ids in true load order (index 0 loads first). Drives the
+  // per-conflict reorder control's "who currently wins" and the splice math.
+  const [orderedEnabledIds, setOrderedEnabledIds] = useState<string[]>([]);
   // Set of ignored pair keys ("identityA::identityB" sorted). Used both to
   // filter detected conflicts (defense-in-depth — backend already filters)
   // and to render the "Ignored" panel.
@@ -159,6 +174,12 @@ export default function Conflicts() {
         map.set(info.identity, info);
       }
       setModsMap(map);
+      setOrderedEnabledIds(
+        (modsResult as Mod[])
+          .filter((m) => m.enabled)
+          .sort((a, b) => modLoadOrder(a) - modLoadOrder(b))
+          .map((m) => m.id)
+      );
       setConflicts(conflictResult);
       setIgnored(new Set(ignoredResult));
     } catch (err) {
@@ -183,6 +204,36 @@ export default function Conflicts() {
       // Sidebar's badge count is derived from getConflicts() and only refreshes
       // on mods-list changes. Ignore/unignore don't touch mods, so notify the
       // Sidebar explicitly — otherwise the badge stays stale until restart.
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  /**
+   * Reorder so `winnerId` loads immediately after `loserId` (later load wins
+   * overlapping files). Reuses reorderMods with the full enabled-mod ordering,
+   * the same path the Installed load-order editor uses. For a priority conflict
+   * the dense renumber also splits the shared slot, clearing the pair; a file
+   * overlap stays flagged but now resolves deterministically to the winner.
+   */
+  const handleSetWinner = async (conflict: ModConflict, winnerId: string, loserId: string) => {
+    const key = getConflictIgnoreKey(conflict);
+    setPendingPair(key);
+    try {
+      const order = orderedEnabledIds.slice();
+      const winnerIdx = order.indexOf(winnerId);
+      if (winnerIdx === -1 || !order.includes(loserId)) {
+        throw new Error('Both mods must be enabled to set their load order.');
+      }
+      order.splice(winnerIdx, 1);
+      const loserIdx = order.indexOf(loserId);
+      order.splice(loserIdx + 1, 0, winnerId);
+      await reorderMods(order);
+      await loadMods();
+      await loadConflicts();
       window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
     } catch (err) {
       setError(String(err));
@@ -462,6 +513,15 @@ export default function Conflicts() {
                   )}
                 </div>
               </div>
+
+              <ConflictReorderActions
+                conflict={conflict}
+                modA={{ id: modA.id, name: modA.name }}
+                modB={{ id: modB.id, name: modB.name }}
+                orderedEnabledIds={orderedEnabledIds}
+                busy={pendingPair === getConflictIgnoreKey(conflict)}
+                onSetWinner={(winnerId, loserId) => handleSetWinner(conflict, winnerId, loserId)}
+              />
             </div>
           );
         })}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -4519,11 +4519,17 @@ function ModCard({
   // Compact cards stay single-line (too small to wrap nicely); standard grid
   // cards wrap so a hero + category + 18+ + files chip never clips mid-chip.
   const gridTagsClasses = viewMode === 'compact' ? 'h-[26px] flex-nowrap' : 'min-h-7 flex-wrap';
+  // Locker global axis (HUD, Soul Containers, ...). Surfaced as a card chip so a
+  // manual or auto global tag is visible here, not just in the Locker. A global
+  // mod has no hero, so the two chips never both show.
+  const cardGlobalType = getEffectiveGlobalType(mod);
   const showCategoryChip = viewMode !== 'compact' || !mod.lockerHero;
   const compactBaseChipCount =
     (mod.lockerHero ? 1 : 0) + (showCategoryChip && mod.categoryName ? 1 : 0);
-  const showNsfwChip = !!mod.nsfw && (!isCompact || compactBaseChipCount < 2);
-  const showGroupChip = !!group && (!isCompact || compactBaseChipCount + (showNsfwChip ? 1 : 0) < 2);
+  const showGlobalChip = !!cardGlobalType && (!isCompact || compactBaseChipCount < 2);
+  const compactChipCount = compactBaseChipCount + (showGlobalChip ? 1 : 0);
+  const showNsfwChip = !!mod.nsfw && (!isCompact || compactChipCount < 2);
+  const showGroupChip = !!group && (!isCompact || compactChipCount + (showNsfwChip ? 1 : 0) < 2);
   const actions = (
     <div className="ml-auto flex items-center gap-1">
       <div className="relative" ref={menuRef} data-card-action="true">
@@ -4950,6 +4956,13 @@ function ModCard({
                 iconClassName={tagIconClassName}
                 iconOnly
               />
+              {showGlobalChip && cardGlobalType && (
+                <MetaTextChip
+                  label={GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType}
+                  className={metaChipClasses}
+                  title={`Locker: ${GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType}`}
+                />
+              )}
               {showCategoryChip && mod.categoryName && heroNameForLabel(mod.categoryName) !== mod.lockerHero && (
                 <CategoryChip
                   label={mod.categoryName}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -71,7 +71,6 @@ import MergeModsModal from '../components/MergeModsModal';
 import MergedContentsModal from '../components/MergedContentsModal';
 import PriorityEditor from '../components/PriorityEditor';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
-import { setModGlobalType } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
 import { LockerOverridesModal } from '../components/LockerOverridesModal';
@@ -367,6 +366,7 @@ export default function Installed() {
     reorderMods,
     editLocalMod,
     setModLockerHero,
+    setModGlobalType,
     setVariantLabel,
     importCustomMod,
     soundVolume,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -70,7 +70,7 @@ import VariantPickerModal from '../components/VariantPickerModal';
 import MergeModsModal from '../components/MergeModsModal';
 import MergedContentsModal from '../components/MergedContentsModal';
 import PriorityEditor from '../components/PriorityEditor';
-import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
+import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
 import { setModGlobalType } from '../lib/api';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { Button, Tag } from '../components/common/ui';
@@ -3156,7 +3156,7 @@ export default function Installed() {
                     <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
                       Hero
                     </div>
-                    {HERO_NAMES.map((name) => (
+                    {HERO_NAMES_SORTED.map((name) => (
                       <button
                         key={name}
                         type="button"
@@ -4660,7 +4660,9 @@ function ModCard({
                     <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
                       Hero
                     </div>
-                    {HERO_NAMES.map((heroName) => (
+                    {HERO_NAMES_SORTED.map((heroName) => {
+                      const tagged = canonicalHeroName(mod.lockerHero) === heroName;
+                      return (
                       <button
                         key={heroName}
                         type="button"
@@ -4670,7 +4672,7 @@ function ModCard({
                         }}
                         disabled={menuBusy}
                         className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50 ${
-                          mod.lockerHero === heroName
+                          tagged
                             ? mod.lockerHeroSource === 'manual'
                               ? 'text-accent'
                               : 'text-sky-200'
@@ -4678,9 +4680,10 @@ function ModCard({
                         }`}
                       >
                         <HeroTagLabel heroName={heroName} />
-                        {mod.lockerHero === heroName && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
+                        {tagged && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
                       </button>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import {
   DndContext,
   DragOverlay,
@@ -4353,15 +4354,24 @@ function ModCard({
   // near the top of the scroll area that clips it. Flip downward when there's
   // little room above. Measured from the trigger on open.
   const [menuPlacement, setMenuPlacement] = useState<'up' | 'down'>('up');
+  // Trigger rect captured on open (and on scroll/resize) so the menu can be
+  // portaled to <body> and positioned in fixed coordinates. The card sits in an
+  // overflow-auto/transform-gpu subtree that would otherwise clip an absolutely
+  // (or even fixed) positioned menu, hiding its left edge behind the sidebar.
+  const [menuRect, setMenuRect] = useState<DOMRect | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
     const onMouseDown = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setMenuOpen(false);
-        setTagPickerOpen(false);
-      }
+      const target = event.target as Node;
+      // The menu is portaled out of menuRef, so check both the trigger and the
+      // portaled panel before treating a click as "outside".
+      if (menuRef.current?.contains(target)) return;
+      if (menuPanelRef.current?.contains(target)) return;
+      setMenuOpen(false);
+      setTagPickerOpen(false);
     };
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -4369,11 +4379,20 @@ function ModCard({
         setTagPickerOpen(false);
       }
     };
+    // Keep the portaled menu anchored to its card as the list scrolls/resizes.
+    // Inner-container scroll doesn't bubble, so listen in the capture phase.
+    const reposition = () => {
+      if (menuRef.current) setMenuRect(menuRef.current.getBoundingClientRect());
+    };
     window.addEventListener('mousedown', onMouseDown);
     window.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
     return () => {
       window.removeEventListener('mousedown', onMouseDown);
       window.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
     };
   }, [menuOpen]);
 
@@ -4516,6 +4535,7 @@ function ModCard({
               const willOpen = !open;
               if (willOpen && menuRef.current) {
                 const rect = menuRef.current.getBoundingClientRect();
+                setMenuRect(rect);
                 // The menu can grow tall (tag picker). Prefer opening upward,
                 // but flip down when there's clearly more room below.
                 const spaceAbove = rect.top;
@@ -4535,13 +4555,19 @@ function ModCard({
         >
           <MoreHorizontal className="w-4 h-4" />
         </button>
-        {menuOpen && (
+        {menuOpen && menuRect && createPortal(
           <div
+            ref={menuPanelRef}
             role="menu"
             data-card-menu-open
-            className={`absolute right-0 z-[70] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in ${
-              menuPlacement === 'up' ? 'bottom-full mb-2' : 'top-full mt-2'
-            }`}
+            className="z-[100] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
+            style={{
+              position: 'fixed',
+              right: Math.max(8, window.innerWidth - menuRect.right),
+              ...(menuPlacement === 'up'
+                ? { bottom: window.innerHeight - menuRect.top + 8 }
+                : { top: menuRect.bottom + 8 }),
+            }}
           >
             {menuError && (
               <div className="mb-1 rounded-md border border-state-danger/30 bg-state-danger/10 px-2 py-1.5 text-xs text-state-danger">
@@ -4730,7 +4756,8 @@ function ModCard({
                 </button>
               </>
             )}
-          </div>
+          </div>,
+          document.body
         )}
       </div>
         <button

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Mod, AppSettings, EditLocalModArgs } from '../types/mod';
+import type { Mod, AppSettings, EditLocalModArgs, GlobalModType } from '../types/mod';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { setDateFormat } from '../lib/dateFormat';
 import * as api from '../lib/api';
@@ -201,6 +201,7 @@ interface AppState {
   reorderMods: (orderedIds: string[]) => Promise<void>;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
+  setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<void>;
   setVariantLabel: (modId: string, label: string) => Promise<void>;
   importCustomMod: (args: { vpkPath: string; name: string; thumbnailDataUrl?: string; nsfw?: boolean }) => Promise<void>;
 
@@ -402,6 +403,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setModLockerHero: async (modId: string, heroName: string | null) => {
     const updated = await api.setModLockerHero(modId, heroName);
+    set({
+      mods: get().mods.map((m) => (m.id === modId ? updated : m)),
+    });
+  },
+
+  setModGlobalType: async (modId: string, globalType: GlobalModType | null) => {
+    const updated = await api.setModGlobalType(modId, globalType);
     set({
       mods: get().mods.map((m) => (m.id === modId ? updated : m)),
     });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,6 +8,17 @@
     "types": ["vite/client"],
     "skipLibCheck": true,
 
+    /* Resolve the shared @grimoire/social-types workspace package directly from
+       the sibling checkout. pnpm's symlink for this out-of-root package
+       (../grimoire-social/packages/*) resolves to the wrong depth in CI's
+       nested directory layout, leaving it dangling so tsc can't find it; an
+       explicit path makes resolution deterministic in both CI and local dev. */
+    "baseUrl": ".",
+    "paths": {
+      "@grimoire/social-types": ["../grimoire-social/packages/social-types/src/schemas.ts"],
+      "@grimoire/social-types/heroes": ["../grimoire-social/packages/social-types/src/heroes.ts"]
+    },
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
Five user-reported fixes, one commit each so they stay reviewable independently.

## 1. Conflict window: set the load-order winner `feat(conflicts)`
Each conflict card gets a reorder control: pick which mod wins and it is moved to load immediately after the other (later load overrides shared files), reusing `reorderMods` (the same path the Installed load-order editor uses).
- Priority conflicts (shared pak slot): the dense renumber also splits the slot, clearing the pair.
- File overlaps: stay flagged but now resolve deterministically to the chosen winner.
- Disabled until both mods are enabled (a disabled mod has no load-order slot).

## 2. Side mouse buttons close the open overlay `fix(mod-details)`
The back/forward mouse buttons walked the router history (e.g. Browse to Installed) out from under an open mod detail modal or image lightbox. While the modal is mounted, both side buttons now close the topmost overlay (same precedence as Escape) and suppress the navigation. Handles either button since the physical mapping varies by mouse.

> Note: Chromium's suppression of mouse-button history nav is platform-dependent. Please verify on Linux. If nav still leaks, the follow-up is a `popstate` safety net.

## 3. Locker-tag menu no longer clipped behind the sidebar `fix(locker)`
The per-card actions menu rendered as an absolutely positioned child of the mod card, which lives in an `overflow-auto` + `transform-gpu` subtree that clipped its left edge behind the sidebar. It is now portaled to `document.body` and positioned in fixed coordinates from the trigger rect (right-aligned, flips up/down as before), with a panel ref so outside-click still works and reposition on scroll/resize.

## 4. Alphabetize + de-dupe the Installed hero tag list `fix(locker)`
The Installed **Set Locker tag** menu mapped the raw `HERO_NAMES` roster (newer heroes appended out of order, plus both `Doorman` and `The Doorman`). It now uses a sorted, de-duped `HERO_NAMES_SORTED` so it matches the Locker tag menu. Tag-state comparison is canonicalized so a mod tagged `The Doorman` still checks under `Doorman`. Client display only: the shared `social-types` roster and server-side inference are untouched.

## 5. HUD / global auto-tags for local mods `fix(locker)`
Global-type classification ran only inside `enrichMod`'s metadata branch, so a VPK added straight to `citadel/addons` (no metadata row) never got a `globalType` and its HUD / Soul Container tag never appeared. Classification now runs for every scanned mod, with a classifier-version stamp so a stale `null` result re-runs when the patterns improve (reaching already-installed mods without a manual retag). Positive/manual types are preserved.

> Note: `HUD_PATTERN` coverage was left as-is. If a specific local HUD VPK still doesn't auto-tag, sharing its file tree lets us widen the pattern and bump `GLOBAL_CLASSIFIER_VERSION` to propagate the fix.

## Verification
- Typecheck (renderer + node) and ESLint pass for all changed files.
- Manual: see each section above. No test framework in this repo (TS strict + ESLint are the gate).