### PR TITLE
feat(installed): GameBanana link button on Fix Unknown search results

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -58,6 +58,7 @@ import {
   ChevronRight,
   Folder,
   FileText,
+  Banana,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -3901,7 +3902,9 @@ function UnknownManualSearch({
           <span className="font-medium text-text-primary">Find it on GameBanana and link it.</span>{' '}
           Results update as you type, or open GameBanana (or the Browse tab) side by side to
           find the mod, then search for it here. Linking tags this exact file: nothing is
-          re-downloaded.
+          re-downloaded. Use the{' '}
+          <Banana className="inline-block w-3.5 h-3.5 -mt-0.5 text-yellow-400" /> button on any
+          result to open it on GameBanana and download there directly.
         </div>
       </div>
 
@@ -3966,6 +3969,12 @@ function UnknownManualSearch({
         <div className="max-h-64 overflow-y-auto space-y-1.5 pr-1">
           {results.map((gbMod) => {
             const isSel = selected?.id === gbMod.id;
+            // Direct GameBanana page so the user can download it there (often
+            // faster than Grimoire's queue) while still linking it here. Prefer
+            // the record's own URL; fall back to one built from the id/section.
+            const gbUrl =
+              gbMod.profileUrl ||
+              `https://gamebanana.com/${section === 'Sound' ? 'sounds' : 'mods'}/${gbMod.id}`;
             return (
               <div
                 key={gbMod.id}
@@ -3973,28 +3982,41 @@ function UnknownManualSearch({
                   isSel ? 'bg-accent/10 border-accent/40' : 'bg-bg-primary/40 border-white/5 hover:border-white/15'
                 }`}
               >
-                <button
-                  type="button"
-                  onClick={() => void selectMod(gbMod)}
-                  className="w-full text-left flex items-center gap-3 p-2 cursor-pointer"
-                >
-                  <ModThumbnail
-                    src={getModThumbnail(gbMod)}
-                    alt={gbMod.name}
-                    nsfw={gbMod.nsfw}
-                    hideNsfw
-                    className="w-16 h-11 rounded bg-bg-primary border border-white/10 flex-shrink-0"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-text-primary truncate" title={gbMod.name}>
-                      {gbMod.name}
+                <div className="flex items-center pr-2">
+                  <button
+                    type="button"
+                    onClick={() => void selectMod(gbMod)}
+                    className="min-w-0 flex-1 text-left flex items-center gap-3 p-2 cursor-pointer"
+                  >
+                    <ModThumbnail
+                      src={getModThumbnail(gbMod)}
+                      alt={gbMod.name}
+                      nsfw={gbMod.nsfw}
+                      hideNsfw
+                      className="w-16 h-11 rounded bg-bg-primary border border-white/10 flex-shrink-0"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-text-primary truncate" title={gbMod.name}>
+                        {gbMod.name}
+                      </div>
+                      <div className="text-[11px] text-text-tertiary truncate">
+                        {gbMod.rootCategory?.name ?? (section === 'Mod' ? 'Mods' : 'Sounds')} · #{gbMod.id}
+                      </div>
                     </div>
-                    <div className="text-[11px] text-text-tertiary truncate">
-                      {gbMod.rootCategory?.name ?? (section === 'Mod' ? 'Mods' : 'Sounds')} · #{gbMod.id}
-                    </div>
-                  </div>
-                  {isSel && <Check className="w-4 h-4 text-accent flex-shrink-0" />}
-                </button>
+                    {isSel && <Check className="w-4 h-4 text-accent flex-shrink-0" />}
+                  </button>
+
+                  <a
+                    href={gbUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`Open ${gbMod.name} on GameBanana to download it directly`}
+                    aria-label={`Open ${gbMod.name} on GameBanana`}
+                    className="flex-shrink-0 ml-1 inline-flex items-center justify-center w-9 h-9 rounded-md border border-white/10 bg-bg-primary/60 text-text-tertiary transition-colors hover:border-yellow-400/50 hover:text-yellow-400 hover:bg-yellow-400/5"
+                  >
+                    <Banana className="w-4 h-4" />
+                  </a>
+                </div>
 
                 {isSel && (
                   <div className="border-t border-white/5 px-2.5 py-2.5 space-y-2">


### PR DESCRIPTION
## What

Adds a banana-icon link box to each result in the **Fix Unknown** manual-link search (`UnknownManualSearch` in `src/pages/Installed.tsx`). Clicking it opens that mod's GameBanana page in the system browser.

## Why

Downloading through Grimoire's queue is sometimes slow. When that happens the user just grabs the mod from GameBanana directly, but then the local VPK is "unknown" (no link back to its source). This puts a one-click path to the original GameBanana page right next to each candidate, so you can download there *and* still link the existing local file via the unchanged "Link this mod" flow. Nothing re-downloads through the app.

## How

- Per-result banana box (lucide `Banana`), tinted yellow on hover so it reads as GameBanana.
- URL prefers `gbMod.profileUrl`; falls back to `https://gamebanana.com/{mods|sounds}/{id}` (built from the searched section + id) for locally-cached rows that lack a `profileUrl`.
- The link is a **sibling** of the select button, not nested (avoids button-in-button), so clicking it opens the page without selecting the result.
- Opens externally via the existing `setWindowOpenHandler` -> `shell.openExternal` path (https whitelisted), the same mechanism the mod-details title link uses.
- Panel intro copy now points at the button so it's discoverable.

## Notes

- Compact icon box rather than a labeled `🍌 GameBanana` pill, since the card row is tight next to the mod name. Tooltip/`aria-label` spell out the action. Easy to swap to a labeled pill if preferred.
- No telemetry, no new IPC, main process still owns everything.

## Verification

- `tsc -p tsconfig.app.json --noEmit`: clean
- `eslint src/pages/Installed.tsx`: clean