### PR TITLE
fix(installed): stop rendering the type chip twice for global mods

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -5092,7 +5092,15 @@ function ModCard({
   // manual or auto global tag is visible here, not just in the Locker. A global
   // mod has no hero, so the two chips never both show.
   const cardGlobalType = getEffectiveGlobalType(mod);
-  const showCategoryChip = viewMode !== 'compact' || !mod.lockerHero;
+  const cardGlobalLabel = cardGlobalType
+    ? (GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType)
+    : undefined;
+  // A globally-classified mod (HUD, Soul Containers, ...) already shows the
+  // Locker global chip, which makes the GameBanana category chip redundant: for
+  // HUD it was literally rendering "HUD" twice (category + global). Suppress the
+  // category chip whenever a global chip is present and let it stand in.
+  const showCategoryChip =
+    (viewMode !== 'compact' || !mod.lockerHero) && !cardGlobalType;
   const compactBaseChipCount =
     (mod.lockerHero ? 1 : 0) + (showCategoryChip && mod.categoryName ? 1 : 0);
   const showGlobalChip = !!cardGlobalType && (!isCompact || compactBaseChipCount < 2);
@@ -5525,11 +5533,11 @@ function ModCard({
                 iconClassName={tagIconClassName}
                 iconOnly
               />
-              {showGlobalChip && cardGlobalType && (
+              {showGlobalChip && cardGlobalLabel && (
                 <MetaTextChip
-                  label={GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType}
+                  label={cardGlobalLabel}
                   className={metaChipClasses}
-                  title={`Locker: ${GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType}`}
+                  title={`Locker: ${cardGlobalLabel}`}
                 />
               )}
               {showCategoryChip && mod.categoryName && heroNameForLabel(mod.categoryName) !== mod.lockerHero && (


### PR DESCRIPTION
## Problem

Mods in the Installed tab were getting double-tagged: a HUD mod showed two identical **HUD** chips on its card (and similarly for other global types).

## Root cause

A globally-classified mod carries two overlapping pieces of metadata:

- `categoryName: "HUD"` (the GameBanana category)
- `globalType: "hud"` (assigned by the VPK-path classifier in `vpk.ts`, label `"HUD"`)

The card renders both a **global chip** (`MetaTextChip`, label from `GLOBAL_MOD_TYPE_LABELS`) and a **category chip** (`CategoryChip`, label `mod.categoryName`). The category-chip render guard only deduped against the *hero* name (`heroNameForLabel(...) !== mod.lockerHero`), never against the global-type label, so both rendered "HUD".

It surfaced from two recent changes combining:
- **#110** added the global chip to the card (its comment only reasoned about hero vs global mutual exclusivity, not the category chip).
- **#111** broadened the classifier so more mods picked up a `globalType`, making the overlap visible.

## Fix

Suppress the category chip whenever the mod already shows a Locker global chip, and let the global chip stand in. Covers all global types (HUD, Soul Containers, Hideout, Icon Packs, Announcer/SFX, Killstreak Music), not just HUD. Folded into `showCategoryChip` so the compact-view chip budget (`compactBaseChipCount`) stays correct and no empty slot is left behind.

Result on a HUD mod card: one "HUD" chip (the global chip) instead of two.

## Testing

- `tsc -p tsconfig.app.json --noEmit` passes
- `eslint src/pages/Installed.tsx` passes