### PR TITLE
release: v1.15.3 - full-roster ability recolor + sidebar/installed polish

### DIFF
--- a/electron/main/services/heroColors.ts
+++ b/electron/main/services/heroColors.ts
@@ -50,37 +50,42 @@ import type {
  */
 const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
     Paige: 'bookworm',
-    // Added from local disabled-mod particle scans + vpkmerge texture audits.
     Abrams: 'abrams',
     Apollo: 'fencer',
+    Bebop: 'bebop',
+    Billy: 'punkgoat',
     Calico: 'nano',
+    Celeste: 'unicorn',
+    Doorman: 'doorman',
+    Drifter: 'drifter',
+    Dynamo: 'dynamo',
+    Graves: 'necro',
+    'Grey Talon': 'archer',
+    Haze: 'haze',
+    Holliday: 'astro',
+    Infernus: 'inferno',
+    Ivy: 'tengu',
+    Kelvin: 'kelvin',
     'Lady Geist': 'ghost',
     Lash: 'lash',
     McGinnis: 'mcginnis',
-    Pocket: 'pocket',
-    Sinclair: 'magician',
-    // Particle-only heroes (no color textures / vertex colors): their recipe has no
-    // preview_texture, so the live swatch falls back to the approximate CSS chip;
-    // recolor-hero still bakes them. The patcher handles v4 + v5 particles, so each
-    // recolors at full coverage. Keep this in lockstep with `recipe_for` in
-    // vpkmerge-core/src/hero_recolor.rs.
-    Celeste: 'unicorn',
-    Holliday: 'astro',
     Mina: 'vampirebat',
+    Mirage: 'mirage',
+    'Mo & Krill': 'digger',
+    Paradox: 'chrono',
+    Pocket: 'pocket',
+    Rem: 'familiar',
     Seven: 'gigawatt',
+    Shiv: 'shiv',
+    Silver: 'werewolf',
+    Sinclair: 'magician',
+    Venator: 'priest',
+    Victor: 'frank',
+    Vindicta: 'hornet',
+    Viscous: 'viscous',
+    Vyper: 'viper',
+    Warden: 'warden',
     Wraith: 'wraith',
-    Infernus: 'inferno',
-    // Graves: PARTICLES recolor fully and cover most of her VFX (her large ability
-    // maps, e.g. necro_soul_01, are grayscale and tinted by the particle color). Two
-    // small gaps remain, tracked in `recipe_for` (vpkmerge hero_recolor.rs): the
-    // gravestone's green transmissive glow (a 4x4 chromatic texture, hue-shiftable)
-    // and the pickup-sphere/jar tint (a material g_vColorTint CONSTANT, which needs
-    // an in-place .vmat_c patch, not a texture). Neither blocks shipping her here.
-    Graves: 'necro',
-    // Yamato: particles + a handful of chromatic textures (the green blade-dash
-    // self-illum and the shadow-redemption status maps, plus the shadow-form body
-    // albedo). Her recipe also carries the prism animation targets, so she is a
-    // strong Rainbow candidate. Keep in lockstep with `recipe_for`.
     Yamato: 'yamato',
 };
 
@@ -91,8 +96,9 @@ const COLOR_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
  *  g_vColorTint material tints (zombie/jar/gravestone).
  *  v4: Graves picker-hand albedo + transmissive textures + necro_hands tint.
  *  v5: Graves hand flame aura (g_vSelfIllumTint on necro_flame_effect*).
- *  v6: Infernus body self-illum accents + flame materials + arm flame ramp. */
-const RECIPE_CACHE_VERSION = 6;
+ *  v6: Infernus body self-illum accents + flame materials + arm flame ramp.
+ *  v7: bundled vpkmerge main build with full selectable-roster recipe coverage. */
+const RECIPE_CACHE_VERSION = 7;
 
 /** The recolor codename for a hero, or null when no recipe is pinned for it. */
 export function colorCodenameForHero(heroName: string): string | null {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.10.0';
+const VPKMERGE_VERSION = 'v0.11.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'af3e2e37d99890916f80ad90f97f9de3f84e88d7a366bf59b5dd1c4ad0a630a9' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '53acdf4bd8c3aaff573b2ef1710b2f62696480751558250e6e91679902f9e0f5' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'fa9e604f550f0df02105ebefd8d5b64eee9b7b7dd7cc04175e279092ad12658e' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'adc9eac8fd43aef47e2a99168104e53d6c302372345982edd6078d0bb8783967' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '3b6f3ba87a807c95b39cb89a18096d262d97cf8bf209539d2a0cee31f103d9ac' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'f2897eec6c038c0cb6752a437f51c03079406f01ccec933706d5ca9606864f07' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,7 +44,7 @@ import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
 
 const COLLAPSED_KEY = 'grimoire:sidebar-collapsed';
-const LABEL_TRANSITION_MS = 260;
+const LABEL_TRANSITION_MS = 180;
 const DISCOVER_LAST_SEEN_KEY = 'grimoire:discover:last-seen-created-at';
 const DISCOVER_BADGE_POLL_MS = 2 * 60 * 1000;
 const PREVIEW_VOLUME_HIDE_DELAY_MS = 60 * 1000;
@@ -676,11 +676,9 @@ export default function Sidebar() {
       className="grimoire-sidebar bg-bg-secondary border-r border-border flex flex-col h-full min-h-0 shrink-0 overflow-hidden"
     >
       <div className="relative flex h-11 flex-shrink-0 items-center overflow-hidden border-b border-border px-3">
-        {labelMounted && (
+        {labelMounted && !collapsed && (
           <div
-            className={`sidebar-title-shell pointer-events-none absolute inset-y-0 left-0 flex items-center justify-center ${
-              collapsed ? 'right-[46px]' : 'right-9'
-            }`}
+            className="sidebar-title-shell pointer-events-none absolute inset-y-0 left-0 right-9 flex items-center justify-center"
           >
             <span
               className={`flex items-center gap-1.5 text-2xl text-text-primary/85 leading-none ${titleTransitionClass}`}
@@ -845,7 +843,7 @@ export default function Sidebar() {
         )}
 
         {/* Toasts need horizontal room to read, so suppress in collapsed mode. */}
-        {toast && labelMounted && (
+        {toast && labelMounted && !collapsed && (
           <div
             className={`rounded-sm px-2.5 py-1.5 text-xs leading-snug ${
               toast.kind === 'error'

--- a/src/index.css
+++ b/src/index.css
@@ -706,29 +706,26 @@ body {
 }
 
 .grimoire-sidebar {
+  /* Keep width changes discrete. Animating this flex item forces the whole
+     routed page to re-layout every frame, which is visibly janky on heavy tabs. */
   width: 14rem;
-  transition: width 260ms cubic-bezier(0.22, 1, 0.36, 1);
-  will-change: width;
 }
 
 .grimoire-sidebar[data-collapsed='true'] {
   width: 4rem;
 }
 
-.sidebar-title-shell,
 .sidebar-collapse-toggle {
   transition:
-    right 260ms cubic-bezier(0.22, 1, 0.36, 1),
     color 160ms ease-out,
     background-color 160ms ease-out;
-  will-change: right;
 }
 
 .sidebar-title-text {
   white-space: nowrap;
   transition:
     opacity 180ms ease-out,
-    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
   will-change: opacity, transform;
 }
 
@@ -743,23 +740,21 @@ body {
 }
 
 .sidebar-collapsible-label {
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   transition:
     opacity 180ms ease-out,
-    max-width 260ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
-  will-change: opacity, max-width, transform;
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
 }
 
 .sidebar-collapsible-label--visible {
-  max-width: 10rem;
   opacity: 1;
   transform: translateX(0);
 }
 
 .sidebar-collapsible-label--hidden {
-  max-width: 0;
   opacity: 0;
   transform: translateX(-0.25rem);
 }
@@ -771,7 +766,7 @@ body {
 }
 
 .sidebar-offset-transition {
-  transition: left 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: none;
 }
 
 .sidebar-active-backdrop {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2533,9 +2533,9 @@ export default function Installed() {
     );
   }
 
-  // Conflicts and update-all buttons live on the section header row (next to
-  // Fix Order) rather than the top action bar — when both are active the top
-  // bar gets cramped, so move them to the line below where there's room.
+  // Conflicts, update-all, and fix-unknown buttons. Rendered once, in the top
+  // action bar's right cluster (next to Fix Order). The right cluster wraps when
+  // cramped, so there's no need to relocate them to a section header.
   const hasStatusButtons =
     conflictCount > 0 || updatesAvailable.size > 0 || !!updateAllProgress || unknownMods.length > 0;
   const statusButtons = hasStatusButtons ? (
@@ -2935,8 +2935,6 @@ export default function Installed() {
         <div>
           <div className="flex items-baseline justify-between mb-[14px]">
             <SectionHeader count={visibleDisabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">Disabled</SectionHeader>
-            {/* Fall back here when there's nothing in the Enabled section to host the status buttons. */}
-            {visibleEnabled.length === 0 && statusButtons}
           </div>
           {renderSortableSection('disabled')}
         </div>

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -823,7 +823,7 @@ export default function Locker() {
 
       {selectedHero && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in transition-[left] duration-200 ease-out"
+          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <LockerHeroView
@@ -864,7 +864,7 @@ export default function Locker() {
 
       {selectedHeroMissing && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in transition-[left] duration-200 ease-out"
+          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <div className="flex h-full flex-col items-center justify-center p-6 text-text-secondary">
@@ -882,7 +882,7 @@ export default function Locker() {
       )}
       {globalSelected && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in transition-[left] duration-200 ease-out"
+          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <LockerGlobalView


### PR DESCRIPTION
## v1.15.3

### New Features
- **Ability-color recolor now covers the full selectable roster (38 heroes).** `COLOR_CODENAME_BY_HERO` expanded, `RECIPE_CACHE_VERSION` bumped to 7. Backed by **vpkmerge v0.11.0**, which carries the expanded `recolor-hero` recipe set. Bundled CLI pin (`scripts/fetch-vpkmerge.mjs`) bumped to v0.11.0 with verified release sha256s for all three platforms.

### Bug Fixes
- **Sidebar collapse no longer stutters.** It was animating `width` every frame, forcing a full page relayout (janky on heavy tabs). Width changes are now discrete; Locker panels track the sidebar via the now-static `sidebar-offset-transition`.
- **Installed status buttons no longer duplicate.** Conflicts / Update All / Fix Unknown rendered twice when the Enabled section was empty; now rendered once in the top action bar.

### Notes
- Verified in-app: recolor renders correctly on newly-added heroes.
- Lint clean (0 errors; 2 pre-existing `Stats.tsx` warnings, unrelated).
- Local Linux package (AppImage + deb) built and smoke-tested; bundled vpkmerge verifies as the released 0.11.0 (`adc9eac8...`).

Already merged since v1.15.2 and shipping in this release: #139 (GameBanana labeled changelogs), #140 (browse/profile overwrite-confirm, legible titles, true Recently Added).