### PR TITLE
fix(locker): restore 3D previews in packaged builds

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -307,7 +307,17 @@ if (!gotTheLock) {
                             // entry is here so any future renderer-side asset (e.g. avatar URL
                             // not on Steam's CDN) doesn't trip CSP unexpectedly. Update when a
                             // dedicated grimoire-social production domain is locked.
-                            "connect-src 'self' https://gamebanana.com https://*.gamebanana.com https://api.deadlock-api.com https://*.workers.dev"
+                            //
+                            // The `grimoire-soul:`/`grimoire-hero:` schemes serve the
+                            // Locker's 3D GLBs; GLTFLoader fetches them, so they must be
+                            // allowed here or the load is blocked under the prod CSP (dev
+                            // has no CSP, which is why the 3D previews work in `pnpm dev`
+                            // but not in a packaged build). `blob:` is required too:
+                            // three's GLTFLoader extracts each embedded GLB texture into a
+                            // blob: URL and loads it via ImageBitmapLoader, which fetch()es
+                            // it; without blob: here the textures fail and models render
+                            // untextured (white).
+                            "connect-src 'self' blob: data: grimoire-soul: grimoire-hero: https://gamebanana.com https://*.gamebanana.com https://api.deadlock-api.com https://*.workers.dev"
                         ]
                     }
                 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.6.0';
+const VPKMERGE_VERSION = 'v0.7.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '293f8e2c44f22025c323b43ab1e95f947303b55b283dab8e867d40fd3f29c52e' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '76b9134e97c658a344b8a01032d9cc933326edf02a838cd79f32f3980909835d' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '484db0c1b9cadb176de721e747243b4713b670c7ba208a72bbf889016587c24c' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '942ac53417b882f23eaaadb11a0fdb8174cfd54251cdd8cd59dd778d295086ea' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '056b558f6dd0c95f7501136850cbca8152cd817068d9f41004d3e3603793ec74' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'b6a255dee90e7c3e345455ba48c911df0893e4f3f431fce7d8a21f147618bc3e' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Packaged-only breakage of the Locker 3D previews (both worked in `pnpm dev`).

- **CSP blocked the GLB loads.** `connect-src` now allows `blob: data: grimoire-soul: grimoire-hero:` so GLTFLoader can fetch the model (privileged schemes) and its embedded textures (`blob:` via ImageBitmapLoader). Fixes white/untextured and non-loading models.
- **Hero poses failed** on `--require-pose`, absent from the pinned vpkmerge 0.6.0. Bumps the pin to **v0.7.0** (adds --require-pose + deterministic hero discovery + comic-outline shell drop).

Hotfix for v1.14.2.