### PR TITLE
fix(build): track pnpm-workspace.yaml so build scripts run on pnpm 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
-pnpm-workspace.yaml
 
 node_modules
 dist

--- a/package.json
+++ b/package.json
@@ -9,13 +9,6 @@
   },
   "type": "module",
   "main": "dist/main/index.js",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "better-sqlite3",
-      "electron"
-    ]
-  },
   "scripts": {
     "postinstall": "node scripts/fetch-vpkmerge.mjs",
     "fetch-vpkmerge": "node scripts/fetch-vpkmerge.mjs",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+packages:
+  - '../grimoire-social/packages/social-types'
+
+onlyBuiltDependencies:
+  - better-sqlite3
+  - electron
+  - electron-winstaller
+  - esbuild


### PR DESCRIPTION
## Problem

A fresh `pnpm dev` fails with `Error: Electron uninstall` (thrown by electron-vite's `getElectronPath` when the Electron binary is missing). Reported on pnpm v11.5.0:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.onlyBuiltDependencies".
```

## Root cause

The build-script allowlist (`electron`, `better-sqlite3`, `esbuild`, ...) lived in `package.json`'s `pnpm.onlyBuiltDependencies` field. **pnpm 11 no longer reads that field** - the allowlist moved to `pnpm-workspace.yaml`. With it ignored, `electron`'s postinstall (which downloads the Electron binary) is skipped. `electron-rebuild` still fixes `better-sqlite3` and Vite still builds the main/preload bundles, so the failure only surfaces when Electron tries to launch.

`pnpm-workspace.yaml` had been added to `.gitignore` in e816db8 (an unrelated "harden installs" commit), which simultaneously deleted the tracked workspace file. That removed the allowlist from version control entirely, so the only remaining copy was the now-inert `package.json` field.

## Fix

- Un-ignore `pnpm-workspace.yaml` and track it.
- Declare `onlyBuiltDependencies` there (the only location pnpm 11 reads) plus the `@grimoire/social-types` workspace member (the lockfile already links `../grimoire-social/packages/social-types`).
- Remove the dead `pnpm` field from `package.json`.

## Verification

`pnpm install --frozen-lockfile` succeeds with no lockfile drift, pnpm accepts the workspace path, and build scripts run (`electron-winstaller install ... Done`).

## Notes

No standalone-clone regression: the committed lockfile already requires `../grimoire-social` as a sibling, so installs already depend on it being checked out alongside this repo.