### PR TITLE
feat(locker): gradient ability-color recolor mode

### DIFF
--- a/electron/main/ipc/abilityColors.ts
+++ b/electron/main/ipc/abilityColors.ts
@@ -56,10 +56,19 @@ ipcMain.handle(
         saturation: number,
         brightness: number,
         animated: boolean,
+        gradient: string | null,
     ): Promise<ApplyHeroPrismResult> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return applyHeroPrism(deadlockPath, heroName, hue, saturation, brightness, animated);
+        return applyHeroPrism(
+            deadlockPath,
+            heroName,
+            hue,
+            saturation,
+            brightness,
+            animated,
+            gradient,
+        );
     },
 );
 

--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -50,12 +50,22 @@ import type {
  */
 const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
     Paige: 'bookworm',
+    // Added from local disabled-mod particle scans + vpkmerge texture audits.
+    Abrams: 'abrams',
+    Apollo: 'fencer',
+    Calico: 'nano',
+    'Lady Geist': 'ghost',
+    Lash: 'lash',
+    McGinnis: 'mcginnis',
+    Pocket: 'pocket',
+    Sinclair: 'magician',
     // Particle-only heroes (no color textures / vertex colors): their recipe has no
     // preview_texture, so the live swatch falls back to the approximate CSS chip;
     // recolor-hero still bakes them. The patcher handles v4 + v5 particles, so each
     // recolors at full coverage. Keep this in lockstep with `recipe_for` in
     // vpkmerge-core/src/hero_recolor.rs.
     Celeste: 'unicorn',
+    Holliday: 'astro',
     Mina: 'vampirebat',
     Seven: 'gigawatt',
     Wraith: 'wraith',
@@ -160,14 +170,18 @@ function prismCachePath(
     sat: number,
     brightness: number,
     animated: boolean,
+    gradient: string | null,
 ): string {
     const dir = join(app.getPath('userData'), 'ability-colors');
     const s = Math.round(sat * 100);
     const b = Math.round(brightness * 100);
     const anim = animated ? '_anim' : '';
+    // Gradient is part of the bake identity. Sanitize the spec into a filesystem-
+    // safe token (preset name stays readable, custom stops keep their structure).
+    const grad = gradient ? `_g${gradient.replace(/[^a-z0-9]+/gi, '-')}` : '';
     return join(
         dir,
-        `${codename}_prism_h${hue}_s${s}_b${b}${anim}_v${RECIPE_CACHE_VERSION}_dir.vpk`,
+        `${codename}_prism_h${hue}_s${s}_b${b}${anim}${grad}_v${RECIPE_CACHE_VERSION}_dir.vpk`,
     );
 }
 
@@ -227,15 +241,17 @@ async function ensureHeroPrismBake(
     sat: number,
     brightness: number,
     animated: boolean,
+    gradient: string | null,
 ): Promise<string> {
-    const cachePath = prismCachePath(codename, hue, sat, brightness, animated);
+    const cachePath = prismCachePath(codename, hue, sat, brightness, animated, gradient);
     if (existsSync(cachePath)) return cachePath;
 
     const dir = join(app.getPath('userData'), 'ability-colors');
     await fs.mkdir(dir, { recursive: true });
     const tmp = join(dir, `.${codename}_prism_${randomUUID()}_dir.vpk`);
     try {
-        // In prism mode `hue` is the spectrum rotation (degrees), not an absolute hue.
+        // In prism mode `hue` is the spectrum rotation (degrees), not an absolute hue;
+        // `gradient` (when set) spreads the spectrum over a preset/custom ramp.
         const args = [
             'prism',
             '--hero',
@@ -252,6 +268,7 @@ async function ensureHeroPrismBake(
             tmp,
         ];
         if (animated) args.push('--animated');
+        if (gradient) args.push('--gradient', gradient);
         await runVpkmerge(args);
         await verifyVpkOutput(tmp);
         await fs.rename(tmp, cachePath);
@@ -294,11 +311,12 @@ async function rebuildLockerColors(
         throw new Error('Base game pak01_dir.vpk not found; check the Deadlock path in Settings.');
     }
 
-    // Bake (or reuse) each hero's recolor addon: single hue or rainbow prism.
+    // Bake (or reuse) each hero's recolor addon: single hue, rainbow prism, or a
+    // custom gradient (prism + a gradient spec).
     const caches: string[] = [];
     for (const sel of valid) {
         caches.push(
-            sel.mode === 'prism'
+            sel.mode === 'prism' || sel.mode === 'gradient'
                 ? await ensureHeroPrismBake(
                       pak01,
                       sel.heroCodename,
@@ -306,6 +324,7 @@ async function rebuildLockerColors(
                       sel.saturation,
                       sel.brightness,
                       sel.animated ?? false,
+                      sel.mode === 'gradient' ? (sel.gradient ?? null) : null,
                   )
                 : await ensureHeroColorBake(
                       pak01,
@@ -393,6 +412,7 @@ export async function applyHeroPrism(
     saturation: number,
     brightness: number,
     animated: boolean,
+    gradient: string | null,
 ): Promise<ApplyHeroPrismResult> {
     vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
     const codename = colorCodenameForHero(heroName);
@@ -401,10 +421,12 @@ export async function applyHeroPrism(
     }
     ensureGrimoireConfigured(deadlockPath);
 
-    // In prism mode `hue` is the spectrum rotation; saturation/brightness scale it.
+    // In prism/gradient mode `hue` is the spectrum rotation; saturation/brightness
+    // scale it. A non-empty `gradient` spec switches to gradient mode.
     const normHue = normalizeHue(hue);
     const normSat = normalizeSaturation(saturation);
     const normBright = normalizeBrightness(brightness);
+    const grad = gradient && gradient.trim() ? gradient.trim() : null;
     const current = currentColorSelections();
     const next: LockerColorSelection[] = [
         ...current.filter((s) => s.heroCodename !== codename),
@@ -414,13 +436,14 @@ export async function applyHeroPrism(
             hue: normHue,
             saturation: normSat,
             brightness: normBright,
-            mode: 'prism',
+            mode: grad ? 'gradient' : 'prism',
             animated,
+            ...(grad ? { gradient: grad } : {}),
             addedAt: new Date().toISOString(),
         },
     ];
     await rebuildLockerColors(deadlockPath, next);
-    return { hue: normHue, saturation: normSat, brightness: normBright, animated };
+    return { hue: normHue, saturation: normSat, brightness: normBright, animated, gradient: grad };
 }
 
 /** Remove hero X's ability color, reverting its VFX to vanilla. */
@@ -452,6 +475,7 @@ export function getActiveHeroColor(heroName: string): ActiveHeroColor | null {
               brightness: sel.brightness,
               mode: sel.mode ?? 'hue',
               animated: sel.animated ?? false,
+              ...(sel.gradient ? { gradient: sel.gradient } : {}),
           }
         : null;
 }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -842,7 +842,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
         saturation: number,
         brightness: number,
         animated: boolean,
-    ) => ipcRenderer.invoke('apply-hero-prism', heroName, hue, saturation, brightness, animated),
+        gradient: string | null,
+    ) =>
+        ipcRenderer.invoke(
+            'apply-hero-prism',
+            heroName,
+            hue,
+            saturation,
+            brightness,
+            animated,
+            gradient,
+        ),
     previewHeroColor: (heroName: string, hue: number, saturation: number, brightness: number) =>
         ipcRenderer.invoke('preview-hero-color', heroName, hue, saturation, brightness),
     revertHeroColor: (heroName: string) =>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -353,7 +353,7 @@ export default function Layout() {
                     ? 'border-red-500/40 bg-red-500/15 text-red-200'
                     : isSuccess
                     ? 'border-green-500/40 bg-green-500/15 text-green-200'
-                    : 'border-accent/40 bg-accent/15 text-accent-foreground'
+                    : 'border-accent/40 bg-accent/15 text-text-primary'
                 }`}
               >
                 <div className="flex items-center gap-2 px-4 py-2">

--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -26,6 +26,12 @@ import {
 } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import { getHeroChipIconPath } from '../lib/lockerUtils';
+import {
+    rainbowCss,
+    gradientCss,
+    stopsForSpec,
+    gradientLabelOf,
+} from '../lib/abilityColorPreview';
 import type {
     AbilitySlot,
     AbilitySoundParams,
@@ -633,6 +639,41 @@ export function LockerOverridesModal({
                                 {colors.map((color) => {
                                     const key = `color:${color.heroName}`;
                                     const isRemoving = removing === key;
+                                    const mode = color.mode ?? 'hue';
+                                    // The swatch + label reflect the recolor MODE: a flat hue
+                                    // chip, the rainbow prism, or the chosen gradient ramp (sampled
+                                    // the same way the engine bakes it).
+                                    const swatchStyle =
+                                        mode === 'prism'
+                                            ? {
+                                                  background: rainbowCss(
+                                                      color.hue,
+                                                      color.saturation,
+                                                      color.brightness,
+                                                  ),
+                                              }
+                                            : mode === 'gradient'
+                                              ? {
+                                                    background: gradientCss(
+                                                        stopsForSpec(color.gradient),
+                                                        color.hue,
+                                                        color.saturation,
+                                                        color.brightness,
+                                                    ),
+                                                }
+                                              : {
+                                                    backgroundColor: swatchColor(
+                                                        color.hue,
+                                                        color.saturation,
+                                                        color.brightness,
+                                                    ),
+                                                };
+                                    const headline =
+                                        mode === 'prism'
+                                            ? `Rainbow · rot ${Math.round(color.hue)}°`
+                                            : mode === 'gradient'
+                                              ? `${gradientLabelOf(color.gradient)} gradient · rot ${Math.round(color.hue)}°`
+                                              : `Hue ${Math.round(color.hue)}°`;
                                     return (
                                         <div
                                             key={key}
@@ -641,13 +682,7 @@ export function LockerOverridesModal({
                                             <HeroIcon heroName={color.heroName} />
                                             <span
                                                 className="h-9 w-9 flex-shrink-0 rounded-full ring-1 ring-white/15"
-                                                style={{
-                                                    backgroundColor: swatchColor(
-                                                        color.hue,
-                                                        color.saturation,
-                                                        color.brightness,
-                                                    ),
-                                                }}
+                                                style={swatchStyle}
                                                 aria-hidden
                                             />
                                             <div className="min-w-0 flex-1">
@@ -655,7 +690,7 @@ export function LockerOverridesModal({
                                                     {color.heroName}
                                                 </div>
                                                 <div className="truncate text-xs text-text-secondary tabular-nums">
-                                                    Hue {Math.round(color.hue)}&deg;
+                                                    {headline}
                                                     {color.saturation !== 1 &&
                                                         ` · Sat ${color.saturation.toFixed(2)}x`}
                                                     {color.brightness !== 1 &&

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -329,10 +329,10 @@ export default function ModDetailsModal({
           disabled={isBusyThis}
           className={`flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2 min-w-[110px] text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
             isUpdate
-              ? 'bg-accent hover:bg-accent-hover text-white'
+              ? 'bg-accent hover:bg-accent-hover text-accent-foreground'
               : isInstalled
                 ? 'bg-bg-secondary hover:bg-bg-primary text-text-primary border border-border'
-                : 'bg-accent hover:bg-accent-hover text-white'
+                : 'bg-accent hover:bg-accent-hover text-accent-foreground'
           }`}
         >
           {isDownloadingThis ? (

--- a/src/components/crosshair/CrosshairPresetCard.tsx
+++ b/src/components/crosshair/CrosshairPresetCard.tsx
@@ -40,7 +40,7 @@ export default function CrosshairPresetCard({
                 {/* Active indicator */}
                 {isActive && (
                     <div className="absolute top-2 right-2 bg-accent rounded-full p-1">
-                        <Check className="w-3 h-3 text-white" />
+                        <Check className="w-3 h-3 text-accent-foreground" />
                     </div>
                 )}
 

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -180,7 +180,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
                     {group.modFileName.replace(/_dir\.vpk$/, '')}
                   </span>
                   {isApplied ? (
-                    <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
+                    <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-accent-foreground">
                       <Check className="h-2.5 w-2.5" /> Applied
                     </span>
                   ) : (

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw, Sparkles } from 'lucide-react';
+import { Palette, Loader2, AlertCircle, Check, RefreshCw, RotateCcw, Sparkles, Blend } from 'lucide-react';
 import {
   applyHeroColor,
   applyHeroPrism,
@@ -9,6 +9,16 @@ import {
   getHeroColorSupport,
   getGameRunningStatus,
 } from '../../lib/api';
+import {
+  GRADIENT_PRESETS,
+  DEFAULT_CUSTOM_STOPS,
+  gradientCss,
+  rainbowCss,
+  gradientSpecOf,
+  selectedGradientStops,
+  parseGradientSpec,
+  type GStop,
+} from '../../lib/abilityColorPreview';
 
 interface HeroColorPickerProps {
   heroName: string;
@@ -62,19 +72,6 @@ function approxSwatch(hue: number, saturation: number, brightness: number): stri
 
 const pct = (scale: number): number => Math.round(scale * 100);
 
-/** Rainbow swatch for the prism preview, rotated + scaled to mirror the spectrum
- *  tuning (no per-pixel bake to show). `hue` rotates the start; saturation and
- *  brightness scale the chips, matching what `prism --hue-offset/--saturation/
- *  --brightness` does to the baked VFX. */
-function rainbowGradient(hue: number, saturation: number, brightness: number): string {
-  const s = clamp(Math.round(85 * saturation), 0, 100);
-  const l = clamp(Math.round(55 * brightness), 12, 92);
-  const stops = [0, 60, 120, 180, 240, 300, 360]
-    .map((d) => `hsl(${Math.round((hue + d) % 360)}, ${s}%, ${l}%)`)
-    .join(', ');
-  return `linear-gradient(135deg, ${stops})`;
-}
-
 /**
  * EXPERIMENTAL: recolor a hero's ability VFX (particles + color textures + baked
  * vertex colors) to a chosen color. The target is hue + a saturation scale + a
@@ -95,12 +92,16 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   const [hue, setHue] = useState(DEFAULT_HUE);
   const [saturation, setSaturation] = useState(DEFAULT_SCALE);
   const [brightness, setBrightness] = useState(DEFAULT_SCALE);
-  // Recolor mode: a single picked color, or the rainbow prism (static/animated).
-  const [mode, setMode] = useState<'hue' | 'prism'>('hue');
+  // Recolor mode: a single picked color, the rainbow prism, or a custom gradient.
+  const [mode, setMode] = useState<'hue' | 'prism' | 'gradient'>('hue');
   const [animated, setAnimated] = useState(false);
-  // What's applied in-game: the mode (null = nothing) and, for prism, its animated flag.
-  const [activeMode, setActiveMode] = useState<'hue' | 'prism' | null>(null);
+  // Gradient mode: the chosen preset name (or 'custom') and the custom editor stops.
+  const [gradientPreset, setGradientPreset] = useState<string>(GRADIENT_PRESETS[0].name);
+  const [customStops, setCustomStops] = useState<GStop[]>(DEFAULT_CUSTOM_STOPS);
+  // What's applied in-game: the mode (null = nothing), its animated flag, and gradient.
+  const [activeMode, setActiveMode] = useState<'hue' | 'prism' | 'gradient' | null>(null);
   const [activeAnimated, setActiveAnimated] = useState(false);
+  const [activeGradient, setActiveGradient] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [changed, setChanged] = useState(false);
@@ -123,6 +124,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     setPreviewUnavailable(false);
     setMode('hue');
     setAnimated(false);
+    setGradientPreset(GRADIENT_PRESETS[0].name);
+    setCustomStops(DEFAULT_CUSTOM_STOPS);
     Promise.all([
       getHeroColorSupport(heroName),
       getActiveHeroColor(heroName),
@@ -137,9 +140,18 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
         setActiveSaturation(active?.saturation ?? null);
         setActiveBrightness(active?.brightness ?? null);
         setActiveAnimated(active?.animated ?? false);
-        if (active && activeM === 'prism') {
-          setMode('prism');
+        setActiveGradient(active?.gradient ?? null);
+        if (active && (activeM === 'prism' || activeM === 'gradient')) {
+          setMode(activeM);
           setAnimated(active.animated ?? false);
+          setHue(active.hue);
+          setSaturation(active.saturation);
+          setBrightness(active.brightness);
+          if (activeM === 'gradient') {
+            const parsed = parseGradientSpec(active.gradient);
+            setGradientPreset(parsed.preset);
+            setCustomStops(parsed.stops);
+          }
         } else if (active) {
           setHue(active.hue);
           setSaturation(active.saturation);
@@ -162,8 +174,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   // sliders stay smooth. Best-effort: if it can't render (no game path, old
   // binary) we silently fall back to the approximate CSS swatch.
   useEffect(() => {
-    // Prism has no per-pixel swatch to bake; it shows a rainbow chip instead.
-    if (!supported || busy || previewUnavailable || mode === 'prism') return;
+    // Prism / gradient have no per-pixel swatch to bake; they show a CSS chip instead.
+    if (!supported || busy || previewUnavailable || mode !== 'hue') return;
     let cancelled = false;
     setPreviewLoading(true);
     const handle = setTimeout(() => {
@@ -203,14 +215,16 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
     setBusy(true);
     setActionError(null);
     try {
-      if (mode === 'prism') {
-        const result = await applyHeroPrism(heroName, hue, saturation, brightness, animated);
+      if (mode === 'prism' || mode === 'gradient') {
+        const grad = mode === 'gradient' ? gradientSpecOf(gradientPreset, customStops) : null;
+        const result = await applyHeroPrism(heroName, hue, saturation, brightness, animated, grad);
         if (!mounted.current) return;
-        setActiveMode('prism');
+        setActiveMode(mode);
         setActiveHue(result.hue);
         setActiveSaturation(result.saturation);
         setActiveBrightness(result.brightness);
         setActiveAnimated(result.animated);
+        setActiveGradient(result.gradient);
       } else {
         const result = await applyHeroColor(heroName, hue, saturation, brightness);
         if (!mounted.current) return;
@@ -240,6 +254,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
       setActiveSaturation(null);
       setActiveBrightness(null);
       setActiveAnimated(false);
+      setActiveGradient(null);
       setChanged(true);
       await refreshGameRunning();
     } catch (err) {
@@ -256,17 +271,26 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
   };
 
   const applied = activeMode !== null;
+  const gradientSpec = gradientSpecOf(gradientPreset, customStops);
+  const gradientStops = selectedGradientStops(gradientPreset, customStops);
+  const gradientLabel =
+    gradientPreset === 'custom'
+      ? 'Custom'
+      : (GRADIENT_PRESETS.find((g) => g.name === gradientPreset)?.label ?? gradientPreset);
+  const spectrumDirty =
+    activeAnimated !== animated ||
+    activeHue !== hue ||
+    activeSaturation !== saturation ||
+    activeBrightness !== brightness;
   const dirty =
-    mode === 'prism'
-      ? activeMode !== 'prism' ||
-        activeAnimated !== animated ||
-        activeHue !== hue ||
-        activeSaturation !== saturation ||
-        activeBrightness !== brightness
-      : activeMode !== 'hue' ||
-        activeHue !== hue ||
-        activeSaturation !== saturation ||
-        activeBrightness !== brightness;
+    mode === 'gradient'
+      ? activeMode !== 'gradient' || activeGradient !== gradientSpec || spectrumDirty
+      : mode === 'prism'
+        ? activeMode !== 'prism' || spectrumDirty
+        : activeMode !== 'hue' ||
+          activeHue !== hue ||
+          activeSaturation !== saturation ||
+          activeBrightness !== brightness;
 
   const swatchCss = approxSwatch(hue, saturation, brightness);
 
@@ -304,7 +328,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
         <>
           <p className="text-xs text-text-secondary">
             Recolor {heroName}&apos;s ability effects (particles, projectiles, and the ult body).
-            Pick a single color, or spread the VFX across a rainbow with Prism.
+            Pick a single color, a rainbow, or spread the VFX over a gradient.
           </p>
 
           {/* Mode toggle: a single picked color vs the rainbow prism. */}
@@ -315,8 +339,8 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               onClick={() => setMode('hue')}
               className={`flex items-center gap-1.5 rounded px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed ${
                 mode === 'hue'
-                  ? 'bg-accent text-white'
-                  : 'text-text-secondary hover:text-text-primary'
+                  ? 'border border-accent/40 bg-accent/10 text-text-primary'
+                  : 'border border-transparent text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
               }`}
             >
               <Palette className="h-3.5 w-3.5" /> Single Color
@@ -327,11 +351,23 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               onClick={() => setMode('prism')}
               className={`flex items-center gap-1.5 rounded px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed ${
                 mode === 'prism'
-                  ? 'bg-accent text-white'
-                  : 'text-text-secondary hover:text-text-primary'
+                  ? 'border border-accent/40 bg-accent/10 text-text-primary'
+                  : 'border border-transparent text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
               }`}
             >
               <Sparkles className="h-3.5 w-3.5" /> Rainbow
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setMode('gradient')}
+              className={`flex items-center gap-1.5 rounded px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed ${
+                mode === 'gradient'
+                  ? 'border border-accent/40 bg-accent/10 text-text-primary'
+                  : 'border border-transparent text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
+              }`}
+            >
+              <Blend className="h-3.5 w-3.5" /> Gradient
             </button>
           </div>
 
@@ -341,13 +377,17 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-md border border-border shadow-inner"
               style={
                 mode === 'prism'
-                  ? { background: rainbowGradient(hue, saturation, brightness) }
-                  : { backgroundColor: swatchCss }
+                  ? { background: rainbowCss(hue, saturation, brightness) }
+                  : mode === 'gradient'
+                    ? { background: gradientCss(gradientStops, hue, saturation, brightness) }
+                    : { backgroundColor: swatchCss }
               }
               aria-label={
                 mode === 'prism'
                   ? `Rainbow prism${animated ? ', animated' : ''}`
-                  : `Hue ${hue}, saturation ${pct(saturation)}%, brightness ${pct(brightness)}%`
+                  : mode === 'gradient'
+                    ? `${gradientLabel} gradient${animated ? ', animated' : ''}`
+                    : `Hue ${hue}, saturation ${pct(saturation)}%, brightness ${pct(brightness)}%`
               }
             >
               {mode === 'hue' && previewUrl && !previewFailed && (
@@ -368,7 +408,9 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               <div className="text-sm font-semibold text-text-primary tabular-nums">
                 {mode === 'prism'
                   ? `Rainbow${animated ? ' (animated)' : ''} · rot ${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`
-                  : `${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`}
+                  : mode === 'gradient'
+                    ? `${gradientLabel}${animated ? ' (animated)' : ''} · rot ${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`
+                    : `${hue}° · S ${pct(saturation)}% · B ${pct(brightness)}%`}
               </div>
               <div className="text-[11px] text-text-secondary">
                 {!applied
@@ -377,7 +419,9 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
                     ? 'Applied'
                     : activeMode === 'prism'
                       ? `Applied: Rainbow${activeAnimated ? ' (animated)' : ''} · rot ${activeHue ?? 0}°`
-                      : `Applied: ${activeHue}° / S ${pct(activeSaturation ?? 1)}% / B ${pct(activeBrightness ?? 1)}%`}
+                      : activeMode === 'gradient'
+                        ? `Applied: ${activeGradient && GRADIENT_PRESETS.some((g) => g.name === activeGradient) ? (GRADIENT_PRESETS.find((g) => g.name === activeGradient)?.label ?? 'Gradient') : 'Custom'} gradient${activeAnimated ? ' (animated)' : ''}`
+                        : `Applied: ${activeHue}° / S ${pct(activeSaturation ?? 1)}% / B ${pct(activeBrightness ?? 1)}%`}
               </div>
             </div>
           </div>
@@ -386,7 +430,7 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
               spectrum starts rather than picking one color. */}
           <label className="block space-y-1">
             <span className="text-[11px] font-medium text-text-secondary">
-              {mode === 'prism' ? 'Rainbow rotation' : 'Hue'}
+              {mode === 'hue' ? 'Hue' : 'Rotation'}
             </span>
             <input
               type="range"
@@ -489,20 +533,113 @@ export default function HeroColorPicker({ heroName }: HeroColorPickerProps) {
             </div>
           )}
 
+          {mode === 'gradient' && (
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-1.5">
+                {GRADIENT_PRESETS.map((g) => (
+                  <button
+                    key={g.name}
+                    type="button"
+                    disabled={busy}
+                    onClick={() => setGradientPreset(g.name)}
+                    title={g.label}
+                    className={`h-7 w-10 rounded border transition-transform hover:scale-105 disabled:cursor-not-allowed ${
+                      gradientPreset === g.name
+                        ? 'border-text-primary ring-2 ring-accent/60'
+                        : 'border-border'
+                    }`}
+                    style={{ background: gradientCss(g.stops, 0, 1, 1) }}
+                    aria-label={g.label}
+                  />
+                ))}
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setGradientPreset('custom')}
+                  title="Custom gradient"
+                  className={`flex h-7 items-center rounded border px-2 text-[11px] font-medium transition-colors disabled:cursor-not-allowed ${
+                    gradientPreset === 'custom'
+                      ? 'border-text-primary text-text-primary ring-2 ring-accent/60'
+                      : 'border-border text-text-secondary hover:text-text-primary'
+                  }`}
+                >
+                  Custom
+                </button>
+              </div>
+
+              {gradientPreset === 'custom' && (
+                <div className="space-y-1.5 rounded-md border border-border/60 bg-bg-secondary/40 p-2">
+                  {customStops.map((st, i) => (
+                    <label key={i} className="block space-y-0.5">
+                      <span className="text-[10px] font-medium text-text-secondary">
+                        Stop {i + 1}{' '}
+                        <span className="tabular-nums text-text-secondary/70">
+                          {Math.round(st.hue)}&deg;
+                        </span>
+                      </span>
+                      <input
+                        type="range"
+                        min={0}
+                        max={359}
+                        step={1}
+                        value={Math.round(st.hue)}
+                        disabled={busy}
+                        onChange={(e) => {
+                          const hueVal = Number(e.target.value);
+                          setCustomStops((prev) =>
+                            prev.map((s, j) => (j === i ? { ...s, hue: hueVal } : s)),
+                          );
+                        }}
+                        className="h-2.5 w-full cursor-pointer appearance-none rounded-full disabled:cursor-not-allowed"
+                        style={{
+                          background:
+                            'linear-gradient(to right, hsl(0,85%,55%), hsl(60,85%,55%), hsl(120,85%,55%), hsl(180,85%,55%), hsl(240,85%,55%), hsl(300,85%,55%), hsl(360,85%,55%))',
+                        }}
+                      />
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              <label className="flex items-center gap-2 text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={animated}
+                  disabled={busy}
+                  onChange={(e) => setAnimated(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-accent disabled:cursor-not-allowed"
+                />
+                <span className="font-medium text-text-primary">Animated</span>
+                <span>sweep the gradient over each effect&apos;s lifetime</span>
+              </label>
+              <p className="text-[11px] text-text-secondary/80">
+                Gradient spreads {heroName}&apos;s ability colors over a chosen ramp instead of the
+                full rainbow. Pick a preset or Custom (a hue per stop); the sliders above rotate and
+                tune it.
+              </p>
+            </div>
+          )}
+
           {/* Actions */}
           <div className="flex items-center gap-2 pt-1">
             <button
               type="button"
               onClick={handleApply}
               disabled={busy || !dirty}
-              className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-accent-foreground transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               {busy ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : (
                 <Check className="h-3.5 w-3.5" />
               )}
-              {applied && !dirty ? 'Applied' : mode === 'prism' ? 'Apply Rainbow' : 'Apply Color'}
+              {applied && !dirty
+                ? 'Applied'
+                : mode === 'prism'
+                  ? 'Apply Rainbow'
+                  : mode === 'gradient'
+                    ? 'Apply Gradient'
+                    : 'Apply Color'}
             </button>
             {applied && (
               <button

--- a/src/components/locker/HeroSoundPicker.tsx
+++ b/src/components/locker/HeroSoundPicker.tsx
@@ -193,7 +193,7 @@ function SoundSourceRow({
         {isBusy ? (
           <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-accent" />
         ) : isActive ? (
-          <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
+          <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-accent-foreground">
             <Check className="h-2.5 w-2.5" /> Applied
           </span>
         ) : (
@@ -256,7 +256,7 @@ function SoundToggleRow({
           )}
         </span>
         {mod.enabled ? (
-          <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-white">
+          <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-accent-foreground">
             <Check className="h-2.5 w-2.5" /> On
           </span>
         ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,11 @@
   --color-bg-tertiary: #242424;
   --color-accent: #f97316;
   --color-accent-hover: #ea580c;
+  /* Foreground (text/icon) color for solid `bg-accent` surfaces. Flips between
+     white and near-black based on the accent's luminance so a light user accent
+     (cyan, emerald, amber) stays readable. Computed at runtime in
+     applyAccentColor(); this default matches the shipped Ember orange. */
+  --color-accent-foreground: #ffffff;
   --color-text-primary: #ffffff;
   --color-text-secondary: #a1a1aa;
   --color-text-tertiary: #8a8a94;

--- a/src/lib/abilityColorPreview.ts
+++ b/src/lib/abilityColorPreview.ts
@@ -1,0 +1,149 @@
+/**
+ * CSS previews for ability-color recolors, kept in sync with vpkmerge's engine so
+ * the swatch the user sees matches what gets baked (hero_recolor.rs):
+ *  - single hue  -> a flat hsl chip
+ *  - rainbow     -> the full wheel, rotated/scaled by the spectrum tuning
+ *  - gradient    -> a custom ramp sampled along the SHORTEST hue arc (matching
+ *                   PrismGradient::sample), so a wrap-crossing gradient (e.g. pink
+ *                   -> orange) reads through red, not the long way through cyan.
+ *
+ * The bake keeps each effect's own brightness; these chips use a fixed lightness,
+ * so the hue path + saturation match exactly while brightness is approximate.
+ */
+
+export interface GStop {
+  pos: number;
+  hue: number;
+  sat: number;
+}
+
+export interface GradientPreset {
+  name: string;
+  label: string;
+  stops: GStop[];
+}
+
+/** Built-in gradients. Hues mirror vpkmerge's `PrismGradient::preset`. */
+export const GRADIENT_PRESETS: ReadonlyArray<GradientPreset> = [
+  { name: 'fire', label: 'Fire', stops: [{ pos: 0, hue: 0, sat: 1 }, { pos: 0.5, hue: 25, sat: 1 }, { pos: 1, hue: 50, sat: 1 }] },
+  { name: 'ice', label: 'Ice', stops: [{ pos: 0, hue: 190, sat: 1 }, { pos: 0.5, hue: 215, sat: 0.9 }, { pos: 1, hue: 205, sat: 0.25 }] },
+  { name: 'toxic', label: 'Toxic', stops: [{ pos: 0, hue: 110, sat: 1 }, { pos: 0.5, hue: 90, sat: 1 }, { pos: 1, hue: 72, sat: 1 }] },
+  { name: 'sunset', label: 'Sunset', stops: [{ pos: 0, hue: 280, sat: 1 }, { pos: 0.5, hue: 325, sat: 0.95 }, { pos: 1, hue: 30, sat: 1 }] },
+  { name: 'ocean', label: 'Ocean', stops: [{ pos: 0, hue: 175, sat: 1 }, { pos: 0.5, hue: 205, sat: 1 }, { pos: 1, hue: 235, sat: 1 }] },
+  { name: 'neon', label: 'Neon', stops: [{ pos: 0, hue: 300, sat: 1 }, { pos: 0.5, hue: 240, sat: 1 }, { pos: 1, hue: 180, sat: 1 }] },
+  { name: 'gold', label: 'Gold', stops: [{ pos: 0, hue: 25, sat: 1 }, { pos: 0.5, hue: 45, sat: 1 }, { pos: 1, hue: 55, sat: 0.55 }] },
+  { name: 'void', label: 'Void', stops: [{ pos: 0, hue: 270, sat: 1 }, { pos: 0.5, hue: 305, sat: 1 }, { pos: 1, hue: 240, sat: 1 }] },
+];
+
+/** Default 3-stop custom gradient (purple -> teal -> gold). */
+export const DEFAULT_CUSTOM_STOPS: GStop[] = [
+  { pos: 0, hue: 280, sat: 1 },
+  { pos: 0.5, hue: 190, sat: 1 },
+  { pos: 1, hue: 50, sat: 1 },
+];
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+/** (hue, sat) at spectral position `t`, shortest-arc hue interp. Mirrors the Rust
+ *  `PrismGradient::sample`, so previews track the bake. */
+function sampleHueSat(stops: GStop[], t: number): { hue: number; sat: number } {
+  const tt = clamp(t, 0, 1);
+  if (tt <= stops[0].pos) return { hue: stops[0].hue, sat: stops[0].sat };
+  const last = stops[stops.length - 1];
+  if (tt >= last.pos) return { hue: last.hue, sat: last.sat };
+  for (let i = 0; i < stops.length - 1; i++) {
+    const a = stops[i];
+    const b = stops[i + 1];
+    if (tt >= a.pos && tt <= b.pos) {
+      const f = (tt - a.pos) / Math.max(1e-9, b.pos - a.pos);
+      let dh = b.hue - a.hue;
+      if (dh > 180) dh -= 360;
+      else if (dh < -180) dh += 360;
+      return { hue: a.hue + dh * f, sat: a.sat + (b.sat - a.sat) * f };
+    }
+  }
+  return { hue: last.hue, sat: last.sat };
+}
+
+/** CSS `linear-gradient` for a stop list, sampled at 12 steps along the shortest
+ *  hue arc so it follows the same path the engine bakes. rotation/sat/brightness
+ *  layer on top, mirroring `prism --hue-offset/--saturation/--brightness`. */
+export function gradientCss(
+  stops: GStop[],
+  rotation: number,
+  satScale: number,
+  brightScale: number
+): string {
+  const l = clamp(Math.round(55 * brightScale), 12, 92);
+  const steps = 12;
+  const parts: string[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const { hue, sat } = sampleHueSat(stops, t);
+    const h = ((Math.round(hue + rotation) % 360) + 360) % 360;
+    const s = clamp(Math.round(85 * sat * satScale), 0, 100);
+    parts.push(`hsl(${h}, ${s}%, ${l}%) ${Math.round(t * 100)}%`);
+  }
+  return `linear-gradient(135deg, ${parts.join(', ')})`;
+}
+
+/** CSS for the full rainbow prism, rotated/scaled by the spectrum tuning. */
+export function rainbowCss(rotation: number, satScale: number, brightScale: number): string {
+  const s = clamp(Math.round(85 * satScale), 0, 100);
+  const l = clamp(Math.round(55 * brightScale), 12, 92);
+  const stops = [0, 60, 120, 180, 240, 300, 360]
+    .map((d) => `hsl(${((Math.round(rotation + d) % 360) + 360) % 360}, ${s}%, ${l}%)`)
+    .join(', ');
+  return `linear-gradient(135deg, ${stops})`;
+}
+
+/** A flat hue chip (single-color mode). */
+export function hueSwatch(hue: number, saturation: number, brightness: number): string {
+  const s = clamp(Math.round(72 * saturation), 0, 100);
+  const l = clamp(Math.round(52 * brightness), 8, 92);
+  return `hsl(${Math.round(hue)}, ${s}%, ${l}%)`;
+}
+
+/** The `--gradient` spec sent to vpkmerge: a preset name, or `pos:hue:sat,...`. */
+export function gradientSpecOf(preset: string, customStops: GStop[]): string {
+  if (preset !== 'custom') return preset;
+  return customStops.map((s) => `${s.pos}:${Math.round(s.hue)}:${s.sat}`).join(',');
+}
+
+/** The stops backing the current gradient selection (preset or custom editor). */
+export function selectedGradientStops(preset: string, customStops: GStop[]): GStop[] {
+  if (preset === 'custom') return customStops;
+  return GRADIENT_PRESETS.find((g) => g.name === preset)?.stops ?? GRADIENT_PRESETS[0].stops;
+}
+
+/** Resolve a persisted/applied gradient spec into its stops (preset or custom). */
+export function stopsForSpec(spec: string | undefined | null): GStop[] {
+  const parsed = parseGradientSpec(spec ?? undefined);
+  return selectedGradientStops(parsed.preset, parsed.stops);
+}
+
+/** Parse a gradient spec back into (preset, stops) for the editor / preview. */
+export function parseGradientSpec(spec: string | undefined): { preset: string; stops: GStop[] } {
+  if (spec && GRADIENT_PRESETS.some((g) => g.name === spec)) {
+    return { preset: spec, stops: DEFAULT_CUSTOM_STOPS };
+  }
+  if (spec) {
+    const stops = spec
+      .split(',')
+      .map((part) => part.split(':').map(Number))
+      .filter((n) => n.length >= 2 && n.every((x) => Number.isFinite(x)))
+      .map(([pos, hue, sat]) => ({ pos, hue, sat: sat ?? 1 }));
+    if (stops.length >= 2) return { preset: 'custom', stops };
+  }
+  return { preset: GRADIENT_PRESETS[0].name, stops: DEFAULT_CUSTOM_STOPS };
+}
+
+/** A human label for an applied gradient spec (preset label or "Custom"). */
+export function gradientLabelOf(spec: string | undefined | null): string {
+  if (spec && GRADIENT_PRESETS.some((g) => g.name === spec)) {
+    return GRADIENT_PRESETS.find((g) => g.name === spec)?.label ?? spec;
+  }
+  return 'Custom';
+}

--- a/src/lib/accentColor.ts
+++ b/src/lib/accentColor.ts
@@ -34,6 +34,23 @@ function darken(hex: string, amount = 0.12): string {
 }
 
 /**
+ * Readable text/icon color (white or near-black) for a solid swatch of `hex`.
+ *
+ * Uses WCAG relative luminance. The 0.35 threshold sits just above the shipped
+ * Ember orange (L ~ 0.32) so the default keeps white text, while genuinely
+ * light accents (cyan ~ 0.38, emerald ~ 0.36, amber ~ 0.44) flip to near-black.
+ * Near-black is the app's bg-primary so it reads as "ink" rather than pure #000.
+ */
+export function accentForeground(hex: string): string {
+  const m = (hex || '').replace('#', '').match(/.{2}/g);
+  if (!m) return '#ffffff';
+  const [r, g, b] = m.map((c) => parseInt(c, 16) / 255);
+  const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  const luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  return luminance > 0.35 ? '#0f0f0f' : '#ffffff';
+}
+
+/**
  * Write the accent color to the document root as CSS variables. Tailwind's
  * @theme tokens read these at use-site (e.g. `bg-accent`), so every component
  * already wired to `--color-accent` updates without rerendering.
@@ -48,4 +65,5 @@ export function applyAccentColor(color: string | null | undefined): void {
   const root = document.documentElement;
   root.style.setProperty('--color-accent', base);
   root.style.setProperty('--color-accent-hover', hover);
+  root.style.setProperty('--color-accent-foreground', accentForeground(base));
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -204,16 +204,26 @@ export async function applyHeroColor(
   return window.electronAPI.applyHeroColor(heroName, hue, saturation, brightness);
 }
 
-/** Apply the rainbow prism to a hero's ability VFX. In prism mode `hue` is the
- *  spectrum rotation (degrees); saturation/brightness scale the spectrum. */
+/** Apply the rainbow prism (or a custom gradient) to a hero's ability VFX. In
+ *  prism/gradient mode `hue` is the spectrum rotation (degrees); saturation/
+ *  brightness scale the spectrum. A non-null `gradient` spec (preset name or
+ *  `pos:hue:sat,...` stops) switches from the full rainbow to that ramp. */
 export async function applyHeroPrism(
   heroName: string,
   hue: number,
   saturation: number,
   brightness: number,
-  animated: boolean
+  animated: boolean,
+  gradient: string | null
 ): Promise<ApplyHeroPrismResult> {
-  return window.electronAPI.applyHeroPrism(heroName, hue, saturation, brightness, animated);
+  return window.electronAPI.applyHeroPrism(
+    heroName,
+    hue,
+    saturation,
+    brightness,
+    animated,
+    gradient
+  );
 }
 
 /** Render a fast PNG swatch of the recolor target as a data URL (live preview). */

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2604,7 +2604,7 @@ export default function Installed() {
                 title="Sort and filter installed mods"
               />
               {activeAdjustmentCount > 0 && (
-                <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-bg-primary">
+                <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-accent-foreground ring-2 ring-bg-primary">
                   {activeAdjustmentCount}
                 </span>
               )}
@@ -2736,7 +2736,7 @@ export default function Installed() {
                             >
                               <span
                                 className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
-                                  checked ? 'border-accent bg-accent text-white' : 'border-border'
+                                  checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
                                 }`}
                               >
                                 {checked && <Check className="h-3 w-3" />}
@@ -2827,7 +2827,7 @@ export default function Installed() {
                 title="Locker overrides: review and remove applied hero cards, ability sounds, and ability colors"
               />
               {lockerOverrideCount > 0 && (
-                <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-white ring-2 ring-bg-primary">
+                <span className="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-accent-foreground ring-2 ring-bg-primary">
                   {lockerOverrideCount}
                 </span>
               )}
@@ -5715,7 +5715,7 @@ function ModCard({
               selected ? 'bg-accent border-accent' : 'bg-bg-primary/85 border-white/40'
             }`}
           >
-            {selected && <Check className="w-4 h-4 text-white" strokeWidth={3} />}
+            {selected && <Check className="w-4 h-4 text-accent-foreground" strokeWidth={3} />}
           </div>
         </>
         )}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -352,6 +352,7 @@ export interface ElectronAPI {
         saturation: number,
         brightness: number,
         animated: boolean,
+        gradient: string | null,
     ) => Promise<ApplyHeroPrismResult>;
     previewHeroColor: (
         heroName: string,

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -223,12 +223,17 @@ export interface LockerColorSelection {
   /** Brightness (HSV value) scale (1 = keep source, >1 lighter, <1 darker). */
   brightness: number;
   /** Recolor mode. 'hue' (or absent, for older persisted entries) = one absolute
-   *  color via `recolor-hero`. 'prism' = a rainbow spectrum via `vpkmerge prism`;
-   *  in prism mode hue/saturation/brightness are ignored. */
-  mode?: 'hue' | 'prism';
-  /** Prism only: animate the spectrum so it sweeps over each particle's lifetime
-   *  (`prism --animated`). Ignored in hue mode. */
+   *  color via `recolor-hero`. 'prism' = a rainbow spectrum via `vpkmerge prism`.
+   *  'gradient' = a prism spread over a custom gradient (see `gradient`). In
+   *  prism/gradient modes hue is a spectrum rotation, not an absolute color. */
+  mode?: 'hue' | 'prism' | 'gradient';
+  /** Prism/gradient only: animate the spectrum so it sweeps over each particle's
+   *  lifetime (`prism --animated`). Ignored in hue mode. */
   animated?: boolean;
+  /** Gradient mode only: the `--gradient` spec, either a preset name
+   *  (fire/ice/toxic/sunset/ocean/neon/gold/void) or a stop list
+   *  `pos:hue:sat,...`. */
+  gradient?: string;
   addedAt: string;
 }
 
@@ -253,11 +258,13 @@ export interface ActiveHeroColor {
   saturation: number;
   /** Applied brightness scale (1 = source). */
   brightness: number;
-  /** Which recolor is applied: a single hue or the rainbow prism. Absent on
-   *  older persisted entries (treat as 'hue'). */
-  mode?: 'hue' | 'prism';
-  /** Prism only: whether the applied spectrum is animated. */
+  /** Which recolor is applied: a single hue, the rainbow prism, or a custom
+   *  gradient. Absent on older persisted entries (treat as 'hue'). */
+  mode?: 'hue' | 'prism' | 'gradient';
+  /** Prism/gradient only: whether the applied spectrum is animated. */
   animated?: boolean;
+  /** Gradient mode only: the applied gradient spec (preset name or stop list). */
+  gradient?: string;
 }
 
 export interface ApplyHeroColorResult {
@@ -269,7 +276,7 @@ export interface ApplyHeroColorResult {
   brightness: number | null;
 }
 
-/** Result of applying the rainbow prism to a hero's ability VFX. */
+/** Result of applying the rainbow prism (or a custom gradient) to a hero's VFX. */
 export interface ApplyHeroPrismResult {
   /** Applied spectrum rotation in degrees (prism reuses the hue field as a rotation). */
   hue: number;
@@ -279,6 +286,8 @@ export interface ApplyHeroPrismResult {
   brightness: number;
   /** Whether the applied spectrum animates over each particle's lifetime. */
   animated: boolean;
+  /** The applied gradient spec, or null for the full rainbow. */
+  gradient: string | null;
 }
 
 /**


### PR DESCRIPTION
Adds a third hero ability-color recolor mode and fixes accent-button readability on light accents.

## Gradient recolor mode
- New **Gradient** mode in the hero color picker, alongside Single Color and Rainbow.
- Spread a hero's ability VFX over a chosen gradient ramp: presets or a custom per-stop hue editor.
- The existing rotation / saturation / brightness sliders tune the ramp; optional animated sweep over each effect's lifetime.
- Gradient spec is folded into the prism bake identity (cache path) and passed through to vpkmerge via `--gradient`.
- Wired through preload, `api.ts`, and the mod / electron types; the chosen ramp surfaces in Locker Overrides.
- New helper `src/lib/abilityColorPreview.ts` (gradient CSS + spec parsing).

## Accent-button contrast fix
- The accent color is user-configurable (cyan, emerald, amber, ...), but solid `bg-accent` surfaces hardcoded `text-white`, which is unreadable on a light accent.
- Adds a `--color-accent-foreground` token computed from the accent's WCAG luminance (near-black above 0.35, else white) in `applyAccentColor`.
- Swaps `text-white` for `text-accent-foreground` on solid-accent badges, buttons, count chips, and checkboxes across ModDetailsModal, HeroCardPicker, HeroSoundPicker, CrosshairPresetCard, and Installed.
- The picker mode tabs adopt the accent-agnostic outlined-active style (matching ViewModeToggle); the translucent toast keeps light text.
- Default token matches the shipped Ember orange, so dark accents are unchanged.

## Notes
- Branched off `main` after the prism work (#123) squash-merged.
- `tsc` (renderer + electron) and `eslint` pass clean. No test framework in this repo.