### PR TITLE
feat(locker): per-hero ability VFX recolor + colors in Locker Overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ README.txt
 icon-32.png
 /.pnpm-store
 .codex-run/
+
+# Project summary (LaTeX source + build artifacts)
+docs/grimoire-project-summary.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ Design docs and references live in `docs/`:
 - `deadlock-api-architecture.md` + `DEADLOCK_STATS_API.md` - deadlock-api.com integration
 - `design-overhaul-brief.md` - UI design language reference
 - `social-architecture.md` + `social-architecture-decisions.md` - Architecture and ADRs for the planned `grimoire-social` companion service (see below)
+- `ability-vfx-recolor.md` - Hero ability VFX layer extraction + in app recoloring. Read before touching `detectVfxLayer`/`extractVfxLayer` (in `vpk.ts`/`modMerger.ts`) or building the recolor/Locker surface. Covers why particle recolor must use an in place scalar patch, not a KV3 re-encode.
 
 ## Companion Service: grimoire-social
 

--- a/docs/ability-vfx-recolor.md
+++ b/docs/ability-vfx-recolor.md
@@ -2,6 +2,8 @@
 
 Status: in progress. Particle layer extraction and particle recoloring are proven end to end (verified in game on Paige). The texture recolor primitive (dragon, projectile) now ships as `vpkmerge texture`; the particle-recolor CLI surface and the Locker UI are still to build, and the in-game dragon check is still pending.
 
+The recolor target is no longer hue-only: it carries a **saturation scale** and a **brightness scale** on top of the hue (see "Color accuracy" below), so pale/pastel colors like light blue are reachable, and the washed-out look of a hue-only retint on low-saturation source textures is fixable. The Locker picker (`HeroColorPicker.tsx`) exposes hue + saturation + brightness sliders with a **live recolored preview** (a real ability texture run through the recolor, not a CSS guess).
+
 ## Goal
 
 Two related capabilities for a hero's ability visual effects (VFX), independent of the body skin:
@@ -56,7 +58,17 @@ The fix is a byte faithful, in place patch that changes only the color channels 
 
 Build the edits by walking the decoded value tree for color/tint keyed integer arrays (length 3 or 4, values 0 to 255) and emitting `(path + Index(channel), new_value)` per RGB channel. Color channels (including 0 and 255) are stored as typed bytes, so all patch cleanly (188 of 267 Paige files carry color; 0 patch errors). The other 79 files get their color elsewhere (material, dragon) and are left alone.
 
-Color transform: convert each color to HSV, set the hue to the target, and keep each color's saturation and value. Gradients then keep their light to dark fade (cleaner than a flat retint). Verified `m_ConstantColor [0,255,148,255] -> [170,0,255,255]` at hue 280 (purple), output stays v5, renders correctly in game.
+Color transform: convert each color to HSV, set the hue to the target, then scale its saturation and value by the target's scales (1.0 = keep source). Gradients then keep their light to dark fade (cleaner than a flat retint). Verified `m_ConstantColor [0,255,148,255] -> [170,0,255,255]` at hue 280 (purple), unit scales, output stays v5, renders correctly in game.
+
+## Color accuracy: saturation + brightness scales (built)
+
+Hue-only recolor inherits each source pixel's saturation and value. Paige's color textures (self-illum ramps, the illustrated albedos) carry a lot of pale, low-saturation pixels, so a hue-only retint reads "drowned out": the right hue but a washed, muddy version of the picked color. And hue alone can't express a color like *light blue* at all, since light/pastel is the saturation + brightness axes, not hue.
+
+Fix: the recolor target is now `Recolor { hue, saturation, value }` (`vpkmerge-core/src/recolor.rs`). `set_color(rgb, hue, sat_scale, val_scale)` sets the hue, then **scales** saturation and value (both clamped, value always kept structural so the gradient survives). `saturation > 1` lifts pale areas toward the picked color; `value > 1` lightens (pastel), `< 1` darkens (ink). Neutral pixels (saturation 0: white cores, black shadows) stay neutral under any saturation scale, so hot cores don't get tinted. All three mechanisms (particles, textures, vertex colors) take the one `Recolor`, so the scales land them on the same color. `set_hue` is kept as the `(1.0, 1.0)` convenience the original tests pin.
+
+CLI: `--saturation <SCALE>` and `--brightness <SCALE>` (default 1.0) on `texture`, `recolor-hero`, and `model recolor`. Plus `recolor-hero --preview-png <FILE>`: a fast path that recolors only the recipe's representative texture (`preview_texture`, Paige = `bookworm_ui_effects_color`) and writes a PNG swatch, no bake/re-encode (~170 ms), for the live UI preview. Core API: `recolor_hero_preview_png(vpk, base, codename, recolor)`.
+
+Grimoire: `LockerColorSelection` / `ActiveHeroColor` / `ApplyHeroColorResult` carry `saturation` + `brightness`; the bake cache key includes them (integer-percent encoded, e.g. `_s60_b140_`) and `RECIPE_CACHE_VERSION` bumped to 2. `previewHeroColor` IPC returns a `data:` PNG the picker shows as a debounced live swatch.
 
 Prototype: `vpkmerge/vpkmerge-core/examples/recolor_particles.rs` (the walk + HSV + patch + pack). To productionize, promote it to a `vpkmerge particle recolor` subcommand and bump the Grimoire binary pin.
 
@@ -104,12 +116,12 @@ vpkmerge texture models/heroes_wip/bookworm/materials/bookworm_dragon_color.vtex
 Mechanism: `morphic::decode` the top mip, set every pixel's hue to the target (keeping each pixel's saturation and value), then `morphic::replace_mip_chain` re-encodes the full mip chain in the texture's own format. The bytes pack at the source entry path and override the base texture in place, no `.vmat_c` edit (sidestepping the content-hashed texture rename).
 
 Decisions worth knowing:
-- **Hue is set (absolute), not rotated**, to match the particle recolor: the same hue value lands the dragon, the projectile, and the particle params on one color. Neutral pixels (saturation 0: white highlights, black shadows) stay neutral, since their chroma is zero at any hue. So a fire dragon at `--hue 280` keeps its value/saturation structure but reads purple.
+- **Hue is set (absolute), not rotated**, to match the particle recolor: the same hue value lands the dragon, the projectile, and the particle params on one color. Saturation and brightness are **scaled** (default 1.0), not set, so the texture keeps its structure (a flat set would wipe the gradient). Neutral pixels (saturation 0: white highlights, black shadows) stay neutral under any saturation scale, since their chroma is zero. So a fire dragon at `--hue 280` keeps its value/saturation structure but reads purple; `--saturation 1.4` makes it pop, `--brightness 1.3` lightens it.
 - **Operates on the stored 8-bit display channels**, the same space the particle `Color32` recolor edits, so the two paths stay consistent.
 - **LDR (8-bit) only.** An HDR (f16) texture is refused with a clear error rather than silently mangled; the Deadlock color maps this targets are all LDR.
 - `--preview <PNG>` is the design-intent color straight off the decode (fast, no re-encode); the same `recolor_texture_image` primitive is what a live UI hue slider should call. The lossy `BCn` re-encode only happens on `--encode` / `--encode-vpk`.
 
-Core API (also for the Grimoire UI): `recolor_texture_hue(bytes, hue) -> Vec<u8>` (full re-encode), `recolor_texture_image(bytes, hue) -> Image` (fast preview), `recolor_texture_preview_png(bytes, hue) -> Vec<u8>`, `inspect_texture(bytes) -> TextureSummary`, plus `read_vpk_entry(vpk, entry)` for callers without a `valve_pak` dep. Covered by unit tests in `vpkmerge-core/src/recolor.rs` (documented-example color, hue wrap, neutral-pixel invariance, hue-set with S/V preserved on the chromatic fixture, loadable round-trip, HDR rejection).
+Core API (also for the Grimoire UI): `recolor_texture_hue(bytes, recolor) -> Vec<u8>` (full re-encode), `recolor_texture_image(bytes, recolor) -> Image` (fast preview), `recolor_texture_preview_png(bytes, recolor) -> Vec<u8>`, `inspect_texture(bytes) -> TextureSummary`, plus `read_vpk_entry(vpk, entry)` for callers without a `valve_pak` dep. All recolor entry points now take a `Recolor { hue, saturation, value }` (was a bare `hue: f64`). Covered by unit tests in `vpkmerge-core/src/recolor.rs` (documented-example color, hue wrap, neutral-pixel invariance, hue-set with S/V preserved on the chromatic fixture, loadable round-trip, HDR rejection).
 
 The 9 entry paths are listed in the table above.
 
@@ -153,4 +165,5 @@ Full diagnosis + workflow: `vpkmerge/docs/handoff-vertex-color-recolor.md`.
 - Built: VFX layer detection + extraction (Grimoire), `morphic::patch_kv3_resource_scalars` (the particle recolor primitive), `vpkmerge texture` (+ `vpkmerge_core::recolor`, the texture recolor primitive), and `vpkmerge model recolor` (the vertex-color recolor primitive) - all multi-entry batch -> one addon.
 - Done for Paige (in game): particle recolor to purple (`pak02`) + the 9-texture ability/bullet/model recolor to purple (`pak04`) + the **ult horse/knight vertex-color recolor to purple**. Confirmed in game: bullets, abilities 1/2/3, and the ult body all read purple.
 - **Three color mechanisms, not two.** Beyond particles (params) and model/self-illum textures, the **ult horse/knight is colored by baked mesh vertex colors** (material `bookworm_knight.vmat`: `F_PAINT_VERTEX_COLORS=1`, gray albedo, `g_bApplyTintToVertexColors=0`), so it stayed green after the first two passes and a tint can't fix it. The vertex-color recolor (above) handles it - **in-game confirmed purple**. Two lessons baked in: find the rendered model via the ult's model particle (`bookworm_ultimate_model.vpcf_c` -> `models/particle/bookworm_horse_knight.vmdl`, not the `heroes_wip` copies), and never re-encode meshopt (convert it to uncompressed instead).
-- Pending: the `vpkmerge particle recolor` subcommand (promote `recolor_particles.rs`); a vpkmerge release + Grimoire pin bump; and the Locker UI (hue slider + live preview, calling `recolor_texture_image`).
+- Built: the Locker UI (`HeroColorPicker.tsx`): hue + saturation + brightness sliders, full-color presets (incl. light blue), and a live recolored preview via `recolor-hero --preview-png` (fast, no bake). Saturation/brightness scales fix the hue-only "drowned out" look and unlock pastel colors. The bundled `resources/vpkmerge` binary was rebuilt with the scale flags (local dev; a tagged vpkmerge release + pin bump is still pending).
+- Pending: the `vpkmerge particle recolor` subcommand (promote `recolor_particles.rs`); a vpkmerge release + Grimoire pin bump; and the in-game confirmation of a saturation/brightness-tuned (non-hue-only) Paige bake.

--- a/docs/ability-vfx-recolor.md
+++ b/docs/ability-vfx-recolor.md
@@ -160,10 +160,20 @@ Core API (also for the Grimoire UI): `recolor_model_vertex_colors(bytes, hue) ->
 
 Full diagnosis + workflow: `vpkmerge/docs/handoff-vertex-color-recolor.md`.
 
+## Supported heroes (recipes)
+
+Per-hero recipes are pinned in vpkmerge `recipe_for` (`vpkmerge-core/src/hero_recolor.rs`) and gated in Grimoire by `COLOR_CODENAME_BY_HERO` (`heroColors.ts`). Add a hero in lockstep: a recipe in vpkmerge + a `DisplayName: 'codename'` line in Grimoire.
+
+- **Paige** (`bookworm`): all three mechanisms (267 particles + 9 color textures + 2 vertex-color models). `preview_texture` = `bookworm_ui_effects_color`.
+- **Celeste** (`unicorn`): **particle-only**: her ability VFX carry color purely through `.vpcf_c` params (no color-bearing textures, no baked vertex colors), so the recipe is just the `particles/abilities/unicorn/` prefix. Pinned from her in-game pink recolor mod (target hue ~329). Because there is no color texture, `preview_texture` is `None`: `recolor_hero_preview_png` returns a clear error and the picker falls back to the approximate CSS chip (which is representative for a flat particle color). The full bake still works via `recolor-hero`.
+
+This is why `HeroRecolorRecipe.preview_texture` is `Option<String>` and the empty `texture_entries`/`model_entries` are valid (a particle-only hero recolors fine with only the prefix).
+
 ## Status summary
 
 - Built: VFX layer detection + extraction (Grimoire), `morphic::patch_kv3_resource_scalars` (the particle recolor primitive), `vpkmerge texture` (+ `vpkmerge_core::recolor`, the texture recolor primitive), and `vpkmerge model recolor` (the vertex-color recolor primitive) - all multi-entry batch -> one addon.
 - Done for Paige (in game): particle recolor to purple (`pak02`) + the 9-texture ability/bullet/model recolor to purple (`pak04`) + the **ult horse/knight vertex-color recolor to purple**. Confirmed in game: bullets, abilities 1/2/3, and the ult body all read purple.
 - **Three color mechanisms, not two.** Beyond particles (params) and model/self-illum textures, the **ult horse/knight is colored by baked mesh vertex colors** (material `bookworm_knight.vmat`: `F_PAINT_VERTEX_COLORS=1`, gray albedo, `g_bApplyTintToVertexColors=0`), so it stayed green after the first two passes and a tint can't fix it. The vertex-color recolor (above) handles it - **in-game confirmed purple**. Two lessons baked in: find the rendered model via the ult's model particle (`bookworm_ultimate_model.vpcf_c` -> `models/particle/bookworm_horse_knight.vmdl`, not the `heroes_wip` copies), and never re-encode meshopt (convert it to uncompressed instead).
 - Built: the Locker UI (`HeroColorPicker.tsx`): hue + saturation + brightness sliders, full-color presets (incl. light blue), and a live recolored preview via `recolor-hero --preview-png` (fast, no bake). Saturation/brightness scales fix the hue-only "drowned out" look and unlock pastel colors. The bundled `resources/vpkmerge` binary was rebuilt with the scale flags (local dev; a tagged vpkmerge release + pin bump is still pending).
-- Pending: the `vpkmerge particle recolor` subcommand (promote `recolor_particles.rs`); a vpkmerge release + Grimoire pin bump; and the in-game confirmation of a saturation/brightness-tuned (non-hue-only) Paige bake.
+- Built: **Celeste** (`unicorn`) as the 2nd supported hero, particle-only (recipe + Grimoire registration); `preview_texture` is now `Option` to model heroes with no color texture.
+- Pending: the `vpkmerge particle recolor` subcommand (promote `recolor_particles.rs`); a vpkmerge release + Grimoire pin bump; rebuilding the bundled `resources/vpkmerge` binary with the Celeste recipe; and the in-game confirmation of a saturation/brightness-tuned (non-hue-only) Paige bake + the Celeste recolor.

--- a/docs/ability-vfx-recolor.md
+++ b/docs/ability-vfx-recolor.md
@@ -1,0 +1,71 @@
+# Ability VFX layer + recolor
+
+Status: in progress. Particle layer extraction and particle recoloring are proven end to end (verified in game on Paige). The dragon texture recolor, the `vpkmerge` CLI surface, and the Locker UI are still to build.
+
+## Goal
+
+Two related capabilities for a hero's ability visual effects (VFX), independent of the body skin:
+
+1. **Extract** a hero's ability VFX as a standalone addon, so a recolor can ride on top of any body skin (today two skins for the same hero conflict because both ship the full particle set).
+2. **Recolor** those abilities to an arbitrary new color in app.
+
+Sounds are out of scope here (they are a separate axis, see `per-ability-sound-map.md`).
+
+## Where ability VFX live
+
+Per hero, keyed by the model/particle codename (Paige = `bookworm`, the namespace used by `models/` and `particles/abilities/`, NOT the sound codename):
+
+- `particles/abilities/<codename>/*.vpcf_c` (Paige: 222 files)
+- `particles/weapon_fx/<codename>/*.vpcf_c` (Paige: 45 files)
+
+These paths map 1:1 onto the base game `pak01_dir.vpk`. A Deadlock addon VPK only ships the files it overrides, so an addon containing these paths overrides the base particles in place. No diff against base is needed to "find" the ability files: they are self identifying by path.
+
+The ult **dragon** is the exception. Its color is not in particles: `bookworm_dragonfire.vpcf_c` is byte identical to base. The dragon's color lives in its model material under `models/heroes_wip/<codename>/materials/<codename>_dragon*`, so it is handled separately (see Dragon below).
+
+## Layer extraction (built)
+
+`detectVfxLayer(paths)` / `detectVfxLayerFromVpk(vpk)` in `electron/main/services/vpk.ts` find a single hero VFX layer in a VPK's path list (returns the codename, the matched paths, and the split prefixes, or null on multi hero / no VFX, matching the existing `inferHeroFromVpk` "one confident answer or nothing" contract).
+
+`extractVfxLayer(srcVpk, outVpk, prefixes)` in `electron/main/services/modMerger.ts` runs `vpkmerge split` with a plan routing only those two particle roots into a standalone addon and dropping everything else (body model, dragon material, shared masks). Validated: the blue Paige skin (276 entries) extracts to a 267 entry particles only addon.
+
+To mix body from skin A with VFX from skin B: split each into the layers you want, then `vpkmerge` merge the chosen layers (last input wins).
+
+## Recolor mechanism (proven, not yet productionized)
+
+Color lives in the compiled `.vpcf_c` KV3 `DATA` block as Color32 integer arrays (0 to 255):
+
+- `m_ConstantColor` (RGBA), the dominant knob.
+- gradient `...m_Gradient/m_Stops[]/m_Color` (RGB).
+
+### Do not recolor by full re-encode
+
+The tempting path (decode the KV3 to a value tree, edit, re-encode with `morphic::encode_kv3_resource`) **breaks particles**. That encoder:
+
+1. downgrades KV3 v5 to v4, and
+2. drops KV3 value flags (`Resource`, `SoundEvent`, ...) and auxiliary buffer typed array tags.
+
+Particles store their child system and material references as flag tagged resource strings. Re-encoding strips the flags, so the engine sees plain strings, fails to bind the references, and renders the Source 2 **error particle** (a dense red lattice over the scene). Soundevents tolerate this (they carry no resource flagged strings), which is why the `soundevents` edit path works and is misleading here.
+
+### Recolor by in place scalar patch
+
+The fix is a byte faithful, in place patch that changes only the color channels and preserves everything else. Added `morphic::patch_kv3_resource_scalars(file_bytes, edits)`:
+
+- `rewrap_uncompressed` the DATA block (keeps v5 framing, value flags, and typed array tags byte for byte),
+- `kv3::set_scalars` overwrites the targeted integer scalars in place (erroring if a value will not fit the field's on disk width),
+- `rebuild_with_data` splices the block back with corrected offsets.
+
+Build the edits by walking the decoded value tree for color/tint keyed integer arrays (length 3 or 4, values 0 to 255) and emitting `(path + Index(channel), new_value)` per RGB channel. Color channels (including 0 and 255) are stored as typed bytes, so all patch cleanly (188 of 267 Paige files carry color; 0 patch errors). The other 79 files get their color elsewhere (material, dragon) and are left alone.
+
+Color transform: convert each color to HSV, set the hue to the target, and keep each color's saturation and value. Gradients then keep their light to dark fade (cleaner than a flat retint). Verified `m_ConstantColor [0,255,148,255] -> [170,0,255,255]` at hue 280 (purple), output stays v5, renders correctly in game.
+
+Prototype: `vpkmerge/vpkmerge-core/examples/recolor_particles.rs` (the walk + HSV + patch + pack). To productionize, promote it to a `vpkmerge particle recolor` subcommand and bump the Grimoire binary pin.
+
+## Dragon (planned)
+
+The ult dragon recolors via a texture hue shift, not particles. Decode the base dragon color texture (`morphic::decode`), rotate hue on the `Image`, re-encode with `replace_face_mip_chain`, and pack the `.vtex_c` at its base path so it overrides in place (no `.vmat_c` edit, sidestepping the content hashed texture rename). Exposed via a new `vpkmerge texture` subcommand. UI: explicit hue degrees with a live preview.
+
+## Status summary
+
+- Built: VFX layer detection + extraction (Grimoire), `morphic::patch_kv3_resource_scalars` (the recolor primitive).
+- Proven via prototype: particle recolor to an arbitrary hue.
+- Pending: `vpkmerge particle recolor` + `vpkmerge texture` subcommands (and a vpkmerge release + pin bump), the dragon texture recolor, and the Locker UI (hue slider + live preview).

--- a/docs/ability-vfx-recolor.md
+++ b/docs/ability-vfx-recolor.md
@@ -60,6 +60,31 @@ Color transform: convert each color to HSV, set the hue to the target, and keep 
 
 Prototype: `vpkmerge/vpkmerge-core/examples/recolor_particles.rs` (the walk + HSV + patch + pack). To productionize, promote it to a `vpkmerge particle recolor` subcommand and bump the Grimoire binary pin.
 
+## Texture recolor: identifying color-bearing assets (handoff)
+
+Particle-param recolor only tints effects that render through a white/grayscale mask. Where a bullet or ability renders with a texture that has baked-in color (an albedo / color ramp / self-illum color), the param tint multiplies over that color and the result is muddy, not the new hue. Those `.vtex_c` need their own hue shift (the same texture pipeline as the dragon).
+
+Identifier (next agent runs this): `vpkmerge-core/examples/recolor_assets.rs`
+
+```
+cargo run --example recolor_assets -- <base pak01_dir.vpk> bookworm
+```
+
+It walks each ability/weapon_fx particle's KV3 for material refs (`.vmat`), each material for texture refs (`.vtex`), then classifies every texture by mean saturation over opaque pixels, with two filters:
+- name-based data-map exclusion (`normal`/`rough`/`ao`/`mask`/`metal`/`selfillummask`): packed normal maps read ~0.5 saturation but carry no albedo, so exclude by name not chroma.
+- hero-specific vs shared: only recolor textures whose path names the codename. Shared `materials/default/*` and generic `materials/particle/{projected,model}/*` are used by other heroes; recoloring them bleeds across the roster.
+
+Paige (bookworm) result, 26 referenced textures:
+- **Recolor target (hero-specific, color-bearing): 1** - `materials/particle/abilities/bookworm/bookworm_projectile_self_illum_vmat_g_tcolor_*` (sat 0.92), her projectile/bullet color.
+- Shared color (do NOT recolor): the generic projected cone self-illum + a default texture.
+- 23 data maps / masks: tinted by particle param, no texture recolor needed.
+
+Coverage gaps this particle-centric scan does NOT cover, and the next agent should add:
+1. Ability/projectile **models** (`.vmdl_c`: sword, book, dragon) -> their materials -> albedo textures. The dragon albedo and `bookworm_book_color_*` carry the hero's color and are reached via models, not particle materials. Extend the walk to follow `.vmdl` refs in particles and the hero's own ability models.
+2. HUD **ability icons** (panorama UI images), which no particle references at all.
+
+Heuristic is a starting filter, not ground truth: print the saturation and eyeball borderline cases (decode to PNG with the texture path) before committing a recolor.
+
 ## Dragon (planned)
 
 The ult dragon recolors via a texture hue shift, not particles. Decode the base dragon color texture (`morphic::decode`), rotate hue on the `Image`, re-encode with `replace_face_mip_chain`, and pack the `.vtex_c` at its base path so it overrides in place (no `.vmat_c` edit, sidestepping the content hashed texture rename). Exposed via a new `vpkmerge texture` subcommand. UI: explicit hue degrees with a live preview.

--- a/docs/ability-vfx-recolor.md
+++ b/docs/ability-vfx-recolor.md
@@ -1,6 +1,6 @@
 # Ability VFX layer + recolor
 
-Status: in progress. Particle layer extraction and particle recoloring are proven end to end (verified in game on Paige). The dragon texture recolor, the `vpkmerge` CLI surface, and the Locker UI are still to build.
+Status: in progress. Particle layer extraction and particle recoloring are proven end to end (verified in game on Paige). The texture recolor primitive (dragon, projectile) now ships as `vpkmerge texture`; the particle-recolor CLI surface and the Locker UI are still to build, and the in-game dragon check is still pending.
 
 ## Goal
 
@@ -60,37 +60,97 @@ Color transform: convert each color to HSV, set the hue to the target, and keep 
 
 Prototype: `vpkmerge/vpkmerge-core/examples/recolor_particles.rs` (the walk + HSV + patch + pack). To productionize, promote it to a `vpkmerge particle recolor` subcommand and bump the Grimoire binary pin.
 
-## Texture recolor: identifying color-bearing assets (handoff)
+## Texture recolor: the color-bearing asset set (Paige, done)
 
-Particle-param recolor only tints effects that render through a white/grayscale mask. Where a bullet or ability renders with a texture that has baked-in color (an albedo / color ramp / self-illum color), the param tint multiplies over that color and the result is muddy, not the new hue. Those `.vtex_c` need their own hue shift (the same texture pipeline as the dragon).
+Particle-param recolor only tints effects that render through a white/grayscale mask. Where a bullet or ability renders with a texture that has baked-in color (an albedo / color ramp / self-illum color), the param tint multiplies over that color and the result is muddy, not the new hue. Those `.vtex_c` need their own hue shift.
 
-Identifier (next agent runs this): `vpkmerge-core/examples/recolor_assets.rs`
+The particle-only scan (`recolor_assets.rs`, particle -> material -> texture) found just 1 hero-specific color-bearing texture (the projectile self-illum). The rest are reached via **models**, which that scan doesn't follow. The reliable way to find the full set turned out to be a saturation sweep over every `bookworm*.vtex_c` in the base pak, classifying by chroma + name (a throwaway scan; productionizing it is optional). Paige's color-bearing **ability VFX** textures are all green (hue 120-164); her portrait/card art is orange (hue ~28, leave it); the rest are grayscale data maps (tinted by the particle param, no recolor). Note some live in shared dirs (`materials/particle/{projected,ground}/`) but are **hero-named**, so overriding those exact paths only touches Paige.
+
+The 9 recolored (all set to hue 280 to match the particle recolor):
+
+| Entry | What | Notes |
+|---|---|---|
+| `materials/particle/abilities/bookworm/bookworm_projectile_self_illum_vmat_g_tcolor_7b26a19f` | bullets | 4x4 color swatch |
+| `materials/particle/projected/bookworm_aoe_ground_projected_vmat_g_tselfillum_670d93d` | AOE | hero-named in shared dir |
+| `materials/particle/ground/ground_streak_bookworm_psd_5a44028c` | ground streak | near-black, low impact |
+| `models/heroes_wip/bookworm/materials/bookworm_ui_effects_color_psd_a29be817` | effects | 2048 |
+| `models/heroes_wip/bookworm/materials/bookworm_shield_illustrated_color_psd_81f5497b` | shield | 2048 |
+| `models/heroes_wip/bookworm/materials/bookworm_sword_illustrated_color_psd_4eb22603` | sword | 512x2048, alpha-0 RGB decal |
+| `models/heroes_wip/bookworm/materials/bookworm_stone_illustrated_color_psd_8ed29960` | stone | 4096x4096 (slow re-encode) |
+| `models/heroes_wip/bookworm/materials/bookworm_dragon_color_tga_ed3d3b5` | dragon body | 2048 |
+| `materials/models/particle/bookworm/neutral_black_dragon_color_psd_b8c8249f` | particle dragon | 2048 |
+
+Excluded on purpose: the brown book object (`bookworm_book_color_dragon`, hue 20, not the green VFX), the orange portrait/loadout cards, grayscale `bookworm_graphic*`/`knight`/`effects_flat` (tinted by param), and all data maps (ao/rough/normal/mask/metal/outline/transmissive). HUD ability icons (panorama) are also left (grayscale or separate concern).
+
+Built into the CLI: `vpkmerge texture` now takes **several entries -> one addon**: `vpkmerge texture E1 E2 ... --from-vpk pak01_dir.vpk --hue 280 --encode-vpk paige_vfx_textures_dir.vpk`. Each entry recolors and packs at its own path, overriding the base in place.
+
+### Cross-check against the "blue paige vfx" reference mod
+
+`blue_paige_vfx` (a light-blue Paige mod, `pak75_dir.vpk`) overrides 276 entries: **267 `.vpcf_c` (particles) recolored blue + 8 dragon `.vtex_c` + 1 `bookworm_dragon.vmat_c`**. But of those 8, only the dragon albedo/ao/rough/tintmask got new content hashes, and decoding the new albedo shows it is **still green** - the mod re-exported the dragon material (and repointed the `.vmat`) without actually recoloring the body, and left the sword/shield/stone/projectile model textures untouched. So that mod recolors the *effects* (particles) but not the *model albedos*. Confirms the split: particles are one axis, the 9 model/self-illum color textures above are the other, and a complete recolor needs both. (It also shows the heavier material-rename approach; our in-place override at the base path avoids the `.vmat` edit.)
+
+## Dragon / texture recolor (built: `vpkmerge texture`)
+
+The ult dragon (and the projectile self-illum from the texture scan) recolor via a texture hue shift, not particles. Built as `vpkmerge texture` on top of a new `vpkmerge_core::recolor` module:
 
 ```
-cargo run --example recolor_assets -- <base pak01_dir.vpk> bookworm
+# loose file, eyeball a preview first, then write the recolored .vtex_c:
+vpkmerge texture dragon_color.vtex_c --hue 280 --preview dragon_280.png --encode dragon_280.vtex_c
+
+# straight from the base pak into a standalone addon that overrides in place:
+vpkmerge texture models/heroes_wip/bookworm/materials/bookworm_dragon_color.vtex_c \
+  --from-vpk pak01_dir.vpk --hue 280 --encode-vpk dragon_recolor_dir.vpk
 ```
 
-It walks each ability/weapon_fx particle's KV3 for material refs (`.vmat`), each material for texture refs (`.vtex`), then classifies every texture by mean saturation over opaque pixels, with two filters:
-- name-based data-map exclusion (`normal`/`rough`/`ao`/`mask`/`metal`/`selfillummask`): packed normal maps read ~0.5 saturation but carry no albedo, so exclude by name not chroma.
-- hero-specific vs shared: only recolor textures whose path names the codename. Shared `materials/default/*` and generic `materials/particle/{projected,model}/*` are used by other heroes; recoloring them bleeds across the roster.
+Mechanism: `morphic::decode` the top mip, set every pixel's hue to the target (keeping each pixel's saturation and value), then `morphic::replace_mip_chain` re-encodes the full mip chain in the texture's own format. The bytes pack at the source entry path and override the base texture in place, no `.vmat_c` edit (sidestepping the content-hashed texture rename).
 
-Paige (bookworm) result, 26 referenced textures:
-- **Recolor target (hero-specific, color-bearing): 1** - `materials/particle/abilities/bookworm/bookworm_projectile_self_illum_vmat_g_tcolor_*` (sat 0.92), her projectile/bullet color.
-- Shared color (do NOT recolor): the generic projected cone self-illum + a default texture.
-- 23 data maps / masks: tinted by particle param, no texture recolor needed.
+Decisions worth knowing:
+- **Hue is set (absolute), not rotated**, to match the particle recolor: the same hue value lands the dragon, the projectile, and the particle params on one color. Neutral pixels (saturation 0: white highlights, black shadows) stay neutral, since their chroma is zero at any hue. So a fire dragon at `--hue 280` keeps its value/saturation structure but reads purple.
+- **Operates on the stored 8-bit display channels**, the same space the particle `Color32` recolor edits, so the two paths stay consistent.
+- **LDR (8-bit) only.** An HDR (f16) texture is refused with a clear error rather than silently mangled; the Deadlock color maps this targets are all LDR.
+- `--preview <PNG>` is the design-intent color straight off the decode (fast, no re-encode); the same `recolor_texture_image` primitive is what a live UI hue slider should call. The lossy `BCn` re-encode only happens on `--encode` / `--encode-vpk`.
 
-Coverage gaps this particle-centric scan does NOT cover, and the next agent should add:
-1. Ability/projectile **models** (`.vmdl_c`: sword, book, dragon) -> their materials -> albedo textures. The dragon albedo and `bookworm_book_color_*` carry the hero's color and are reached via models, not particle materials. Extend the walk to follow `.vmdl` refs in particles and the hero's own ability models.
-2. HUD **ability icons** (panorama UI images), which no particle references at all.
+Core API (also for the Grimoire UI): `recolor_texture_hue(bytes, hue) -> Vec<u8>` (full re-encode), `recolor_texture_image(bytes, hue) -> Image` (fast preview), `recolor_texture_preview_png(bytes, hue) -> Vec<u8>`, `inspect_texture(bytes) -> TextureSummary`, plus `read_vpk_entry(vpk, entry)` for callers without a `valve_pak` dep. Covered by unit tests in `vpkmerge-core/src/recolor.rs` (documented-example color, hue wrap, neutral-pixel invariance, hue-set with S/V preserved on the chromatic fixture, loadable round-trip, HDR rejection).
 
-Heuristic is a starting filter, not ground truth: print the saturation and eyeball borderline cases (decode to PNG with the texture path) before committing a recolor.
+The 9 entry paths are listed in the table above.
 
-## Dragon (planned)
+### Installed for in-game test (Paige, purple)
 
-The ult dragon recolors via a texture hue shift, not particles. Decode the base dragon color texture (`morphic::decode`), rotate hue on the `Image`, re-encode with `replace_face_mip_chain`, and pack the `.vtex_c` at its base path so it overrides in place (no `.vmat_c` edit, sidestepping the content hashed texture rename). Exposed via a new `vpkmerge texture` subcommand. UI: explicit hue degrees with a live preview.
+In the local Deadlock addons folder (`game/citadel/addons/`):
+- `pak02_dir.vpk` (pre-existing): the **particle** recolor, 188 `.vpcf_c` to hue 280.
+- `pak04_dir.vpk` (this work): the 9 **VFX textures** above, all hue 280, one 47 MB addon. Built with `vpkmerge texture <9 entries> --from-vpk pak01_dir.vpk --hue 280 --encode-vpk ...`. Source copy in `vpkmerge/.scratch/paige_vfx_textures_hue280_dir.vpk`.
+
+Together = a complete purple Paige (effects + model/self-illum albedos). Still pending: load in game and confirm each ability reads purple (placement is manual, so Grimoire's "apply" may renumber/remove `pak04`; re-test before re-running Grimoire). To remove: delete `addons/pak04_dir.vpk`.
+
+## Vertex-color recolor (built + in-game confirmed: `vpkmerge model recolor`)
+
+The ult horse/knight is the **third** color mechanism: its green is baked into the mesh's per-vertex `COLOR` attribute, which neither the particle param edit nor the texture recolor reaches (its material `bookworm_knight.vmat` has `g_bApplyTintToVertexColors = 0`, so a tint cannot touch the vertex colors). Built as `vpkmerge model recolor`; **confirmed purple in game**.
+
+**The body that renders is found via the ult's model particle, not by guessing the name.** Paige's ult body is `models/particle/bookworm_horse_knight.vmdl_c` (referenced by `bookworm_ultimate_model.vpcf_c`); the `heroes_wip/bookworm/bookworm_horse*` models are **not** spawned by the ult (editing them did nothing). `bookworm_mace` (melee swing) is the mace.
+
+```
+# recolor the ult body + mace into one addon (each overrides its base entry):
+vpkmerge model recolor --vpk pak01_dir.vpk --hue 280 \
+  --encode-vpk ultbody_hue280_dir.vpk \
+  models/particle/bookworm_horse_knight.vmdl_c \
+  models/particle/bookworm_mace.vmdl_c
+
+# --list first to see each model's color-bearing vertex buffers.
+```
+
+Mechanism: decode each mesh's vertex buffer, set every `COLOR` vertex's hue to the target (keeping saturation + value, **the same `set_hue` the texture/particle recolor uses**, so one hue lands all three mechanisms), write it back. Positions/normals/UVs/skin weights are byte-preserved.
+
+The encoding was the hard part (two wrong turns, both now handled), because the *engine* is stricter than morphic's own decoder:
+- **Uncompressed** buffer (hero models): the COLOR bytes are patched **in place** in the file (byte-identical except the color lane; no container rebuild/realign).
+- **Meshopt** buffer (`models/particle/*`): **not re-encoded** - morphic's meshopt encoder emits codec v1 all-literal, Valve wrote these as v0, and the re-encode renders garbled in game. Instead the buffer is decoded, color-edited, and stored **uncompressed**, flipping `m_bMeshoptCompressed` to false in the CTRL registry byte-faithfully (`morphic::kv3::set_bools`). The engine reads uncompressed buffers natively.
+- **Hue is set (absolute), 8-bit display space**, identical to the texture path - no linear-space adjustment was needed in game.
+
+Core API (also for the Grimoire UI): `recolor_model_vertex_colors(bytes, hue) -> (Vec<u8>, ModelRecolorStats)`, `recolor_models_to_addon(vpk, entries, base, hue, out)`; in `morphic`, `recolor_vertex_buffer` / `read_vertex_colors` / `OnDiskBuffer::write_colors` / `kv3::set_bools`. Tested: `write_colors` lane isolation (unit) + `recolor_vertex_colors_round_trips_local` (gated on a real pak; asserts the meshopt->uncompressed conversion + byte-identical geometry on both paths).
+
+Full diagnosis + workflow: `vpkmerge/docs/handoff-vertex-color-recolor.md`.
 
 ## Status summary
 
-- Built: VFX layer detection + extraction (Grimoire), `morphic::patch_kv3_resource_scalars` (the recolor primitive).
-- Proven via prototype: particle recolor to an arbitrary hue.
-- Pending: `vpkmerge particle recolor` + `vpkmerge texture` subcommands (and a vpkmerge release + pin bump), the dragon texture recolor, and the Locker UI (hue slider + live preview).
+- Built: VFX layer detection + extraction (Grimoire), `morphic::patch_kv3_resource_scalars` (the particle recolor primitive), `vpkmerge texture` (+ `vpkmerge_core::recolor`, the texture recolor primitive), and `vpkmerge model recolor` (the vertex-color recolor primitive) - all multi-entry batch -> one addon.
+- Done for Paige (in game): particle recolor to purple (`pak02`) + the 9-texture ability/bullet/model recolor to purple (`pak04`) + the **ult horse/knight vertex-color recolor to purple**. Confirmed in game: bullets, abilities 1/2/3, and the ult body all read purple.
+- **Three color mechanisms, not two.** Beyond particles (params) and model/self-illum textures, the **ult horse/knight is colored by baked mesh vertex colors** (material `bookworm_knight.vmat`: `F_PAINT_VERTEX_COLORS=1`, gray albedo, `g_bApplyTintToVertexColors=0`), so it stayed green after the first two passes and a tint can't fix it. The vertex-color recolor (above) handles it - **in-game confirmed purple**. Two lessons baked in: find the rendered model via the ult's model particle (`bookworm_ultimate_model.vpcf_c` -> `models/particle/bookworm_horse_knight.vmdl`, not the `heroes_wip` copies), and never re-encode meshopt (convert it to uncompressed instead).
+- Pending: the `vpkmerge particle recolor` subcommand (promote `recolor_particles.rs`); a vpkmerge release + Grimoire pin bump; and the Locker UI (hue slider + live preview, calling `recolor_texture_image`).

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -72,6 +72,7 @@ import './ipc/social';
 import './ipc/diagnostics';
 import './ipc/portraits';
 import './ipc/abilitySounds';
+import './ipc/abilityColors';
 import './ipc/locker';
 import './ipc/previewCache';
 

--- a/electron/main/ipc/abilityColors.ts
+++ b/electron/main/ipc/abilityColors.ts
@@ -5,6 +5,7 @@ import {
     revertHeroColor,
     getActiveHeroColor,
     getHeroColorSupport,
+    previewHeroColor,
 } from '../services/heroColors';
 import type { ActiveHeroColor, ApplyHeroColorResult } from '../../../src/types/mod';
 
@@ -28,10 +29,31 @@ ipcMain.handle(
 
 ipcMain.handle(
     'apply-hero-color',
-    async (_, heroName: string, hue: number): Promise<ApplyHeroColorResult> => {
+    async (
+        _,
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+    ): Promise<ApplyHeroColorResult> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return applyHeroColor(deadlockPath, heroName, hue);
+        return applyHeroColor(deadlockPath, heroName, hue, saturation, brightness);
+    },
+);
+
+ipcMain.handle(
+    'preview-hero-color',
+    async (
+        _,
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+    ): Promise<string> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return previewHeroColor(deadlockPath, heroName, hue, saturation, brightness);
     },
 );
 

--- a/electron/main/ipc/abilityColors.ts
+++ b/electron/main/ipc/abilityColors.ts
@@ -1,0 +1,50 @@
+import { ipcMain } from 'electron';
+import { loadSettings } from '../services/settings';
+import {
+    applyHeroColor,
+    revertHeroColor,
+    getActiveHeroColor,
+    getHeroColorSupport,
+} from '../services/heroColors';
+import type { ActiveHeroColor, ApplyHeroColorResult } from '../../../src/types/mod';
+
+/** Active Deadlock install path (dev override wins, same as ipc/abilitySounds.ts). */
+function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+// Per-hero ability-COLOR recolor (services/heroColors.ts). Mirrors the
+// apply/revert/get trio in ipc/abilitySounds.ts: recolor a hero's ability VFX to
+// one hue, revert it, and read back the active hue. Plus a sync support check so
+// the picker can gate heroes with no pinned recipe.
+ipcMain.handle(
+    'get-hero-color-support',
+    (_, heroName: string): boolean => getHeroColorSupport(heroName),
+);
+
+ipcMain.handle(
+    'apply-hero-color',
+    async (_, heroName: string, hue: number): Promise<ApplyHeroColorResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return applyHeroColor(deadlockPath, heroName, hue);
+    },
+);
+
+ipcMain.handle(
+    'revert-hero-color',
+    async (_, heroName: string): Promise<ApplyHeroColorResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return revertHeroColor(deadlockPath, heroName);
+    },
+);
+
+ipcMain.handle(
+    'get-active-hero-color',
+    (_, heroName: string): ActiveHeroColor | null => getActiveHeroColor(heroName),
+);

--- a/electron/main/ipc/locker.ts
+++ b/electron/main/ipc/locker.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import { listAppliedCards, clearAllHeroCards, getAppliedCardThumbnails } from '../services/heroCards';
 import { listAppliedSounds, clearAllHeroSounds } from '../services/heroSounds';
-import { clearAllHeroColors } from '../services/heroColors';
+import { clearAllHeroColors, listAppliedColors } from '../services/heroColors';
 import type { LockerCardThumbnail, LockerClearScope, LockerOverview } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as the other locker IPC). */
@@ -15,16 +15,18 @@ function getActiveDeadlockPath(): string | null {
 }
 
 // Cross-cutting Locker IPC: a summary of everything the Locker is currently
-// overriding (cards + ability sounds), plus a bulk clear. Drives the
-// Installed-tab "Locker Overrides" popup (toolbar Wand2 icon).
+// overriding (cards + ability sounds + ability colors), plus a bulk clear.
+// Drives the Installed-tab "Locker Overrides" popup (toolbar Wand2 icon).
 ipcMain.handle('get-locker-overview', async (): Promise<LockerOverview> => {
     const deadlockPath = getActiveDeadlockPath();
-    if (!deadlockPath) return { cards: [], sounds: [] };
+    if (!deadlockPath) return { cards: [], sounds: [], colors: [] };
     const [cards, sounds] = await Promise.all([
         listAppliedCards(deadlockPath),
         listAppliedSounds(deadlockPath),
     ]);
-    return { cards, sounds };
+    // Colors come from the metadata manifest (synchronous, no path needed).
+    const colors = listAppliedColors();
+    return { cards, sounds, colors };
 });
 
 // Lazy companion to the overview: decode the real applied card art into one

--- a/electron/main/ipc/locker.ts
+++ b/electron/main/ipc/locker.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import { listAppliedCards, clearAllHeroCards, getAppliedCardThumbnails } from '../services/heroCards';
 import { listAppliedSounds, clearAllHeroSounds } from '../services/heroSounds';
+import { clearAllHeroColors } from '../services/heroColors';
 import type { LockerCardThumbnail, LockerClearScope, LockerOverview } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as the other locker IPC). */
@@ -42,5 +43,6 @@ ipcMain.handle(
         if (!deadlockPath) throw new Error('No Deadlock path configured');
         if (scope === 'cards' || scope === 'all') await clearAllHeroCards(deadlockPath);
         if (scope === 'sounds' || scope === 'all') await clearAllHeroSounds(deadlockPath);
+        if (scope === 'colors' || scope === 'all') await clearAllHeroColors(deadlockPath);
     },
 );

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -1,0 +1,236 @@
+/**
+ * Per-hero ability-COLOR apply pipeline.
+ *
+ * The Locker color picker lets a user recolor a hero's ability VFX to a single
+ * hue. The recolor spans all three color mechanisms at once (particle params +
+ * color textures + baked mesh vertex colors) via the bundled
+ * `vpkmerge recolor-hero` (one `--hue` lands them on the same color). Every
+ * applied choice lives in ONE Locker-managed VPK in citadel/grimoire (pak03),
+ * rebuilt from a selection set on each apply/revert. The grimoire folder wins by
+ * SearchPaths precedence, so the recolor overrides the base game VFX (and any
+ * skin's particles) in place.
+ *
+ * `recolor-hero` is EXPENSIVE (a full BCn texture re-encode: tens of seconds for
+ * Paige), so each (codename, hue) bake is cached under userData. A rebuild only
+ * re-bakes a hero whose hue actually changed; everyone else's cached addon is
+ * merged in. Clearing a hero just drops it from the set and rebuilds.
+ *
+ * Only heroes with a pinned recipe in vpkmerge are supported (Paige / `bookworm`
+ * today); colorCodenameForHero gates the rest.
+ *
+ * NOTE: addons mount only at game start, so an applied color change needs a full
+ * Deadlock restart to take effect.
+ */
+import { promises as fs, existsSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { app } from 'electron';
+import { getCitadelPath, getGrimoirePath } from './deadlock';
+import { invalidateVpkParseCache } from './vpk';
+import { runVpkmerge, vpkmergeBinaryPath, verifyVpkOutput } from './modMerger';
+import { LOCKER_COLORS_KEY, lockerColorsVpkPath, ensureGrimoireConfigured } from './lockerVpk';
+import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import type {
+    ActiveHeroColor,
+    ApplyHeroColorResult,
+    LockerColorSelection,
+    LockerColorsInfo,
+} from '../../../src/types/mod';
+
+/**
+ * Display name -> model/particle recolor codename, scoped to heroes that have a
+ * pinned recipe in vpkmerge's `recolor-hero` (the recipe key must match exactly).
+ * This is deliberately its OWN table, not the sound/panorama codename maps: the
+ * recolor recipe is keyed by the `models/` + `particles/abilities/` codename,
+ * which can diverge from those. Add a hero here in lockstep with adding its
+ * recipe to vpkmerge (`recipe_for` in vpkmerge-core/src/hero_recolor.rs).
+ */
+const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
+    Paige: 'bookworm',
+};
+
+/** Bumped when the recolor recipe/binary changes in a way that should re-bake
+ *  cached addons. Part of the cache filename so a stale bake is never reused. */
+const RECIPE_CACHE_VERSION = 1;
+
+/** The recolor codename for a hero, or null when no recipe is pinned for it. */
+export function colorCodenameForHero(heroName: string): string | null {
+    return COLOR_CODENAME_BY_HERO[heroName] ?? null;
+}
+
+/** Whether ability-color recolor is available for this hero (a recipe exists). */
+export function getHeroColorSupport(heroName: string): boolean {
+    return colorCodenameForHero(heroName) !== null;
+}
+
+/** Normalize any hue to an integer in [0, 360). */
+function normalizeHue(hue: number): number {
+    return (((Math.round(hue) % 360) + 360) % 360);
+}
+
+/** Current color selection set (one per hero), from the synthetic metadata key.
+ *  Unlike sounds/cards there's no in-addons fallback: colors never lived there. */
+function currentColorSelections(): LockerColorSelection[] {
+    return getModMetadata(LOCKER_COLORS_KEY)?.lockerColors?.colors ?? [];
+}
+
+/** Cache path for one hero's baked recolor addon, keyed by codename+hue+version
+ *  so the same color is baked once and reused across rebuilds. */
+function colorCachePath(codename: string, hue: number): string {
+    const dir = join(app.getPath('userData'), 'ability-colors');
+    return join(dir, `${codename}_h${hue}_v${RECIPE_CACHE_VERSION}_dir.vpk`);
+}
+
+/**
+ * Ensure a hero's recolor addon for `hue` exists in the cache, baking it via
+ * `vpkmerge recolor-hero` (reading the base game VFX from pak01) if missing.
+ * Bakes to a temp file then renames, so an interrupted bake never leaves a
+ * partial cache entry. Returns the cache path.
+ */
+async function ensureHeroColorBake(pak01: string, codename: string, hue: number): Promise<string> {
+    const cachePath = colorCachePath(codename, hue);
+    if (existsSync(cachePath)) return cachePath;
+
+    const dir = join(app.getPath('userData'), 'ability-colors');
+    await fs.mkdir(dir, { recursive: true });
+    const tmp = join(dir, `.${codename}_h${hue}_${randomUUID()}_dir.vpk`);
+    try {
+        await runVpkmerge([
+            'recolor-hero',
+            '--hero',
+            codename,
+            '--vpk',
+            pak01,
+            '--hue',
+            String(hue),
+            '--encode-vpk',
+            tmp,
+        ]);
+        await verifyVpkOutput(tmp);
+        await fs.rename(tmp, cachePath);
+    } finally {
+        await fs.unlink(tmp).catch(() => {});
+    }
+    return cachePath;
+}
+
+interface RebuildResult {
+    fileName: string | null;
+}
+
+/**
+ * Rebuild the consolidated Locker colors VPK from `desired`. Bakes each hero's
+ * recolor addon (cached by codename+hue) and folds them into one VPK at the fixed
+ * grimoire slot. One selection copies straight in; several merge (each hero's
+ * paths are codename-namespaced, so disjoint). Empty deletes the VPK + metadata.
+ */
+async function rebuildLockerColors(
+    deadlockPath: string,
+    desired: LockerColorSelection[],
+): Promise<RebuildResult> {
+    const destPath = lockerColorsVpkPath(deadlockPath);
+
+    // One selection per codename (last wins), so a re-apply replaces, not stacks.
+    const byCodename = new Map<string, LockerColorSelection>();
+    for (const sel of desired) byCodename.set(sel.heroCodename, sel);
+    const valid = [...byCodename.values()];
+
+    if (valid.length === 0) {
+        await fs.unlink(destPath).catch(() => {});
+        removeModMetadata(LOCKER_COLORS_KEY);
+        invalidateVpkParseCache(destPath);
+        return { fileName: null };
+    }
+
+    const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+    if (!existsSync(pak01)) {
+        throw new Error('Base game pak01_dir.vpk not found; check the Deadlock path in Settings.');
+    }
+
+    // Bake (or reuse) each hero's recolor addon.
+    const caches: string[] = [];
+    for (const sel of valid) {
+        caches.push(await ensureHeroColorBake(pak01, sel.heroCodename, sel.hue));
+    }
+
+    const grimoireDir = getGrimoirePath(deadlockPath);
+    await fs.mkdir(grimoireDir, { recursive: true });
+
+    if (caches.length === 1) {
+        // Single hero: the cache IS the addon; copy it into the fixed slot
+        // (copy, not rename, so the cache survives for the next rebuild).
+        await fs.copyFile(caches[0], destPath);
+    } else {
+        const buildOut = join(grimoireDir, `.locker-colors-build-${randomUUID()}.out.vpk`);
+        try {
+            // Disjoint per-hero paths, so no collision; merge into the slot.
+            await runVpkmerge([buildOut, ...caches]);
+            await verifyVpkOutput(buildOut);
+            await fs.unlink(destPath).catch(() => {});
+            await fs.rename(buildOut, destPath);
+        } finally {
+            await fs.unlink(buildOut).catch(() => {});
+        }
+    }
+    await verifyVpkOutput(destPath);
+    invalidateVpkParseCache(destPath);
+
+    const info: LockerColorsInfo = { colors: valid, rebuiltAt: new Date().toISOString() };
+    setModMetadata(LOCKER_COLORS_KEY, { modName: 'Locker Ability Colors', lockerColors: info });
+    return { fileName: destPath };
+}
+
+/**
+ * Apply hero X's ability VFX recolor to `hue`, replacing any prior color for
+ * that hero. Bakes the recolor (cached) and folds it into the managed colors VPK.
+ */
+export async function applyHeroColor(
+    deadlockPath: string,
+    heroName: string,
+    hue: number,
+): Promise<ApplyHeroColorResult> {
+    vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    const codename = colorCodenameForHero(heroName);
+    if (!codename) {
+        throw new Error(`Ability color recolor isn't available for ${heroName} yet.`);
+    }
+    ensureGrimoireConfigured(deadlockPath);
+
+    const normHue = normalizeHue(hue);
+    const current = currentColorSelections();
+    const next: LockerColorSelection[] = [
+        ...current.filter((s) => s.heroCodename !== codename),
+        { heroName, heroCodename: codename, hue: normHue, addedAt: new Date().toISOString() },
+    ];
+    await rebuildLockerColors(deadlockPath, next);
+    return { hue: normHue };
+}
+
+/** Remove hero X's ability color, reverting its VFX to vanilla. */
+export async function revertHeroColor(
+    deadlockPath: string,
+    heroName: string,
+): Promise<ApplyHeroColorResult> {
+    const codename = colorCodenameForHero(heroName);
+    if (!codename) return { hue: null };
+    ensureGrimoireConfigured(deadlockPath);
+
+    const current = currentColorSelections();
+    if (current.length === 0) return { hue: null };
+    const next = current.filter((s) => s.heroCodename !== codename);
+    await rebuildLockerColors(deadlockPath, next);
+    return { hue: null };
+}
+
+/** The hue currently applied for a hero's ability VFX, or null. */
+export function getActiveHeroColor(heroName: string): ActiveHeroColor | null {
+    const codename = colorCodenameForHero(heroName);
+    if (!codename) return null;
+    const sel = currentColorSelections().find((s) => s.heroCodename === codename);
+    return sel ? { hue: sel.hue } : null;
+}
+
+/** Clear every applied ability color (rebuild to empty, deleting the VPK). */
+export async function clearAllHeroColors(deadlockPath: string): Promise<void> {
+    await rebuildLockerColors(deadlockPath, []);
+}

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -47,6 +47,10 @@ import type {
  */
 const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
     Paige: 'bookworm',
+    // Celeste is particle-only (no color textures / vertex colors), so her recipe
+    // has no preview_texture and the live swatch falls back to the approximate
+    // chip (representative for a flat particle color). recolor-hero still bakes her.
+    Celeste: 'unicorn',
 };
 
 /** Bumped when the recolor recipe/binary changes in a way that should re-bake

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -50,8 +50,9 @@ const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
 };
 
 /** Bumped when the recolor recipe/binary changes in a way that should re-bake
- *  cached addons. Part of the cache filename so a stale bake is never reused. */
-const RECIPE_CACHE_VERSION = 1;
+ *  cached addons. Part of the cache filename so a stale bake is never reused.
+ *  v2: recolor target gained saturation + brightness scales (was hue-only). */
+const RECIPE_CACHE_VERSION = 2;
 
 /** The recolor codename for a hero, or null when no recipe is pinned for it. */
 export function colorCodenameForHero(heroName: string): string | null {
@@ -68,27 +69,64 @@ function normalizeHue(hue: number): number {
     return (((Math.round(hue) % 360) + 360) % 360);
 }
 
+/** Default scale (no change) for saturation/brightness on older selections that
+ *  predate those knobs, and the bounds the UI sliders are clamped to. */
+const DEFAULT_SCALE = 1;
+const SATURATION_BOUNDS = { min: 0, max: 3 } as const;
+const BRIGHTNESS_BOUNDS = { min: 0.2, max: 2 } as const;
+
+/** Clamp a saturation/brightness scale and quantize to 2 decimals so the cache
+ *  key is stable (a slider's float jitter doesn't spawn near-duplicate bakes). */
+function normalizeScale(x: number, bounds: { min: number; max: number }): number {
+    const v = Number.isFinite(x) ? x : DEFAULT_SCALE;
+    const clamped = Math.min(bounds.max, Math.max(bounds.min, v));
+    return Math.round(clamped * 100) / 100;
+}
+
+const normalizeSaturation = (x: number): number => normalizeScale(x, SATURATION_BOUNDS);
+const normalizeBrightness = (x: number): number => normalizeScale(x, BRIGHTNESS_BOUNDS);
+
+/** Fill in saturation/brightness defaults for a selection (older persisted
+ *  entries are hue-only and lack the scales). */
+function withScales(sel: LockerColorSelection): LockerColorSelection {
+    return {
+        ...sel,
+        saturation: normalizeSaturation(sel.saturation ?? DEFAULT_SCALE),
+        brightness: normalizeBrightness(sel.brightness ?? DEFAULT_SCALE),
+    };
+}
+
 /** Current color selection set (one per hero), from the synthetic metadata key.
  *  Unlike sounds/cards there's no in-addons fallback: colors never lived there. */
 function currentColorSelections(): LockerColorSelection[] {
-    return getModMetadata(LOCKER_COLORS_KEY)?.lockerColors?.colors ?? [];
+    return (getModMetadata(LOCKER_COLORS_KEY)?.lockerColors?.colors ?? []).map(withScales);
 }
 
-/** Cache path for one hero's baked recolor addon, keyed by codename+hue+version
- *  so the same color is baked once and reused across rebuilds. */
-function colorCachePath(codename: string, hue: number): string {
+/** Cache path for one hero's baked recolor addon, keyed by
+ *  codename+hue+saturation+brightness+version so the same target is baked once
+ *  and reused across rebuilds. Scales are encoded as integer percents (no dots,
+ *  so the `_dir.vpk` suffix and numbered siblings stay unambiguous). */
+function colorCachePath(codename: string, hue: number, sat: number, brightness: number): string {
     const dir = join(app.getPath('userData'), 'ability-colors');
-    return join(dir, `${codename}_h${hue}_v${RECIPE_CACHE_VERSION}_dir.vpk`);
+    const s = Math.round(sat * 100);
+    const b = Math.round(brightness * 100);
+    return join(dir, `${codename}_h${hue}_s${s}_b${b}_v${RECIPE_CACHE_VERSION}_dir.vpk`);
 }
 
 /**
- * Ensure a hero's recolor addon for `hue` exists in the cache, baking it via
- * `vpkmerge recolor-hero` (reading the base game VFX from pak01) if missing.
- * Bakes to a temp file then renames, so an interrupted bake never leaves a
- * partial cache entry. Returns the cache path.
+ * Ensure a hero's recolor addon for (hue, saturation, brightness) exists in the
+ * cache, baking it via `vpkmerge recolor-hero` (reading the base game VFX from
+ * pak01) if missing. Bakes to a temp file then renames, so an interrupted bake
+ * never leaves a partial cache entry. Returns the cache path.
  */
-async function ensureHeroColorBake(pak01: string, codename: string, hue: number): Promise<string> {
-    const cachePath = colorCachePath(codename, hue);
+async function ensureHeroColorBake(
+    pak01: string,
+    codename: string,
+    hue: number,
+    sat: number,
+    brightness: number,
+): Promise<string> {
+    const cachePath = colorCachePath(codename, hue, sat, brightness);
     if (existsSync(cachePath)) return cachePath;
 
     const dir = join(app.getPath('userData'), 'ability-colors');
@@ -103,6 +141,10 @@ async function ensureHeroColorBake(pak01: string, codename: string, hue: number)
             pak01,
             '--hue',
             String(hue),
+            '--saturation',
+            String(sat),
+            '--brightness',
+            String(brightness),
             '--encode-vpk',
             tmp,
         ]);
@@ -150,7 +192,15 @@ async function rebuildLockerColors(
     // Bake (or reuse) each hero's recolor addon.
     const caches: string[] = [];
     for (const sel of valid) {
-        caches.push(await ensureHeroColorBake(pak01, sel.heroCodename, sel.hue));
+        caches.push(
+            await ensureHeroColorBake(
+                pak01,
+                sel.heroCodename,
+                sel.hue,
+                sel.saturation,
+                sel.brightness,
+            ),
+        );
     }
 
     const grimoireDir = getGrimoirePath(deadlockPath);
@@ -188,6 +238,8 @@ export async function applyHeroColor(
     deadlockPath: string,
     heroName: string,
     hue: number,
+    saturation: number,
+    brightness: number,
 ): Promise<ApplyHeroColorResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
     const codename = colorCodenameForHero(heroName);
@@ -197,13 +249,22 @@ export async function applyHeroColor(
     ensureGrimoireConfigured(deadlockPath);
 
     const normHue = normalizeHue(hue);
+    const normSat = normalizeSaturation(saturation);
+    const normBright = normalizeBrightness(brightness);
     const current = currentColorSelections();
     const next: LockerColorSelection[] = [
         ...current.filter((s) => s.heroCodename !== codename),
-        { heroName, heroCodename: codename, hue: normHue, addedAt: new Date().toISOString() },
+        {
+            heroName,
+            heroCodename: codename,
+            hue: normHue,
+            saturation: normSat,
+            brightness: normBright,
+            addedAt: new Date().toISOString(),
+        },
     ];
     await rebuildLockerColors(deadlockPath, next);
-    return { hue: normHue };
+    return { hue: normHue, saturation: normSat, brightness: normBright };
 }
 
 /** Remove hero X's ability color, reverting its VFX to vanilla. */
@@ -211,23 +272,75 @@ export async function revertHeroColor(
     deadlockPath: string,
     heroName: string,
 ): Promise<ApplyHeroColorResult> {
+    const reverted: ApplyHeroColorResult = { hue: null, saturation: null, brightness: null };
     const codename = colorCodenameForHero(heroName);
-    if (!codename) return { hue: null };
+    if (!codename) return reverted;
     ensureGrimoireConfigured(deadlockPath);
 
     const current = currentColorSelections();
-    if (current.length === 0) return { hue: null };
+    if (current.length === 0) return reverted;
     const next = current.filter((s) => s.heroCodename !== codename);
     await rebuildLockerColors(deadlockPath, next);
-    return { hue: null };
+    return reverted;
 }
 
-/** The hue currently applied for a hero's ability VFX, or null. */
+/** The color currently applied for a hero's ability VFX, or null. */
 export function getActiveHeroColor(heroName: string): ActiveHeroColor | null {
     const codename = colorCodenameForHero(heroName);
     if (!codename) return null;
     const sel = currentColorSelections().find((s) => s.heroCodename === codename);
-    return sel ? { hue: sel.hue } : null;
+    return sel
+        ? { hue: sel.hue, saturation: sel.saturation, brightness: sel.brightness }
+        : null;
+}
+
+/**
+ * Render a fast PNG swatch of a hero's recolor (the recipe's representative
+ * ability texture, recolored to the target) for the live picker preview. Returns
+ * a `data:image/png;base64,...` URL. No bake/re-encode, so it is cheap enough to
+ * call as the user drags (the renderer still debounces). Reads the base game VFX
+ * from pak01.
+ */
+export async function previewHeroColor(
+    deadlockPath: string,
+    heroName: string,
+    hue: number,
+    saturation: number,
+    brightness: number,
+): Promise<string> {
+    const codename = colorCodenameForHero(heroName);
+    if (!codename) {
+        throw new Error(`Ability color recolor isn't available for ${heroName} yet.`);
+    }
+    const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+    if (!existsSync(pak01)) {
+        throw new Error('Base game pak01_dir.vpk not found; check the Deadlock path in Settings.');
+    }
+
+    const dir = join(app.getPath('userData'), 'ability-colors');
+    await fs.mkdir(dir, { recursive: true });
+    const tmpPng = join(dir, `.preview_${codename}_${randomUUID()}.png`);
+    try {
+        await runVpkmerge([
+            'recolor-hero',
+            '--hero',
+            codename,
+            '--vpk',
+            pak01,
+            '--hue',
+            String(normalizeHue(hue)),
+            '--saturation',
+            String(normalizeSaturation(saturation)),
+            '--brightness',
+            String(normalizeBrightness(brightness)),
+            '--preview-png',
+            tmpPng,
+        ]);
+        const png = await fs.readFile(tmpPng);
+        return `data:image/png;base64,${png.toString('base64')}`;
+    } finally {
+        await fs.unlink(tmpPng).catch(() => {});
+    }
 }
 
 /** Clear every applied ability color (rebuild to empty, deleting the VPK). */

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -106,6 +106,13 @@ function currentColorSelections(): LockerColorSelection[] {
     return (getModMetadata(LOCKER_COLORS_KEY)?.lockerColors?.colors ?? []).map(withScales);
 }
 
+/** Applied ability-color recolors (one per hero), for the Locker Overrides popup
+ *  and its count badge. Reads the colors manifest only, so it's cheap (no bake)
+ *  and mirrors listAppliedCards / listAppliedSounds. */
+export function listAppliedColors(): LockerColorSelection[] {
+    return currentColorSelections();
+}
+
 /** Cache path for one hero's baked recolor addon, keyed by
  *  codename+hue+saturation+brightness+version so the same target is baked once
  *  and reused across rebuilds. Scales are encoded as integer percents (no dots,

--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -51,12 +51,56 @@ const MODEL_CODENAME_OVERRIDES: Readonly<Record<string, string[]>> = {
     Seven: ['gigawatt_prisoner'],
 };
 
+/**
+ * Heroes Valve reworked in the "6 hero update": the current body model moved to
+ * `models/heroes_wip/<name>/<name>.vmdl_c` (a fresh dir keyed by the display
+ * name) while the pre-rework model stayed behind under
+ * `heroes_staging/<codename>[_vN]`. `--hero <codename>` discovery picks the
+ * highest-`_vN` basename match, so for these heroes it lands on the STALE model
+ * and the Locker showed the wrong body. Pin the exact current entry instead.
+ *
+ * An explicit `--entry` is also more correct than `--hero` once a skin is active:
+ * a modern skin overrides the game's canonical path (these very paths), which a
+ * codename/version mismatch in discovery could miss, silently falling back to
+ * the vanilla base mesh.
+ *
+ * Verified against the installed pak (2026-05-29) and reconciled live in-game by
+ * a community reporter (#bugs "3D Preview pulling wrong model"): each entry
+ * decodes, carries a real menu pose, and is the current model. Viscous is a
+ * no-op today (`--hero viscous` already resolves here) but pinned for the same
+ * skin-path robustness. Deliberately NOT pinned: Infernus (its current
+ * `heroes_wip/inferno` ships no menu/idle pose clip, so `--require-pose` would
+ * drop it to a 2D portrait; `--hero inferno` already resolves to a poseable
+ * same-size model) and Billy (`punkgoat` ships the rig but no pose clip and
+ * already falls back to 2D).
+ */
+const MODEL_ENTRY_OVERRIDES: Readonly<Record<string, string>> = {
+    Abrams: 'models/heroes_wip/abrams/abrams.vmdl_c',
+    McGinnis: 'models/heroes_wip/mcginnis/mcginnis.vmdl_c',
+    Pocket: 'models/heroes_wip/pocket/pocket.vmdl_c',
+    Ivy: 'models/heroes_wip/ivy/ivy.vmdl_c',
+    'Lady Geist': 'models/heroes_wip/geist/geist.vmdl_c',
+    Viscous: 'models/heroes_staging/viscous/viscous.vmdl_c',
+};
+
 /** Model codenames to try for a hero, most-specific first: any divergent
  *  body-model basename, then the panorama codename(s) that cover the rest of
  *  the roster. De-duplicated, order preserved. */
 function modelCodenamesForHero(heroName: string): string[] {
     const ordered = [...(MODEL_CODENAME_OVERRIDES[heroName] ?? []), ...codenamesForHero(heroName)];
     return [...new Set(ordered)];
+}
+
+/**
+ * The vpkmerge `model export` selectors to try for a hero, in order. A reworked
+ * hero with a pinned entry resolves to a single exact `--entry`; everyone else
+ * falls back to `--hero <codename>` auto-discovery for each candidate codename.
+ * Each element is the discriminating arg pair spliced into the export command.
+ */
+function modelSelectorsForHero(heroName: string): string[][] {
+    const entry = MODEL_ENTRY_OVERRIDES[heroName];
+    if (entry) return [['--entry', entry]];
+    return modelCodenamesForHero(heroName).map((codename) => ['--hero', codename]);
 }
 
 function sanitize(value: string): string {
@@ -90,8 +134,12 @@ function modelFile(key: string): string {
  * v2: bundled vpkmerge gained deterministic hero-model discovery, `--require-pose`
  * (so clipless WIP heroes fall back to the 2D portrait instead of a T-pose), and
  * the comic-outline (`*jitter*`) shell drop. Pre-v2 GLBs (unversioned) are stale.
+ *
+ * v3: reworked heroes (Abrams, McGinnis, Pocket, Ivy, Lady Geist, ...) now pin
+ * their exact current `heroes_wip` entry instead of `--hero` discovery, which had
+ * been resolving to the stale pre-rework body. Pre-v3 GLBs cached the wrong model.
  */
-const POSE_CACHE_VERSION = '2';
+const POSE_CACHE_VERSION = '3';
 
 function versionFile(key: string): string {
     return join(modelDir(key), '.cache-version');
@@ -168,9 +216,11 @@ const inFlightExports = new Map<string, Promise<HeroPoseInfo>>();
 
 /**
  * Generate a hero's pose still by running the bundled `vpkmerge model export
- * --pose`. The body model is auto-discovered from the hero's codename
- * (`--hero`), trying any divergent body-model basename first and falling back
- * to the panorama codename(s). `skinMetaKey` (the active skin VPK) supplies the
+ * --pose`. The body model is selected by modelSelectorsForHero: a reworked hero
+ * uses its pinned exact `--entry`, otherwise the model is auto-discovered from
+ * the hero's codename (`--hero`), trying any divergent body-model basename first
+ * and falling back to the panorama codename(s). `skinMetaKey` (the active skin
+ * VPK) supplies the
  * mesh + textures; a texture-only or absent skin falls back to the base pak's
  * mesh while the skin's textures still win. Falls back to a vanilla pose if the
  * skin VPK can't be resolved.
@@ -200,8 +250,8 @@ async function runHeroPoseExport(
     heroName: string,
     skinMetaKey?: string
 ): Promise<HeroPoseInfo> {
-    const codenames = modelCodenamesForHero(heroName);
-    if (codenames.length === 0) {
+    const selectors = modelSelectorsForHero(heroName);
+    if (selectors.length === 0) {
         throw new Error(`No known model codename for hero "${heroName}".`);
     }
 
@@ -217,15 +267,14 @@ async function runHeroPoseExport(
     const out = modelFile(key);
 
     let lastError: unknown;
-    for (const codename of codenames) {
+    for (const selector of selectors) {
         try {
             await runVpkmerge([
                 'model',
                 'export',
                 '--vpk',
                 sourceVpk,
-                '--hero',
-                codename,
+                ...selector,
                 '--base',
                 pak01,
                 '--pose',

--- a/electron/main/services/lockerVpk.ts
+++ b/electron/main/services/lockerVpk.ts
@@ -30,10 +30,12 @@ import { readStash } from './launch';
  *  VPK filename so they never collide with a user mod). */
 export const LOCKER_CARDS_KEY = 'locker:cards';
 export const LOCKER_SOUNDS_KEY = 'locker:sounds';
+export const LOCKER_COLORS_KEY = 'locker:colors';
 
 /** Fixed filenames inside citadel/grimoire. */
 const GRIMOIRE_CARDS_FILE = 'pak01_dir.vpk';
 const GRIMOIRE_SOUNDS_FILE = 'pak02_dir.vpk';
+const GRIMOIRE_COLORS_FILE = 'pak03_dir.vpk';
 
 /** Absolute path to the managed cards VPK in citadel/grimoire. */
 export function lockerCardsVpkPath(deadlockPath: string): string {
@@ -43,6 +45,13 @@ export function lockerCardsVpkPath(deadlockPath: string): string {
 /** Absolute path to the managed sounds VPK in citadel/grimoire. */
 export function lockerSoundsVpkPath(deadlockPath: string): string {
     return join(getGrimoirePath(deadlockPath), GRIMOIRE_SOUNDS_FILE);
+}
+
+/** Absolute path to the managed ability-colors VPK in citadel/grimoire. The
+ *  colors VPK never lived in citadel/addons (it's a feature newer than the
+ *  grimoire search path), so unlike cards/sounds it has no migration path. */
+export function lockerColorsVpkPath(deadlockPath: string): string {
+    return join(getGrimoirePath(deadlockPath), GRIMOIRE_COLORS_FILE);
 }
 
 /** Whether the grimoire search path (and addons) is active in gameinfo.gi. The

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -60,6 +60,11 @@ export interface ModMetadata {
      *  the VPK as Locker-managed so other surfaces hide it. Separate from
      *  lockerCosmetics (disjoint paths, independent lifecycle). */
     lockerSounds?: import('../../../src/types/mod').LockerSoundsInfo;
+    /** Set on the single Locker-managed colors VPK that holds applied ability
+     *  recolors. The selection set; rebuilt on every apply/revert. Presence
+     *  marks the VPK as Locker-managed. Separate from lockerCosmetics/lockerSounds
+     *  (disjoint paths, independent lifecycle). */
+    lockerColors?: import('../../../src/types/mod').LockerColorsInfo;
     /** Per-ability sound classification from the VPK file tree. Tri-state like
      *  globalType: an AbilitySoundClassification when the mod has recognized
      *  hero ability/VO sounds, `null` when classified and it has none, and

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -1,5 +1,6 @@
 import { promises as fs, existsSync } from 'fs';
 import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
@@ -166,6 +167,37 @@ export async function verifyVpkOutput(path: string): Promise<void> {
         }
     } finally {
         await fh.close();
+    }
+}
+
+/**
+ * Extract a hero's ability-VFX layer from a skin VPK into a standalone addon
+ * VPK via `vpkmerge split`, routing only the ability/weapon_fx particle dirs
+ * (`prefixes` from detectVfxLayer in vpk.ts) and dropping everything else (no
+ * residual). The result overrides the base particles in-place, so it can be
+ * layered onto a different body skin. Pass the prefixes from a non-null
+ * detectVfxLayer() result; an empty/non-matching set yields a useless VPK.
+ */
+export async function extractVfxLayer(
+    srcVpkPath: string,
+    outVpkPath: string,
+    prefixes: string[]
+): Promise<void> {
+    if (prefixes.length === 0) {
+        throw new Error('No VFX prefixes to extract.');
+    }
+    // `split` writes each output to the path named INSIDE the plan, so the
+    // destination lives in the plan JSON rather than argv. With no residual,
+    // unmatched entries (body model, dragon material, shared masks) are dropped.
+    await fs.mkdir(dirname(outVpkPath), { recursive: true });
+    const plan = { outputs: [{ path: outVpkPath, prefixes }] };
+    const planPath = join(tmpdir(), `grimoire-vfx-split-${randomUUID()}.json`);
+    await fs.writeFile(planPath, JSON.stringify(plan));
+    try {
+        await runVpkmerge(['split', srcVpkPath, '--plan', planPath]);
+        await verifyVpkOutput(outVpkPath);
+    } finally {
+        try { await fs.unlink(planPath); } catch { /* best-effort temp cleanup */ }
     }
 }
 

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -423,6 +423,75 @@ export function classifyGlobalModFromVpk(vpkPath: string): GlobalModType | null 
 }
 
 /**
+ * Ability-VFX layer roots. A hero's recolorable ability effects live in two
+ * particle dirs, keyed by the model/particle codename (Paige = `bookworm`),
+ * which is the namespace used by `models/`+`particles/abilities/`, NOT the
+ * sound-path codename used by SOUND_HERO_PATTERNS:
+ *   particles/abilities/<codename>/   (the 4 abilities + ult, melee, dash)
+ *   particles/weapon_fx/<codename>/   (primary-fire muzzle/tracer/impact fx)
+ * Isolating exactly these lets the recolor be layered onto a different body
+ * skin. The ult-dragon material (models/heroes_wip/<codename>/materials/) and
+ * ability sounds are deliberately out of scope here: the dragon has no path
+ * convention separating it from the body model, so it's handled by a
+ * regenerate-from-base hue shift instead of extraction (see docs).
+ */
+const VFX_LAYER_PATTERNS: RegExp[] = [
+    /(?:^|\/)particles\/abilities\/([a-z0-9_]+)\//i,
+    /(?:^|\/)particles\/weapon_fx\/([a-z0-9_]+)\//i,
+];
+
+export interface VfxLayer {
+    /** Model/particle codename the VFX targets (e.g. `bookworm` = Paige). */
+    codename: string;
+    /** Every `particles/{abilities,weapon_fx}/<codename>/` entry in the VPK. */
+    paths: string[];
+    /** Split-plan prefixes that select exactly this layer (no leading slash,
+     *  to match valve_pak entry paths and vpkmerge's starts_with predicate). */
+    prefixes: string[];
+}
+
+/**
+ * Detect a single-hero ability-VFX layer in a VPK's path list. Returns null
+ * when no ability/weapon_fx particles are present, or when more than one
+ * codename appears (we won't guess which hero owns a mixed VPK). Mirrors
+ * inferHeroFromVpkPaths' "one confident answer or nothing" contract.
+ */
+export function detectVfxLayer(paths: string[]): VfxLayer | null {
+    const byCodename = new Map<string, string[]>();
+    for (const filePath of paths) {
+        for (const re of VFX_LAYER_PATTERNS) {
+            const match = filePath.match(re);
+            if (!match) continue;
+            const codename = match[1].toLowerCase();
+            const list = byCodename.get(codename);
+            if (list) list.push(filePath);
+            else byCodename.set(codename, [filePath]);
+            break;
+        }
+    }
+    if (byCodename.size !== 1) return null;
+    const [codename, vfxPaths] = [...byCodename][0];
+    return {
+        codename,
+        paths: vfxPaths.sort(),
+        prefixes: [
+            `particles/abilities/${codename}/`,
+            `particles/weapon_fx/${codename}/`,
+        ],
+    };
+}
+
+/**
+ * Convenience wrapper: parse the VPK directory (cached) and detect a VFX layer.
+ * Returns null when the VPK can't be parsed or carries no single-hero VFX.
+ */
+export function detectVfxLayerFromVpk(vpkPath: string): VfxLayer | null {
+    const paths = parseVpkDirectoryCached(vpkPath);
+    if (!paths || paths.length === 0) return null;
+    return detectVfxLayer(paths);
+}
+
+/**
  * Best-effort label derived from a VPK's file tree (VPKs have no authored
  * title). Returns null when nothing distinctive matches — caller should
  * fall back to the filename rather than guess.

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -824,8 +824,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('get-active-hero-sounds', heroName),
     getHeroColorSupport: (heroName: string) =>
         ipcRenderer.invoke('get-hero-color-support', heroName),
-    applyHeroColor: (heroName: string, hue: number) =>
-        ipcRenderer.invoke('apply-hero-color', heroName, hue),
+    applyHeroColor: (heroName: string, hue: number, saturation: number, brightness: number) =>
+        ipcRenderer.invoke('apply-hero-color', heroName, hue, saturation, brightness),
+    previewHeroColor: (heroName: string, hue: number, saturation: number, brightness: number) =>
+        ipcRenderer.invoke('preview-hero-color', heroName, hue, saturation, brightness),
     revertHeroColor: (heroName: string) =>
         ipcRenderer.invoke('revert-hero-color', heroName),
     getActiveHeroColor: (heroName: string) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -822,6 +822,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('revert-hero-sound', heroName, slot),
     getActiveHeroSounds: (heroName: string) =>
         ipcRenderer.invoke('get-active-hero-sounds', heroName),
+    getHeroColorSupport: (heroName: string) =>
+        ipcRenderer.invoke('get-hero-color-support', heroName),
+    applyHeroColor: (heroName: string, hue: number) =>
+        ipcRenderer.invoke('apply-hero-color', heroName, hue),
+    revertHeroColor: (heroName: string) =>
+        ipcRenderer.invoke('revert-hero-color', heroName),
+    getActiveHeroColor: (heroName: string) =>
+        ipcRenderer.invoke('get-active-hero-color', heroName),
     getLockerOverview: () =>
         ipcRenderer.invoke('get-locker-overview'),
     getLockerCardThumbnails: () =>

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.7.0';
+const VPKMERGE_VERSION = 'v0.8.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '942ac53417b882f23eaaadb11a0fdb8174cfd54251cdd8cd59dd778d295086ea' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '056b558f6dd0c95f7501136850cbca8152cd817068d9f41004d3e3603793ec74' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'b6a255dee90e7c3e345455ba48c911df0893e4f3f431fce7d8a21f147618bc3e' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'cf6dac3abf42da03bb24f9ff8cca65d72c66f1ff268e58361fa21400b3f50bfd' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '9e70ac2caed634138632f43c0a648810c77f4886b7d56a4427b4c8957228ef3e' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'd296c1932c65bf07234419cf396a99fb3b748bdbc231037b10fc903811b54c78' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -4,6 +4,7 @@ import {
     X,
     Image as ImageIcon,
     Volume2,
+    Palette,
     Wand2,
     RotateCcw,
     RefreshCw,
@@ -19,6 +20,7 @@ import {
     clearLockerOverrides,
     revertHeroCard,
     revertHeroSound,
+    revertHeroColor,
     applyHeroSound,
     getGameRunningStatus,
 } from '../lib/api';
@@ -38,10 +40,19 @@ const PITCH_MAX = 2;
 /** Re-apply (rebuild the sound VPK) this long after the last slider move. */
 const PARAM_COMMIT_DELAY_MS = 600;
 
-type Tab = 'cards' | 'sounds';
+type Tab = 'cards' | 'sounds' | 'colors';
 
 function abilityLabel(slot: AbilitySlot): string {
     return slot === 4 ? 'Ultimate' : `Ability ${slot}`;
+}
+
+/** Representative CSS swatch for an applied recolor. Hue is absolute; the
+ *  saturation/brightness scales (1 = source) are mapped onto a vivid mid chip so
+ *  it reads as "roughly this color" without baking the real preview PNG. */
+function swatchColor(hue: number, saturation: number, brightness: number): string {
+    const s = Math.max(0, Math.min(100, Math.round(saturation * 60)));
+    const l = Math.max(0, Math.min(100, Math.round(brightness * 50)));
+    return `hsl(${Math.round(hue)}, ${s}%, ${l}%)`;
 }
 
 /** Strip the `_dir.vpk` tail for a friendlier source label. */
@@ -140,9 +151,10 @@ function ParamSliders({
 
 /**
  * Cross-hero management popup for the Grimoire-managed Locker overrides (hero
- * cards + per-ability sounds). They live in citadel/grimoire, off the mod list
- * and the 99-slot budget, so this is the one place to review everything that's
- * applied, preview it, retune sounds, and remove individual overrides.
+ * cards + per-ability sounds + per-hero ability colors). They live in
+ * citadel/grimoire, off the mod list and the 99-slot budget, so this is the one
+ * place to review everything that's applied, preview it, retune sounds, and
+ * remove individual overrides.
  *
  * "Remove" reverts a single override (rebuild the managed VPK from the
  * remaining selections); it never deletes the source mod, hence Remove not
@@ -210,10 +222,12 @@ export function LockerOverridesModal({
             .catch(() => setGameRunning(false));
     }, [refresh]);
 
-    // Default to the tab that actually has content on open.
+    // Default to the first tab that actually has content on open.
     useEffect(() => {
         if (!overview) return;
-        if (overview.cards.length === 0 && overview.sounds.length > 0) setTab('sounds');
+        if (overview.cards.length > 0) return;
+        if (overview.sounds.length > 0) setTab('sounds');
+        else if (overview.colors.length > 0) setTab('colors');
     }, [overview]);
 
     // Decode the real applied card art whenever the applied-card SET changes
@@ -298,6 +312,20 @@ export function LockerOverridesModal({
         }
     };
 
+    const removeColor = async (heroName: string) => {
+        if (busy) return;
+        setRemoving(`color:${heroName}`);
+        setActionError(null);
+        try {
+            await revertHeroColor(heroName);
+            await afterChange();
+        } catch (err) {
+            setActionError(String(err));
+        } finally {
+            setRemoving(null);
+        }
+    };
+
     const clearTab = async (which: Tab) => {
         if (busy) return;
         setClearing(which);
@@ -355,6 +383,7 @@ export function LockerOverridesModal({
 
     const cards = overview?.cards ?? [];
     const sounds = overview?.sounds ?? [];
+    const colors = overview?.colors ?? [];
 
     return (
         <div
@@ -394,6 +423,7 @@ export function LockerOverridesModal({
                     {([
                         { id: 'cards' as const, label: 'Hero Cards', icon: ImageIcon, count: cards.length },
                         { id: 'sounds' as const, label: 'Ability Sounds', icon: Volume2, count: sounds.length },
+                        { id: 'colors' as const, label: 'Ability Colors', icon: Palette, count: colors.length },
                     ]).map(({ id, label, icon: Icon, count }) => (
                         <button
                             key={id}
@@ -588,6 +618,66 @@ export function LockerOverridesModal({
                             </div>
                         )
                     )}
+
+                    {tab === 'colors' && (
+                        colors.length === 0 ? (
+                            <EmptyState
+                                kind="colors"
+                                onOpenLocker={() => {
+                                    onClose();
+                                    navigate('/locker');
+                                }}
+                            />
+                        ) : (
+                            <div className="space-y-3">
+                                {colors.map((color) => {
+                                    const key = `color:${color.heroName}`;
+                                    const isRemoving = removing === key;
+                                    return (
+                                        <div
+                                            key={key}
+                                            className="flex items-center gap-3 overflow-hidden rounded-md border border-border bg-bg-tertiary/40 p-2.5"
+                                        >
+                                            <HeroIcon heroName={color.heroName} />
+                                            <span
+                                                className="h-9 w-9 flex-shrink-0 rounded-full ring-1 ring-white/15"
+                                                style={{
+                                                    backgroundColor: swatchColor(
+                                                        color.hue,
+                                                        color.saturation,
+                                                        color.brightness,
+                                                    ),
+                                                }}
+                                                aria-hidden
+                                            />
+                                            <div className="min-w-0 flex-1">
+                                                <div className="truncate text-sm font-medium text-text-primary">
+                                                    {color.heroName}
+                                                </div>
+                                                <div className="truncate text-xs text-text-secondary tabular-nums">
+                                                    Hue {Math.round(color.hue)}&deg;
+                                                    {color.saturation !== 1 &&
+                                                        ` · Sat ${color.saturation.toFixed(2)}x`}
+                                                    {color.brightness !== 1 &&
+                                                        ` · Bright ${color.brightness.toFixed(2)}x`}
+                                                </div>
+                                            </div>
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                icon={isRemoving ? undefined : RotateCcw}
+                                                isLoading={isRemoving}
+                                                disabled={busy}
+                                                onClick={() => removeColor(color.heroName)}
+                                            >
+                                                Remove
+                                            </Button>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )
+                    )}
                 </div>
 
                 {/* Footer: per-tab clear-all + a link to add more in the Locker. */}
@@ -603,7 +693,9 @@ export function LockerOverridesModal({
                         <ExternalLink className="h-3.5 w-3.5" />
                         Add or change in the Locker
                     </button>
-                    {((tab === 'cards' && cards.length > 0) || (tab === 'sounds' && sounds.length > 0)) && (
+                    {((tab === 'cards' && cards.length > 0) ||
+                        (tab === 'sounds' && sounds.length > 0) ||
+                        (tab === 'colors' && colors.length > 0)) && (
                         <Button
                             variant="danger"
                             size="sm"
@@ -612,7 +704,7 @@ export function LockerOverridesModal({
                             disabled={busy}
                             onClick={() => clearTab(tab)}
                         >
-                            Remove all {tab === 'cards' ? 'cards' : 'sounds'}
+                            Remove all {tab === 'cards' ? 'cards' : tab === 'sounds' ? 'sounds' : 'colors'}
                         </Button>
                     )}
                 </div>
@@ -629,12 +721,13 @@ function EmptyState({
     kind: Tab;
     onOpenLocker: () => void;
 }) {
-    const Icon = kind === 'cards' ? ImageIcon : Volume2;
+    const Icon = kind === 'cards' ? ImageIcon : kind === 'sounds' ? Volume2 : Palette;
+    const noun = kind === 'cards' ? 'hero card' : kind === 'sounds' ? 'ability sound' : 'ability color';
     return (
         <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
             <Icon className="h-8 w-8 text-text-secondary/50" />
             <p className="text-sm text-text-secondary">
-                No {kind === 'cards' ? 'hero card' : 'ability sound'} overrides applied yet.
+                No {noun} overrides applied yet.
             </p>
             <Button variant="secondary" size="sm" icon={ExternalLink} onClick={onOpenLocker}>
                 Open the Locker

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -89,11 +89,18 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewFailed, setPreviewFailed] = useState(false);
+  // Set when this hero has no live preview (e.g. particle-only heroes carry no
+  // color texture to swatch); we then stop attempting it and show the CSS chip.
+  const [previewUnavailable, setPreviewUnavailable] = useState(false);
   const mounted = useRef(true);
 
   useEffect(() => {
     mounted.current = true;
     setLoading(true);
+    // Fresh hero: drop any prior hero's preview state.
+    setPreviewUrl(null);
+    setPreviewFailed(false);
+    setPreviewUnavailable(false);
     Promise.all([
       getHeroColorSupport(heroName),
       getActiveHeroColor(heroName),
@@ -127,7 +134,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   // sliders stay smooth. Best-effort: if it can't render (no game path, old
   // binary) we silently fall back to the approximate CSS swatch.
   useEffect(() => {
-    if (!supported || busy) return;
+    if (!supported || busy || previewUnavailable) return;
     let cancelled = false;
     setPreviewLoading(true);
     const handle = setTimeout(() => {
@@ -137,9 +144,12 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
           setPreviewUrl(url);
           setPreviewFailed(false);
         })
-        .catch(() => {
+        .catch((err) => {
           if (cancelled || !mounted.current) return;
           setPreviewFailed(true);
+          // A particle-only hero has no swatch to render: stop retrying every
+          // tick and just show the CSS chip. Other (transient) errors keep trying.
+          if (String(err).includes('particle-only')) setPreviewUnavailable(true);
         })
         .finally(() => {
           if (!cancelled && mounted.current) setPreviewLoading(false);
@@ -149,7 +159,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       cancelled = true;
       clearTimeout(handle);
     };
-  }, [heroName, hue, saturation, brightness, supported, busy]);
+  }, [heroName, hue, saturation, brightness, supported, busy, previewUnavailable]);
 
   const refreshGameRunning = async () => {
     try {

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useRef, useState } from 'react';
+import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw } from 'lucide-react';
+import {
+  applyHeroColor,
+  revertHeroColor,
+  getActiveHeroColor,
+  getHeroColorSupport,
+  getGameRunningStatus,
+} from '../../lib/api';
+
+interface HeroColorPickerProps {
+  heroName: string;
+}
+
+/** Default hue when nothing is applied yet: 280 (purple), the in-game-verified
+ *  reference color the recolor work was proven against. */
+const DEFAULT_HUE = 280;
+
+/** Quick-pick hues so a user doesn't have to drag for a common color. */
+const PRESET_HUES: ReadonlyArray<{ hue: number; label: string }> = [
+  { hue: 0, label: 'Red' },
+  { hue: 30, label: 'Orange' },
+  { hue: 55, label: 'Gold' },
+  { hue: 120, label: 'Green' },
+  { hue: 190, label: 'Cyan' },
+  { hue: 215, label: 'Blue' },
+  { hue: 280, label: 'Purple' },
+  { hue: 320, label: 'Pink' },
+];
+
+/** Indicative swatch color for a hue. The recolor keeps each source pixel's
+ *  saturation/value, so this is a representative chip, not the exact result. */
+function swatch(hue: number): string {
+  return `hsl(${hue}, 85%, 55%)`;
+}
+
+/**
+ * EXPERIMENTAL: recolor a hero's ability VFX (particles + color textures + baked
+ * vertex colors) to a single hue. The pick is baked by the bundled vpkmerge
+ * `recolor-hero` and isolated into a single Locker-managed VPK that wins by load
+ * order; remove it to revert to vanilla. Only heroes with a pinned recipe are
+ * supported (Paige today); others show a coming-soon notice.
+ */
+export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // The hue currently applied in-game (null when none), and the slider's value.
+  const [activeHue, setActiveHue] = useState<number | null>(null);
+  const [hue, setHue] = useState(DEFAULT_HUE);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [changed, setChanged] = useState(false);
+  const [gameRunning, setGameRunning] = useState(false);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    setLoading(true);
+    Promise.all([
+      getHeroColorSupport(heroName),
+      getActiveHeroColor(heroName),
+      getGameRunningStatus().catch(() => ({ running: false })),
+    ])
+      .then(([isSupported, active, status]) => {
+        if (!mounted.current) return;
+        setSupported(isSupported);
+        setActiveHue(active?.hue ?? null);
+        if (active) setHue(active.hue);
+        setGameRunning(status.running);
+      })
+      .catch((err) => {
+        if (mounted.current) setError(String(err));
+      })
+      .finally(() => {
+        if (mounted.current) setLoading(false);
+      });
+    return () => {
+      mounted.current = false;
+    };
+  }, [heroName]);
+
+  const refreshGameRunning = async () => {
+    try {
+      setGameRunning((await getGameRunningStatus()).running);
+    } catch {
+      // keep prior value
+    }
+  };
+
+  const handleApply = async () => {
+    if (busy) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      const result = await applyHeroColor(heroName, hue);
+      if (!mounted.current) return;
+      setActiveHue(result.hue);
+      setChanged(true);
+      await refreshGameRunning();
+    } catch (err) {
+      if (mounted.current) setActionError(String(err));
+    } finally {
+      if (mounted.current) setBusy(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (busy) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      await revertHeroColor(heroName);
+      if (!mounted.current) return;
+      setActiveHue(null);
+      setChanged(true);
+      await refreshGameRunning();
+    } catch (err) {
+      if (mounted.current) setActionError(String(err));
+    } finally {
+      if (mounted.current) setBusy(false);
+    }
+  };
+
+  const dirty = activeHue !== hue;
+
+  return (
+    <section className="space-y-3 border-t border-border/60 pt-5">
+      <div className="flex items-center gap-2">
+        <Palette className="h-4 w-4 text-accent" />
+        <h3 className="text-sm font-semibold text-text-primary">Ability Color</h3>
+        <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+          Experimental
+        </span>
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 py-4 text-xs text-text-secondary">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading...
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span className="break-words">{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && supported === false && (
+        <p className="text-xs text-text-secondary">
+          Ability color recolor isn&apos;t available for {heroName} yet. It&apos;s currently
+          supported for Paige; more heroes are coming.
+        </p>
+      )}
+
+      {!loading && !error && supported && (
+        <>
+          <p className="text-xs text-text-secondary">
+            Recolor {heroName}&apos;s ability effects (particles, projectiles, and the ult body) to
+            a single color. Pick a hue and apply it; remove to go back to vanilla.
+          </p>
+
+          {/* Preview swatch + current hue */}
+          <div className="flex items-center gap-3">
+            <div
+              className="h-12 w-12 flex-shrink-0 rounded-md border border-border shadow-inner"
+              style={{ backgroundColor: swatch(hue) }}
+              aria-label={`Hue ${hue}`}
+            />
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-text-primary tabular-nums">{hue}&deg;</div>
+              <div className="text-[11px] text-text-secondary">
+                {activeHue === null
+                  ? 'No color applied'
+                  : activeHue === hue
+                    ? 'Applied'
+                    : `Applied: ${activeHue}°`}
+              </div>
+            </div>
+          </div>
+
+          {/* Hue slider over a rainbow track */}
+          <input
+            type="range"
+            min={0}
+            max={359}
+            step={1}
+            value={hue}
+            disabled={busy}
+            onChange={(e) => setHue(Number(e.target.value))}
+            className="h-3 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
+            style={{
+              background:
+                'linear-gradient(to right, hsl(0,85%,55%), hsl(60,85%,55%), hsl(120,85%,55%), hsl(180,85%,55%), hsl(240,85%,55%), hsl(300,85%,55%), hsl(360,85%,55%))',
+            }}
+          />
+
+          {/* Preset hues */}
+          <div className="flex flex-wrap gap-1.5">
+            {PRESET_HUES.map((p) => (
+              <button
+                key={p.hue}
+                type="button"
+                disabled={busy}
+                onClick={() => setHue(p.hue)}
+                title={`${p.label} (${p.hue}°)`}
+                className={`h-6 w-6 rounded-full border transition-transform hover:scale-110 disabled:cursor-not-allowed ${
+                  hue === p.hue ? 'border-text-primary ring-2 ring-accent/60' : 'border-border'
+                }`}
+                style={{ backgroundColor: swatch(p.hue) }}
+                aria-label={p.label}
+              />
+            ))}
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={busy || (!dirty && activeHue !== null)}
+              className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Check className="h-3.5 w-3.5" />
+              )}
+              {activeHue !== null && !dirty ? 'Applied' : 'Apply Color'}
+            </button>
+            {activeHue !== null && (
+              <button
+                type="button"
+                onClick={handleRemove}
+                disabled={busy}
+                className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-semibold text-text-secondary transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Remove
+              </button>
+            )}
+          </div>
+
+          {busy && (
+            <p className="text-[11px] text-text-secondary/80">
+              Baking the recolor. The first time for a given color can take up to a minute (it
+              re-encodes every effect texture); the same color is instant after that.
+            </p>
+          )}
+
+          {actionError && (
+            <div className="flex items-start gap-2 py-1 text-xs text-red-400">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <span className="break-words">{actionError}</span>
+            </div>
+          )}
+
+          {changed && (
+            <div
+              className={`flex items-start gap-2 rounded-md border px-3 py-2 text-xs ${
+                gameRunning
+                  ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+                  : 'border-border bg-bg-secondary/70 text-text-secondary'
+              }`}
+            >
+              <RefreshCw className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+              <span>
+                {gameRunning
+                  ? 'Restart Deadlock for this color change to take effect (addons mount at game start).'
+                  : 'Saved. This color mounts the next time you Launch Modded.'}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw } from 'lucide-react';
 import {
   applyHeroColor,
+  previewHeroColor,
   revertHeroColor,
   getActiveHeroColor,
   getHeroColorSupport,
@@ -12,31 +13,59 @@ interface HeroColorPickerProps {
   heroName: string;
 }
 
-/** Default hue when nothing is applied yet: 280 (purple), the in-game-verified
- *  reference color the recolor work was proven against. */
+/** Default target when nothing is applied yet: 280 (purple) at source
+ *  saturation/brightness, the in-game-verified reference the recolor was proven
+ *  against. */
 const DEFAULT_HUE = 280;
+const DEFAULT_SCALE = 1;
 
-/** Quick-pick hues so a user doesn't have to drag for a common color. */
-const PRESET_HUES: ReadonlyArray<{ hue: number; label: string }> = [
-  { hue: 0, label: 'Red' },
-  { hue: 30, label: 'Orange' },
-  { hue: 55, label: 'Gold' },
-  { hue: 120, label: 'Green' },
-  { hue: 190, label: 'Cyan' },
-  { hue: 215, label: 'Blue' },
-  { hue: 280, label: 'Purple' },
-  { hue: 320, label: 'Pink' },
+/** Saturation/brightness slider bounds (scales), matching heroColors.ts. */
+const SAT_MIN = 0;
+const SAT_MAX = 3;
+const BRIGHT_MIN = 0.2;
+const BRIGHT_MAX = 2;
+
+interface Preset {
+  hue: number;
+  saturation: number;
+  brightness: number;
+  label: string;
+}
+
+/** Quick-pick colors. Hue alone can't make a "light blue": the pale presets dial
+ *  saturation down and brightness up. Each sets all three knobs at once. */
+const PRESETS: ReadonlyArray<Preset> = [
+  { hue: 0, saturation: 1, brightness: 1, label: 'Red' },
+  { hue: 30, saturation: 1, brightness: 1, label: 'Orange' },
+  { hue: 50, saturation: 1, brightness: 1.1, label: 'Gold' },
+  { hue: 120, saturation: 1, brightness: 1, label: 'Green' },
+  { hue: 190, saturation: 1, brightness: 1, label: 'Cyan' },
+  { hue: 205, saturation: 0.6, brightness: 1.4, label: 'Light Blue' },
+  { hue: 220, saturation: 1, brightness: 1, label: 'Blue' },
+  { hue: 280, saturation: 1, brightness: 1, label: 'Purple' },
+  { hue: 320, saturation: 0.85, brightness: 1.15, label: 'Pink' },
 ];
 
-/** Indicative swatch color for a hue. The recolor keeps each source pixel's
- *  saturation/value, so this is a representative chip, not the exact result. */
-function swatch(hue: number): string {
-  return `hsl(${hue}, 85%, 55%)`;
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
 }
+
+/** A rough CSS chip for a target, used for the preset buttons and as a fallback
+ *  while/if the real recolored preview can't be rendered. Not the exact in-game
+ *  color (that's what the live preview thumbnail is for). */
+function approxSwatch(hue: number, saturation: number, brightness: number): string {
+  const s = clamp(Math.round(72 * saturation), 0, 100);
+  const l = clamp(Math.round(52 * brightness), 8, 92);
+  return `hsl(${hue}, ${s}%, ${l}%)`;
+}
+
+const pct = (scale: number): number => Math.round(scale * 100);
 
 /**
  * EXPERIMENTAL: recolor a hero's ability VFX (particles + color textures + baked
- * vertex colors) to a single hue. The pick is baked by the bundled vpkmerge
+ * vertex colors) to a chosen color. The target is hue + a saturation scale + a
+ * brightness scale, so pale/pastel colors (e.g. light blue) are reachable, not
+ * just a flat hue rotation. The pick is baked by the bundled vpkmerge
  * `recolor-hero` and isolated into a single Locker-managed VPK that wins by load
  * order; remove it to revert to vanilla. Only heroes with a pinned recipe are
  * supported (Paige today); others show a coming-soon notice.
@@ -45,13 +74,21 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   const [supported, setSupported] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // The hue currently applied in-game (null when none), and the slider's value.
+  // The target currently applied in-game (null when none), and the live picks.
   const [activeHue, setActiveHue] = useState<number | null>(null);
+  const [activeSaturation, setActiveSaturation] = useState<number | null>(null);
+  const [activeBrightness, setActiveBrightness] = useState<number | null>(null);
   const [hue, setHue] = useState(DEFAULT_HUE);
+  const [saturation, setSaturation] = useState(DEFAULT_SCALE);
+  const [brightness, setBrightness] = useState(DEFAULT_SCALE);
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [changed, setChanged] = useState(false);
   const [gameRunning, setGameRunning] = useState(false);
+  // Live recolored swatch (a real ability texture run through the recolor).
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewFailed, setPreviewFailed] = useState(false);
   const mounted = useRef(true);
 
   useEffect(() => {
@@ -66,7 +103,13 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
         if (!mounted.current) return;
         setSupported(isSupported);
         setActiveHue(active?.hue ?? null);
-        if (active) setHue(active.hue);
+        setActiveSaturation(active?.saturation ?? null);
+        setActiveBrightness(active?.brightness ?? null);
+        if (active) {
+          setHue(active.hue);
+          setSaturation(active.saturation);
+          setBrightness(active.brightness);
+        }
         setGameRunning(status.running);
       })
       .catch((err) => {
@@ -79,6 +122,34 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       mounted.current = false;
     };
   }, [heroName]);
+
+  // Live preview: render the real recolored ability texture, debounced so the
+  // sliders stay smooth. Best-effort: if it can't render (no game path, old
+  // binary) we silently fall back to the approximate CSS swatch.
+  useEffect(() => {
+    if (!supported || busy) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    const handle = setTimeout(() => {
+      previewHeroColor(heroName, hue, saturation, brightness)
+        .then((url) => {
+          if (cancelled || !mounted.current) return;
+          setPreviewUrl(url);
+          setPreviewFailed(false);
+        })
+        .catch(() => {
+          if (cancelled || !mounted.current) return;
+          setPreviewFailed(true);
+        })
+        .finally(() => {
+          if (!cancelled && mounted.current) setPreviewLoading(false);
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [heroName, hue, saturation, brightness, supported, busy]);
 
   const refreshGameRunning = async () => {
     try {
@@ -93,9 +164,11 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     setBusy(true);
     setActionError(null);
     try {
-      const result = await applyHeroColor(heroName, hue);
+      const result = await applyHeroColor(heroName, hue, saturation, brightness);
       if (!mounted.current) return;
       setActiveHue(result.hue);
+      setActiveSaturation(result.saturation);
+      setActiveBrightness(result.brightness);
       setChanged(true);
       await refreshGameRunning();
     } catch (err) {
@@ -113,6 +186,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       await revertHeroColor(heroName);
       if (!mounted.current) return;
       setActiveHue(null);
+      setActiveSaturation(null);
+      setActiveBrightness(null);
       setChanged(true);
       await refreshGameRunning();
     } catch (err) {
@@ -122,7 +197,20 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     }
   };
 
-  const dirty = activeHue !== hue;
+  const applyPreset = (p: Preset) => {
+    setHue(p.hue);
+    setSaturation(p.saturation);
+    setBrightness(p.brightness);
+  };
+
+  const applied = activeHue !== null;
+  const dirty =
+    !applied ||
+    activeHue !== hue ||
+    activeSaturation !== saturation ||
+    activeBrightness !== brightness;
+
+  const swatchCss = approxSwatch(hue, saturation, brightness);
 
   return (
     <section className="space-y-3 border-t border-border/60 pt-5">
@@ -158,60 +246,124 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
         <>
           <p className="text-xs text-text-secondary">
             Recolor {heroName}&apos;s ability effects (particles, projectiles, and the ult body) to
-            a single color. Pick a hue and apply it; remove to go back to vanilla.
+            a color. Adjust hue, saturation, and brightness; the preview shows a real ability
+            texture recolored to your pick.
           </p>
 
-          {/* Preview swatch + current hue */}
+          {/* Live recolored preview + current target */}
           <div className="flex items-center gap-3">
             <div
-              className="h-12 w-12 flex-shrink-0 rounded-md border border-border shadow-inner"
-              style={{ backgroundColor: swatch(hue) }}
-              aria-label={`Hue ${hue}`}
-            />
+              className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-md border border-border shadow-inner"
+              style={{ backgroundColor: swatchCss }}
+              aria-label={`Hue ${hue}, saturation ${pct(saturation)}%, brightness ${pct(brightness)}%`}
+            >
+              {previewUrl && !previewFailed && (
+                <img
+                  src={previewUrl}
+                  alt="Ability color preview"
+                  className="h-full w-full object-cover"
+                  style={{ imageRendering: 'auto' }}
+                />
+              )}
+              {previewLoading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+                  <Loader2 className="h-4 w-4 animate-spin text-white/80" />
+                </div>
+              )}
+            </div>
             <div className="min-w-0">
-              <div className="text-sm font-semibold text-text-primary tabular-nums">{hue}&deg;</div>
+              <div className="text-sm font-semibold text-text-primary tabular-nums">
+                {hue}&deg; &middot; S {pct(saturation)}% &middot; B {pct(brightness)}%
+              </div>
               <div className="text-[11px] text-text-secondary">
-                {activeHue === null
+                {!applied
                   ? 'No color applied'
-                  : activeHue === hue
+                  : !dirty
                     ? 'Applied'
-                    : `Applied: ${activeHue}°`}
+                    : `Applied: ${activeHue}° / S ${pct(activeSaturation ?? 1)}% / B ${pct(activeBrightness ?? 1)}%`}
               </div>
             </div>
           </div>
 
           {/* Hue slider over a rainbow track */}
-          <input
-            type="range"
-            min={0}
-            max={359}
-            step={1}
-            value={hue}
-            disabled={busy}
-            onChange={(e) => setHue(Number(e.target.value))}
-            className="h-3 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
-            style={{
-              background:
-                'linear-gradient(to right, hsl(0,85%,55%), hsl(60,85%,55%), hsl(120,85%,55%), hsl(180,85%,55%), hsl(240,85%,55%), hsl(300,85%,55%), hsl(360,85%,55%))',
-            }}
-          />
+          <label className="block space-y-1">
+            <span className="text-[11px] font-medium text-text-secondary">Hue</span>
+            <input
+              type="range"
+              min={0}
+              max={359}
+              step={1}
+              value={hue}
+              disabled={busy}
+              onChange={(e) => setHue(Number(e.target.value))}
+              className="h-3 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
+              style={{
+                background:
+                  'linear-gradient(to right, hsl(0,85%,55%), hsl(60,85%,55%), hsl(120,85%,55%), hsl(180,85%,55%), hsl(240,85%,55%), hsl(300,85%,55%), hsl(360,85%,55%))',
+              }}
+            />
+          </label>
 
-          {/* Preset hues */}
+          {/* Saturation slider: gray -> full chroma at the current hue */}
+          <label className="block space-y-1">
+            <span className="text-[11px] font-medium text-text-secondary">
+              Saturation <span className="tabular-nums text-text-secondary/70">{pct(saturation)}%</span>
+            </span>
+            <input
+              type="range"
+              min={SAT_MIN * 100}
+              max={SAT_MAX * 100}
+              step={5}
+              value={pct(saturation)}
+              disabled={busy}
+              onChange={(e) => setSaturation(Number(e.target.value) / 100)}
+              className="h-3 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
+              style={{
+                background: `linear-gradient(to right, hsl(${hue},0%,55%), hsl(${hue},90%,50%))`,
+              }}
+            />
+          </label>
+
+          {/* Brightness slider: dark -> light at the current hue */}
+          <label className="block space-y-1">
+            <span className="text-[11px] font-medium text-text-secondary">
+              Brightness <span className="tabular-nums text-text-secondary/70">{pct(brightness)}%</span>
+            </span>
+            <input
+              type="range"
+              min={BRIGHT_MIN * 100}
+              max={BRIGHT_MAX * 100}
+              step={5}
+              value={pct(brightness)}
+              disabled={busy}
+              onChange={(e) => setBrightness(Number(e.target.value) / 100)}
+              className="h-3 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
+              style={{
+                background: `linear-gradient(to right, hsl(${hue},70%,12%), hsl(${hue},70%,55%), hsl(${hue},60%,85%))`,
+              }}
+            />
+          </label>
+
+          {/* Preset colors (each sets hue + saturation + brightness) */}
           <div className="flex flex-wrap gap-1.5">
-            {PRESET_HUES.map((p) => (
-              <button
-                key={p.hue}
-                type="button"
-                disabled={busy}
-                onClick={() => setHue(p.hue)}
-                title={`${p.label} (${p.hue}°)`}
-                className={`h-6 w-6 rounded-full border transition-transform hover:scale-110 disabled:cursor-not-allowed ${
-                  hue === p.hue ? 'border-text-primary ring-2 ring-accent/60' : 'border-border'
-                }`}
-                style={{ backgroundColor: swatch(p.hue) }}
-                aria-label={p.label}
-              />
-            ))}
+            {PRESETS.map((p) => {
+              const selected =
+                hue === p.hue && saturation === p.saturation && brightness === p.brightness;
+              return (
+                <button
+                  key={p.label}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => applyPreset(p)}
+                  title={`${p.label} (${p.hue}°, S ${pct(p.saturation)}%, B ${pct(p.brightness)}%)`}
+                  className={`h-6 w-6 rounded-full border transition-transform hover:scale-110 disabled:cursor-not-allowed ${
+                    selected ? 'border-text-primary ring-2 ring-accent/60' : 'border-border'
+                  }`}
+                  style={{ backgroundColor: approxSwatch(p.hue, p.saturation, p.brightness) }}
+                  aria-label={p.label}
+                />
+              );
+            })}
           </div>
 
           {/* Actions */}
@@ -219,7 +371,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
             <button
               type="button"
               onClick={handleApply}
-              disabled={busy || (!dirty && activeHue !== null)}
+              disabled={busy || !dirty}
               className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               {busy ? (
@@ -227,9 +379,9 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               ) : (
                 <Check className="h-3.5 w-3.5" />
               )}
-              {activeHue !== null && !dirty ? 'Applied' : 'Apply Color'}
+              {applied && !dirty ? 'Applied' : 'Apply Color'}
             </button>
-            {activeHue !== null && (
+            {applied && (
               <button
                 type="button"
                 onClick={handleRemove}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -185,9 +185,21 @@ export async function getHeroColorSupport(heroName: string): Promise<boolean> {
 
 export async function applyHeroColor(
   heroName: string,
-  hue: number
+  hue: number,
+  saturation: number,
+  brightness: number
 ): Promise<ApplyHeroColorResult> {
-  return window.electronAPI.applyHeroColor(heroName, hue);
+  return window.electronAPI.applyHeroColor(heroName, hue, saturation, brightness);
+}
+
+/** Render a fast PNG swatch of the recolor target as a data URL (live preview). */
+export async function previewHeroColor(
+  heroName: string,
+  hue: number,
+  saturation: number,
+  brightness: number
+): Promise<string> {
+  return window.electronAPI.previewHeroColor(heroName, hue, saturation, brightness);
 }
 
 export async function revertHeroColor(heroName: string): Promise<ApplyHeroColorResult> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
 import type { HeroPortrait, SoulModelInfo, HeroPoseInfo } from '../types/portrait';
 import type {
   GameBananaModsResponse,
@@ -177,6 +177,25 @@ export async function revertHeroSound(
 
 export async function getActiveHeroSounds(heroName: string): Promise<ActiveHeroSound[]> {
   return window.electronAPI.getActiveHeroSounds(heroName);
+}
+
+export async function getHeroColorSupport(heroName: string): Promise<boolean> {
+  return window.electronAPI.getHeroColorSupport(heroName);
+}
+
+export async function applyHeroColor(
+  heroName: string,
+  hue: number
+): Promise<ApplyHeroColorResult> {
+  return window.electronAPI.applyHeroColor(heroName, hue);
+}
+
+export async function revertHeroColor(heroName: string): Promise<ApplyHeroColorResult> {
+  return window.electronAPI.revertHeroColor(heroName);
+}
+
+export async function getActiveHeroColor(heroName: string): Promise<ActiveHeroColor | null> {
+  return window.electronAPI.getActiveHeroColor(heroName);
 }
 
 export async function getLockerOverview(): Promise<LockerOverview> {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -435,7 +435,7 @@ export default function Installed() {
   const refreshLockerOverrideCount = useCallback(async () => {
     try {
       const ov = await getLockerOverview();
-      setLockerOverrideCount(ov.cards.length + ov.sounds.length);
+      setLockerOverrideCount(ov.cards.length + ov.sounds.length + ov.colors.length);
     } catch {
       setLockerOverrideCount(0);
     }
@@ -2542,9 +2542,9 @@ export default function Installed() {
               title={selectMode ? 'Exit selection mode' : 'Select multiple mods for bulk delete, enable, or disable'}
             />
 
-            {/* Locker overrides: hero cards + ability sounds applied off the
-                mod list. The badge shows how many are active; the popup reviews,
-                previews, and removes them. */}
+            {/* Locker overrides: hero cards + ability sounds + ability colors
+                applied off the mod list. The badge shows how many are active;
+                the popup reviews, previews, and removes them. */}
             <div className="relative">
               <Button
                 variant="secondary"
@@ -2552,7 +2552,7 @@ export default function Installed() {
                 icon={Wand2}
                 className="!px-2.5"
                 aria-label="Locker overrides"
-                title="Locker overrides: review and remove applied hero cards and ability sounds"
+                title="Locker overrides: review and remove applied hero cards, ability sounds, and ability colors"
               />
               {lockerOverrideCount > 0 && (
                 <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-bg-primary">

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1070,11 +1070,18 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
                           background shows through; other types keep a solid bg. */}
                       <div
                         className={`relative mb-2 aspect-video w-full overflow-hidden rounded-lg border border-white/[0.08] ${
-                          activeType === 'soul-container'
-                            ? 'bg-white/[0.04] backdrop-blur-md'
-                            : 'bg-bg-tertiary'
+                          activeType === 'soul-container' ? '' : 'bg-bg-tertiary'
                         }`}
                       >
+                        {/* Frosted-glass panel for soul containers, kept as a
+                            separate inner layer rather than on the media container
+                            itself: a backdrop-filter turns its element into a
+                            stacking context, which would sink this subtree (and
+                            the retag kebab below) under the z-10 full-card toggle
+                            and swallow the kebab's clicks. */}
+                        {activeType === 'soul-container' && (
+                          <div className="pointer-events-none absolute inset-0 bg-white/[0.04] backdrop-blur-md" />
+                        )}
                         {/* Soul containers show a live 3D model on a clear window
                             (no 2D thumbnail behind it); other types show their
                             GameBanana thumbnail. */}

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Layers, Star, Music, Shirt, Images, Box, Loader2 } from 'lucide-react';
+import { ArrowLeft, Layers, Star, Music, Shirt, Images, Box, Loader2, Palette } from 'lucide-react';
 import { Skeleton } from '../components/common/Skeleton';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
@@ -13,6 +13,7 @@ import { getActiveDeadlockPath } from '../lib/appSettings';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import HeroCardPicker from '../components/locker/HeroCardPicker';
 import HeroSoundPicker from '../components/locker/HeroSoundPicker';
+import HeroColorPicker from '../components/locker/HeroColorPicker';
 // three.js viewer is heavy; only pull the chunk when the user flips to 3D.
 const HeroPoseViewer = lazy(() => import('../components/locker/HeroPoseViewer'));
 import type { GameBananaCategoryNode } from '../types/gamebanana';
@@ -371,7 +372,7 @@ export function LockerHeroView({
   const [renderFallbackStep, setRenderFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
   const [view3d, setView3d] = useState(false);
-  const [section, setSection] = useState<'skins' | 'sounds' | 'cards'>('skins');
+  const [section, setSection] = useState<'skins' | 'sounds' | 'cards' | 'colors'>('skins');
   // The active skin to pose: the hero's first enabled skin mod, if any. Its
   // metaKey is the source VPK; undefined poses the vanilla base model.
   const activeSkinMetaKey = useMemo(
@@ -559,13 +560,15 @@ export function LockerHeroView({
             <span className="text-sm text-text-secondary">
               {activeSection === 'cards'
                 ? 'Card art'
-                : activeSection === 'sounds'
-                  ? soundCount > 0
-                    ? `${soundCount} sound${soundCount !== 1 ? 's' : ''}`
-                    : 'No sounds'
-                  : skinCount > 0
-                    ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}`
-                    : 'No skins'}
+                : activeSection === 'colors'
+                  ? 'Ability color'
+                  : activeSection === 'sounds'
+                    ? soundCount > 0
+                      ? `${soundCount} sound${soundCount !== 1 ? 's' : ''}`
+                      : 'No sounds'
+                    : skinCount > 0
+                      ? `${skinCount} skin${skinCount !== 1 ? 's' : ''}`
+                      : 'No skins'}
             </span>
           </div>
 
@@ -620,12 +623,28 @@ export function LockerHeroView({
               <Images className="w-3.5 h-3.5" />
               Cards
             </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeSection === 'colors'}
+              onClick={() => setSection('colors')}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors cursor-pointer ${
+                activeSection === 'colors'
+                  ? 'bg-accent/15 text-text-primary border border-accent/40'
+                  : 'text-text-secondary hover:text-text-primary border border-transparent'
+              }`}
+            >
+              <Palette className="w-3.5 h-3.5" />
+              Colors
+            </button>
           </div>
 
-          {/* Skin / Sound / Card selection */}
+          {/* Skin / Sound / Card / Color selection */}
           <div className="space-y-4">
             {activeSection === 'cards' ? (
               <HeroCardPicker heroName={hero.name} />
+            ) : activeSection === 'colors' ? (
+              <HeroColorPicker heroName={hero.name} />
             ) : activeSection === 'sounds' ? (
               <HeroSoundPicker heroName={hero.name} soundList={soundList} onSelect={onSelect} />
             ) : (

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -336,7 +336,18 @@ export interface ElectronAPI {
     revertHeroSound: (heroName: string, slot: AbilitySlot) => Promise<ApplyHeroSoundResult>;
     getActiveHeroSounds: (heroName: string) => Promise<ActiveHeroSound[]>;
     getHeroColorSupport: (heroName: string) => Promise<boolean>;
-    applyHeroColor: (heroName: string, hue: number) => Promise<ApplyHeroColorResult>;
+    applyHeroColor: (
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+    ) => Promise<ApplyHeroColorResult>;
+    previewHeroColor: (
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+    ) => Promise<string>;
     revertHeroColor: (heroName: string) => Promise<ApplyHeroColorResult>;
     getActiveHeroColor: (heroName: string) => Promise<ActiveHeroColor | null>;
     getLockerOverview: () => Promise<LockerOverview>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -18,6 +18,8 @@ import type {
     AbilitySoundParams,
     ActiveHeroSound,
     ApplyHeroSoundResult,
+    ActiveHeroColor,
+    ApplyHeroColorResult,
     LockerOverview,
     LockerCardThumbnail,
     LockerClearScope,
@@ -333,6 +335,10 @@ export interface ElectronAPI {
     ) => Promise<ApplyHeroSoundResult>;
     revertHeroSound: (heroName: string, slot: AbilitySlot) => Promise<ApplyHeroSoundResult>;
     getActiveHeroSounds: (heroName: string) => Promise<ActiveHeroSound[]>;
+    getHeroColorSupport: (heroName: string) => Promise<boolean>;
+    applyHeroColor: (heroName: string, hue: number) => Promise<ApplyHeroColorResult>;
+    revertHeroColor: (heroName: string) => Promise<ApplyHeroColorResult>;
+    getActiveHeroColor: (heroName: string) => Promise<ActiveHeroColor | null>;
     getLockerOverview: () => Promise<LockerOverview>;
     getLockerCardThumbnails: () => Promise<LockerCardThumbnail[]>;
     clearLockerOverrides: (scope: LockerClearScope) => Promise<void>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -179,7 +179,7 @@ export interface LockerOverview {
 }
 
 /** Which slice of Locker overrides to clear. */
-export type LockerClearScope = 'all' | 'cards' | 'sounds';
+export type LockerClearScope = 'all' | 'cards' | 'sounds' | 'colors';
 
 /** One applied hero card decoded to a preview thumbnail, for the popup. Decoded
  *  on demand from the managed cosmetics VPK (the real applied art, not the
@@ -199,6 +199,46 @@ export interface ActiveHeroSound {
    *  sound picker compares this against each mod's metaKey to mark the active row. */
   sourceFileName: string;
   params?: AbilitySoundParams;
+}
+
+/**
+ * One per-hero ability-color choice inside the Locker colors VPK. The user
+ * recolored this hero's ability VFX (particles + color textures + baked vertex
+ * colors) to a single absolute `hue`; the rebuild bakes that hero's VFX (cached
+ * by codename+hue) and folds it into the consolidated colors VPK. At most one
+ * selection per hero.
+ */
+export interface LockerColorSelection {
+  heroName: string;
+  /** Model/particle codename the recolor targets (Paige = `bookworm`). */
+  heroCodename: string;
+  /** Absolute hue (0-359 degrees) every ability color is set to. */
+  hue: number;
+  addedAt: string;
+}
+
+/**
+ * Manifest on the single Locker-managed colors VPK that holds every applied
+ * ability recolor. Presence marks the VPK as Locker-managed so other surfaces
+ * hide it. Rebuilt on every apply/revert. Separate from lockerCosmetics (cards)
+ * and lockerSounds (disjoint paths, independent lifecycle).
+ */
+export interface LockerColorsInfo {
+  /** One entry per hero (heroCodename). */
+  colors: LockerColorSelection[];
+  rebuiltAt: string;
+}
+
+/** The hue applied for a hero's ability VFX, read back so the color picker can
+ *  reflect the active selection. */
+export interface ActiveHeroColor {
+  /** Applied absolute hue (0-359 degrees). */
+  hue: number;
+}
+
+export interface ApplyHeroColorResult {
+  /** The applied hue (0-359), or null after a revert. */
+  hue: number | null;
 }
 
 /**

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -214,6 +214,12 @@ export interface LockerColorSelection {
   heroCodename: string;
   /** Absolute hue (0-359 degrees) every ability color is set to. */
   hue: number;
+  /** Saturation scale applied on top of each source color (1 = keep source, >1
+   *  lifts pale washed-out areas toward the picked color, <1 mutes to a pastel).
+   *  Hue alone can't make e.g. a light blue: saturation + brightness do. */
+  saturation: number;
+  /** Brightness (HSV value) scale (1 = keep source, >1 lighter, <1 darker). */
+  brightness: number;
   addedAt: string;
 }
 
@@ -229,16 +235,24 @@ export interface LockerColorsInfo {
   rebuiltAt: string;
 }
 
-/** The hue applied for a hero's ability VFX, read back so the color picker can
+/** The color applied for a hero's ability VFX, read back so the color picker can
  *  reflect the active selection. */
 export interface ActiveHeroColor {
   /** Applied absolute hue (0-359 degrees). */
   hue: number;
+  /** Applied saturation scale (1 = source). */
+  saturation: number;
+  /** Applied brightness scale (1 = source). */
+  brightness: number;
 }
 
 export interface ApplyHeroColorResult {
   /** The applied hue (0-359), or null after a revert. */
   hue: number | null;
+  /** The applied saturation scale, or null after a revert. */
+  saturation: number | null;
+  /** The applied brightness scale, or null after a revert. */
+  brightness: number | null;
 }
 
 /**

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -176,6 +176,8 @@ export interface LockerOverviewSound {
 export interface LockerOverview {
   cards: LockerOverviewCard[];
   sounds: LockerOverviewSound[];
+  /** Applied ability-color recolors, one per hero (see LockerColorSelection). */
+  colors: LockerColorSelection[];
 }
 
 /** Which slice of Locker overrides to clear. */


### PR DESCRIPTION
## Summary

Adds **per-hero ability VFX recolor** to the Locker: recolor a hero's ability particles, color textures, and baked vertex colors to any target hue (plus saturation and brightness), applied as an always-on Locker override that lives in `citadel/grimoire`, off the mod list and the 99-slot cap. Recipes ship for Paige (`bookworm`) and Celeste (`unicorn`).

This branch also folds in the supporting work: surfacing those recolors in the wand "Locker Overrides" popup, a Soul Container hotfix, and the vpkmerge bump the recolor pipeline depends on.

## What's in here

- **Ability color recolor** (per-hero Locker surface): hue + saturation + brightness target, live PNG swatch preview (no bake), baked addons cached by codename+hue+sat+bright. Backed by vpkmerge `recolor-hero`. Paige and Celeste recipes.
- **Locker Overrides popup** now tracks ability colors: a third **Ability Colors** tab next to Hero Cards and Ability Sounds (hero, hue/sat/bright readout, swatch chip, Remove + Remove all), and the toolbar wand badge counts them.
- **Hotfix (v1.14.2):** the 3-dot retag button on Soul Container cards in Locker > Global was unclickable. `backdrop-blur` on the media container made it a stacking context with `z-index: auto`, sinking the `z-20` kebab beneath the `z-10` full-card toggle so clicks just toggled the mod. Moved the frosted glass to an inner `pointer-events-none` layer; only Soul Container cards carried the blur, so only they were affected.
- **vpkmerge bundled binary -> v0.8.0**, required by the recolor features: v0.8.0 adds the `--saturation` / `--brightness` target and the Celeste (`unicorn`) recipe to `recolor-hero`. Updates the pin and all three platform sha256s in `scripts/fetch-vpkmerge.mjs`.

## Dependencies

- Requires vpkmerge **v0.8.0** (pinned in `scripts/fetch-vpkmerge.mjs`). Released separately.

## Testing

- `eslint .` clean; `tsc --noEmit` clean for both renderer (`tsconfig.app.json`) and main (`tsconfig.node.json`).
- vpkmerge pin verified: re-ran `scripts/fetch-vpkmerge.mjs`, the linux binary reports `0.8.0` and the sha256 matches.
- Ult vertex-color recolor confirmed in-game during development (commit `95c22e9`).
- The Soul Container hotfix and the new Ability Colors tab have static checks only; not yet smoke-tested in a packaged build.

## Notes

- App version is still `1.14.2` in `package.json`; left for the release cut.
