### PR TITLE
fix: wrap modals in Installed page with createPortal to prevent overl…

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -3139,7 +3139,7 @@ export default function Installed() {
         );
       })()}
 
-      {detailsLoading && (
+      {detailsLoading && createPortal(
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in"
           onClick={closeModDetails}
@@ -3151,10 +3151,11 @@ export default function Installed() {
             <Loader2 className="w-5 h-5 animate-spin text-accent" />
             <span className="text-sm text-text-secondary">Loading mod details...</span>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
-      {detailsError && !detailsMod && (
+      {detailsError && !detailsMod && createPortal(
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
           onClick={closeModDetails}
@@ -3169,7 +3170,8 @@ export default function Installed() {
               <Button onClick={closeModDetails}>Close</Button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {detailsMod && (
@@ -3610,7 +3612,7 @@ function UnknownFilterGuessModal({
 }) {
   const { mod } = state;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
       role="dialog"
@@ -3661,7 +3663,8 @@ function UnknownFilterGuessModal({
         />
 
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 
@@ -3716,7 +3719,7 @@ function BulkUnknownFixModal({
     (mod) => !pendingIds.has(mod.id) && cache[mod.id]?.crcMatch.status === 'not-found'
   ).length;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
       role="dialog"
@@ -3844,7 +3847,8 @@ function BulkUnknownFixModal({
           />
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 
@@ -6047,7 +6051,7 @@ function EditLocalModModal({ mod, onClose, onSave }: EditLocalModModalProps) {
     }
   };
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-bg-primary/75 p-4 backdrop-blur-sm"
       onClick={onClose}
@@ -6175,7 +6179,8 @@ function EditLocalModModal({ mod, onClose, onSave }: EditLocalModModalProps) {
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 
@@ -6322,7 +6327,7 @@ function ImportCustomModModal({
     }
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-bg-secondary border border-border rounded-xl w-full max-w-lg">
         <div className="flex items-center justify-between p-5 border-b border-border">
@@ -6480,6 +6485,7 @@ function ImportCustomModModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
…apping

Fixed an issue where the "Fix Unknown Mods" and "Import Custom Mod" had overlapped text. Wrapping them with createPortal(..., document.body) ensures they correctly overlay the entire viewport.

Before:
<img width="1039" height="781" alt="изображение" src="https://github.com/user-attachments/assets/f56836e9-8abf-462e-8deb-5990b0585c99" />

After:
<img width="877" height="801" alt="изображение" src="https://github.com/user-attachments/assets/3497e3b4-d1d0-4c8f-a764-35d31b08015a" />
