### PR TITLE
fix(mods): heal disabled/enabled name collisions without the spurious 990 cap

### DIFF
--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -630,8 +630,8 @@ export async function extractMergeSource(
     // then swap it into the target's exact path. Staying in-folder keeps the
     // merge at its original load-order position (folder + pakNN) and needs no free
     // slot elsewhere, which matters once the merge lives in an overflow folder:
-    // the old findNextAvailablePriority + setModPriority path is base-only and
-    // would wrongly fail (or move the merge to base) for an overflowed merge.
+    // a base-only "next free pakNN" + setModPriority path would wrongly fail (or
+    // move the merge to the base folder) for a merge that lives in an overflow folder.
     const targetDir = dirname(target.path);
     const buildPath = join(targetDir, `.merge-rebuild-${randomUUID()}.vpk`);
     try {

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -314,6 +314,10 @@ async function reconcileEnabledDisabledCollisions(
     ]);
     const enabledByName = new Map(enabledEntries.map((entry) => [entry.toLowerCase(), entry]));
 
+    // Names already present in .disabled (lowercased). Kept current as we rename
+    // so two collisions healed in one pass can't be given the same new name.
+    const takenDisabledNames = new Set(disabledEntries.map((entry) => entry.toLowerCase()));
+
     for (const disabledEntry of disabledEntries) {
         const enabledEntry = enabledByName.get(disabledEntry.toLowerCase());
         if (!enabledEntry) continue;
@@ -330,10 +334,22 @@ async function reconcileEnabledDisabledCollisions(
             continue;
         }
 
-        const priority = await findNextAvailablePriority(deadlockPath);
+        // Contents differ, so keep both, but the disabled copy must lose the
+        // bare-filename id namespace it shares with the base-folder file. Give it
+        // a free-form name (exactly as disableMod does) rather than a scarce pakNN
+        // slot: disabled VPKs aren't loaded by the engine, so they need no
+        // load-order number, and the free-form namespace has no 99-slot cap.
+        // (The old pakNN allocator scanned only base addons + .disabled and threw
+        // the 990 "enable limit" here once the base folder was full - which is the
+        // norm for anyone who has spilled into overflow folders. Because that throw
+        // happened before the heal completed, the collision never cleared and every
+        // get-mods/get-conflicts/launch scan failed permanently.)
         const metadata = getModMetadata(enabledEntry);
         const owner = await getCollisionMetadataOwner(metadata?.sha256, join(disabledPath, disabledEntry));
-        const renamedFileName = await renameModFileToPriority(disabledPath, disabledEntry, priority);
+        const preferredName = metadata?.modName ?? metadata?.sourceFileName ?? metadata?.variantLabel;
+        const renamedFileName = makeDisabledFileName(disabledEntry, takenDisabledNames, preferredName);
+        await fs.rename(join(disabledPath, disabledEntry), join(disabledPath, renamedFileName));
+        takenDisabledNames.add(renamedFileName.toLowerCase());
         moveCollisionMetadata(enabledEntry, renamedFileName, owner, metadata);
         console.warn(
             `[mods] Renamed conflicting disabled VPK ${disabledEntry} to ${renamedFileName}; contents differ from enabled copy.`
@@ -380,28 +396,6 @@ async function getCollisionMetadataOwner(
     return disabledHash.sha256.toLowerCase() === sha256.toLowerCase() ? 'disabled' : 'enabled';
 }
 
-async function renameModFileToPriority(
-    folder: string,
-    fileName: string,
-    priority: number
-): Promise<string> {
-    const finalName = fileNameForPriority(fileName, priority);
-    if (existsSync(join(folder, finalName))) {
-        throw new Error(`Cannot rename conflicting disabled mod: target already exists (${finalName})`);
-    }
-
-    await fs.rename(join(folder, fileName), join(folder, finalName));
-    return finalName;
-}
-
-function fileNameForPriority(fileName: string, priority: number): string {
-    const renamed = renameWithPriority(fileName, priority);
-    if (renamed !== fileName) return renamed;
-
-    const priorityStr = String(Math.min(MAX_VPK_PRIORITY, priority)).padStart(2, '0');
-    return `pak${priorityStr}_dir.vpk`;
-}
-
 /**
  * Move a mod to a folder under an explicit destination filename, migrating its
  * metadata to follow the rename. Callers compute a collision-free destination
@@ -440,55 +434,6 @@ async function moveModToFolderAs(
         priority: parseVpkPriority(destinationFileName) ?? targetMod.priority,
         path: destinationPath,
     };
-}
-
-/**
- * Get the set of used priorities in BOTH addons AND disabled folders (async)
- * This prevents conflicts when downloading new mods
- */
-export async function getUsedPriorities(deadlockPath: string): Promise<Set<number>> {
-    const addonsPath = getAddonsPath(deadlockPath);
-    const disabledPath = getDisabledPath(deadlockPath);
-    const usedPriorities = new Set<number>();
-
-    const scanPriorities = async (folder: string) => {
-        if (!existsSync(folder)) return;
-        const entries = await fs.readdir(folder);
-        for (const entry of entries) {
-            const priority = parseVpkPriority(entry);
-            if (priority !== null) {
-                usedPriorities.add(priority);
-            }
-        }
-    };
-
-    await Promise.all([
-        scanPriorities(addonsPath),
-        scanPriorities(disabledPath),
-    ]);
-
-    return usedPriorities;
-}
-
-/**
- * Find the next available priority number that doesn't conflict (async)
- * Checks BOTH addons and disabled folders to avoid overwriting disabled mods
- */
-export async function findNextAvailablePriority(deadlockPath: string, startFrom = MIN_VPK_PRIORITY): Promise<number> {
-    const usedPriorities = await getUsedPriorities(deadlockPath);
-
-    // Find next available starting from startFrom (default 1)
-    let priority = startFrom;
-    while (usedPriorities.has(priority) && priority < MAX_VPK_PRIORITY) {
-        priority++;
-    }
-
-    // If all numbers up to 99 are taken, this is an error
-    if (priority >= MAX_VPK_PRIORITY && usedPriorities.has(MAX_VPK_PRIORITY)) {
-        throw new Error(ENABLE_LIMIT_MESSAGE);
-    }
-
-    return priority;
 }
 
 interface AllocatedSlot {
@@ -551,8 +496,7 @@ async function allocateSlot(
 /**
  * Absolute path a brand-new ENABLED VPK should be written to (custom local
  * import, merge output), honoring the multi-folder overflow model so the create
- * still succeeds when the base addons folder is full. Unlike
- * findNextAvailablePriority (base + .disabled only), this spills into overflow
+ * still succeeds when the base addons folder is full: this spills into overflow
  * folders and mints a new one at capacity. Throws ENABLE_LIMIT_MESSAGE at the cap.
  *
  * The caller writes the VPK to this path and then keys its metadata by


### PR DESCRIPTION
## Problem

A user hit a hard-blocking, self-perpetuating crash: every `get-mods` (and `get-conflicts`, and the launch-time Locker VPK heal) failed with:

```
Error invoking remote method 'get-mods': Error: You can have at most 990 mods enabled at once. Disable one to make room.
    at findNextAvailablePriority (...)
    at async reconcileEnabledDisabledCollisions (...)
    at async scanMods (...)
```

...while the user was **nowhere near 990** enabled mods. It looked random but was permanent once triggered: the app was unusable (full-page "Error Loading Mods", Retry does nothing).

## Root cause

`reconcileEnabledDisabledCollisions` runs inside `scanMods`, i.e. on every mod scan. When a `.disabled` file's name collides with a base-folder `pakNN_dir.vpk` (e.g. a legacy disabled `pak05_dir.vpk`) and the contents differ, it healed the clash by renaming the disabled file into a free `pakNN` slot via `findNextAvailablePriority`.

That allocator only scanned the **base** `citadel/addons` + `.disabled` folders for a free `pak01..pak99` slot. Anyone with 99+ enabled mods has a full base folder (the rest spill into overflow `addons1`, `addons2`, ... up to the real 990 ceiling). So the allocator found no free slot and threw `ENABLE_LIMIT_MESSAGE` ("990 mods").

Crucially, the throw happened **before** the heal finished, so the colliding file was never renamed. The collision persisted, and every subsequent scan re-hit it: a permanent, misleading 990-cap error.

## Fix

Rename the colliding disabled file to a **free-form name** (the exact scheme `disableMod` already uses) instead of allocating a scarce `pakNN` slot. Disabled VPKs aren't loaded by the engine, so they need no load-order number, and the free-form namespace:

- has no 99-slot cap, and
- can't collide with base `pakNN` ids (different filename = different metaKey).

The heal now always completes. **Affected installs self-heal on the next scan after updating** (no manual file surgery needed).

Also removed the now-dead base-only allocator (`findNextAvailablePriority`, `getUsedPriorities`, `renameModFileToPriority`, `fileNameForPriority`) so nothing can fall back into that buggy path, and fixed two stale comments that referenced it. The overflow-aware enable/reorder/merge paths (`allocateSlot`, `allocateEnabledVpkPath`, `reorderMods`, `setModPriority`) are untouched and already correct.

## Testing

- `tsc -p tsconfig.node.json --noEmit` clean
- `eslint` clean on changed files
- `electron-vite build` succeeds (all three bundles)

## Suggested release

This unblocks a class of real users whose app is currently bricked. Worth shipping as its own patch release rather than waiting on other in-progress work.