### PR TITLE
fix(browse,profiles): confirm profile overwrite, legible card titles, true Recently Added sort

### DIFF
--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -689,13 +689,16 @@ export async function fetchSubmissions(
     options: GameBananaRequestOptions = {}
 ): Promise<GameBananaModsResponse> {
     let url: string;
-    // The API's default order is already newest-submission-first, so 'recent'/'new'
-    // and 'default' need no explicit sort. 'updated' is distinct (date modified, not
-    // added) and must be requested explicitly or it silently mirrors 'recent'.
+    // GameBanana's default list order (no _sSort) is by date *modified*, not date
+    // added, so "Recently Added" (recent) has to request Generic_Newest explicitly
+    // or it silently mirrors "Recently Updated". 'updated' maps to
+    // Generic_LatestModified (date modified). Sort tokens verified against the live
+    // apiv11 endpoint (Generic_LatestAdded/Generic_New are rejected as UNKNOWN_SORT).
     const sortMap: Record<string, string> = {
         likes: 'Generic_MostLiked',
         popular: 'Generic_MostLiked',
         views: 'Generic_MostViewed',
+        recent: 'Generic_Newest',
         updated: 'Generic_LatestModified',
     };
 

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -12,6 +12,10 @@ export interface AppSettings {
     steamLaunchOptions: string;      // Args written to Steam's localconfig.vdf for Deadlock just before launch
     activeProfileId: string | null;  // Currently active profile
     autoSaveProfile: boolean;        // Auto-save when mods change
+    /** Ask for confirmation before "Update" overwrites a profile with the current
+     *  mod set. On by default: Update sits next to Apply and overwriting is easy to
+     *  trigger by accident, with no undo. Turn off to overwrite immediately. */
+    confirmProfileUpdate: boolean;
     experimentalStats: boolean;
     experimentalCrosshair: boolean;
     experimentalSocial: boolean;     // Grimoire Social: Discover page + publish/account UI
@@ -62,6 +66,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     steamLaunchOptions: '',
     activeProfileId: null,
     autoSaveProfile: false,
+    confirmProfileUpdate: true,
     experimentalStats: false,
     experimentalCrosshair: false,
     experimentalSocial: false,

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,12 @@
   --font-reaver: 'Reaver', serif;
   --font-valvepulp: 'ValvePulp', sans-serif;
   --font-captain: 'American Captain', sans-serif;
+  /* Browse mod-name titles. Radiance (the app-wide face) renders capital I and
+     lowercase l identically, which makes mod names like "Illusion" ambiguous.
+     Reaver is a serif we already ship, so its I gets serif bars and reads
+     distinctly from l. To switch to a cleaner neutral look, change this one line
+     to: Tahoma, Verdana, system-ui, sans-serif (OS fonts, nothing bundled). */
+  --font-mod-title: 'Reaver', serif;
 }
 
 /* Base styles */

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3127,7 +3127,7 @@ function ReadableBrowseModCard({
 
         <div className={`${titleMarginClass} min-w-0`}>
           <h3
-            className={`block truncate font-bold text-[#eee8df] ${
+            className={`block truncate font-mod-title font-bold text-[#eee8df] ${
               isMicro
                 ? 'text-[13px] leading-4'
                 : 'text-[clamp(11px,5.3571cqw,17px)] leading-[1.28] pb-px'
@@ -3137,7 +3137,7 @@ function ReadableBrowseModCard({
             {mod.name}
           </h3>
           {showAuthor && (
-            <p className="-mt-0.5 truncate text-[clamp(10px,4.2857cqw,13px)] font-normal leading-[1.12] text-text-secondary/64">
+            <p className="mt-0 truncate text-[clamp(10px,4.2857cqw,13px)] font-normal leading-[1.12] text-text-secondary/64">
               by {mod.submitter?.name ?? 'Unknown author'}
             </p>
           )}
@@ -3367,7 +3367,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
-            <h3 className="font-medium truncate flex-1">{mod.name}</h3>
+            <h3 className="font-mod-title font-medium truncate flex-1">{mod.name}</h3>
             {installed && installedDisabled && onEnable ? (
               <button
                 onClick={(e) => { e.stopPropagation(); onEnable(); }}
@@ -3600,7 +3600,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
               )}
             </div>
           )}
-          <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
+          <h3 className={`font-mod-title font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
           <div className={`mt-1 flex flex-wrap items-center gap-3 text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${isCompact ? 'text-[11px]' : 'text-xs'}`}>
             <BrowseStatItem type="likes" icon={ThumbsUp} value={formatCount(mod.likeCount)} title={`${mod.likeCount ?? 0} likes`} />
             <BrowseStatItem type="views" icon={Eye} value={formatCount(mod.viewCount)} title={`${mod.viewCount ?? 0} views`} />
@@ -3609,7 +3609,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
         </div>
       ) : (
         <div className={`absolute bottom-0 left-0 right-0 ${isCompact ? 'p-2.5' : 'p-3'}`}>
-          <h3 className={`font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
+          <h3 className={`font-mod-title font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
           <div className={`mt-1 flex flex-wrap items-center gap-3 text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${isCompact ? 'text-xs' : 'text-sm'}`}>
             <BrowseStatItem type="likes" icon={ThumbsUp} value={formatCount(mod.likeCount)} title={`${mod.likeCount ?? 0} likes`} />
             <BrowseStatItem type="views" icon={Eye} value={formatCount(mod.viewCount)} title={`${mod.viewCount ?? 0} views`} />

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -105,6 +105,10 @@ export default function Profiles() {
   const [isCreating, setIsCreating] = useState(false);
   const [applyingId, setApplyingId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  // Profile id pending an "overwrite this profile?" confirmation. Gated on the
+  // confirmProfileUpdate setting (on by default) so Update isn't a one-click,
+  // no-undo overwrite sitting right next to Apply.
+  const [updateConfirmId, setUpdateConfirmId] = useState<string | null>(null);
   const [expandedProfiles, setExpandedProfiles] = useState<Set<string>>(new Set());
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -706,11 +710,15 @@ export default function Profiles() {
                             size="sm"
                             className="flex-1 min-w-0"
                             variant="secondary"
-                            onClick={() => handleUpdateProfile(profile.id)}
+                            onClick={() =>
+                              (settings?.confirmProfileUpdate ?? true)
+                                ? setUpdateConfirmId(profile.id)
+                                : handleUpdateProfile(profile.id)
+                            }
                             disabled={isUpdating || isApplying}
                             isLoading={isUpdating}
                             icon={Save}
-                            title="Overwrite with current mods"
+                            title="Overwrite this profile with your current mods"
                           >
                             Update
                           </Button>
@@ -844,6 +852,31 @@ export default function Profiles() {
           )}
         </div>
       </div>
+
+      {/* Update (overwrite) Confirmation Modal. Gated on confirmProfileUpdate so
+          Update isn't a one-click overwrite that gets fired when Apply was meant. */}
+      <ConfirmModal
+        isOpen={updateConfirmId !== null}
+        onCancel={() => setUpdateConfirmId(null)}
+        onConfirm={() => {
+          const id = updateConfirmId;
+          setUpdateConfirmId(null);
+          if (id) handleUpdateProfile(id);
+        }}
+        title="Update Profile"
+        message={
+          <>
+            Overwrite{' '}
+            <span className="text-text-primary font-medium">
+              {profiles.find((p) => p.id === updateConfirmId)?.name ?? 'this profile'}
+            </span>{' '}
+            with your currently enabled mods? The profile's saved mod list will be
+            replaced and can't be undone. (To load this profile onto your install
+            instead, use Apply.) You can turn this prompt off in Settings &rarr; Preferences.
+          </>
+        }
+        confirmLabel="Update"
+      />
 
       {/* Delete Confirmation Modal */}
       <ConfirmModal

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -317,6 +317,12 @@ export default function Settings() {
     }
   };
 
+  const handleConfirmProfileUpdateChange = async (checked: boolean) => {
+    if (settings) {
+      await saveSettings({ ...settings, confirmProfileUpdate: checked });
+    }
+  };
+
   const handleDateFormatChange = async (format: 'MM/DD/YYYY' | 'DD/MM/YYYY') => {
     if (settings && settings.dateFormat !== format) {
       await saveSettings({ ...settings, dateFormat: format });
@@ -1073,6 +1079,15 @@ export default function Settings() {
               onChange={handleAutoDisableSiblingsChange}
               label="Switch variants instead of stacking them"
               description="When you install a different file of a mod you already have enabled, disable the previous variant so only the new one is active. Turn off to keep multiple variants of the same mod enabled at once. (Updates always replace the old file regardless of this setting.)"
+            />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.confirmProfileUpdate ?? true}
+              onChange={handleConfirmProfileUpdateChange}
+              label="Confirm before updating a profile"
+              description="Ask first when you click Update on a profile, since it overwrites that profile's saved mods with your current set and can't be undone. Turn off to overwrite immediately."
             />
 
             <div className="h-px bg-white/5" />

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -592,6 +592,9 @@ export interface AppSettings {
   steamLaunchOptions: string;
   activeProfileId: string | null;
   autoSaveProfile: boolean;
+  /** Ask for confirmation before "Update" overwrites a profile with the current
+   *  mod set. On by default. */
+  confirmProfileUpdate: boolean;
   experimentalStats: boolean;
   experimentalCrosshair: boolean;
   experimentalSocial: boolean;


### PR DESCRIPTION
Three fixes from a user-report batch.

## 1. Confirm before "Update" overwrites a profile
Update sits right next to Apply and overwriting a profile's saved mods is a no-undo action, so it's easy to fire by accident when Apply was intended.

- New `confirmProfileUpdate` setting, default **on**, added to both `AppSettings` declarations (`settings.ts` + `src/types/mod.ts`).
- Update now opens a confirm dialog naming the profile and spelling out that it replaces the saved mod set (and points at Apply for the usual intent). **Apply is unchanged.**
- Toggle in **Settings -> Preferences**: "Confirm before updating a profile". Off = overwrite immediately, as before.

## 2. Browse card titles: distinguishable I vs l
The whole app uses Radiance, whose capital `I` and lowercase `l` render identically, making mod names like "Illusion" ambiguous on the cards. Every Browse view (readable / list / classic) shares that font, so there was no other-view font to borrow.

- Mod-name titles now use a dedicated `--font-mod-title` token (currently **Reaver**, the serif we already ship, whose `I` has serif bars). Swapping to a neutral OS stack (Tahoma, Verdana, system-ui) is a one-line change at the token, nothing bundled either way.
- Dropped the Radiance-tuned negative margin on the readable-card author line so the serif's descenders no longer overlap "by <author>".

## 3. "Recently Added" was showing recently *updated* mods
The default Browse view (no search / hero / content filter) uses the live GameBanana API, and `fetchSubmissions`'s sort map had no `recent` entry, so it sent no `_sSort`. GameBanana's default list order is by date **modified**, so "Recently Added" silently mirrored "Recently Updated".

- Map `recent -> Generic_Newest` (orders by `_tsDateAdded`).
- Verified against the live apiv11 endpoint: `Generic_Newest` orders by date added, while the obvious guess `Generic_LatestAdded` is rejected as `UNKNOWN_SORT`. The local catalog path already sorted correctly (`date_added DESC`), so this aligns both paths.

## Verification
- `tsc` (app + node) clean, ESLint clean.
- Full production build succeeds; the `font-mod-title` utility is emitted in the bundled CSS.
- Sort tokens checked against live apiv11 data (a months-old, freshly-updated mod like `dl_express` now appears in Recently Updated but not at the top of Recently Added).

## Notes for review
- The card title font (Reaver vs Tahoma/Verdana) is a one-line aesthetic swap if Reaver reads too heavy at small sizes.
