### PR TITLE
feat(installed): let any local mod link to GameBanana, not just unknowns

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2075,7 +2075,12 @@ export default function Installed() {
           onTagGlobal={async (globalType) => {
             await setModGlobalType(mod.id, globalType);
           }}
-          onFixUnknown={mod.isUnknown ? () => openUnknownModFix(mod, 'single') : undefined}
+          onFixUnknown={
+            // Any local (unlinked, non-merged) mod can search GameBanana and
+            // link, not just ones flagged "unknown": naming a local mod via
+            // Edit Local clears isUnknown but it still has no GameBanana source.
+            entryIsLocal(entry) && !mod.merged ? () => openUnknownModFix(mod, 'single') : undefined
+          }
           fixingUnknown={unknownFilterPendingIds.has(mod.id)}
           loadPosition={loadPositionById.get(mod.id)}
           loadCount={enabledModCount}
@@ -3311,8 +3316,12 @@ function UnknownFilterGuessModal({
         <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-white/10">
           <div className="min-w-0">
             <h2 id="unknown-filter-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
-              <Wrench className="w-4 h-4 text-orange-400" />
-              Fix Unknown Mod
+              {mod.isUnknown ? (
+                <Wrench className="w-4 h-4 text-orange-400" />
+              ) : (
+                <Link2 className="w-4 h-4 text-accent" />
+              )}
+              {mod.isUnknown ? 'Fix Unknown Mod' : 'Link to GameBanana'}
             </h2>
             <p className="text-xs text-text-secondary mt-1 truncate" title={mod.fileName}>
               {mod.fileName}
@@ -5293,24 +5302,25 @@ function ModCard({
                 )}
               </>
             )}
-            {mod.isUnknown && (
+            {onFixUnknown && (
               <button
                 type="button"
                 role="menuitem"
                 onClick={(e) => {
                   e.stopPropagation();
                   setMenuOpen(false);
-                  onFixUnknown?.();
+                  onFixUnknown();
                 }}
-                disabled={!onFixUnknown}
                 className={menuItemClasses}
               >
                 {fixingUnknown ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                ) : (
+                ) : mod.isUnknown ? (
                   <Wrench className="w-3.5 h-3.5" />
+                ) : (
+                  <Link2 className="w-3.5 h-3.5" />
                 )}
-                Fix unknown match
+                {mod.isUnknown ? 'Fix unknown match' : 'Link to GameBanana'}
               </button>
             )}
             {mod.merged && onCopyShareCode && (


### PR DESCRIPTION
## What

Makes the GameBanana **search-and-link** flow available for **all local mods**, not just ones flagged `isUnknown`.

## Why

`isUnknown` is `false` once a local mod has a custom name (naming it via **Edit Local** sets `modName`, which clears the unknown flag). But the mod still has no GameBanana source, so the user had no way to link it back to the original mod. This is the gap reported in #117's follow-up: people download from GameBanana directly (faster than the in-app queue), import locally, and want to link to the source even after naming it.

## How (all in `src/pages/Installed.tsx`)

- **Per-card gate**: broadened from `mod.isUnknown` to `entryIsLocal(entry) && !mod.merged`, so any local (unlinked, non-merged) mod gets the action. Group cards and already-linked mods stay excluded.
- **Card menu item**: now shown whenever the action is available, with adaptive label/icon:
  - genuine unknown -> `Fix unknown match` (wrench)
  - named local mod -> `Link to GameBanana` (link)
- **Modal header** mirrors that: `Fix Unknown Mod` vs `Link to GameBanana`.

The modal's inner panel ("find the mod on GameBanana and link this local file", Make Custom Mod, Auto-detect) was already generic, and the `associate-unknown-mod` IPC has no `isUnknown` requirement, so linking behaves identically. After linking, the mod gains a `gameBananaId` and leaves the local/unknown state as before.

## Scope notes

- The "Unknown" overlay badge and the bulk "Fix unknown (N)" banner stay tied to genuine unknowns intentionally (we don't want to badge every named local mod).
- Merged mods are excluded (no single GameBanana source).

## Verification

- `tsc -p tsconfig.app.json --noEmit`: clean
- `eslint src/pages/Installed.tsx`: clean