### PR TITLE
feat(locker): rainbow prism controls (rotation/sat/brightness) + Yamato

### DIFF
--- a/electron/main/ipc/abilityColors.ts
+++ b/electron/main/ipc/abilityColors.ts
@@ -2,12 +2,17 @@ import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import {
     applyHeroColor,
+    applyHeroPrism,
     revertHeroColor,
     getActiveHeroColor,
     getHeroColorSupport,
     previewHeroColor,
 } from '../services/heroColors';
-import type { ActiveHeroColor, ApplyHeroColorResult } from '../../../src/types/mod';
+import type {
+    ActiveHeroColor,
+    ApplyHeroColorResult,
+    ApplyHeroPrismResult,
+} from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/abilitySounds.ts). */
 function getActiveDeadlockPath(): string | null {
@@ -39,6 +44,22 @@ ipcMain.handle(
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
         return applyHeroColor(deadlockPath, heroName, hue, saturation, brightness);
+    },
+);
+
+ipcMain.handle(
+    'apply-hero-prism',
+    async (
+        _,
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+        animated: boolean,
+    ): Promise<ApplyHeroPrismResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return applyHeroPrism(deadlockPath, heroName, hue, saturation, brightness, animated);
     },
 );
 

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -35,6 +35,7 @@ import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import type {
     ActiveHeroColor,
     ApplyHeroColorResult,
+    ApplyHeroPrismResult,
     LockerColorSelection,
     LockerColorsInfo,
 } from '../../../src/types/mod';
@@ -66,6 +67,11 @@ const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
     // and the pickup-sphere/jar tint (a material g_vColorTint CONSTANT, which needs
     // an in-place .vmat_c patch, not a texture). Neither blocks shipping her here.
     Graves: 'necro',
+    // Yamato: particles + a handful of chromatic textures (the green blade-dash
+    // self-illum and the shadow-redemption status maps, plus the shadow-form body
+    // albedo). Her recipe also carries the prism animation targets, so she is a
+    // strong Rainbow candidate. Keep in lockstep with `recipe_for`.
+    Yamato: 'yamato',
 };
 
 /** Bumped when the recolor recipe/binary changes in a way that should re-bake
@@ -144,6 +150,27 @@ function colorCachePath(codename: string, hue: number, sat: number, brightness: 
     return join(dir, `${codename}_h${hue}_s${s}_b${b}_v${RECIPE_CACHE_VERSION}_dir.vpk`);
 }
 
+/** Cache path for one hero's baked rainbow-prism addon. Keyed by codename + the
+ *  spectrum tuning (hue rotation + saturation/brightness scales) + animated flag +
+ *  version. The prism spreads the hero's own colors across a spectrum; the tuning
+ *  rotates/scales that spectrum, so it's part of the cache identity. */
+function prismCachePath(
+    codename: string,
+    hue: number,
+    sat: number,
+    brightness: number,
+    animated: boolean,
+): string {
+    const dir = join(app.getPath('userData'), 'ability-colors');
+    const s = Math.round(sat * 100);
+    const b = Math.round(brightness * 100);
+    const anim = animated ? '_anim' : '';
+    return join(
+        dir,
+        `${codename}_prism_h${hue}_s${s}_b${b}${anim}_v${RECIPE_CACHE_VERSION}_dir.vpk`,
+    );
+}
+
 /**
  * Ensure a hero's recolor addon for (hue, saturation, brightness) exists in the
  * cache, baking it via `vpkmerge recolor-hero` (reading the base game VFX from
@@ -187,6 +214,53 @@ async function ensureHeroColorBake(
     return cachePath;
 }
 
+/**
+ * Ensure a hero's rainbow-prism addon exists in the cache, baking it via
+ * `vpkmerge prism` (reading the base game VFX from pak01) if missing. With
+ * `animated`, passes `--animated` so the spectrum sweeps over each particle's
+ * lifetime. Same temp-then-rename discipline as the single-hue bake.
+ */
+async function ensureHeroPrismBake(
+    pak01: string,
+    codename: string,
+    hue: number,
+    sat: number,
+    brightness: number,
+    animated: boolean,
+): Promise<string> {
+    const cachePath = prismCachePath(codename, hue, sat, brightness, animated);
+    if (existsSync(cachePath)) return cachePath;
+
+    const dir = join(app.getPath('userData'), 'ability-colors');
+    await fs.mkdir(dir, { recursive: true });
+    const tmp = join(dir, `.${codename}_prism_${randomUUID()}_dir.vpk`);
+    try {
+        // In prism mode `hue` is the spectrum rotation (degrees), not an absolute hue.
+        const args = [
+            'prism',
+            '--hero',
+            codename,
+            '--vpk',
+            pak01,
+            '--hue-offset',
+            String(hue),
+            '--saturation',
+            String(sat),
+            '--brightness',
+            String(brightness),
+            '--encode-vpk',
+            tmp,
+        ];
+        if (animated) args.push('--animated');
+        await runVpkmerge(args);
+        await verifyVpkOutput(tmp);
+        await fs.rename(tmp, cachePath);
+    } finally {
+        await fs.unlink(tmp).catch(() => {});
+    }
+    return cachePath;
+}
+
 interface RebuildResult {
     fileName: string | null;
 }
@@ -220,17 +294,26 @@ async function rebuildLockerColors(
         throw new Error('Base game pak01_dir.vpk not found; check the Deadlock path in Settings.');
     }
 
-    // Bake (or reuse) each hero's recolor addon.
+    // Bake (or reuse) each hero's recolor addon: single hue or rainbow prism.
     const caches: string[] = [];
     for (const sel of valid) {
         caches.push(
-            await ensureHeroColorBake(
-                pak01,
-                sel.heroCodename,
-                sel.hue,
-                sel.saturation,
-                sel.brightness,
-            ),
+            sel.mode === 'prism'
+                ? await ensureHeroPrismBake(
+                      pak01,
+                      sel.heroCodename,
+                      sel.hue,
+                      sel.saturation,
+                      sel.brightness,
+                      sel.animated ?? false,
+                  )
+                : await ensureHeroColorBake(
+                      pak01,
+                      sel.heroCodename,
+                      sel.hue,
+                      sel.saturation,
+                      sel.brightness,
+                  ),
         );
     }
 
@@ -298,6 +381,48 @@ export async function applyHeroColor(
     return { hue: normHue, saturation: normSat, brightness: normBright };
 }
 
+/**
+ * Apply hero X's rainbow-prism recolor (static or animated), replacing any prior
+ * color for that hero. Bakes the prism (cached by codename + animated) and folds
+ * it into the managed colors VPK, exactly like the single-hue apply.
+ */
+export async function applyHeroPrism(
+    deadlockPath: string,
+    heroName: string,
+    hue: number,
+    saturation: number,
+    brightness: number,
+    animated: boolean,
+): Promise<ApplyHeroPrismResult> {
+    vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    const codename = colorCodenameForHero(heroName);
+    if (!codename) {
+        throw new Error(`Ability color recolor isn't available for ${heroName} yet.`);
+    }
+    ensureGrimoireConfigured(deadlockPath);
+
+    // In prism mode `hue` is the spectrum rotation; saturation/brightness scale it.
+    const normHue = normalizeHue(hue);
+    const normSat = normalizeSaturation(saturation);
+    const normBright = normalizeBrightness(brightness);
+    const current = currentColorSelections();
+    const next: LockerColorSelection[] = [
+        ...current.filter((s) => s.heroCodename !== codename),
+        {
+            heroName,
+            heroCodename: codename,
+            hue: normHue,
+            saturation: normSat,
+            brightness: normBright,
+            mode: 'prism',
+            animated,
+            addedAt: new Date().toISOString(),
+        },
+    ];
+    await rebuildLockerColors(deadlockPath, next);
+    return { hue: normHue, saturation: normSat, brightness: normBright, animated };
+}
+
 /** Remove hero X's ability color, reverting its VFX to vanilla. */
 export async function revertHeroColor(
     deadlockPath: string,
@@ -321,7 +446,13 @@ export function getActiveHeroColor(heroName: string): ActiveHeroColor | null {
     if (!codename) return null;
     const sel = currentColorSelections().find((s) => s.heroCodename === codename);
     return sel
-        ? { hue: sel.hue, saturation: sel.saturation, brightness: sel.brightness }
+        ? {
+              hue: sel.hue,
+              saturation: sel.saturation,
+              brightness: sel.brightness,
+              mode: sel.mode ?? 'hue',
+              animated: sel.animated ?? false,
+          }
         : null;
 }
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -836,6 +836,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('get-hero-color-support', heroName),
     applyHeroColor: (heroName: string, hue: number, saturation: number, brightness: number) =>
         ipcRenderer.invoke('apply-hero-color', heroName, hue, saturation, brightness),
+    applyHeroPrism: (
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+        animated: boolean,
+    ) => ipcRenderer.invoke('apply-hero-prism', heroName, hue, saturation, brightness, animated),
     previewHeroColor: (heroName: string, hue: number, saturation: number, brightness: number) =>
         ipcRenderer.invoke('preview-hero-color', heroName, hue, saturation, brightness),
     revertHeroColor: (heroName: string) =>

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw } from 'lucide-react';
+import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw, Sparkles } from 'lucide-react';
 import {
   applyHeroColor,
+  applyHeroPrism,
   previewHeroColor,
   revertHeroColor,
   getActiveHeroColor,
@@ -61,6 +62,19 @@ function approxSwatch(hue: number, saturation: number, brightness: number): stri
 
 const pct = (scale: number): number => Math.round(scale * 100);
 
+/** Rainbow swatch for the prism preview, rotated + scaled to mirror the spectrum
+ *  tuning (no per-pixel bake to show). `hue` rotates the start; saturation and
+ *  brightness scale the chips, matching what `prism --hue-offset/--saturation/
+ *  --brightness` does to the baked VFX. */
+function rainbowGradient(hue: number, saturation: number, brightness: number): string {
+  const s = clamp(Math.round(85 * saturation), 0, 100);
+  const l = clamp(Math.round(55 * brightness), 12, 92);
+  const stops = [0, 60, 120, 180, 240, 300, 360]
+    .map((d) => `hsl(${Math.round((hue + d) % 360)}, ${s}%, ${l}%)`)
+    .join(', ');
+  return `linear-gradient(135deg, ${stops})`;
+}
+
 /**
  * EXPERIMENTAL: recolor a hero's ability VFX (particles + color textures + baked
  * vertex colors) to a chosen color. The target is hue + a saturation scale + a
@@ -81,6 +95,12 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   const [hue, setHue] = useState(DEFAULT_HUE);
   const [saturation, setSaturation] = useState(DEFAULT_SCALE);
   const [brightness, setBrightness] = useState(DEFAULT_SCALE);
+  // Recolor mode: a single picked color, or the rainbow prism (static/animated).
+  const [mode, setMode] = useState<'hue' | 'prism'>('hue');
+  const [animated, setAnimated] = useState(false);
+  // What's applied in-game: the mode (null = nothing) and, for prism, its animated flag.
+  const [activeMode, setActiveMode] = useState<'hue' | 'prism' | null>(null);
+  const [activeAnimated, setActiveAnimated] = useState(false);
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [changed, setChanged] = useState(false);
@@ -97,10 +117,12 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   useEffect(() => {
     mounted.current = true;
     setLoading(true);
-    // Fresh hero: drop any prior hero's preview state.
+    // Fresh hero: drop any prior hero's preview + mode state.
     setPreviewUrl(null);
     setPreviewFailed(false);
     setPreviewUnavailable(false);
+    setMode('hue');
+    setAnimated(false);
     Promise.all([
       getHeroColorSupport(heroName),
       getActiveHeroColor(heroName),
@@ -109,10 +131,16 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       .then(([isSupported, active, status]) => {
         if (!mounted.current) return;
         setSupported(isSupported);
+        const activeM = active ? (active.mode ?? 'hue') : null;
+        setActiveMode(activeM);
         setActiveHue(active?.hue ?? null);
         setActiveSaturation(active?.saturation ?? null);
         setActiveBrightness(active?.brightness ?? null);
-        if (active) {
+        setActiveAnimated(active?.animated ?? false);
+        if (active && activeM === 'prism') {
+          setMode('prism');
+          setAnimated(active.animated ?? false);
+        } else if (active) {
           setHue(active.hue);
           setSaturation(active.saturation);
           setBrightness(active.brightness);
@@ -134,7 +162,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   // sliders stay smooth. Best-effort: if it can't render (no game path, old
   // binary) we silently fall back to the approximate CSS swatch.
   useEffect(() => {
-    if (!supported || busy || previewUnavailable) return;
+    // Prism has no per-pixel swatch to bake; it shows a rainbow chip instead.
+    if (!supported || busy || previewUnavailable || mode === 'prism') return;
     let cancelled = false;
     setPreviewLoading(true);
     const handle = setTimeout(() => {
@@ -159,7 +188,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       cancelled = true;
       clearTimeout(handle);
     };
-  }, [heroName, hue, saturation, brightness, supported, busy, previewUnavailable]);
+  }, [heroName, hue, saturation, brightness, supported, busy, previewUnavailable, mode]);
 
   const refreshGameRunning = async () => {
     try {
@@ -174,11 +203,22 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     setBusy(true);
     setActionError(null);
     try {
-      const result = await applyHeroColor(heroName, hue, saturation, brightness);
-      if (!mounted.current) return;
-      setActiveHue(result.hue);
-      setActiveSaturation(result.saturation);
-      setActiveBrightness(result.brightness);
+      if (mode === 'prism') {
+        const result = await applyHeroPrism(heroName, hue, saturation, brightness, animated);
+        if (!mounted.current) return;
+        setActiveMode('prism');
+        setActiveHue(result.hue);
+        setActiveSaturation(result.saturation);
+        setActiveBrightness(result.brightness);
+        setActiveAnimated(result.animated);
+      } else {
+        const result = await applyHeroColor(heroName, hue, saturation, brightness);
+        if (!mounted.current) return;
+        setActiveMode('hue');
+        setActiveHue(result.hue);
+        setActiveSaturation(result.saturation);
+        setActiveBrightness(result.brightness);
+      }
       setChanged(true);
       await refreshGameRunning();
     } catch (err) {
@@ -195,9 +235,11 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     try {
       await revertHeroColor(heroName);
       if (!mounted.current) return;
+      setActiveMode(null);
       setActiveHue(null);
       setActiveSaturation(null);
       setActiveBrightness(null);
+      setActiveAnimated(false);
       setChanged(true);
       await refreshGameRunning();
     } catch (err) {
@@ -213,12 +255,18 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     setBrightness(p.brightness);
   };
 
-  const applied = activeHue !== null;
+  const applied = activeMode !== null;
   const dirty =
-    !applied ||
-    activeHue !== hue ||
-    activeSaturation !== saturation ||
-    activeBrightness !== brightness;
+    mode === 'prism'
+      ? activeMode !== 'prism' ||
+        activeAnimated !== animated ||
+        activeHue !== hue ||
+        activeSaturation !== saturation ||
+        activeBrightness !== brightness
+      : activeMode !== 'hue' ||
+        activeHue !== hue ||
+        activeSaturation !== saturation ||
+        activeBrightness !== brightness;
 
   const swatchCss = approxSwatch(hue, saturation, brightness);
 
@@ -255,19 +303,54 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       {!loading && !error && supported && (
         <>
           <p className="text-xs text-text-secondary">
-            Recolor {heroName}&apos;s ability effects (particles, projectiles, and the ult body) to
-            a color. Adjust hue, saturation, and brightness; the preview shows a real ability
-            texture recolored to your pick.
+            Recolor {heroName}&apos;s ability effects (particles, projectiles, and the ult body).
+            Pick a single color, or spread the VFX across a rainbow with Prism.
           </p>
+
+          {/* Mode toggle: a single picked color vs the rainbow prism. */}
+          <div className="inline-flex rounded-md border border-border p-0.5 text-xs">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setMode('hue')}
+              className={`flex items-center gap-1.5 rounded px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed ${
+                mode === 'hue'
+                  ? 'bg-accent text-white'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              <Palette className="h-3.5 w-3.5" /> Single Color
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setMode('prism')}
+              className={`flex items-center gap-1.5 rounded px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed ${
+                mode === 'prism'
+                  ? 'bg-accent text-white'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              <Sparkles className="h-3.5 w-3.5" /> Rainbow
+            </button>
+          </div>
 
           {/* Live recolored preview + current target */}
           <div className="flex items-center gap-3">
             <div
               className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-md border border-border shadow-inner"
-              style={{ backgroundColor: swatchCss }}
-              aria-label={`Hue ${hue}, saturation ${pct(saturation)}%, brightness ${pct(brightness)}%`}
+              style={
+                mode === 'prism'
+                  ? { background: rainbowGradient(hue, saturation, brightness) }
+                  : { backgroundColor: swatchCss }
+              }
+              aria-label={
+                mode === 'prism'
+                  ? `Rainbow prism${animated ? ', animated' : ''}`
+                  : `Hue ${hue}, saturation ${pct(saturation)}%, brightness ${pct(brightness)}%`
+              }
             >
-              {previewUrl && !previewFailed && (
+              {mode === 'hue' && previewUrl && !previewFailed && (
                 <img
                   src={previewUrl}
                   alt="Ability color preview"
@@ -275,7 +358,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
                   style={{ imageRendering: 'auto' }}
                 />
               )}
-              {previewLoading && (
+              {mode === 'hue' && previewLoading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/20">
                   <Loader2 className="h-4 w-4 animate-spin text-white/80" />
                 </div>
@@ -283,21 +366,28 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
             </div>
             <div className="min-w-0">
               <div className="text-sm font-semibold text-text-primary tabular-nums">
-                {hue}&deg; &middot; S {pct(saturation)}% &middot; B {pct(brightness)}%
+                {mode === 'prism'
+                  ? `Rainbow${animated ? ' (animated)' : ''} · rot ${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`
+                  : `${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`}
               </div>
               <div className="text-[11px] text-text-secondary">
                 {!applied
                   ? 'No color applied'
                   : !dirty
                     ? 'Applied'
-                    : `Applied: ${activeHue}° / S ${pct(activeSaturation ?? 1)}% / B ${pct(activeBrightness ?? 1)}%`}
+                    : activeMode === 'prism'
+                      ? `Applied: Rainbow${activeAnimated ? ' (animated)' : ''} · rot ${activeHue ?? 0}°`
+                      : `Applied: ${activeHue}° / S ${pct(activeSaturation ?? 1)}% / B ${pct(activeBrightness ?? 1)}%`}
               </div>
             </div>
           </div>
 
-          {/* Hue slider over a rainbow track */}
+          {/* Hue slider over a rainbow track. In prism mode it rotates where the
+              spectrum starts rather than picking one color. */}
           <label className="block space-y-1">
-            <span className="text-[11px] font-medium text-text-secondary">Hue</span>
+            <span className="text-[11px] font-medium text-text-secondary">
+              {mode === 'prism' ? 'Rainbow rotation' : 'Hue'}
+            </span>
             <input
               type="range"
               min={0}
@@ -354,7 +444,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
             />
           </label>
 
-          {/* Preset colors (each sets hue + saturation + brightness) */}
+          {/* Preset colors (single-color mode only; each sets hue + saturation + brightness) */}
+          {mode === 'hue' && (
           <div className="flex flex-wrap gap-1.5">
             {PRESETS.map((p) => {
               const selected =
@@ -375,6 +466,28 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               );
             })}
           </div>
+          )}
+
+          {mode === 'prism' && (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={animated}
+                  disabled={busy}
+                  onChange={(e) => setAnimated(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-accent disabled:cursor-not-allowed"
+                />
+                <span className="font-medium text-text-primary">Animated</span>
+                <span>sweep the spectrum over each effect&apos;s lifetime</span>
+              </label>
+              <p className="text-[11px] text-text-secondary/80">
+                Prism spreads {heroName}&apos;s existing ability colors across a rainbow instead of
+                one hue. Use the sliders above to rotate the spectrum and tune its saturation /
+                brightness. Animated adds a moving sweep on the showy effects (glow, beams, trails).
+              </p>
+            </div>
+          )}
 
           {/* Actions */}
           <div className="flex items-center gap-2 pt-1">
@@ -389,7 +502,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               ) : (
                 <Check className="h-3.5 w-3.5" />
               )}
-              {applied && !dirty ? 'Applied' : 'Apply Color'}
+              {applied && !dirty ? 'Applied' : mode === 'prism' ? 'Apply Rainbow' : 'Apply Color'}
             </button>
             {applied && (
               <button

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
 import type { HeroPortrait, SoulModelInfo, HeroPoseInfo } from '../types/portrait';
 import type {
   GameBananaModsResponse,
@@ -202,6 +202,18 @@ export async function applyHeroColor(
   brightness: number
 ): Promise<ApplyHeroColorResult> {
   return window.electronAPI.applyHeroColor(heroName, hue, saturation, brightness);
+}
+
+/** Apply the rainbow prism to a hero's ability VFX. In prism mode `hue` is the
+ *  spectrum rotation (degrees); saturation/brightness scale the spectrum. */
+export async function applyHeroPrism(
+  heroName: string,
+  hue: number,
+  saturation: number,
+  brightness: number,
+  animated: boolean
+): Promise<ApplyHeroPrismResult> {
+  return window.electronAPI.applyHeroPrism(heroName, hue, saturation, brightness, animated);
 }
 
 /** Render a fast PNG swatch of the recolor target as a data URL (live preview). */

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -21,6 +21,7 @@ import type {
     ApplyHeroSoundResult,
     ActiveHeroColor,
     ApplyHeroColorResult,
+    ApplyHeroPrismResult,
     LockerOverview,
     LockerCardThumbnail,
     LockerClearScope,
@@ -345,6 +346,13 @@ export interface ElectronAPI {
         saturation: number,
         brightness: number,
     ) => Promise<ApplyHeroColorResult>;
+    applyHeroPrism: (
+        heroName: string,
+        hue: number,
+        saturation: number,
+        brightness: number,
+        animated: boolean,
+    ) => Promise<ApplyHeroPrismResult>;
     previewHeroColor: (
         heroName: string,
         hue: number,

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -222,6 +222,13 @@ export interface LockerColorSelection {
   saturation: number;
   /** Brightness (HSV value) scale (1 = keep source, >1 lighter, <1 darker). */
   brightness: number;
+  /** Recolor mode. 'hue' (or absent, for older persisted entries) = one absolute
+   *  color via `recolor-hero`. 'prism' = a rainbow spectrum via `vpkmerge prism`;
+   *  in prism mode hue/saturation/brightness are ignored. */
+  mode?: 'hue' | 'prism';
+  /** Prism only: animate the spectrum so it sweeps over each particle's lifetime
+   *  (`prism --animated`). Ignored in hue mode. */
+  animated?: boolean;
   addedAt: string;
 }
 
@@ -240,12 +247,17 @@ export interface LockerColorsInfo {
 /** The color applied for a hero's ability VFX, read back so the color picker can
  *  reflect the active selection. */
 export interface ActiveHeroColor {
-  /** Applied absolute hue (0-359 degrees). */
+  /** Applied absolute hue (0-359 degrees). Meaningless in prism mode. */
   hue: number;
   /** Applied saturation scale (1 = source). */
   saturation: number;
   /** Applied brightness scale (1 = source). */
   brightness: number;
+  /** Which recolor is applied: a single hue or the rainbow prism. Absent on
+   *  older persisted entries (treat as 'hue'). */
+  mode?: 'hue' | 'prism';
+  /** Prism only: whether the applied spectrum is animated. */
+  animated?: boolean;
 }
 
 export interface ApplyHeroColorResult {
@@ -255,6 +267,18 @@ export interface ApplyHeroColorResult {
   saturation: number | null;
   /** The applied brightness scale, or null after a revert. */
   brightness: number | null;
+}
+
+/** Result of applying the rainbow prism to a hero's ability VFX. */
+export interface ApplyHeroPrismResult {
+  /** Applied spectrum rotation in degrees (prism reuses the hue field as a rotation). */
+  hue: number;
+  /** Applied saturation scale on the spectrum. */
+  saturation: number;
+  /** Applied brightness scale on the spectrum. */
+  brightness: number;
+  /** Whether the applied spectrum animates over each particle's lifetime. */
+  animated: boolean;
 }
 
 /**


### PR DESCRIPTION
> **Draft.** Stacked on `feat/hero-recolor-roster` (base), and depends on **vpkmerge 0.9.0** (Slush97/vpkmerge#14) for the new `prism --hue-offset/--saturation/--brightness` flags. The bundled vpkmerge binary is gitignored and fetched from a release, so this can't go green until 0.9.0 ships and `scripts/fetch-vpkmerge.mjs` is bumped to point at it.

## What

Adds a **Single Color / Rainbow** toggle to the hero Ability Color picker (Locker → hero → Ability Color).

- **Rainbow mode** drives `vpkmerge prism` instead of `recolor-hero`. The existing hue/saturation/brightness sliders are reused: hue becomes the spectrum **rotation**, saturation/brightness scale the spectrum. Plus an **Animated** checkbox (`prism --animated`).
- The swatch shows a live rotated/tinted rainbow; solid-color presets are hidden in Rainbow mode.
- **Yamato** is wired into the hero ability-color map, so both single-hue and prism are now available for her.

## How

- `heroColors.ts`: `applyHeroPrism` + `ensureHeroPrismBake` shell out to `prism --hue-offset/--saturation/--brightness [--animated]`, cached per (codename, rotation, sat, brightness, animated), and fold into the same Locker colors VPK as the single-hue bakes.
- IPC `apply-hero-prism` + preload + `electron.d.ts` + `api.ts` + `mod.ts` types.
- `HeroColorPicker.tsx`: mode toggle, prism-aware preview/dirty/apply, Animated checkbox.

## Test plan

- `tsc --noEmit` (app + node projects) and ESLint clean on all changed files.
- In-app + in-game: not yet exercised (needs the 0.9.0 binary + a Deadlock restart to mount). Once 0.9.0 is released: open Colors tab → hero → **Rainbow**, drag rotation/sat/brightness, **Apply**, confirm in game.

## Merge order

1. Land/merge `feat/hero-recolor-roster` (this PR's base).
2. Merge & release vpkmerge#14 as **0.9.0**; bump `scripts/fetch-vpkmerge.mjs` (version + sha).
3. Re-target this PR to `main` and merge.