### PR TITLE
chore(release): v1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the **1.14.1** patch release.

Bundles the 6 PRs merged since \`v1.14.0\`:

- #113 feat(locker): live 3D hero pose preview (2D/3D toggle)
- #112 fix(installed): stop rendering the type chip twice for global mods
- #111 feat(installed): manual link + file-tree tagging for unknown mods
- #110 Locker + Conflicts UX batch (5 user-reported fixes)
- #108 feat(locker): 3D soul-container previews in the Global view
- #107 fix(browse): correct Recently Updated and Name sort ordering

**Pre-release checks (local):**
- vpkmerge pinned binary restored/verified at \`v0.6.0\` (hash matches \`fetch-vpkmerge.mjs\`)
- \`electron-vite build\` passes with production \`GRIMOIRE_SOCIAL_BASE_URL\`
- Source lints clean (0 errors)

Tag \`v1.14.1\` after merge to trigger \`release.yml\`.