### PR TITLE
Browse: dockable details sidebar, artist mode, and card polish

### DIFF
--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -35,6 +35,7 @@ interface BrowseModsArgs {
 interface GetModDetailsArgs {
     modId: number;
     section?: string;
+    includeSubmitter?: boolean;
 }
 
 interface GetModCommentsArgs {
@@ -77,8 +78,8 @@ ipcMain.handle(
 ipcMain.handle(
     'get-mod-details',
     async (_, args: GetModDetailsArgs): Promise<GameBananaModDetails> => {
-        const { modId, section = 'Mod' } = args;
-        const details = await fetchModDetails(modId, section);
+        const { modId, section = 'Mod', includeSubmitter } = args;
+        const details = await fetchModDetails(modId, section, { includeSubmitter });
 
         // Enrich local cache with the NSFW flag from detail response
         try {

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -31,6 +31,7 @@ interface BrowseModsArgs {
     section?: string;
     categoryId?: number;
     sort?: string;
+    submitterId?: number;
 }
 
 interface GetModDetailsArgs {
@@ -70,8 +71,8 @@ function getActiveDeadlockPath(): string | null {
 ipcMain.handle(
     'browse-mods',
     async (_, args: BrowseModsArgs): Promise<GameBananaModsResponse> => {
-        const { page, perPage, search, section = 'Mod', categoryId, sort } = args;
-        return fetchSubmissions(section, page, perPage, search, categoryId, sort);
+        const { page, perPage, search, section = 'Mod', categoryId, sort, submitterId } = args;
+        return fetchSubmissions(section, page, perPage, search, categoryId, sort, submitterId);
     }
 );
 

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -8,6 +8,7 @@ import {
     fetchModFileList,
     fetchModComments,
     fetchModUpdates,
+    fetchSubmitterLinks,
     fetchCollection,
     fetchCollectionItems,
     GameBananaSection,
@@ -163,6 +164,14 @@ ipcMain.handle(
     async (_, args: GetModUpdatesArgs): Promise<GameBananaModUpdatesResponse> => {
         const { modId, section = 'Mod', page = 1 } = args;
         return fetchModUpdates(modId, section, page);
+    }
+);
+
+// get-submitter-links — artist social/contact links from their member profile
+ipcMain.handle(
+    'get-submitter-links',
+    async (_, memberId: number) => {
+        return fetchSubmitterLinks(memberId);
     }
 );
 

--- a/electron/main/services/archiveCrc.ts
+++ b/electron/main/services/archiveCrc.ts
@@ -1,5 +1,6 @@
 import { createReadStream } from 'fs';
 import { validateDownloadUrl } from './security';
+import { GRIMOIRE_USER_AGENT } from './userAgent';
 
 export interface ArchiveVpkCrcEntry {
     name: string;
@@ -194,7 +195,7 @@ async function fetchArchiveRange(
     const response = await fetch(url, {
         headers: {
             Range: `bytes=${start}-${end}`,
-            'User-Agent': 'DeadlockModManager/1.0',
+            'User-Agent': GRIMOIRE_USER_AGENT,
         },
         redirect: 'follow',
         signal,
@@ -245,7 +246,7 @@ async function fetchArchiveSuffixRange(
     const response = await fetch(url, {
         headers: {
             Range: `bytes=-${suffixBytes}`,
-            'User-Agent': 'DeadlockModManager/1.0',
+            'User-Agent': GRIMOIRE_USER_AGENT,
         },
         redirect: 'follow',
         signal,

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -1088,8 +1088,10 @@ export async function fetchSubmitterLinks(memberId: number): Promise<GameBananaA
             links = mapContactInfo(raw._aContactInfo);
         }
     } catch (err) {
+        // Don't cache the failure: a transient 429 or network blip would
+        // otherwise hide this artist's socials until the app restarts.
         console.warn('[gamebanana] Failed to load submitter links:', err);
-        links = [];
+        return [];
     }
 
     submitterLinksCache.set(memberId, links);

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -60,6 +60,8 @@ export interface GameBananaSubmitter {
     id: number;
     name: string;
     avatarUrl?: string;
+    profileUrl?: string;
+    kofiUrl?: string;
 }
 
 export interface GameBananaPreviewMedia {
@@ -161,6 +163,7 @@ export interface GameBananaModDetails {
     category?: GameBananaCategory;
     files?: GameBananaFile[];
     previewMedia?: GameBananaPreviewMedia;
+    submitter?: GameBananaSubmitter;
 }
 
 export interface GameBananaCollection {
@@ -232,7 +235,9 @@ interface ModRaw {
     _aSubmitter?: {
         _idRow: number;
         _sName: string;
+        _sProfileUrl?: string;
         _sAvatarUrl?: string;
+        _aDonationMethods?: DonationMethodRaw[];
     };
     _aPreviewMedia?: {
         _aImages?: Array<{
@@ -331,6 +336,14 @@ interface ModDetailsRaw {
     _aFiles?: FileRaw[];
     _aPreviewMedia?: ModRaw['_aPreviewMedia'];
     _aCategory?: ModRaw['_aRootCategory'];
+    _aSubmitter?: ModRaw['_aSubmitter'];
+}
+
+interface DonationMethodRaw {
+    _sTitle?: string;
+    _sValue?: string;
+    _sIconClasses?: string;
+    _bIsUrl?: boolean;
 }
 
 interface CollectionRaw {
@@ -550,13 +563,7 @@ function mapMod(raw: ModRaw): GameBananaMod {
         // _bIsNsfw is only returned by detail API, but _bHasContentRatings is returned by list API
         // and correlates with NSFW status, so use it as fallback
         nsfw: raw._bIsNsfw ?? raw._bHasContentRatings ?? false,
-        submitter: raw._aSubmitter
-            ? {
-                id: raw._aSubmitter._idRow,
-                name: raw._aSubmitter._sName,
-                avatarUrl: raw._aSubmitter._sAvatarUrl,
-            }
-            : undefined,
+        submitter: mapSubmitter(raw._aSubmitter),
         previewMedia: (raw._aPreviewMedia?._aImages || raw._aPreviewMedia?._aMetadata)
             ? {
                 images: raw._aPreviewMedia._aImages
@@ -768,10 +775,24 @@ export async function fetchSubmissions(
  */
 export async function fetchModDetails(
     modId: number,
-    section = 'Mod'
+    section = 'Mod',
+    options: { includeSubmitter?: boolean } = {}
 ): Promise<GameBananaModDetails> {
     // Fetch mod details with NSFW flag
-    const url = `${GAMEBANANA_API_BASE}/${section}/${modId}?_csvProperties=_idRow,_sName,_sText,_bIsNsfw,_aCategory,_aFiles,_aPreviewMedia`;
+    const fields = [
+        '_idRow',
+        '_sName',
+        '_sText',
+        '_bIsNsfw',
+        '_aCategory',
+        '_aFiles',
+        '_aPreviewMedia',
+    ];
+    if (options.includeSubmitter) {
+        fields.push('_aSubmitter');
+    }
+    const params = new URLSearchParams({ _csvProperties: fields.join(',') });
+    const url = `${GAMEBANANA_API_BASE}/${section}/${modId}?${params.toString()}`;
     debugGameBanana('[fetchModDetails] URL:', url);
     const raw = await fetchJson<ModDetailsRaw>(url);
 
@@ -812,6 +833,7 @@ export async function fetchModDetails(
                     : undefined,
             }
         : undefined,
+        submitter: mapSubmitter(raw._aSubmitter),
     };
 }
 
@@ -1009,7 +1031,38 @@ function mapSubmitter(raw: ModRaw['_aSubmitter']): GameBananaSubmitter | undefin
         id: raw._idRow,
         name: raw._sName,
         avatarUrl: raw._sAvatarUrl,
+        profileUrl: raw._sProfileUrl,
+        kofiUrl: extractKofiUrl(raw._aDonationMethods),
     };
+}
+
+function extractKofiUrl(methods: DonationMethodRaw[] | undefined): string | undefined {
+    for (const method of methods ?? []) {
+        const title = method._sTitle?.toLowerCase() ?? '';
+        const icon = method._sIconClasses?.toLowerCase() ?? '';
+        if (!title.includes('ko-fi') && !title.includes('kofi') && !icon.includes('kofi')) {
+            continue;
+        }
+
+        const url = normalizeKofiUrl(method._sValue);
+        if (url) return url;
+    }
+    return undefined;
+}
+
+function normalizeKofiUrl(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) return undefined;
+
+    try {
+        const url = new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`);
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+        const hostname = url.hostname.toLowerCase();
+        if (hostname !== 'ko-fi.com' && hostname !== 'www.ko-fi.com') return undefined;
+        return url.toString();
+    } catch {
+        return undefined;
+    }
 }
 
 function mapPreviewMedia(raw: ModRaw['_aPreviewMedia']): GameBananaPreviewMedia | undefined {

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron';
 import { gamebananaRateLimiter } from './rateLimiter';
+import { GRIMOIRE_USER_AGENT } from './userAgent';
 
 // Debounce the rate-limit warning so a burst of 429s (e.g. the unknown-mod CRC
 // matcher fanning out) produces one toast, not a flood. Broadcasting via
@@ -441,7 +442,7 @@ async function fetchJson<T>(url: string, timeoutMs = 30000, options: GameBananaR
             const response = await fetch(url, {
                 headers: {
                     Accept: 'application/json',
-                    'User-Agent': 'DeadlockModManager/1.0',
+                    'User-Agent': GRIMOIRE_USER_AGENT,
                 },
                 signal: request.signal,
             });

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -64,6 +64,12 @@ export interface GameBananaSubmitter {
     kofiUrl?: string;
 }
 
+export interface GameBananaArtistLink {
+    label: string;
+    platform: string;
+    url: string;
+}
+
 export interface GameBananaPreviewMedia {
     images?: GameBananaImage[];
     metadata?: GameBananaPreviewMetadata;
@@ -1034,6 +1040,118 @@ function mapSubmitter(raw: ModRaw['_aSubmitter']): GameBananaSubmitter | undefin
         profileUrl: raw._sProfileUrl,
         kofiUrl: extractKofiUrl(raw._aDonationMethods),
     };
+}
+
+interface ContactInfoRaw {
+    _sTitle?: string;
+    _sValue?: string;
+    _sIconClasses?: string;
+    _sValueTemplate?: string;
+}
+
+interface ProfilePageRaw {
+    _bIsPrivate?: boolean;
+    _aContactInfo?: ContactInfoRaw[];
+}
+
+// Artist social links aren't carried on a mod's submitter payload; they live on
+// the member's profile. Cache per member id so reopening mods by the same
+// author (common while browsing) doesn't refetch.
+const submitterLinksCache = new Map<number, GameBananaArtistLink[]>();
+
+/**
+ * Fetch an artist's social/contact links (Bluesky, YouTube, Discord, website,
+ * etc.) from their GameBanana member profile. Best-effort: a private profile,
+ * a network error, or an empty contact list all resolve to an empty array so
+ * the details view simply shows no extra links.
+ */
+export async function fetchSubmitterLinks(memberId: number): Promise<GameBananaArtistLink[]> {
+    if (!Number.isFinite(memberId) || memberId <= 0) return [];
+
+    const cached = submitterLinksCache.get(memberId);
+    if (cached) return cached;
+
+    let links: GameBananaArtistLink[] = [];
+    try {
+        const raw = await fetchJson<ProfilePageRaw>(`${GAMEBANANA_API_BASE}/Member/${memberId}/ProfilePage`);
+        if (!raw._bIsPrivate) {
+            links = mapContactInfo(raw._aContactInfo);
+        }
+    } catch (err) {
+        console.warn('[gamebanana] Failed to load submitter links:', err);
+        links = [];
+    }
+
+    submitterLinksCache.set(memberId, links);
+    return links;
+}
+
+function mapContactInfo(items: ContactInfoRaw[] | undefined): GameBananaArtistLink[] {
+    const out: GameBananaArtistLink[] = [];
+    const seen = new Set<string>();
+    for (const item of items ?? []) {
+        const label = item._sTitle?.trim();
+        if (!label) continue;
+        const url = buildContactUrl(item);
+        if (!url || seen.has(url)) continue;
+        seen.add(url);
+        out.push({ label, platform: normalizeContactPlatform(item._sIconClasses, label), url });
+    }
+    return out;
+}
+
+/**
+ * Resolve a contact entry's stored value into a usable absolute URL. GameBanana
+ * stores either a bare handle (combined with a `%VALUE%` href template) or, when
+ * users paste a full path, a value that already contains the host - in which
+ * case naive template substitution double-prefixes it (e.g.
+ * `bsky.app/profile/bsky.app/...`). We detect that and use the value directly.
+ */
+function buildContactUrl(item: ContactInfoRaw): string | undefined {
+    const value = item._sValue?.trim();
+    if (!value) return undefined;
+
+    let candidate: string | undefined;
+    if (/^https?:\/\//i.test(value)) {
+        candidate = value;
+    } else {
+        const hrefMatch = item._sValueTemplate?.match(/href="([^"]*%VALUE%[^"]*)"/i);
+        const templateHref = hrefMatch?.[1];
+        if (templateHref) {
+            const prefix = templateHref.split('%VALUE%')[0];
+            let host = '';
+            try {
+                host = new URL(prefix).hostname.toLowerCase();
+            } catch {
+                host = '';
+            }
+            candidate =
+                host && value.toLowerCase().includes(host)
+                    ? `https://${value.replace(/^https?:\/\//i, '')}`
+                    : templateHref.replace('%VALUE%', value);
+        } else {
+            candidate = `https://${value.replace(/^https?:\/\//i, '')}`;
+        }
+    }
+
+    try {
+        const url = new URL(candidate);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+        return url.toString();
+    } catch {
+        return undefined;
+    }
+}
+
+// GameBanana tags each contact with an icon class like
+// "ContactTypeIcon BlueskyIcon"; pull the platform token out of it (ignoring the
+// generic "ContactType" prefix), falling back to a slug of the label.
+function normalizeContactPlatform(iconClasses: string | undefined, label: string): string {
+    const tokens = [...(iconClasses ?? '').matchAll(/([A-Za-z0-9]+)Icon\b/g)]
+        .map((m) => m[1].toLowerCase())
+        .filter((token) => token !== 'contacttype');
+    if (tokens.length > 0) return tokens[0];
+    return label.toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
 function extractKofiUrl(methods: DonationMethodRaw[] | undefined): string | undefined {

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -699,6 +699,7 @@ export async function fetchSubmissions(
     search?: string,
     categoryId?: number,
     sort?: string,
+    submitterId?: number,
     options: GameBananaRequestOptions = {}
 ): Promise<GameBananaModsResponse> {
     let url: string;
@@ -735,6 +736,10 @@ export async function fetchSubmissions(
             params.set('_aFilters[Generic_Category]', String(categoryId));
         }
 
+        if (submitterId && submitterId > 0) {
+            params.set('_aFilters[Generic_Submitter]', String(submitterId));
+        }
+
         if (sort && sortMap[sort]) {
             params.set('_sSort', sortMap[sort]);
         }
@@ -751,6 +756,10 @@ export async function fetchSubmissions(
 
         if (categoryId) {
             params.set('_aFilters[Generic_Category]', String(categoryId));
+        }
+
+        if (submitterId && submitterId > 0) {
+            params.set('_aFilters[Generic_Submitter]', String(submitterId));
         }
 
         if (sort && sort !== 'default' && sortMap[sort]) {

--- a/electron/main/services/stats.ts
+++ b/electron/main/services/stats.ts
@@ -21,6 +21,7 @@ import type {
     HeroStatsParams,
     BuildSearchParams,
 } from '../../../src/types/deadlock-stats'
+import { GRIMOIRE_USER_AGENT } from './userAgent'
 
 // Local flat types for counter/synergy stats (API returns flat arrays, not nested)
 export interface FlatHeroCounterStats {
@@ -74,7 +75,7 @@ async function fetchFromAPI<T>(
 
     const headers: Record<string, string> = {
         Accept: 'application/json',
-        'User-Agent': 'DeadlockModManager/1.0',
+        'User-Agent': GRIMOIRE_USER_AGENT,
     }
 
     if (options?.apiKey) {

--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -687,6 +687,7 @@ async function fetchCandidateModsPage(
         bucket.search,
         bucket.categoryId,
         'default',
+        undefined,
         { signal }
     );
     debugUnknownCrc(

--- a/electron/main/services/userAgent.ts
+++ b/electron/main/services/userAgent.ts
@@ -1,0 +1,15 @@
+import { app } from 'electron';
+
+// Identify outbound API/asset requests as Grimoire so GameBanana and
+// deadlock-api can see the traffic comes from the mod manager (GameBanana tool
+// 22583) rather than an anonymous client. Computed once; app.getVersion() reads
+// the bundled package version and is safe to call before the app is ready.
+function resolveAppVersion(): string {
+    try {
+        return app.getVersion();
+    } catch {
+        return '0.0.0';
+    }
+}
+
+export const GRIMOIRE_USER_AGENT = `Grimoire/${resolveAppVersion()} (Deadlock mod manager; +https://grimoiremods.com)`;

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -403,6 +403,7 @@ interface BrowseModsArgs {
     section?: string;
     categoryId?: number;
     sort?: string;
+    submitterId?: number;
 }
 
 interface GetModDetailsArgs {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../src/types/portableProfile';
 import type { SnapshotSummary, SnapshotTrigger } from '../../src/types/snapshot';
 import type { SocialSessionStatus } from '../../src/types/social';
+import type { GameBananaArtistLink } from '../../src/types/gamebanana';
 import type {
     AbilitySlot,
     AbilitySoundParams,
@@ -101,6 +102,7 @@ export interface ElectronAPI {
     getModFileList: (args: GetModDetailsArgs) => Promise<GameBananaModFileList>;
     getModComments: (args: GetModCommentsArgs) => Promise<GameBananaCommentsResponse>;
     getModUpdates: (args: GetModCommentsArgs) => Promise<GameBananaModUpdatesResponse>;
+    getSubmitterLinks: (memberId: number) => Promise<GameBananaArtistLink[]>;
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;
     getGameBananaCategories: (args: GetCategoriesArgs) => Promise<GameBananaCategoryNode[]>;
@@ -940,6 +942,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getModFileList: (args: GetModDetailsArgs) => ipcRenderer.invoke('get-mod-file-list', args),
     getModComments: (args: GetModCommentsArgs) => ipcRenderer.invoke('get-mod-comments', args),
     getModUpdates: (args: GetModCommentsArgs) => ipcRenderer.invoke('get-mod-updates', args),
+    getSubmitterLinks: (memberId: number) => ipcRenderer.invoke('get-submitter-links', memberId),
     downloadMod: (args: DownloadModArgs) => ipcRenderer.invoke('download-mod', args),
     getGameBananaSections: () => ipcRenderer.invoke('get-gamebanana-sections'),
     getGameBananaCategories: (args: GetCategoriesArgs) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -406,6 +406,7 @@ interface BrowseModsArgs {
 interface GetModDetailsArgs {
     modId: number;
     section?: string;
+    includeSubmitter?: boolean;
 }
 
 interface GetModCommentsArgs {
@@ -580,9 +581,11 @@ interface GameBananaModDetails {
     id: number;
     name: string;
     description?: string;
+    nsfw?: boolean;
     category?: unknown;
     files?: unknown[];
     previewMedia?: unknown;
+    submitter?: unknown;
 }
 
 interface GameBananaModFileList {

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -580,10 +580,13 @@ export default function ModDetailsModal({
       className="mod-details-navigation-skeleton absolute inset-0 bg-bg-secondary"
       aria-hidden
     >
-      <div className="flex h-full min-h-0 flex-col overflow-hidden lg:flex-row">
-        <div className="lg:w-[460px] lg:flex-shrink-0 p-5 lg:pr-3 space-y-3 overflow-hidden">
+      {/* Match the real body's layout per variant: the sidebar stacks into one
+          column, so its loading skeleton must too (the modal's lg:flex-row /
+          460px image column would overflow and clip a ~440px panel). */}
+      <div className={`flex h-full min-h-0 flex-col overflow-hidden ${isSidebar ? '' : 'lg:flex-row'}`}>
+        <div className={`space-y-3 overflow-hidden ${isSidebar ? 'p-4' : 'lg:w-[460px] lg:flex-shrink-0 p-5 lg:pr-3'}`}>
           <Skeleton className="aspect-[16/9] w-full" rounded="lg" />
-          <Skeleton className="aspect-[16/10] w-full" rounded="lg" />
+          {!isSidebar && <Skeleton className="aspect-[16/10] w-full" rounded="lg" />}
           <div className="rounded-lg border border-border bg-bg-tertiary p-3">
             <div className="mb-2 flex items-center gap-2">
               <Skeleton className="h-4 w-4" rounded="full" />
@@ -593,7 +596,7 @@ export default function ModDetailsModal({
           </div>
         </div>
 
-        <div className="flex-1 min-w-0 p-5 lg:pl-3 space-y-5 overflow-hidden">
+        <div className={`flex-1 min-w-0 space-y-5 overflow-hidden ${isSidebar ? 'p-4' : 'p-5 lg:pl-3'}`}>
           <section>
             <Skeleton className="mb-2 h-3 w-16" />
             <div className="flex items-center gap-2">
@@ -675,7 +678,10 @@ export default function ModDetailsModal({
     <div
       className={outerClass}
       onClick={isSidebar ? undefined : onClose}
-      role="dialog"
+      // The docked sidebar is a persistent, non-blocking panel, so it's a
+      // labelled region, not a modal dialog (which would wrongly imply a
+      // focus trap / inert background to screen readers).
+      role={isSidebar ? 'region' : 'dialog'}
       aria-modal={isSidebar ? undefined : true}
       aria-label={isNavigating ? navigationLabel ?? 'Loading mod details' : mod.name}
       aria-busy={isNavigating}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -22,19 +22,11 @@ import {
   Bell,
   Trash2,
   Coffee,
-  Youtube,
-  Twitter,
-  Twitch,
-  Instagram,
-  Facebook,
-  Github,
-  Globe,
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import DOMPurify from 'dompurify';
-import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate, GameBananaArtistLink } from '../types/gamebanana';
+import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate } from '../types/gamebanana';
 import { isModOutdated, formatDate } from '../types/gamebanana';
-import { getModComments, getModUpdates, getSubmitterLinks } from '../lib/api';
+import { getModComments, getModUpdates } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
 import { Skeleton } from './common/Skeleton';
@@ -42,24 +34,6 @@ import { ArchivedTag } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
 
 type ModDetailsNavigationDirection = 'previous' | 'next';
-
-// Lucide ships brand glyphs for some platforms but not newer ones (Bluesky,
-// Discord, TikTok, Ko-fi...); those fall back to a generic globe so every link
-// still renders a recognizable chip. Keys are the normalized platform tokens
-// from the GameBanana contact icon classes.
-const SOCIAL_ICONS: Record<string, LucideIcon> = {
-  youtube: Youtube,
-  twitter: Twitter,
-  x: Twitter,
-  twitch: Twitch,
-  instagram: Instagram,
-  facebook: Facebook,
-  github: Github,
-};
-
-function socialIcon(platform: string): LucideIcon {
-  return SOCIAL_ICONS[platform] ?? Globe;
-}
 
 interface ModDetailsModalProps {
   mod: GameBananaModDetails;
@@ -113,6 +87,9 @@ interface ModDetailsModalProps {
   /** When provided, render a dock/pop-out button in the header that switches
    *  between the two presentations. The caller persists the choice. */
   onChangeView?: (view: 'modal' | 'sidebar') => void;
+  /** When provided, clicking the artist opens "artist mode" (a grid of all the
+   *  artist's mods) instead of their GameBanana profile. */
+  onViewArtist?: (artist: { id: number; name: string; avatarUrl?: string; profileUrl?: string; kofiUrl?: string }) => void;
 }
 
 export default function ModDetailsModal({
@@ -145,6 +122,7 @@ export default function ModDetailsModal({
   onDeleteFile,
   variant = 'modal',
   onChangeView,
+  onViewArtist,
 }: ModDetailsModalProps) {
   const isSidebar = variant === 'sidebar';
   const images = mod.previewMedia?.images ?? [];
@@ -160,8 +138,6 @@ export default function ModDetailsModal({
   const swipeStartXRef = useRef<number | null>(null);
   // Falls back to a monogram when the artist avatar URL 404s or is blocked.
   const [avatarFailed, setAvatarFailed] = useState(false);
-  // Artist social/contact links, loaded lazily from the member profile.
-  const [artistLinks, setArtistLinks] = useState<GameBananaArtistLink[]>([]);
   const [comments, setComments] = useState<GameBananaComment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
   const [commentsTotalCount, setCommentsTotalCount] = useState(0);
@@ -250,26 +226,6 @@ export default function ModDetailsModal({
     swipeStartXRef.current = null;
     setAvatarFailed(false);
   }, [mod.id]);
-
-  // Pull the artist's social/contact links from their member profile. Cleared
-  // up front so a different artist's links never linger during the fetch; the
-  // main-process layer caches by member id, so repeat artists resolve instantly.
-  useEffect(() => {
-    const memberId = mod.submitter?.id;
-    setArtistLinks([]);
-    if (!memberId || memberId <= 0) return;
-    let cancelled = false;
-    getSubmitterLinks(memberId)
-      .then((links) => {
-        if (!cancelled) setArtistLinks(links);
-      })
-      .catch(() => {
-        if (!cancelled) setArtistLinks([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [mod.submitter?.id]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -392,6 +348,35 @@ export default function ModDetailsModal({
   const submitterProfileUrl = mod.submitter?.profileUrl
     ?? (mod.submitter && mod.submitter.id > 0 ? `https://gamebanana.com/members/${mod.submitter.id}` : undefined);
   const submitterKofiUrl = mod.submitter?.kofiUrl;
+  // When the host provides onViewArtist, the artist becomes a click target that
+  // opens "artist mode" (all of their mods) instead of the GameBanana profile.
+  const submitter = mod.submitter;
+  const openArtist =
+    submitter && submitter.id > 0 && onViewArtist
+      ? () =>
+          onViewArtist({
+            id: submitter.id,
+            name: submitter.name,
+            avatarUrl: submitter.avatarUrl,
+            profileUrl: submitterProfileUrl,
+            kofiUrl: submitterKofiUrl,
+          })
+      : undefined;
+  const avatarVisual = submitter ? (
+    submitter.avatarUrl && !avatarFailed ? (
+      <img
+        src={submitter.avatarUrl}
+        alt={submitter.name}
+        loading="lazy"
+        onError={() => setAvatarFailed(true)}
+        className="h-11 w-11 flex-shrink-0 rounded-full border border-border object-cover"
+      />
+    ) : (
+      <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-base font-bold uppercase text-accent">
+        {submitter.name.charAt(0)}
+      </div>
+    )
+  ) : null;
   const modalBodyTransitionClass = isNavigating
     ? navigationDirection === 'previous'
       ? 'mod-details-body--loading-previous'
@@ -1254,38 +1239,46 @@ export default function ModDetailsModal({
                 </div>
               )}
 
-              {mod.submitter && (
+              {submitter && (
                 <section>
-                  <div className="space-y-3 rounded-xl border border-border bg-bg-tertiary/40 p-3">
-                  <div className="flex items-center gap-3">
-                    {mod.submitter.avatarUrl && !avatarFailed ? (
-                      <img
-                        src={mod.submitter.avatarUrl}
-                        alt={mod.submitter.name}
-                        loading="lazy"
-                        onError={() => setAvatarFailed(true)}
-                        className="h-11 w-11 flex-shrink-0 rounded-full border border-border object-cover"
-                      />
+                  <div className="flex items-center gap-3 rounded-xl border border-border bg-bg-tertiary/40 p-3">
+                    {openArtist ? (
+                      <button
+                        type="button"
+                        onClick={openArtist}
+                        title={`View ${submitter.name}'s mods`}
+                        className="flex-shrink-0 rounded-full transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 cursor-pointer"
+                      >
+                        {avatarVisual}
+                      </button>
                     ) : (
-                      <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-base font-bold uppercase text-accent">
-                        {mod.submitter.name.charAt(0)}
-                      </div>
+                      avatarVisual
                     )}
                     <div className="min-w-0 flex-1">
                       <div className="text-[10px] font-semibold uppercase tracking-wide text-text-tertiary">Artist</div>
-                      {submitterProfileUrl ? (
+                      {openArtist ? (
+                        <button
+                          type="button"
+                          onClick={openArtist}
+                          title={`View ${submitter.name}'s mods`}
+                          className="group/artist inline-flex min-w-0 max-w-full items-center gap-1.5 font-semibold text-text-primary transition-colors hover:text-accent cursor-pointer"
+                        >
+                          <span className="min-w-0 truncate">{submitter.name}</span>
+                          <ChevronRight className="h-4 w-4 flex-shrink-0 text-text-tertiary transition-colors group-hover/artist:text-accent" />
+                        </button>
+                      ) : submitterProfileUrl ? (
                         <a
                           href={submitterProfileUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          title={`View ${mod.submitter.name} on GameBanana`}
+                          title={`View ${submitter.name} on GameBanana`}
                           className="group/artist inline-flex min-w-0 max-w-full items-center gap-1.5 font-semibold text-text-primary transition-colors hover:text-accent"
                         >
-                          <span className="min-w-0 truncate">{mod.submitter.name}</span>
+                          <span className="min-w-0 truncate">{submitter.name}</span>
                           <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover/artist:text-accent" />
                         </a>
                       ) : (
-                        <span className="block min-w-0 truncate font-semibold text-text-primary">{mod.submitter.name}</span>
+                        <span className="block min-w-0 truncate font-semibold text-text-primary">{submitter.name}</span>
                       )}
                     </div>
                     {submitterKofiUrl && (
@@ -1293,42 +1286,13 @@ export default function ModDetailsModal({
                         href={submitterKofiUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        title={`Support ${mod.submitter.name} on Ko-fi`}
+                        title={`Support ${submitter.name} on Ko-fi`}
                         className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5E5B]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary"
                       >
                         <Coffee className="h-4 w-4" />
                         Ko-fi
                       </a>
                     )}
-                  </div>
-                  {(() => {
-                    // Drop a Ko-fi contact entry when we already show the brand
-                    // button so it isn't listed twice.
-                    const chips = artistLinks.filter(
-                      (link) => !(submitterKofiUrl && link.platform === 'kofi')
-                    );
-                    if (chips.length === 0) return null;
-                    return (
-                      <div className="flex flex-wrap gap-1.5">
-                        {chips.map((link) => {
-                          const Icon = socialIcon(link.platform);
-                          return (
-                            <a
-                              key={link.url}
-                              href={link.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title={link.label}
-                              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-bg-secondary/60 px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-text-primary"
-                            >
-                              <Icon className="h-3.5 w-3.5" />
-                              {link.label}
-                            </a>
-                          );
-                        })}
-                      </div>
-                    );
-                  })()}
                   </div>
                 </section>
               )}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -32,6 +32,8 @@ import { Skeleton } from './common/Skeleton';
 import { ArchivedTag } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
 
+type ModDetailsNavigationDirection = 'previous' | 'next';
+
 interface ModDetailsModalProps {
   mod: GameBananaModDetails;
   section: string;
@@ -58,6 +60,9 @@ interface ModDetailsModalProps {
   hideNsfwPreviews: boolean;
   dateAdded?: number;
   dateModified?: number;
+  isNavigating?: boolean;
+  navigationDirection?: ModDetailsNavigationDirection;
+  navigationLabel?: string;
   updateAvailable?: boolean;
   /** When provided, render a toggle next to the Update/Installed badge that
    *  flips the underlying mod's ignoreUpdates flag. Only meaningful in the
@@ -90,6 +95,9 @@ export default function ModDetailsModal({
   hideNsfwPreviews,
   dateAdded,
   dateModified,
+  isNavigating = false,
+  navigationDirection = 'next',
+  navigationLabel,
   updateAvailable,
   ignoreUpdates,
   onToggleIgnoreUpdates,
@@ -209,7 +217,7 @@ export default function ModDetailsModal({
       if (lightboxOpen && images.length > 1) {
         if (e.key === 'ArrowLeft') goToPrevious();
         if (e.key === 'ArrowRight') goToNext();
-      } else if (!deleteCandidate) {
+      } else if (!deleteCandidate && !isNavigating) {
         const target = e.target as HTMLElement | null;
         const tag = target?.tagName?.toLowerCase();
         const editing =
@@ -264,6 +272,7 @@ export default function ModDetailsModal({
     lightboxOpen,
     deleteCandidate,
     deleteInProgress,
+    isNavigating,
     onNavigatePrevious,
     onNavigateNext,
   ]);
@@ -309,6 +318,11 @@ export default function ModDetailsModal({
   const submitterProfileUrl = mod.submitter?.profileUrl
     ?? (mod.submitter && mod.submitter.id > 0 ? `https://gamebanana.com/members/${mod.submitter.id}` : undefined);
   const submitterKofiUrl = mod.submitter?.kofiUrl;
+  const modalBodyTransitionClass = isNavigating
+    ? navigationDirection === 'previous'
+      ? 'mod-details-body--loading-previous'
+      : 'mod-details-body--loading-next'
+    : '';
   const formatUpdateVersion = (version: string) =>
     version.trim().match(/^v/i) ? version.trim() : `v${version.trim()}`;
 
@@ -379,7 +393,7 @@ export default function ModDetailsModal({
     return (
       <div
         key={file.id}
-        className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+        className={`grid grid-cols-[auto,minmax(0,1fr)] items-center gap-x-3 gap-y-2 p-3 rounded-lg border transition-colors sm:grid-cols-[auto,minmax(0,1fr),auto] ${
           isUpdate
             ? 'border-accent/40 bg-accent/5'
             : isActive
@@ -391,7 +405,7 @@ export default function ModDetailsModal({
                   : 'border-border bg-bg-tertiary'
         }`}
       >
-        <div className={`flex-shrink-0 w-10 h-10 rounded-md flex items-center justify-center ${
+        <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md ${
           isUpdate
             ? 'bg-accent/15 text-accent'
             : isActive
@@ -404,9 +418,9 @@ export default function ModDetailsModal({
         }`}>
           <FileArchive className="w-5 h-5" />
         </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 min-w-0">
-            <p className="font-medium truncate text-sm" title={file.fileName}>{file.fileName}</p>
+        <div className="min-w-0">
+          <div className="flex min-w-0 max-w-full items-center gap-2">
+            <p className="min-w-0 flex-1 truncate text-sm font-medium" title={file.fileName}>{file.fileName}</p>
             {archived && <ArchivedTag />}
             {isActive && (
               <span className="flex-shrink-0 text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5">
@@ -419,15 +433,15 @@ export default function ModDetailsModal({
               {file.description}
             </p>
           )}
-          <div className="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
-            <span>{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
+          <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-secondary">
+            <span className="whitespace-nowrap">{(file.fileSize / 1024 / 1024).toFixed(2)} MB</span>
             <span className="opacity-50">-</span>
-            <span>{file.downloadCount.toLocaleString()} downloads</span>
+            <span className="whitespace-nowrap">{file.downloadCount.toLocaleString()} downloads</span>
             {file.dateAdded && file.dateAdded > 0 && (
               <>
                 <span className="opacity-50">-</span>
                 <span
-                  className="flex items-center gap-1"
+                  className="flex items-center gap-1 whitespace-nowrap"
                   title={`Uploaded ${formatDate(file.dateAdded)} ${new Date(file.dateAdded * 1000).toLocaleTimeString()}`}
                 >
                   <Clock className="w-3 h-3" />
@@ -445,14 +459,14 @@ export default function ModDetailsModal({
             </div>
           )}
         </div>
-        <div className="flex flex-shrink-0 items-center gap-2">
+        <div className="col-start-2 flex min-w-0 flex-wrap items-center justify-end gap-2 sm:col-start-3 sm:row-start-1">
           {showEnablePill && installedFileState && (
             <button
               type="button"
               onClick={() => onEnableFile!(installedFileState.modId)}
               disabled={isBusyThis}
               title="Enable this mod"
-              className="flex items-center justify-center gap-1.5 rounded-md border border-yellow-500/40 bg-yellow-500/15 px-3 py-2 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-500/25 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+              className="flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-yellow-500/40 bg-yellow-500/15 px-3 py-2 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-500/25 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
             >
               <Power className="w-3.5 h-3.5" />
               Enable
@@ -474,7 +488,7 @@ export default function ModDetailsModal({
             type="button"
             onClick={() => onDownload(file.id, file.fileName)}
             disabled={isBusyThis}
-            className={`flex min-w-[110px] items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer ${
+            className={`flex min-w-[110px] max-w-full items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer ${
               isUpdate || !isInstalled
                 ? 'border-accent/45 bg-accent/10 text-text-primary hover:border-accent/65 hover:bg-accent/20'
                 : 'border-border bg-bg-secondary text-text-primary hover:bg-bg-primary'
@@ -502,6 +516,79 @@ export default function ModDetailsModal({
     );
   };
 
+  const navigationSkeleton = (
+    <div
+      className="mod-details-navigation-skeleton absolute inset-0 bg-bg-secondary"
+      aria-hidden
+    >
+      <div className="flex h-full min-h-0 flex-col overflow-hidden lg:flex-row">
+        <div className="lg:w-[460px] lg:flex-shrink-0 p-5 lg:pr-3 space-y-3 overflow-hidden">
+          <Skeleton className="aspect-[16/9] w-full" rounded="lg" />
+          <Skeleton className="aspect-[16/10] w-full" rounded="lg" />
+          <div className="rounded-lg border border-border bg-bg-tertiary p-3">
+            <div className="mb-2 flex items-center gap-2">
+              <Skeleton className="h-4 w-4" rounded="full" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="h-9 w-full" rounded="lg" />
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0 p-5 lg:pl-3 space-y-5 overflow-hidden">
+          <section>
+            <Skeleton className="mb-2 h-3 w-16" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-7 w-20" rounded="md" />
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="mb-2 h-3 w-14" />
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-11/12" />
+              <Skeleton className="h-3 w-4/5" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="mb-2 h-3 w-20" />
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 rounded-lg border border-border bg-bg-tertiary p-3">
+                  <Skeleton className="h-10 w-10 flex-shrink-0" rounded="md" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-3 w-3/4" />
+                    <Skeleton className="h-2.5 w-1/2" />
+                  </div>
+                  <Skeleton className="h-9 w-24 flex-shrink-0" rounded="md" />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="mb-3 h-3 w-24" />
+            <div className="space-y-3">
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div key={i} className="flex gap-3">
+                  <Skeleton className="h-7 w-7 flex-shrink-0" rounded="full" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-3 w-28" />
+                    <Skeleton className="h-2.5 w-full" />
+                    <Skeleton className="h-2.5 w-2/3" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+
   if (typeof document === 'undefined') return null;
 
   const modal = (
@@ -510,7 +597,8 @@ export default function ModDetailsModal({
       onClick={onClose}
       role="dialog"
       aria-modal="true"
-      aria-label={mod.name}
+      aria-label={isNavigating ? navigationLabel ?? 'Loading mod details' : mod.name}
+      aria-busy={isNavigating}
     >
       <div
         className="relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl"
@@ -519,29 +607,39 @@ export default function ModDetailsModal({
         {onNavigatePrevious && !lightboxOpen && (
           <button
             type="button"
+            disabled={isNavigating}
             onClick={(e) => {
               e.stopPropagation();
               onNavigatePrevious();
             }}
             aria-label={previousLabel ? `Previous mod: ${previousLabel}` : 'Previous mod'}
             title={previousLabel ? `Previous: ${previousLabel}` : 'Previous mod'}
-            className="absolute -left-16 top-1/2 z-20 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-primary shadow-2xl transition-colors hover:border-accent/60 hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 cursor-pointer"
+            className="absolute -left-16 top-1/2 z-20 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-primary shadow-2xl transition-colors hover:border-accent/60 hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-wait disabled:opacity-70 cursor-pointer"
           >
-            <ChevronLeft className="h-8 w-8" />
+            {isNavigating && navigationDirection === 'previous' ? (
+              <Loader2 className="h-6 w-6 animate-spin" />
+            ) : (
+              <ChevronLeft className="h-8 w-8" />
+            )}
           </button>
         )}
         {onNavigateNext && !lightboxOpen && (
           <button
             type="button"
+            disabled={isNavigating}
             onClick={(e) => {
               e.stopPropagation();
               onNavigateNext();
             }}
             aria-label={nextLabel ? `Next mod: ${nextLabel}` : 'Next mod'}
             title={nextLabel ? `Next: ${nextLabel}` : 'Next mod'}
-            className="absolute -right-16 top-1/2 z-20 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-primary shadow-2xl transition-colors hover:border-accent/60 hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 cursor-pointer"
+            className="absolute -right-16 top-1/2 z-20 flex h-14 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-primary shadow-2xl transition-colors hover:border-accent/60 hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-wait disabled:opacity-70 cursor-pointer"
           >
-            <ChevronRight className="h-8 w-8" />
+            {isNavigating && navigationDirection === 'next' ? (
+              <Loader2 className="h-6 w-6 animate-spin" />
+            ) : (
+              <ChevronRight className="h-8 w-8" />
+            )}
           </button>
         )}
         {/* Header. Status badges, title, and dense metadata stay compact so
@@ -605,17 +703,24 @@ export default function ModDetailsModal({
               </span>
             )}
           </div>
-          <h2 className="text-lg lg:text-xl font-bold leading-tight min-w-0 flex-1" title={mod.name}>
-            <a
-              href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`View ${mod.name} on GameBanana`}
-              className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
-            >
-              <span className="min-w-0 truncate">{mod.name}</span>
-              <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
-            </a>
+          <h2 className="text-lg lg:text-xl font-bold leading-tight min-w-0 flex-1" title={isNavigating ? navigationLabel : mod.name}>
+            {isNavigating ? (
+              <span className="inline-flex w-full max-w-sm items-center gap-2">
+                <Skeleton className="h-5 w-full max-w-[20rem]" />
+                <span className="sr-only">Loading {navigationLabel ?? 'mod details'}</span>
+              </span>
+            ) : (
+              <a
+                href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`View ${mod.name} on GameBanana`}
+                className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
+              >
+                <span className="min-w-0 truncate">{mod.name}</span>
+                <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+              </a>
+            )}
           </h2>
           {(() => {
             // Hide the modified date when it formats to the same day as the
@@ -723,7 +828,8 @@ export default function ModDetailsModal({
             two independently-scrollable columns on lg+. Independent scroll
             on wide is critical now that previews stack vertically: scrolling
             comments shouldn't drag the image column away, and vice versa. */}
-        <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
+        <div className={`mod-details-body relative flex-1 min-h-0 overflow-hidden ${modalBodyTransitionClass}`}>
+          <div className="mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
             {/* Image / preview column */}
             <div className="lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pr-3 space-y-3">
               {images.length > 0 ? (
@@ -1104,6 +1210,8 @@ export default function ModDetailsModal({
                 View on GameBanana
               </a>
             </div>
+          </div>
+          {isNavigating && navigationSkeleton}
         </div>
       </div>
 

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Volume2,
@@ -17,6 +17,7 @@ import {
   CheckCircle2,
   Power,
   Maximize2,
+  PanelRight,
   BellOff,
   Bell,
   Trash2,
@@ -78,6 +79,14 @@ interface ModDetailsModalProps {
   /** Browse-only file removal. Receives the local installed mod id that backs
    *  the GameBanana file row. */
   onDeleteFile?: (modId: string) => Promise<void> | void;
+  /** 'modal' (centered overlay, the default) or 'sidebar' (docked right-side
+   *  panel that lets the user keep browsing the grid). The sidebar shell
+   *  (width, full-height, border) is provided by the caller; this component
+   *  fills it and forces a single-column stacked body. */
+  variant?: 'modal' | 'sidebar';
+  /** When provided, render a dock/pop-out button in the header that switches
+   *  between the two presentations. The caller persists the choice. */
+  onChangeView?: (view: 'modal' | 'sidebar') => void;
 }
 
 export default function ModDetailsModal({
@@ -108,7 +117,10 @@ export default function ModDetailsModal({
   previousLabel,
   nextLabel,
   onDeleteFile,
+  variant = 'modal',
+  onChangeView,
 }: ModDetailsModalProps) {
+  const isSidebar = variant === 'sidebar';
   const images = mod.previewMedia?.images ?? [];
   const audioPreviewUrl = mod.previewMedia?.metadata?.audioUrl;
   const soundVolume = useAppStore((state) => state.soundVolume);
@@ -117,6 +129,11 @@ export default function ModDetailsModal({
   // It tracks which image is currently zoomed and which one keyboard arrows
   // step through while the lightbox is open.
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  // Pointer X at the start of a sidebar-carousel swipe; compared on pointer-up
+  // to decide whether the gesture stepped to the prev/next image.
+  const swipeStartXRef = useRef<number | null>(null);
+  // Falls back to a monogram when the artist avatar URL 404s or is blocked.
+  const [avatarFailed, setAvatarFailed] = useState(false);
   const [comments, setComments] = useState<GameBananaComment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
   const [commentsTotalCount, setCommentsTotalCount] = useState(0);
@@ -196,6 +213,15 @@ export default function ModDetailsModal({
       cancelled = true;
     };
   }, [mod.id, section]);
+
+  // Reset the image cursor when the mod changes so the sidebar carousel (and a
+  // subsequently-opened lightbox) starts on the first preview rather than a
+  // stale index that may be out of range for the new mod's image count.
+  useEffect(() => {
+    setCurrentImageIndex(0);
+    swipeStartXRef.current = null;
+    setAvatarFailed(false);
+  }, [mod.id]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -591,20 +617,44 @@ export default function ModDetailsModal({
 
   if (typeof document === 'undefined') return null;
 
+  // The sidebar shares this whole JSX tree with the modal; only the outer
+  // chrome and the body layout differ. The caller's <aside> supplies the
+  // sidebar's width/height/border, so here we just fill it and force the
+  // single-column stacked body (the modal's lg:flex-row two-column layout is
+  // viewport-keyed and would overflow a ~440px panel on a wide screen).
+  const outerClass = isSidebar
+    ? 'h-full w-full'
+    : 'fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 md:px-24 z-50 animate-fade-in';
+  const panelClass = isSidebar
+    ? 'relative bg-bg-secondary h-full w-full overflow-hidden flex flex-col'
+    : 'relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl';
+  const bodyContentClass = isSidebar
+    ? 'mod-details-body-content flex h-full min-h-0 flex-col overflow-y-auto'
+    : 'mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto lg:overflow-hidden';
+  const imageColClass = isSidebar
+    ? 'p-4 space-y-3'
+    : 'lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pr-3 space-y-3';
+  const detailsColClass = isSidebar
+    ? 'flex-1 min-w-0 p-4 space-y-5'
+    : 'flex-1 min-w-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pl-3 space-y-5';
+
   const modal = (
     <div
-      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 md:px-24 z-50 animate-fade-in"
-      onClick={onClose}
+      className={outerClass}
+      onClick={isSidebar ? undefined : onClose}
       role="dialog"
-      aria-modal="true"
+      aria-modal={isSidebar ? undefined : true}
       aria-label={isNavigating ? navigationLabel ?? 'Loading mod details' : mod.name}
       aria-busy={isNavigating}
     >
       <div
-        className="relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
+        className={panelClass}
+        onClick={isSidebar ? undefined : (e) => e.stopPropagation()}
       >
-        {onNavigatePrevious && !lightboxOpen && (
+        {/* Big floating step arrows belong to the centered modal only; they sit
+            outside the panel (-left-16/-right-16) which a clipped sidebar can't
+            show. The sidebar gets compact inline arrows in its header instead. */}
+        {!isSidebar && onNavigatePrevious && !lightboxOpen && (
           <button
             type="button"
             disabled={isNavigating}
@@ -623,7 +673,7 @@ export default function ModDetailsModal({
             )}
           </button>
         )}
-        {onNavigateNext && !lightboxOpen && (
+        {!isSidebar && onNavigateNext && !lightboxOpen && (
           <button
             type="button"
             disabled={isNavigating}
@@ -646,6 +696,40 @@ export default function ModDetailsModal({
             the modal's vertical budget goes to content. Title shrinks/truncates
             first when space gets tight; metadata hides on narrow screens. */}
         <div className="flex items-center gap-3 px-5 py-3 border-b border-border flex-shrink-0">
+          {/* Sidebar-only: compact step arrows live inline since the big
+              floating ones have nowhere to go in a docked panel. */}
+          {isSidebar && (onNavigatePrevious || onNavigateNext) && !lightboxOpen && (
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <button
+                type="button"
+                disabled={isNavigating || !onNavigatePrevious}
+                onClick={() => onNavigatePrevious?.()}
+                aria-label={previousLabel ? `Previous mod: ${previousLabel}` : 'Previous mod'}
+                title={previousLabel ? `Previous: ${previousLabel}` : 'Previous mod'}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border bg-bg-tertiary text-text-secondary transition-colors hover:border-accent/60 hover:text-text-primary disabled:cursor-default disabled:opacity-40 cursor-pointer"
+              >
+                {isNavigating && navigationDirection === 'previous' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ChevronLeft className="h-4 w-4" />
+                )}
+              </button>
+              <button
+                type="button"
+                disabled={isNavigating || !onNavigateNext}
+                onClick={() => onNavigateNext?.()}
+                aria-label={nextLabel ? `Next mod: ${nextLabel}` : 'Next mod'}
+                title={nextLabel ? `Next: ${nextLabel}` : 'Next mod'}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-border bg-bg-tertiary text-text-secondary transition-colors hover:border-accent/60 hover:text-text-primary disabled:cursor-default disabled:opacity-40 cursor-pointer"
+              >
+                {isNavigating && navigationDirection === 'next' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          )}
           <div className="flex items-center gap-2 flex-shrink-0">
             {updateAvailable && (
               <span className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent border border-accent/40">
@@ -703,25 +787,32 @@ export default function ModDetailsModal({
               </span>
             )}
           </div>
-          <h2 className="text-lg lg:text-xl font-bold leading-tight min-w-0 flex-1" title={isNavigating ? navigationLabel : mod.name}>
-            {isNavigating ? (
-              <span className="inline-flex w-full max-w-sm items-center gap-2">
-                <Skeleton className="h-5 w-full max-w-[20rem]" />
-                <span className="sr-only">Loading {navigationLabel ?? 'mod details'}</span>
-              </span>
-            ) : (
-              <a
-                href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={`View ${mod.name} on GameBanana`}
-                className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
-              >
-                <span className="min-w-0 truncate">{mod.name}</span>
-                <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
-              </a>
-            )}
-          </h2>
+          {/* Sidebar moves the title down into the body (above the artist) to
+              keep this header from cramming, so here it's just a spacer that
+              pushes the action buttons to the right edge. */}
+          {isSidebar ? (
+            <div className="min-w-0 flex-1" />
+          ) : (
+            <h2 className="text-lg lg:text-xl font-bold leading-tight min-w-0 flex-1" title={isNavigating ? navigationLabel : mod.name}>
+              {isNavigating ? (
+                <span className="inline-flex w-full max-w-sm items-center gap-2">
+                  <Skeleton className="h-5 w-full max-w-[20rem]" />
+                  <span className="sr-only">Loading {navigationLabel ?? 'mod details'}</span>
+                </span>
+              ) : (
+                <a
+                  href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`View ${mod.name} on GameBanana`}
+                  className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
+                >
+                  <span className="min-w-0 truncate">{mod.name}</span>
+                  <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+                </a>
+              )}
+            </h2>
+          )}
           {(() => {
             // Hide the modified date when it formats to the same day as the
             // added date - common for fresh uploads where both timestamps
@@ -731,6 +822,9 @@ export default function ModDetailsModal({
             const modifiedStr = dateModified && dateModified > 0 ? formatDate(dateModified) : null;
             const showModified = modifiedStr !== null && modifiedStr !== addedStr;
             if (!addedStr && !showModified && totalDownloads === 0) return null;
+            // The sidebar surfaces this same metadata in its body title block,
+            // so keep it out of the cramped sidebar header.
+            if (isSidebar) return null;
             return (
               <div className="hidden md:flex items-center gap-3 text-xs text-text-secondary flex-shrink-0">
                 {addedStr && (
@@ -761,6 +855,16 @@ export default function ModDetailsModal({
               </div>
             );
           })()}
+          {onChangeView && (
+            <button
+              onClick={() => onChangeView(isSidebar ? 'modal' : 'sidebar')}
+              aria-label={isSidebar ? 'Pop out to centered window' : 'Dock to side'}
+              title={isSidebar ? 'Pop out to centered window' : 'Dock to side'}
+              className="flex-shrink-0 p-1.5 rounded-full text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
+            >
+              {isSidebar ? <Maximize2 className="w-[18px] h-[18px]" /> : <PanelRight className="w-5 h-5" />}
+            </button>
+          )}
           <button
             onClick={onClose}
             aria-label="Close"
@@ -829,10 +933,117 @@ export default function ModDetailsModal({
             on wide is critical now that previews stack vertically: scrolling
             comments shouldn't drag the image column away, and vice versa. */}
         <div className={`mod-details-body relative flex-1 min-h-0 overflow-hidden ${modalBodyTransitionClass}`}>
-          <div className="mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
+          <div className={bodyContentClass}>
             {/* Image / preview column */}
-            <div className="lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pr-3 space-y-3">
+            <div className={imageColClass}>
               {images.length > 0 ? (
+                isSidebar ? (
+                  /* Sidebar carousel - one image slot the user swipes (or clicks
+                     the arrows) through, instead of the modal's tall stack. The
+                     narrow panel has no room to stack every preview, and a
+                     single slot keeps the details (files/about) above the fold. */
+                  (() => {
+                    const idx = Math.min(currentImageIndex, images.length - 1);
+                    const img = images[idx];
+                    const previewSrc = `${img.baseUrl}/${img.file530 || img.file}`;
+                    const fullSrc = `${img.baseUrl}/${img.file}`;
+                    const imageHidden = mod.nsfw && hideNsfwPreviews;
+                    const slot = (
+                      // Fixed-aspect box (not the image's own ratio): portrait and
+                      // landscape previews both letterbox into the same height, so
+                      // the centered arrows never shift as you click through.
+                      <div
+                        className="relative w-full select-none touch-pan-y aspect-[16/9] bg-bg-tertiary rounded-lg overflow-hidden border border-border"
+                        onPointerDown={(e) => { swipeStartXRef.current = e.clientX; }}
+                        onPointerUp={(e) => {
+                          const start = swipeStartXRef.current;
+                          swipeStartXRef.current = null;
+                          if (start === null || images.length < 2) return;
+                          const dx = e.clientX - start;
+                          if (Math.abs(dx) > 40) {
+                            if (dx < 0) goToNext();
+                            else goToPrevious();
+                          }
+                        }}
+                        onPointerCancel={() => { swipeStartXRef.current = null; }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => openLightboxAt(idx)}
+                          aria-label={`View image ${idx + 1} of ${images.length} full size`}
+                          className="group absolute inset-0 h-full w-full cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                        >
+                          <img
+                            src={previewSrc}
+                            alt={`${mod.name} - Image ${idx + 1}`}
+                            draggable={false}
+                            className={`absolute inset-0 h-full w-full object-contain transition-transform duration-200 group-hover:scale-[1.01] ${
+                              imageHidden ? 'blur-xl scale-110' : ''
+                            }`}
+                          />
+                          {imageHidden && (
+                            <div className="absolute inset-0 flex items-center justify-center text-[11px] uppercase tracking-wide text-white/80 bg-black/40">
+                              NSFW preview hidden
+                            </div>
+                          )}
+                          <span className="absolute top-2 right-2 p-1.5 rounded-md bg-black/55 backdrop-blur-sm text-white/80 border border-white/10 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <Maximize2 className="w-3.5 h-3.5" />
+                          </span>
+                        </button>
+                        {images.length > 1 && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={(e) => { e.stopPropagation(); goToPrevious(); }}
+                              aria-label="Previous image"
+                              className="absolute left-2 top-1/2 z-10 -translate-y-1/2 p-1.5 rounded-full bg-black/55 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/15 transition-colors cursor-pointer"
+                            >
+                              <ChevronLeft className="w-5 h-5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={(e) => { e.stopPropagation(); goToNext(); }}
+                              aria-label="Next image"
+                              className="absolute right-2 top-1/2 z-10 -translate-y-1/2 p-1.5 rounded-full bg-black/55 backdrop-blur-sm text-white/90 hover:bg-black/80 hover:text-white border border-white/15 transition-colors cursor-pointer"
+                            >
+                              <ChevronRight className="w-5 h-5" />
+                            </button>
+                            <div className="absolute bottom-2 right-2 px-2 py-0.5 rounded-md bg-black/55 backdrop-blur-sm text-white/85 text-[11px] border border-white/10">
+                              {idx + 1} / {images.length}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    );
+                    return (
+                      <div className="space-y-2" aria-label="Image previews">
+                        {imageHidden ? (
+                          slot
+                        ) : (
+                          <ImageContextMenu src={previewSrc} copySrc={fullSrc} alt={`${mod.name} - Image ${idx + 1}`}>
+                            {slot}
+                          </ImageContextMenu>
+                        )}
+                        {images.length > 1 && images.length <= 10 && (
+                          <div className="flex flex-wrap items-center justify-center gap-1.5">
+                            {images.map((_, dotIndex) => (
+                              <button
+                                key={dotIndex}
+                                type="button"
+                                onClick={() => setCurrentImageIndex(dotIndex)}
+                                aria-label={`Go to image ${dotIndex + 1}`}
+                                aria-current={dotIndex === idx}
+                                className={`h-1.5 rounded-full transition-all ${
+                                  dotIndex === idx ? 'w-4 bg-accent' : 'w-1.5 bg-text-tertiary/50 hover:bg-text-tertiary'
+                                }`}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })()
+                ) : (
                 /* Vertical preview stack - every image renders inline so
                    users scroll naturally to see all of them. Click any one
                    to open the lightbox at that image's index. We use the
@@ -902,6 +1113,7 @@ export default function ModDetailsModal({
                     );
                   })}
                 </div>
+                )
               ) : section === 'Sound' && !audioPreviewUrl ? (
                 <div className="flex items-center justify-center p-8 rounded-lg border border-border bg-bg-tertiary">
                   <div className="flex flex-col items-center gap-2 text-text-secondary">
@@ -940,36 +1152,102 @@ export default function ModDetailsModal({
                 Takes the remaining horizontal space on wide layouts.
                 Independently scrollable on lg+ so reading comments or
                 installing a file doesn't move the image stack on the left. */}
-            <div className="flex-1 min-w-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pl-3 space-y-5">
+            <div className={detailsColClass}>
+              {/* Sidebar-only title block. The header drops the title to stay
+                  uncluttered, so the mod name lives here, right above the artist,
+                  with its dates/downloads underneath. */}
+              {isSidebar && (
+                <div className="space-y-1.5">
+                  {isNavigating ? (
+                    <Skeleton className="h-6 w-3/4" />
+                  ) : (
+                    <a
+                      href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={`View ${mod.name} on GameBanana`}
+                      className="group inline-flex max-w-full items-start gap-1.5 text-xl font-bold leading-tight text-text-primary transition-colors hover:text-accent"
+                    >
+                      <span className="min-w-0">{mod.name}</span>
+                      <ExternalLink className="mt-1 h-4 w-4 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+                    </a>
+                  )}
+                  {(() => {
+                    const addedStr = dateAdded && dateAdded > 0 ? formatDate(dateAdded) : null;
+                    const modifiedStr = dateModified && dateModified > 0 ? formatDate(dateModified) : null;
+                    const showModified = modifiedStr !== null && modifiedStr !== addedStr;
+                    if (!addedStr && !showModified && totalDownloads === 0) return null;
+                    return (
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-secondary">
+                        {addedStr && (
+                          <span className="flex items-center gap-1" title={`Uploaded ${addedStr}`}>
+                            <Clock className="h-3 w-3" />
+                            {addedStr}
+                          </span>
+                        )}
+                        {showModified && (
+                          <span
+                            className={`flex items-center gap-1 ${outdated ? 'text-yellow-400' : ''}`}
+                            title={`Last updated ${modifiedStr}`}
+                          >
+                            <RefreshCw className="h-3 w-3" />
+                            {modifiedStr}
+                          </span>
+                        )}
+                        {totalDownloads > 0 && (
+                          <span className="flex items-center gap-1" title={`${totalDownloads.toLocaleString()} downloads`}>
+                            <Download className="h-3 w-3" />
+                            {totalDownloads.toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              )}
+
               {mod.submitter && (
                 <section>
-                  <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
-                    Artist
-                  </h3>
-                  <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-text-secondary">
-                    {submitterProfileUrl ? (
-                      <a
-                        href={submitterProfileUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title={`View ${mod.submitter.name} on GameBanana`}
-                        className="group/artist inline-flex min-w-0 max-w-full items-center gap-1.5 font-medium text-text-primary transition-colors hover:text-accent"
-                      >
-                        <span className="min-w-0 truncate">{mod.submitter.name}</span>
-                        <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover/artist:text-accent" />
-                      </a>
+                  <div className="flex items-center gap-3 rounded-xl border border-border bg-bg-tertiary/40 p-3">
+                    {mod.submitter.avatarUrl && !avatarFailed ? (
+                      <img
+                        src={mod.submitter.avatarUrl}
+                        alt={mod.submitter.name}
+                        loading="lazy"
+                        onError={() => setAvatarFailed(true)}
+                        className="h-11 w-11 flex-shrink-0 rounded-full border border-border object-cover"
+                      />
                     ) : (
-                      <span className="min-w-0 truncate font-medium text-text-primary">{mod.submitter.name}</span>
+                      <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-base font-bold uppercase text-accent">
+                        {mod.submitter.name.charAt(0)}
+                      </div>
                     )}
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[10px] font-semibold uppercase tracking-wide text-text-tertiary">Artist</div>
+                      {submitterProfileUrl ? (
+                        <a
+                          href={submitterProfileUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={`View ${mod.submitter.name} on GameBanana`}
+                          className="group/artist inline-flex min-w-0 max-w-full items-center gap-1.5 font-semibold text-text-primary transition-colors hover:text-accent"
+                        >
+                          <span className="min-w-0 truncate">{mod.submitter.name}</span>
+                          <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover/artist:text-accent" />
+                        </a>
+                      ) : (
+                        <span className="block min-w-0 truncate font-semibold text-text-primary">{mod.submitter.name}</span>
+                      )}
+                    </div>
                     {submitterKofiUrl && (
                       <a
                         href={submitterKofiUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         title={`Support ${mod.submitter.name} on Ko-fi`}
-                        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 py-1 text-xs font-medium text-accent transition-colors hover:border-accent/50 hover:bg-accent/20"
+                        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5E5B]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary"
                       >
-                        <Coffee className="h-3.5 w-3.5" />
+                        <Coffee className="h-4 w-4" />
                         Ko-fi
                       </a>
                     )}
@@ -1276,5 +1554,7 @@ export default function ModDetailsModal({
     </div>
   );
 
-  return createPortal(modal, document.body);
+  // The sidebar renders inline inside the caller's <aside>; only the centered
+  // modal needs to escape to a body-level portal.
+  return isSidebar ? modal : createPortal(modal, document.body);
 }

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -22,11 +22,19 @@ import {
   Bell,
   Trash2,
   Coffee,
+  Youtube,
+  Twitter,
+  Twitch,
+  Instagram,
+  Facebook,
+  Github,
+  Globe,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import DOMPurify from 'dompurify';
-import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate } from '../types/gamebanana';
+import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate, GameBananaArtistLink } from '../types/gamebanana';
 import { isModOutdated, formatDate } from '../types/gamebanana';
-import { getModComments, getModUpdates } from '../lib/api';
+import { getModComments, getModUpdates, getSubmitterLinks } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
 import { Skeleton } from './common/Skeleton';
@@ -34,6 +42,24 @@ import { ArchivedTag } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
 
 type ModDetailsNavigationDirection = 'previous' | 'next';
+
+// Lucide ships brand glyphs for some platforms but not newer ones (Bluesky,
+// Discord, TikTok, Ko-fi...); those fall back to a generic globe so every link
+// still renders a recognizable chip. Keys are the normalized platform tokens
+// from the GameBanana contact icon classes.
+const SOCIAL_ICONS: Record<string, LucideIcon> = {
+  youtube: Youtube,
+  twitter: Twitter,
+  x: Twitter,
+  twitch: Twitch,
+  instagram: Instagram,
+  facebook: Facebook,
+  github: Github,
+};
+
+function socialIcon(platform: string): LucideIcon {
+  return SOCIAL_ICONS[platform] ?? Globe;
+}
 
 interface ModDetailsModalProps {
   mod: GameBananaModDetails;
@@ -134,6 +160,8 @@ export default function ModDetailsModal({
   const swipeStartXRef = useRef<number | null>(null);
   // Falls back to a monogram when the artist avatar URL 404s or is blocked.
   const [avatarFailed, setAvatarFailed] = useState(false);
+  // Artist social/contact links, loaded lazily from the member profile.
+  const [artistLinks, setArtistLinks] = useState<GameBananaArtistLink[]>([]);
   const [comments, setComments] = useState<GameBananaComment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
   const [commentsTotalCount, setCommentsTotalCount] = useState(0);
@@ -222,6 +250,26 @@ export default function ModDetailsModal({
     swipeStartXRef.current = null;
     setAvatarFailed(false);
   }, [mod.id]);
+
+  // Pull the artist's social/contact links from their member profile. Cleared
+  // up front so a different artist's links never linger during the fetch; the
+  // main-process layer caches by member id, so repeat artists resolve instantly.
+  useEffect(() => {
+    const memberId = mod.submitter?.id;
+    setArtistLinks([]);
+    if (!memberId || memberId <= 0) return;
+    let cancelled = false;
+    getSubmitterLinks(memberId)
+      .then((links) => {
+        if (!cancelled) setArtistLinks(links);
+      })
+      .catch(() => {
+        if (!cancelled) setArtistLinks([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mod.submitter?.id]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1208,7 +1256,8 @@ export default function ModDetailsModal({
 
               {mod.submitter && (
                 <section>
-                  <div className="flex items-center gap-3 rounded-xl border border-border bg-bg-tertiary/40 p-3">
+                  <div className="space-y-3 rounded-xl border border-border bg-bg-tertiary/40 p-3">
+                  <div className="flex items-center gap-3">
                     {mod.submitter.avatarUrl && !avatarFailed ? (
                       <img
                         src={mod.submitter.avatarUrl}
@@ -1251,6 +1300,35 @@ export default function ModDetailsModal({
                         Ko-fi
                       </a>
                     )}
+                  </div>
+                  {(() => {
+                    // Drop a Ko-fi contact entry when we already show the brand
+                    // button so it isn't listed twice.
+                    const chips = artistLinks.filter(
+                      (link) => !(submitterKofiUrl && link.platform === 'kofi')
+                    );
+                    if (chips.length === 0) return null;
+                    return (
+                      <div className="flex flex-wrap gap-1.5">
+                        {chips.map((link) => {
+                          const Icon = socialIcon(link.platform);
+                          return (
+                            <a
+                              key={link.url}
+                              href={link.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title={link.label}
+                              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-bg-secondary/60 px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-text-primary"
+                            >
+                              <Icon className="h-3.5 w-3.5" />
+                              {link.label}
+                            </a>
+                          );
+                        })}
+                      </div>
+                    );
+                  })()}
                   </div>
                 </section>
               )}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -20,6 +20,7 @@ import {
   BellOff,
   Bell,
   Trash2,
+  Coffee,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate } from '../types/gamebanana';
@@ -305,6 +306,9 @@ export default function ModDetailsModal({
   const archivedFiles = files.filter((file) => file.isArchived);
   const totalDownloads = files.reduce((sum, f) => sum + f.downloadCount, 0);
   const outdated = dateModified ? isModOutdated(dateModified) : false;
+  const submitterProfileUrl = mod.submitter?.profileUrl
+    ?? (mod.submitter && mod.submitter.id > 0 ? `https://gamebanana.com/members/${mod.submitter.id}` : undefined);
+  const submitterKofiUrl = mod.submitter?.kofiUrl;
   const formatUpdateVersion = (version: string) =>
     version.trim().match(/^v/i) ? version.trim() : `v${version.trim()}`;
 
@@ -540,9 +544,8 @@ export default function ModDetailsModal({
             <ChevronRight className="h-8 w-8" />
           </button>
         )}
-        {/* Header - single row. Status badges, category, title, and dense
-            metadata cluster all fit on one line so the modal's vertical
-            budget goes to content, not chrome. Title shrinks/truncates
+        {/* Header. Status badges, title, and dense metadata stay compact so
+            the modal's vertical budget goes to content. Title shrinks/truncates
             first when space gets tight; metadata hides on narrow screens. */}
         <div className="flex items-center gap-3 px-5 py-3 border-b border-border flex-shrink-0">
           <div className="flex items-center gap-2 flex-shrink-0">
@@ -832,6 +835,42 @@ export default function ModDetailsModal({
                 Independently scrollable on lg+ so reading comments or
                 installing a file doesn't move the image stack on the left. */}
             <div className="flex-1 min-w-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pl-3 space-y-5">
+              {mod.submitter && (
+                <section>
+                  <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
+                    Artist
+                  </h3>
+                  <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-text-secondary">
+                    {submitterProfileUrl ? (
+                      <a
+                        href={submitterProfileUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`View ${mod.submitter.name} on GameBanana`}
+                        className="group/artist inline-flex min-w-0 max-w-full items-center gap-1.5 font-medium text-text-primary transition-colors hover:text-accent"
+                      >
+                        <span className="min-w-0 truncate">{mod.submitter.name}</span>
+                        <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover/artist:text-accent" />
+                      </a>
+                    ) : (
+                      <span className="min-w-0 truncate font-medium text-text-primary">{mod.submitter.name}</span>
+                    )}
+                    {submitterKofiUrl && (
+                      <a
+                        href={submitterKofiUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`Support ${mod.submitter.name} on Ko-fi`}
+                        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 py-1 text-xs font-medium text-accent transition-colors hover:border-accent/50 hover:bg-accent/20"
+                      >
+                        <Coffee className="h-3.5 w-3.5" />
+                        Ko-fi
+                      </a>
+                    )}
+                  </div>
+                </section>
+              )}
+
               {mod.description && (
                 <section>
                   <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">

--- a/src/components/locker/DownloadableSkinsSection.tsx
+++ b/src/components/locker/DownloadableSkinsSection.tsx
@@ -22,6 +22,9 @@ export default function DownloadableSkinsSection({ categoryId }: DownloadableSki
       heroCategoryId: categoryId,
       categoryId: 'all',
       search: '',
+      // Leave artist mode: it persists in the session store and would
+      // otherwise override the hero filter this entry point asks for.
+      submitter: undefined,
     });
     navigate('/browse');
   };

--- a/src/index.css
+++ b/src/index.css
@@ -693,6 +693,54 @@ body {
   }
 }
 
+@keyframes modDetailsContentOutLeft {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  to {
+    opacity: 0.2;
+    transform: translateX(-28px);
+  }
+}
+
+@keyframes modDetailsContentOutRight {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  to {
+    opacity: 0.2;
+    transform: translateX(28px);
+  }
+}
+
+@keyframes modDetailsSkeletonInFromRight {
+  from {
+    opacity: 0;
+    transform: translateX(44px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes modDetailsSkeletonInFromLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-44px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 .animate-slide-in-left {
   animation: slideInLeft 0.4s ease-out forwards;
 }
@@ -703,6 +751,29 @@ body {
 
 .animate-fade-in {
   animation: fadeIn 0.3s ease-out forwards;
+}
+
+.mod-details-body-content,
+.mod-details-navigation-skeleton {
+  will-change: transform, opacity;
+}
+
+.mod-details-body--loading-next .mod-details-body-content {
+  animation: modDetailsContentOutLeft 180ms ease-out forwards;
+  pointer-events: none;
+}
+
+.mod-details-body--loading-previous .mod-details-body-content {
+  animation: modDetailsContentOutRight 180ms ease-out forwards;
+  pointer-events: none;
+}
+
+.mod-details-body--loading-next .mod-details-navigation-skeleton {
+  animation: modDetailsSkeletonInFromRight 220ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.mod-details-body--loading-previous .mod-details-navigation-skeleton {
+  animation: modDetailsSkeletonInFromLeft 220ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .grimoire-sidebar {
@@ -965,6 +1036,10 @@ body {
   .animate-slide-in-left,
   .animate-hero-zoom-in,
   .animate-fade-in,
+  .mod-details-body--loading-next .mod-details-body-content,
+  .mod-details-body--loading-previous .mod-details-body-content,
+  .mod-details-body--loading-next .mod-details-navigation-skeleton,
+  .mod-details-body--loading-previous .mod-details-navigation-skeleton,
   .skeleton-shimmer,
   .browse-action-button--downloading::after,
   .browse-action-button--complete-pop,
@@ -997,6 +1072,11 @@ body {
 
   .browse-card-media-zoom {
     transform: none !important;
+    will-change: auto;
+  }
+
+  .mod-details-body-content,
+  .mod-details-navigation-skeleton {
     will-change: auto;
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   GameBananaModUpdatesResponse,
   GameBananaCollection,
   GameBananaCollectionItemsResponse,
+  GameBananaArtistLink,
 } from '../types/gamebanana';
 
 // Re-export types for convenience
@@ -407,6 +408,10 @@ export async function getModComments(modId: number, section?: string, page = 1):
 
 export async function getModUpdates(modId: number, section?: string, page = 1): Promise<GameBananaModUpdatesResponse> {
   return window.electronAPI.getModUpdates({ modId, section, page });
+}
+
+export async function getSubmitterLinks(memberId: number): Promise<GameBananaArtistLink[]> {
+  return window.electronAPI.getSubmitterLinks(memberId);
 }
 
 export async function downloadMod(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -393,8 +393,12 @@ export async function getModFileList(modId: number, section?: string): Promise<G
   return window.electronAPI.getModFileList({ modId, section });
 }
 
-export async function getModDetails(modId: number, section?: string): Promise<GameBananaModDetails> {
-  return window.electronAPI.getModDetails({ modId, section });
+export async function getModDetails(
+  modId: number,
+  section?: string,
+  options: { includeSubmitter?: boolean } = {}
+): Promise<GameBananaModDetails> {
+  return window.electronAPI.getModDetails({ modId, section, ...options });
 }
 
 export async function getModComments(modId: number, section?: string, page = 1): Promise<GameBananaCommentsResponse> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -385,9 +385,10 @@ export async function browseMods(
   search?: string,
   section?: string,
   categoryId?: number,
-  sort?: string
+  sort?: string,
+  submitterId?: number
 ): Promise<GameBananaModsResponse> {
-  return window.electronAPI.browseMods({ page, perPage, search, section, categoryId, sort });
+  return window.electronAPI.browseMods({ page, perPage, search, section, categoryId, sort, submitterId });
 }
 
 export async function getModFileList(modId: number, section?: string): Promise<GameBananaModFileList> {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -113,6 +113,33 @@ function browseSocialIcon(platform: string): LucideIcon {
   return BROWSE_SOCIAL_ICONS[platform] ?? Globe;
 }
 
+// Brand colors so the social symbols read as the real platforms. All chosen to
+// contrast with a white glyph; unknown platforms fall back to the accent.
+const BROWSE_SOCIAL_COLORS: Record<string, string> = {
+  youtube: '#FF0000',
+  twitter: '#1D9BF0',
+  x: '#1D9BF0',
+  twitch: '#9146FF',
+  instagram: '#E4405F',
+  facebook: '#1877F2',
+  github: '#333333',
+  discord: '#5865F2',
+  bluesky: '#1185FE',
+  tiktok: '#111111',
+  patreon: '#FF424D',
+  kofi: '#FF5E5B',
+  steam: '#1B2838',
+  reddit: '#FF4500',
+  spotify: '#1DB954',
+  soundcloud: '#FF5500',
+  carrd: '#1F2D3D',
+  linktree: '#43E660',
+};
+
+function browseSocialColor(platform: string): string {
+  return BROWSE_SOCIAL_COLORS[platform] ?? '#f97316';
+}
+
 function clampSidebarWidth(value: number): number {
   return clampNumber(value, BROWSE_SIDEBAR_WIDTH_MIN, BROWSE_SIDEBAR_WIDTH_MAX);
 }
@@ -2558,39 +2585,43 @@ export default function Browse() {
                   </span>
                 )}
               </div>
-              {artistSocials.length > 0 && (
-                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                  {artistSocials.map((link) => {
-                    const Icon = browseSocialIcon(link.platform);
-                    return (
-                      <a
-                        key={link.url}
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title={link.label}
-                        className="inline-flex items-center gap-1.5 rounded-full border border-border bg-bg-secondary/60 px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-text-primary"
-                      >
-                        <Icon className="h-3.5 w-3.5" />
-                        {link.label}
-                      </a>
-                    );
-                  })}
-                </div>
+            </div>
+            {/* Social symbols + Ko-fi grouped on the right. Ko-fi is filtered out
+                of the symbol row since it gets its own labelled brand button. */}
+            <div className="flex flex-shrink-0 items-center gap-1.5">
+              {artistSocials
+                .filter((link) => !(submitter.kofiUrl && link.platform === 'kofi'))
+                .map((link) => {
+                  const Icon = browseSocialIcon(link.platform);
+                  const color = browseSocialColor(link.platform);
+                  return (
+                    <a
+                      key={link.url}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={link.label}
+                      aria-label={link.label}
+                      style={{ backgroundColor: color }}
+                      className="flex h-8 w-8 items-center justify-center rounded-full text-white shadow-sm ring-1 ring-white/10 transition-transform hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                    >
+                      <Icon className="h-4 w-4" />
+                    </a>
+                  );
+                })}
+              {submitter.kofiUrl && (
+                <a
+                  href={submitter.kofiUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`Support ${submitter.name} on Ko-fi`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542]"
+                >
+                  <Coffee className="h-4 w-4" />
+                  Ko-fi
+                </a>
               )}
             </div>
-            {submitter.kofiUrl && (
-              <a
-                href={submitter.kofiUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={`Support ${submitter.name} on Ko-fi`}
-                className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542]"
-              >
-                <Coffee className="h-4 w-4" />
-                Ko-fi
-              </a>
-            )}
             <div className="hidden flex-shrink-0 items-center gap-1 rounded-lg border border-border bg-bg-secondary p-0.5 sm:flex">
               {(['Mod', 'Sound'] as const).map((s) => (
                 <button

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1092,9 +1092,13 @@ export default function Browse() {
   // Artist social/contact links for the banner. Loaded only when an artist is
   // highlighted (not on every mod open), and cached per member id main-side.
   const [artistSocials, setArtistSocials] = useState<GameBananaArtistLink[]>([]);
+  // Falls back to the monogram when the banner avatar URL 404s or is blocked.
+  // Reset per artist in the effect below so one dead URL doesn't stick.
+  const [artistAvatarFailed, setArtistAvatarFailed] = useState(false);
   useEffect(() => {
     const memberId = submitter?.id;
     setArtistSocials([]);
+    setArtistAvatarFailed(false);
     if (!memberId || memberId <= 0) return;
     let cancelled = false;
     getSubmitterLinks(memberId)
@@ -1110,6 +1114,10 @@ export default function Browse() {
     ? Math.max(BROWSE_SIDEBAR_WIDTH_MIN, browseViewportMetrics.windowWidth - BROWSE_SIDEBAR_GRID_RESERVE)
     : BROWSE_SIDEBAR_WIDTH_MAX;
   const effectiveSidebarWidth = Math.min(clampSidebarWidth(browseSidebarWidth), sidebarWidthCeiling);
+  // Tears down an in-flight sidebar drag (listeners + body styles). Held in a ref
+  // so an unmount can finish a drag that's still mid-gesture, instead of leaking
+  // the window listeners and stranding the col-resize cursor on <body>.
+  const sidebarResizeCleanupRef = useRef<(() => void) | null>(null);
   const startSidebarResize = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
     document.body.style.cursor = 'col-resize';
@@ -1119,11 +1127,15 @@ export default function Browse() {
       const next = Math.min(clampSidebarWidth(window.innerWidth - ev.clientX), ceiling);
       setBrowseSidebarWidthState(next);
     };
-    const onUp = () => {
+    const cleanup = () => {
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
+      sidebarResizeCleanupRef.current = null;
+    };
+    const onUp = () => {
+      cleanup();
       // Persist the raw width (not the window-capped value) so widening the
       // window later restores the size the user actually picked.
       setBrowseSidebarWidthState((w) => {
@@ -1131,9 +1143,12 @@ export default function Browse() {
         return w;
       });
     };
+    sidebarResizeCleanupRef.current = cleanup;
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
   }, []);
+  // Drop a half-finished drag if Browse unmounts mid-gesture.
+  useEffect(() => () => sidebarResizeCleanupRef.current?.(), []);
 
   // Load settings on mount (needed for hideNsfwPreviews)
   useEffect(() => {
@@ -2176,8 +2191,10 @@ export default function Browse() {
     if (downloadQueue.some(q => q.modId === mod.id)) return;
 
     try {
-      // Fetch mod details to get the first file
-      const details = await getModDetails(mod.id, section);
+      // Fetch mod details to get the first file. Include the submitter up front
+      // so the multi-file branch below can open the details panel (which shows
+      // the artist card) without a second round-trip against the rate limiter.
+      const details = await getModDetails(mod.id, section, { includeSubmitter: true });
       if (!details.files || details.files.length === 0) {
         setError('No downloadable files found');
         return;
@@ -2185,11 +2202,10 @@ export default function Browse() {
 
       // When a mod has more than one downloadable file (different versions,
       // variant builds, etc.) we used to silently pick whichever had the
-      // highest download count. Forum feedback flagged that — surface the
-      // details modal so the user can choose which file to install.
+      // highest download count. Forum feedback flagged that, so surface the
+      // details modal and let the user choose which file to install.
       if (details.files.length > 1) {
-        const enrichedDetails = await getModDetails(mod.id, section, { includeSubmitter: true });
-        setSelectedMod(enrichedDetails);
+        setSelectedMod(details);
         setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
         return;
       }
@@ -2416,9 +2432,18 @@ export default function Browse() {
     if (section === 'Sound' && heroCategoryId === 'none') {
       nextMods = nextMods.filter((m) => inferHeroFromTitle(m.name) === null);
     }
+    // The NSFW filter is only enforced server-side by the local-search path.
+    // The remote paths (artist mode, and the no-local-cache fallback) return
+    // unfiltered records, so enforce it here too. Local results already match,
+    // so re-filtering them is a no-op.
+    if (nsfw === 'sfw') {
+      nextMods = nextMods.filter((m) => !m.nsfw);
+    } else if (nsfw === 'nsfw') {
+      nextMods = nextMods.filter((m) => m.nsfw);
+    }
 
     return nextMods;
-  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId]);
+  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId, nsfw]);
   const selectedModIndex = selectedMod
     ? displayMods.findIndex((mod) => mod.id === selectedMod.id)
     : -1;
@@ -2552,11 +2577,12 @@ export default function Browse() {
             >
               <ArrowLeft className="h-5 w-5" />
             </button>
-            {submitter.avatarUrl ? (
+            {submitter.avatarUrl && !artistAvatarFailed ? (
               <img
                 src={submitter.avatarUrl}
                 alt={submitter.name}
                 className="h-11 w-11 flex-shrink-0 rounded-full border border-border object-cover"
+                onError={() => setArtistAvatarFailed(true)}
               />
             ) : (
               <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-lg font-bold uppercase text-accent">

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -66,6 +66,7 @@ type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name
 // longer a user choice: it's what small cards become below the size threshold.
 type ViewMode = 'grid' | 'compact' | 'list';
 type BrowseCardDesign = 'classic' | 'readable';
+type ModDetailsNavigationDirection = 'previous' | 'next';
 const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
 const BROWSE_CARD_DESIGN_STORAGE_KEY = 'browseCardDesign';
 // Persist filter UI inputs across page navigation. The store keeps these in
@@ -918,6 +919,8 @@ export default function Browse() {
   const [modCategories, setModCategories] = useState<GameBananaCategoryNode[]>([]);
   const [selectedMod, setSelectedMod] = useState<GameBananaModDetails | null>(null);
   const [selectedModDates, setSelectedModDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
+  const [modalNavigation, setModalNavigation] = useState<{ direction: ModDetailsNavigationDirection; label: string } | null>(null);
+  const modalNavigationRequestRef = useRef(0);
   const [downloading, setDownloading] = useState<{ modId: number; fileId: number } | null>(null);
   const [downloadProgress, setDownloadProgress] = useState<{ downloaded: number; total: number } | null>(null);
   const [extracting, setExtracting] = useState(false);
@@ -1926,42 +1929,68 @@ export default function Browse() {
     setRefreshKey((k) => k + 1);
   }, []);
 
+  const applyLoadedModDetails = async (mod: GameBananaMod, details: GameBananaModDetails) => {
+    setSelectedMod(details);
+    setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
+
+    // Update the mods array with the correct nsfw flag from details
+    // This ensures grid cards show blur after clicking once
+    if (details.nsfw !== mod.nsfw) {
+      setMods(prev => prev.map(m =>
+        m.id === mod.id ? { ...m, nsfw: details.nsfw } : m
+      ));
+
+      // Also update the local cache so future browses show correct status
+      try {
+        await window.electronAPI.updateModNsfw(mod.id, details.nsfw);
+      } catch (cacheErr) {
+        console.warn('Failed to update NSFW cache:', cacheErr);
+      }
+    }
+
+    // Cache the download count from mod details (sum across all files)
+    if (details.files && details.files.length > 0) {
+      const totalDownloads = details.files.reduce((sum, f) => sum + (f.downloadCount || 0), 0);
+      try {
+        await window.electronAPI.updateModDownloadCount(mod.id, totalDownloads);
+        // Update local state so the card shows the count immediately
+        setMods(prev => prev.map(m =>
+          m.id === mod.id ? { ...m, downloadCount: totalDownloads } : m
+        ));
+      } catch (cacheErr) {
+        console.warn('Failed to cache download count:', cacheErr);
+      }
+    }
+  };
+
   const handleModClick = async (mod: GameBananaMod) => {
     try {
       const details = await getModDetails(mod.id, section, { includeSubmitter: true });
-      setSelectedMod(details);
-      setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
-
-      // Update the mods array with the correct nsfw flag from details
-      // This ensures grid cards show blur after clicking once
-      if (details.nsfw !== mod.nsfw) {
-        setMods(prev => prev.map(m =>
-          m.id === mod.id ? { ...m, nsfw: details.nsfw } : m
-        ));
-
-        // Also update the local cache so future browses show correct status
-        try {
-          await window.electronAPI.updateModNsfw(mod.id, details.nsfw);
-        } catch (cacheErr) {
-          console.warn('Failed to update NSFW cache:', cacheErr);
-        }
-      }
-
-      // Cache the download count from mod details (sum across all files)
-      if (details.files && details.files.length > 0) {
-        const totalDownloads = details.files.reduce((sum, f) => sum + (f.downloadCount || 0), 0);
-        try {
-          await window.electronAPI.updateModDownloadCount(mod.id, totalDownloads);
-          // Update local state so the card shows the count immediately
-          setMods(prev => prev.map(m =>
-            m.id === mod.id ? { ...m, downloadCount: totalDownloads } : m
-          ));
-        } catch (cacheErr) {
-          console.warn('Failed to cache download count:', cacheErr);
-        }
-      }
+      await applyLoadedModDetails(mod, details);
     } catch (err) {
       setError(String(err));
+    }
+  };
+
+  const handleNavigateMod = async (mod: GameBananaMod, direction: ModDetailsNavigationDirection) => {
+    if (modalNavigation) return;
+
+    const requestId = modalNavigationRequestRef.current + 1;
+    modalNavigationRequestRef.current = requestId;
+    setModalNavigation({ direction, label: mod.name });
+
+    try {
+      const details = await getModDetails(mod.id, section, { includeSubmitter: true });
+      if (modalNavigationRequestRef.current !== requestId) return;
+      await applyLoadedModDetails(mod, details);
+    } catch (err) {
+      if (modalNavigationRequestRef.current === requestId) {
+        setError(String(err));
+      }
+    } finally {
+      if (modalNavigationRequestRef.current === requestId) {
+        setModalNavigation(null);
+      }
     }
   };
 
@@ -2248,6 +2277,12 @@ export default function Browse() {
     selectedModIndex >= 0 && selectedModIndex < displayMods.length - 1
       ? displayMods[selectedModIndex + 1]
       : undefined;
+  const closeSelectedMod = () => {
+    modalNavigationRequestRef.current += 1;
+    setModalNavigation(null);
+    setSelectedMod(null);
+    setSelectedModDates(null);
+  };
 
   const readableCardTargetWidth = getReadableCardTargetWidth(browseCardSize);
   const gridGap =
@@ -2954,12 +2989,15 @@ export default function Browse() {
           hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           dateAdded={selectedModDates?.dateAdded}
           dateModified={selectedModDates?.dateModified}
-          onClose={() => setSelectedMod(null)}
+          isNavigating={!!modalNavigation}
+          navigationDirection={modalNavigation?.direction}
+          navigationLabel={modalNavigation?.label}
+          onClose={closeSelectedMod}
           onDownload={handleDownload}
           onNavigatePrevious={
-            previousSelectedMod ? () => void handleModClick(previousSelectedMod) : undefined
+            previousSelectedMod ? () => void handleNavigateMod(previousSelectedMod, 'previous') : undefined
           }
-          onNavigateNext={nextSelectedMod ? () => void handleModClick(nextSelectedMod) : undefined}
+          onNavigateNext={nextSelectedMod ? () => void handleNavigateMod(nextSelectedMod, 'next') : undefined}
           previousLabel={previousSelectedMod?.name}
           nextLabel={nextSelectedMod?.name}
           onDeleteFile={deleteMod}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -26,11 +26,22 @@ import {
   Play,
   Maximize2,
   PanelRight,
+  ArrowLeft,
+  ExternalLink,
+  Coffee,
+  Youtube,
+  Twitter,
+  Twitch,
+  Instagram,
+  Facebook,
+  Github,
+  Globe,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import {
   browseMods,
   getModDetails,
+  getSubmitterLinks,
   downloadMod,
   getGamebananaSections,
   getGamebananaCategories,
@@ -42,12 +53,13 @@ import type {
   GameBananaModDetails,
   GameBananaSection,
   GameBananaCategoryNode,
+  GameBananaArtistLink,
 } from '../types/gamebanana';
 import { getModThumbnail, getSoundPreviewUrl, getPrimaryFile, formatDate, isModOutdated } from '../types/gamebanana';
 import {
   useAppStore,
 } from '../stores/appStore';
-import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout } from '../stores/appStore';
+import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout, BrowseArtistRef } from '../stores/appStore';
 import ModThumbnail from '../components/ModThumbnail';
 import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
@@ -86,6 +98,20 @@ const BROWSE_SIDEBAR_WIDTH_DEFAULT = 420;
 // The grid always keeps at least this much room; the sidebar's effective width
 // is capped so a wide drag (or a small window) can't starve the browse area.
 const BROWSE_SIDEBAR_GRID_RESERVE = 360;
+
+const BROWSE_SOCIAL_ICONS: Record<string, LucideIcon> = {
+  youtube: Youtube,
+  twitter: Twitter,
+  x: Twitter,
+  twitch: Twitch,
+  instagram: Instagram,
+  facebook: Facebook,
+  github: Github,
+};
+
+function browseSocialIcon(platform: string): LucideIcon {
+  return BROWSE_SOCIAL_ICONS[platform] ?? Globe;
+}
 
 function clampSidebarWidth(value: number): number {
   return clampNumber(value, BROWSE_SIDEBAR_WIDTH_MIN, BROWSE_SIDEBAR_WIDTH_MAX);
@@ -895,7 +921,10 @@ export default function Browse() {
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
-  const { search, layout, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId } = browseUi;
+  const { search, layout, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId, submitter } = browseUi;
+  // Artist mode: the grid is scoped to one submitter's mods and Browse shows an
+  // artist banner instead of the normal search/filter header.
+  const artistMode = !!submitter;
   const [browseViewportMetrics, setBrowseViewportMetrics] = useState<BrowseViewportMetrics>(DEFAULT_BROWSE_VIEWPORT_METRICS);
   const [browseCardSizeMultiplier, setBrowseCardSizeMultiplierState] = useState(readBrowseCardSizeMultiplier);
   const browseCardSize = getResponsiveBrowseCardSize(browseViewportMetrics, browseCardSizeMultiplier);
@@ -925,7 +954,7 @@ export default function Browse() {
   // wipe loaded results or scroll position. The cache stamp encodes current
   // filters; if filters changed in between (impossible today since they only
   // change on Browse, but defensive) we ignore the stale cache.
-  const initialFilterStamp = `${browseUi.section}|${browseUi.search}|${browseUi.sort}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}`;
+  const initialFilterStamp = `${browseUi.section}|${browseUi.search}|${browseUi.sort}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}`;
   const initialCache = browseSession && browseSession.stamp === initialFilterStamp
     ? browseSession
     : null;
@@ -971,7 +1000,7 @@ export default function Browse() {
   // double effect run in dev — the second setup compares stamps and short-
   // circuits, instead of consuming a one-shot skip flag.
   const lastFetchedStampRef = useRef<string | null>(
-    initialCache ? `${initialCache.page}|${browseUi.search}|${browseUi.sort}|${browseUi.section}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}` : null
+    initialCache ? `${initialCache.page}|${browseUi.search}|${browseUi.sort}|${browseUi.section}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}` : null
   );
   // Monotonic guard for browse/search requests. Filter changes and newer
   // requests invalidate older responses so they cannot append stale pages into
@@ -1032,6 +1061,20 @@ export default function Browse() {
   const detailsSidebarActive =
     browseDetailsView === 'sidebar' &&
     browseViewportMetrics.windowWidth >= BROWSE_SIDEBAR_MIN_WINDOW_WIDTH;
+
+  // Artist social/contact links for the banner. Loaded only when an artist is
+  // highlighted (not on every mod open), and cached per member id main-side.
+  const [artistSocials, setArtistSocials] = useState<GameBananaArtistLink[]>([]);
+  useEffect(() => {
+    const memberId = submitter?.id;
+    setArtistSocials([]);
+    if (!memberId || memberId <= 0) return;
+    let cancelled = false;
+    getSubmitterLinks(memberId)
+      .then((links) => { if (!cancelled) setArtistSocials(links); })
+      .catch(() => { if (!cancelled) setArtistSocials([]); });
+    return () => { cancelled = true; };
+  }, [submitter?.id]);
   // User-resizable sidebar width, persisted. The effective width is also capped
   // so the grid keeps BROWSE_SIDEBAR_GRID_RESERVE px no matter how the user drags
   // or how small the window is.
@@ -1194,7 +1237,7 @@ export default function Browse() {
     return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
   }, [addedWithin, addedTo]);
 
-  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}`;
+  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}`;
   const browseResultsCacheRef = useRef<Map<string, BrowseResultCacheEntry>>(new Map());
   const browseScrollCacheRef = useRef<Map<string, number>>(new Map());
   const activeFetchFilterStampRef = useRef(fetchFilterStamp);
@@ -1355,7 +1398,7 @@ export default function Browse() {
   useEffect(() => {
     return () => {
       const ui = useAppStore.getState().browseUi;
-      const stamp = `${ui.section}|${ui.search}|${ui.sort}|${ui.categoryId}|${ui.heroCategoryId}|${ui.nsfw}|${ui.addedWithin}|${ui.addedFrom}|${ui.addedTo}`;
+      const stamp = `${ui.section}|${ui.search}|${ui.sort}|${ui.categoryId}|${ui.heroCategoryId}|${ui.nsfw}|${ui.addedWithin}|${ui.addedFrom}|${ui.addedTo}|${ui.submitter?.id ?? ''}`;
       const cachedMods = modsRef.current;
       // Don't cache an empty state — would just bypass the next fetch
       // unhelpfully. Clear instead so the next mount starts fresh.
@@ -1382,6 +1425,9 @@ export default function Browse() {
   // which caused fetchMods (API, no hero filter) to race with searchLocal and
   // overwrite real results with an empty API response.
   const useLocalSearch = useMemo(() => {
+    // Artist mode is a GameBanana-only filter (Generic_Submitter); the local
+    // catalog mirror has no submitter column, so always go remote.
+    if (submitter) return false;
     const hasSearchQuery = debouncedSearch.trim().length > 0;
     const hasHeroFilter = heroCategoryId !== 'all';
     // NSFW and recency filters only the local catalog mirror can satisfy: the
@@ -1392,7 +1438,7 @@ export default function Browse() {
     // come from the local mirror (which sorts name COLLATE NOCASE ASC).
     const needsLocalSort = sort === 'name';
     return (hasSearchQuery || hasHeroFilter || hasContentFilter || needsLocalSort) && hasLocalCache && !localSearchFailed;
-  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hasLocalCache, localSearchFailed]);
+  }, [submitter, debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hasLocalCache, localSearchFailed]);
 
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
@@ -1440,10 +1486,14 @@ export default function Browse() {
       const response = await browseMods(
         page,
         perPage,
-        effectiveSearch || undefined,
+        // In artist mode the grid is scoped by submitter; text search and
+        // category don't combine cleanly with that on the API, so they're
+        // dropped while viewing an artist.
+        submitter ? undefined : (effectiveSearch || undefined),
         section,
-        effectiveCategoryId,
-        sort !== 'default' ? sort : undefined
+        submitter ? undefined : effectiveCategoryId,
+        sort !== 'default' ? sort : undefined,
+        submitter?.id
       );
 
       // Enrich results with cached NSFW status from local database
@@ -1519,6 +1569,7 @@ export default function Browse() {
     effectiveCategoryId,
     fetchFilterStamp,
     useLocalSearch,
+    submitter,
   ]);
 
   // Local search function using SQLite cache
@@ -2356,6 +2407,17 @@ export default function Browse() {
     setSelectedModDates(null);
   };
 
+  // Enter artist mode: scope the grid to one submitter. We leave the user's
+  // search/hero/category filters untouched (artist mode ignores them in the
+  // fetch) so clearing artist mode restores their prior browse exactly.
+  const viewArtist = (artist: BrowseArtistRef) => {
+    if (!artist?.id) return;
+    closeSelectedMod();
+    setBrowseUi({ submitter: artist });
+    scrollContainerRef.current?.scrollTo({ top: 0 });
+  };
+  const clearArtist = () => setBrowseUi({ submitter: undefined });
+
   const readableCardTargetWidth = getReadableCardTargetWidth(browseCardSize);
   const gridGap =
     layout === 'list'
@@ -2443,14 +2505,108 @@ export default function Browse() {
         previousLabel={previousSelectedMod?.name}
         nextLabel={nextSelectedMod?.name}
         onDeleteFile={deleteMod}
+        onViewArtist={viewArtist}
       />
     ) : null;
 
   return (
     <div className="flex h-full min-h-0">
       <div className={`flex-1 min-w-0 h-full overflow-y-auto ${isBrowseScrolling ? 'browse-is-scrolling' : ''}`} ref={scrollContainerRef}>
-      {/* Header with Search */}
+      {/* Header: artist banner in artist mode, otherwise the search/filter row. */}
       <div className="sticky top-0 z-40 p-4 border-b border-border bg-bg-primary">
+        {artistMode && submitter ? (
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={clearArtist}
+              aria-label="Back to browse"
+              title="Back to browse"
+              className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-secondary transition-colors hover:border-accent/50 hover:text-text-primary cursor-pointer"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </button>
+            {submitter.avatarUrl ? (
+              <img
+                src={submitter.avatarUrl}
+                alt={submitter.name}
+                className="h-11 w-11 flex-shrink-0 rounded-full border border-border object-cover"
+              />
+            ) : (
+              <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-lg font-bold uppercase text-accent">
+                {submitter.name.charAt(0)}
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                {submitter.profileUrl ? (
+                  <a
+                    href={submitter.profileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`View ${submitter.name} on GameBanana`}
+                    className="group inline-flex min-w-0 items-center gap-1.5 text-lg font-bold text-text-primary transition-colors hover:text-accent"
+                  >
+                    <span className="min-w-0 truncate">{submitter.name}</span>
+                    <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+                  </a>
+                ) : (
+                  <span className="min-w-0 truncate text-lg font-bold text-text-primary">{submitter.name}</span>
+                )}
+                {_totalCount > 0 && (
+                  <span className="flex-shrink-0 rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] font-semibold text-text-secondary border border-border">
+                    {_totalCount.toLocaleString()} {_totalCount === 1 ? 'mod' : 'mods'}
+                  </span>
+                )}
+              </div>
+              {artistSocials.length > 0 && (
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  {artistSocials.map((link) => {
+                    const Icon = browseSocialIcon(link.platform);
+                    return (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={link.label}
+                        className="inline-flex items-center gap-1.5 rounded-full border border-border bg-bg-secondary/60 px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-text-primary"
+                      >
+                        <Icon className="h-3.5 w-3.5" />
+                        {link.label}
+                      </a>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            {submitter.kofiUrl && (
+              <a
+                href={submitter.kofiUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`Support ${submitter.name} on Ko-fi`}
+                className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542]"
+              >
+                <Coffee className="h-4 w-4" />
+                Ko-fi
+              </a>
+            )}
+            <div className="hidden flex-shrink-0 items-center gap-1 rounded-lg border border-border bg-bg-secondary p-0.5 sm:flex">
+              {(['Mod', 'Sound'] as const).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setSection(s)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-colors ${
+                    section === s ? 'bg-accent/15 text-accent' : 'text-text-secondary hover:text-text-primary'
+                  }`}
+                >
+                  {s === 'Mod' ? 'Mods' : 'Sounds'}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
         <form onSubmit={handleSearch}>
           <div className="flex flex-wrap items-center gap-2">
             {/* Search Input with integrated submit */}
@@ -2928,6 +3084,7 @@ export default function Browse() {
             </div>
           )}
         </form>
+        )}
       </div>
 
       {/* Main Content */}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1928,7 +1928,7 @@ export default function Browse() {
 
   const handleModClick = async (mod: GameBananaMod) => {
     try {
-      const details = await getModDetails(mod.id, section);
+      const details = await getModDetails(mod.id, section, { includeSubmitter: true });
       setSelectedMod(details);
       setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
 
@@ -2009,7 +2009,8 @@ export default function Browse() {
       // highest download count. Forum feedback flagged that — surface the
       // details modal so the user can choose which file to install.
       if (details.files.length > 1) {
-        setSelectedMod(details);
+        const enrichedDetails = await getModDetails(mod.id, section, { includeSubmitter: true });
+        setSelectedMod(enrichedDetails);
         setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
         return;
       }

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -24,6 +24,8 @@ import {
   ChevronDown,
   Upload,
   Play,
+  Maximize2,
+  PanelRight,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -66,9 +68,34 @@ type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name
 // longer a user choice: it's what small cards become below the size threshold.
 type ViewMode = 'grid' | 'compact' | 'list';
 type BrowseCardDesign = 'classic' | 'readable';
+// Where a clicked mod's details open: the centered overlay (default) or a
+// docked right-side panel that lets the user keep browsing the grid. Persisted
+// like the other Browse view preferences (card design/size).
+type BrowseDetailsView = 'modal' | 'sidebar';
 type ModDetailsNavigationDirection = 'previous' | 'next';
 const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
 const BROWSE_CARD_DESIGN_STORAGE_KEY = 'browseCardDesign';
+const BROWSE_DETAILS_VIEW_STORAGE_KEY = 'browseDetailsView';
+// Below this window width the docked sidebar would crush the grid, so we force
+// the centered modal regardless of the saved preference.
+const BROWSE_SIDEBAR_MIN_WINDOW_WIDTH = 760;
+const BROWSE_SIDEBAR_WIDTH_KEY = 'browseDetailsSidebarWidth';
+const BROWSE_SIDEBAR_WIDTH_MIN = 320;
+const BROWSE_SIDEBAR_WIDTH_MAX = 720;
+const BROWSE_SIDEBAR_WIDTH_DEFAULT = 420;
+// The grid always keeps at least this much room; the sidebar's effective width
+// is capped so a wide drag (or a small window) can't starve the browse area.
+const BROWSE_SIDEBAR_GRID_RESERVE = 360;
+
+function clampSidebarWidth(value: number): number {
+  return clampNumber(value, BROWSE_SIDEBAR_WIDTH_MIN, BROWSE_SIDEBAR_WIDTH_MAX);
+}
+
+function readBrowseSidebarWidth(): number {
+  if (typeof window === 'undefined') return BROWSE_SIDEBAR_WIDTH_DEFAULT;
+  const stored = Number(window.localStorage.getItem(BROWSE_SIDEBAR_WIDTH_KEY));
+  return Number.isFinite(stored) && stored > 0 ? clampSidebarWidth(stored) : BROWSE_SIDEBAR_WIDTH_DEFAULT;
+}
 // Persist filter UI inputs across page navigation. The store keeps these in
 // memory so visiting Installed and coming back doesn't blow away the user's
 // current search/filter context. Kept out of localStorage so a fresh launch
@@ -991,6 +1018,51 @@ export default function Browse() {
   const setBrowseCardDesign = useCallback((design: BrowseCardDesign) => {
     setBrowseCardDesignState(design);
     window.localStorage.setItem(BROWSE_CARD_DESIGN_STORAGE_KEY, design);
+  }, []);
+  const [browseDetailsView, setBrowseDetailsViewState] = useState<BrowseDetailsView>(() => {
+    if (typeof window === 'undefined') return 'modal';
+    return window.localStorage.getItem(BROWSE_DETAILS_VIEW_STORAGE_KEY) === 'sidebar' ? 'sidebar' : 'modal';
+  });
+  const setBrowseDetailsView = useCallback((view: BrowseDetailsView) => {
+    setBrowseDetailsViewState(view);
+    window.localStorage.setItem(BROWSE_DETAILS_VIEW_STORAGE_KEY, view);
+  }, []);
+  // The sidebar only wins when there's room for it; on a narrow window it would
+  // squeeze the grid into uselessness, so we fall back to the centered modal.
+  const detailsSidebarActive =
+    browseDetailsView === 'sidebar' &&
+    browseViewportMetrics.windowWidth >= BROWSE_SIDEBAR_MIN_WINDOW_WIDTH;
+  // User-resizable sidebar width, persisted. The effective width is also capped
+  // so the grid keeps BROWSE_SIDEBAR_GRID_RESERVE px no matter how the user drags
+  // or how small the window is.
+  const [browseSidebarWidth, setBrowseSidebarWidthState] = useState<number>(readBrowseSidebarWidth);
+  const sidebarWidthCeiling = browseViewportMetrics.windowWidth
+    ? Math.max(BROWSE_SIDEBAR_WIDTH_MIN, browseViewportMetrics.windowWidth - BROWSE_SIDEBAR_GRID_RESERVE)
+    : BROWSE_SIDEBAR_WIDTH_MAX;
+  const effectiveSidebarWidth = Math.min(clampSidebarWidth(browseSidebarWidth), sidebarWidthCeiling);
+  const startSidebarResize = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    const onMove = (ev: PointerEvent) => {
+      const ceiling = Math.max(BROWSE_SIDEBAR_WIDTH_MIN, window.innerWidth - BROWSE_SIDEBAR_GRID_RESERVE);
+      const next = Math.min(clampSidebarWidth(window.innerWidth - ev.clientX), ceiling);
+      setBrowseSidebarWidthState(next);
+    };
+    const onUp = () => {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      // Persist the raw width (not the window-capped value) so widening the
+      // window later restores the size the user actually picked.
+      setBrowseSidebarWidthState((w) => {
+        window.localStorage.setItem(BROWSE_SIDEBAR_WIDTH_KEY, String(w));
+        return w;
+      });
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
   }, []);
 
   // Load settings on mount (needed for hideNsfwPreviews)
@@ -2338,8 +2410,45 @@ export default function Browse() {
     );
   }
 
+  // One details element, two homes: the centered modal portals to <body>, the
+  // sidebar renders inline inside the <aside> below. Same props either way, so
+  // build it once and let `variant` decide the presentation.
+  const renderModDetails = (variant: BrowseDetailsView) =>
+    selectedMod ? (
+      <ModDetailsModal
+        variant={variant}
+        onChangeView={setBrowseDetailsView}
+        mod={selectedMod}
+        section={section}
+        installed={installedIds.has(selectedMod.id)}
+        installedFileIds={installedFileIds}
+        installedFileStates={installedFileStates}
+        onEnableFile={(modId) => toggleMod(modId)}
+        downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
+        queuedFileIds={selectedQueuedFileIds}
+        extracting={extracting}
+        progress={downloadProgress}
+        hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+        dateAdded={selectedModDates?.dateAdded}
+        dateModified={selectedModDates?.dateModified}
+        isNavigating={!!modalNavigation}
+        navigationDirection={modalNavigation?.direction}
+        navigationLabel={modalNavigation?.label}
+        onClose={closeSelectedMod}
+        onDownload={handleDownload}
+        onNavigatePrevious={
+          previousSelectedMod ? () => void handleNavigateMod(previousSelectedMod, 'previous') : undefined
+        }
+        onNavigateNext={nextSelectedMod ? () => void handleNavigateMod(nextSelectedMod, 'next') : undefined}
+        previousLabel={previousSelectedMod?.name}
+        nextLabel={nextSelectedMod?.name}
+        onDeleteFile={deleteMod}
+      />
+    ) : null;
+
   return (
-    <div className={`h-full overflow-y-auto ${isBrowseScrolling ? 'browse-is-scrolling' : ''}`} ref={scrollContainerRef}>
+    <div className="flex h-full min-h-0">
+      <div className={`flex-1 min-w-0 h-full overflow-y-auto ${isBrowseScrolling ? 'browse-is-scrolling' : ''}`} ref={scrollContainerRef}>
       {/* Header with Search */}
       <div className="sticky top-0 z-40 p-4 border-b border-border bg-bg-primary">
         <form onSubmit={handleSearch}>
@@ -2548,6 +2657,32 @@ export default function Browse() {
                               }`}
                             >
                               {design === 'readable' ? 'Default' : 'Classic'}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="mb-2 text-xs font-medium text-text-secondary">Details view</div>
+                      <div className="grid grid-cols-2 gap-2" role="tablist" aria-label="Mod details view">
+                        {(['modal', 'sidebar'] as const).map((view) => {
+                          const active = browseDetailsView === view;
+                          return (
+                            <button
+                              key={view}
+                              type="button"
+                              role="tab"
+                              aria-selected={active}
+                              onClick={() => setBrowseDetailsView(view)}
+                              className={`flex h-9 items-center justify-center gap-1.5 rounded-md border text-xs font-semibold transition-colors ${
+                                active
+                                  ? 'border-accent/50 bg-accent/10 text-accent'
+                                  : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
+                              }`}
+                            >
+                              {view === 'modal' ? <Maximize2 className="h-3.5 w-3.5" /> : <PanelRight className="h-3.5 w-3.5" />}
+                              {view === 'modal' ? 'Window' : 'Sidebar'}
                             </button>
                           );
                         })}
@@ -2973,36 +3108,9 @@ export default function Browse() {
         </div>
       </div>
 
-      {/* Mod Details Modal */}
-      {selectedMod && (
-        <ModDetailsModal
-          mod={selectedMod}
-          section={section}
-          installed={installedIds.has(selectedMod.id)}
-          installedFileIds={installedFileIds}
-          installedFileStates={installedFileStates}
-          onEnableFile={(modId) => toggleMod(modId)}
-          downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
-          queuedFileIds={selectedQueuedFileIds}
-          extracting={extracting}
-          progress={downloadProgress}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
-          dateAdded={selectedModDates?.dateAdded}
-          dateModified={selectedModDates?.dateModified}
-          isNavigating={!!modalNavigation}
-          navigationDirection={modalNavigation?.direction}
-          navigationLabel={modalNavigation?.label}
-          onClose={closeSelectedMod}
-          onDownload={handleDownload}
-          onNavigatePrevious={
-            previousSelectedMod ? () => void handleNavigateMod(previousSelectedMod, 'previous') : undefined
-          }
-          onNavigateNext={nextSelectedMod ? () => void handleNavigateMod(nextSelectedMod, 'next') : undefined}
-          previousLabel={previousSelectedMod?.name}
-          nextLabel={nextSelectedMod?.name}
-          onDeleteFile={deleteMod}
-        />
-      )}
+      {/* Mod details: centered modal (portals to body). The sidebar variant is
+          mounted in the <aside> outside this scroll container instead. */}
+      {!detailsSidebarActive && renderModDetails('modal')}
 
       {collectionModalOpen && (
         <ImportCollectionModal
@@ -3021,6 +3129,29 @@ export default function Browse() {
           onClose={() => setImportProfileOpen(false)}
           onImported={() => { void loadMods(); }}
         />
+      )}
+      </div>
+
+      {/* Docked details sidebar. Shrinking the flex-1 grid above triggers the
+          scroll container's ResizeObserver, which recomputes the virtualized
+          column count, so the grid reflows to fewer columns on its own. */}
+      {selectedMod && detailsSidebarActive && (
+        <aside
+          className="relative flex-shrink-0 h-full border-l border-border bg-bg-secondary overflow-hidden animate-fade-in"
+          style={{ width: effectiveSidebarWidth }}
+        >
+          {/* Drag the left edge to resize; the width is remembered. */}
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize details sidebar"
+            onPointerDown={startSidebarResize}
+            className="group absolute inset-y-0 left-0 z-30 w-2 -ml-1 cursor-col-resize"
+          >
+            <div className="absolute inset-y-0 left-1 w-0.5 bg-transparent transition-colors group-hover:bg-accent/60" />
+          </div>
+          {renderModDetails('sidebar')}
+        </aside>
       )}
     </div>
   );
@@ -3372,6 +3503,13 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
   // Compact chrome (4:3 aspect, smaller text/padding) kicks in for small cards;
   // see the size-threshold derivation of viewMode in the Browse component.
   const isCompact = viewMode === 'compact';
+  // At the smallest grid sizes the bottom overlay (title + stats + author) eats
+  // most of a classic card, burying the art it's drawn over. Below this width
+  // we collapse to just the title at rest and reveal the rest on hover/focus.
+  // Keyed off the real card width (not viewMode, which never resolves to
+  // 'compact' for classic cards) so it tracks the card-size slider.
+  const minimalChrome =
+    cardDesign === 'classic' && typeof cardWidth === 'number' && cardWidth > 0 && cardWidth < 205;
   const isList = viewMode === 'list';
   const isSoundSection = section === 'Sound';
   const hasAudioPreview = Boolean(audioPreview);
@@ -3635,7 +3773,9 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
       </div>
 
       {/* Gradient: for sound cards with audio preview, darken TOP (title) and BOTTOM (player).
-          For other cards, the classic bottom-darkest gradient. */}
+          For other cards, the classic bottom-darkest gradient. On minimal-chrome
+          cards the rest state uses a short fade (just enough for the title line)
+          so the art stays visible; the fuller scrim fades back in on hover below. */}
       <div
         className="absolute inset-0 pointer-events-none"
         style={
@@ -3644,12 +3784,28 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
                 background:
                   'linear-gradient(to bottom, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.35) 35%, rgba(0,0,0,0.35) 60%, rgba(0,0,0,0.9) 100%)',
               }
-            : {
-                background:
-                  'linear-gradient(to top, rgba(0,0,0,0.97) 0%, rgba(0,0,0,0.86) 30%, rgba(0,0,0,0.5) 55%, rgba(0,0,0,0.12) 78%, transparent 100%)',
-              }
+            : minimalChrome
+              ? {
+                  background:
+                    'linear-gradient(to top, rgba(0,0,0,0.9) 0%, rgba(0,0,0,0.55) 22%, rgba(0,0,0,0.08) 45%, transparent 64%)',
+                }
+              : {
+                  background:
+                    'linear-gradient(to top, rgba(0,0,0,0.97) 0%, rgba(0,0,0,0.86) 30%, rgba(0,0,0,0.5) 55%, rgba(0,0,0,0.12) 78%, transparent 100%)',
+                }
         }
       />
+      {/* Hover-only fuller scrim for minimal cards, so the revealed stats/author
+          stay legible once they slide up. */}
+      {minimalChrome && (
+        <div
+          className="absolute inset-0 pointer-events-none opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100"
+          style={{
+            background:
+              'linear-gradient(to top, rgba(0,0,0,0.96) 0%, rgba(0,0,0,0.82) 28%, rgba(0,0,0,0.4) 55%, transparent 80%)',
+          }}
+        />
+      )}
 
       {/* Info: moved to TOP for audio-preview sound cards so it stops covering the player.
           State tags (NSFW/Installed/Outdated) live inside this block too, on a row
@@ -3686,22 +3842,32 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
           </div>
         </div>
       ) : (
-        <div className={`absolute bottom-0 left-0 right-0 ${isCompact ? 'p-2.5' : 'p-3'}`}>
-          <h3 className={`font-mod-title font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
-          <div className={`mt-1 flex flex-wrap items-center gap-3 text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${isCompact ? 'text-xs' : 'text-sm'}`}>
-            <BrowseStatItem type="likes" icon={ThumbsUp} value={formatCount(mod.likeCount)} title={`${mod.likeCount ?? 0} likes`} />
-            <BrowseStatItem type="views" icon={Eye} value={formatCount(mod.viewCount)} title={`${mod.viewCount ?? 0} views`} />
-            {mod.submitter && <span className="truncate">by {mod.submitter.name}</span>}
+        <div className={`absolute bottom-0 left-0 right-0 ${minimalChrome ? 'p-2' : isCompact ? 'p-2.5' : 'p-3'}`}>
+          <h3 className={`font-mod-title font-semibold truncate text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] ${minimalChrome || isCompact ? 'text-sm' : 'text-base'}`}>{mod.name}</h3>
+          {/* Stats / author / outdated. On minimal cards this group is collapsed
+              to zero height at rest and slides up on hover or keyboard focus. */}
+          <div
+            className={
+              minimalChrome
+                ? 'overflow-hidden transition-all duration-200 ease-out max-h-0 opacity-0 group-hover:max-h-20 group-hover:opacity-100 group-focus-within:max-h-20 group-focus-within:opacity-100'
+                : ''
+            }
+          >
+            <div className={`mt-1 flex flex-wrap items-center gap-3 text-white/90 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] ${isCompact ? 'text-xs' : 'text-sm'}`}>
+              <BrowseStatItem type="likes" icon={ThumbsUp} value={formatCount(mod.likeCount)} title={`${mod.likeCount ?? 0} likes`} />
+              <BrowseStatItem type="views" icon={Eye} value={formatCount(mod.viewCount)} title={`${mod.viewCount ?? 0} views`} />
+              {mod.submitter && <span className="truncate">by {mod.submitter.name}</span>}
+            </div>
+            {mod.dateModified > 0 && isModOutdated(mod.dateModified) && (
+              <IconText
+                icon={AlertTriangle}
+                className={`mt-1 max-w-full text-state-warning ${isCompact ? 'text-xs' : 'text-sm'}`}
+                iconClassName="browse-meta-icon"
+              >
+                <span className="truncate">Outdated · {formatDate(mod.dateModified)}</span>
+              </IconText>
+            )}
           </div>
-          {mod.dateModified > 0 && isModOutdated(mod.dateModified) && (
-            <IconText
-              icon={AlertTriangle}
-              className={`mt-1 max-w-full text-state-warning ${isCompact ? 'text-xs' : 'text-sm'}`}
-              iconClassName="browse-meta-icon"
-            >
-              <span className="truncate">Outdated · {formatDate(mod.dateModified)}</span>
-            </IconText>
-          )}
         </div>
       )}
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -386,6 +386,12 @@ const CARD_SIZE_MULTIPLIER_MIN = 0.8;
 const CARD_SIZE_MULTIPLIER_MAX = 2;
 const CARD_SIZE_MULTIPLIER_DEFAULT = 1;
 const CARD_SIZE_MULTIPLIER_STEP = 0.1;
+// Below this multiplier the grid drops to the dense "compact" card (shorter
+// media frame, fewer chips, single-line tags). The size slider doesn't expose a
+// separate compact toggle: dragging toward the small end past this cutoff flips
+// the treatment, same as the old px threshold did before the slider became a
+// responsive multiplier.
+const CARD_SIZE_COMPACT_MULTIPLIER = 0.95;
 const INSTALLED_CARD_SIZE_MULTIPLIER_KEY = 'installedCardSizeMultiplier';
 
 function clampCardSizeMultiplier(value: number): number {
@@ -471,7 +477,12 @@ export default function Installed() {
     () => getCardSizeGridStyle(cardSizeMultiplier),
     [cardSizeMultiplier]
   );
-  const viewMode: ViewMode = layout === 'list' ? 'list' : 'grid';
+  const viewMode: ViewMode =
+    layout === 'list'
+      ? 'list'
+      : cardSizeMultiplier < CARD_SIZE_COMPACT_MULTIPLIER
+        ? 'compact'
+        : 'grid';
   // Locker overrides (hero cards + ability sounds) live off the mod list in
   // citadel/grimoire. The toolbar icon opens the manage popup; the badge shows
   // how many are applied. Count is fetched on mount (covers changes made over
@@ -2475,7 +2486,8 @@ export default function Installed() {
     const activeEntry = draggingSection === section
       ? entries.find((entry) => entry.key === draggingKey)
       : undefined;
-    const gridClasses = layout === 'list' ? 'space-y-1.5' : 'grid gap-4';
+    const gridClasses =
+      layout === 'list' ? 'space-y-1.5' : viewMode === 'compact' ? 'grid gap-3' : 'grid gap-4';
     const gridStyle =
       layout === 'list'
         ? undefined
@@ -2872,7 +2884,7 @@ export default function Installed() {
               className={`order-last flex items-center gap-2 rounded-sm border border-border bg-bg-secondary px-2 py-1.5 transition-opacity ${
                 layout === 'list' ? 'opacity-40' : ''
               }`}
-              title="Card size is responsive for now"
+              title="Card size (drag to the small end for compact cards)"
             >
               <Grid3x3 className="h-4 w-4 flex-shrink-0 text-text-secondary" aria-hidden="true" />
               <input

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -333,7 +333,7 @@ function SortableModEntry({
       // open action menu can only paint within that card. When the menu opens
       // downward it would land behind the next card; lift this wrapper above its
       // siblings whenever it contains an open menu so the dropdown stays on top.
-      className={`has-[[data-card-menu-open]]:z-20 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
+      className={`flex flex-col has-[[data-card-menu-open]]:z-20 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       style={style}
       {...attributes}
       {...listeners}
@@ -5443,8 +5443,8 @@ function ModCard({
   const shellClasses = isList
     ? 'grid min-h-[58px] grid-cols-[52px_64px_minmax(0,1fr)_auto] items-center gap-3 px-3 py-0'
     : isCompact
-      ? 'flex flex-col gap-0 p-2'
-      : 'flex flex-col gap-0 p-2.5';
+      ? 'flex h-full flex-col gap-0 p-2'
+      : 'flex h-full flex-col gap-0 p-2.5';
   const mediaSpacingClasses = 'mb-2';
   const mediaFrameClasses = isCompact ? 'h-[116px]' : 'aspect-video';
   const audioOverlayClasses = isCompact
@@ -5457,7 +5457,9 @@ function ModCard({
     ? 'text-[14px] font-semibold leading-[18px] truncate'
     : 'text-[15px] font-medium leading-[19px] truncate';
   // Compact cards stay single-line (too small to wrap nicely); standard grid
-  // cards wrap so a hero + category + 18+ + files chip never clips mid-chip.
+  // cards may wrap so a hero + category + 18+ + files chip never clips mid-chip.
+  // The resting row no longer carries the hover-date span (see below), so a lone
+  // chip stays on one line and only genuinely chip-heavy cards ever wrap.
   const gridTagsClasses = viewMode === 'compact' ? 'h-[26px] flex-nowrap' : 'min-h-7 flex-wrap';
   // Locker global axis (HUD, Soul Containers, ...). Surfaced as a card chip so a
   // manual or auto global tag is visible here, not just in the Locker. A global
@@ -5909,7 +5911,7 @@ function ModCard({
             {mod.name}
           </h3>
           <div
-            className={`${isCompact ? 'mt-1.5 h-7' : 'mt-1.5'} grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3`}
+            className={`${isCompact ? 'mt-1.5 h-7' : 'mt-1.5'} grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-3`}
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             <div className={`flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary ${gridTagsClasses}`}>
@@ -5950,8 +5952,12 @@ function ModCard({
                 </span>
               )}
               {!isCompact && (
+                // Hidden (not just transparent) until hover so it never occupies
+                // row width at rest: an always-present date span sitting next to a
+                // chip overflowed the column and wrapped the row to a second line,
+                // making chip cards taller than chip-less ones.
                 <span
-                  className="flex-shrink-0 pl-1.5 text-[11px] tabular-nums text-text-secondary/55 opacity-0 transition-opacity duration-200 group-hover/card:opacity-100"
+                  className="hidden flex-shrink-0 items-center pl-1.5 text-[11px] tabular-nums text-text-secondary/55 group-hover/card:inline-flex"
                   title={`Installed ${formatAbsoluteDate(mod.installedAt)}`}
                 >
                   {formatRelativeDate(mod.installedAt)}

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -240,6 +240,9 @@ export default function Locker() {
         heroCategoryId: hero.id,
         categoryId: 'all',
         search: '',
+        // Leave artist mode: it persists in the session store and would
+        // otherwise override the hero filter this entry point asks for.
+        submitter: undefined,
       });
       navigate('/browse');
     },

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -47,6 +47,18 @@ export interface BrowseUiState {
   // For Mod section it collapses to 'all' since every Skin lives under a hero.
   heroCategoryId: number | 'all' | 'none';
   categoryId: number | 'all';
+  // Artist mode: when set, the grid lists only this submitter's mods
+  // (GameBanana Generic_Submitter filter) and Browse shows an artist banner.
+  // Session-only; carries display fields so the banner needs no extra fetch.
+  submitter?: BrowseArtistRef;
+}
+
+export interface BrowseArtistRef {
+  id: number;
+  name: string;
+  avatarUrl?: string;
+  profileUrl?: string;
+  kofiUrl?: string;
 }
 
 // layout + sort behave like preferences. Cache them in localStorage so they

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -50,6 +50,7 @@ export interface BrowseModsArgs {
 export interface GetModDetailsArgs {
     modId: number;
     section?: string;
+    includeSubmitter?: boolean;
 }
 
 export interface DownloadModArgs {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -46,6 +46,7 @@ export interface BrowseModsArgs {
     section?: string;
     categoryId?: number;
     sort?: string;
+    submitterId?: number;
 }
 
 export interface GetModDetailsArgs {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -35,6 +35,7 @@ import type {
     GameBananaCategoryNode,
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
+    GameBananaArtistLink,
 } from './gamebanana';
 import type { HeroPortrait, SoulModelInfo, HeroPoseInfo } from './portrait';
 
@@ -408,6 +409,7 @@ export interface ElectronAPI {
     getModFileList: (args: GetModDetailsArgs) => Promise<GameBananaModFileList>;
     getModComments: (args: { modId: number; section?: string; page?: number }) => Promise<{ comments: Array<{ id: number; text: string; dateAdded: number; poster: { id: number; name: string; avatarUrl?: string } }>; totalCount: number }>;
     getModUpdates: (args: { modId: number; section?: string; page?: number }) => Promise<GameBananaModUpdatesResponse>;
+    getSubmitterLinks: (memberId: number) => Promise<GameBananaArtistLink[]>;
     downloadMod: (args: DownloadModArgs) => Promise<void>;
     getGameBananaSections: () => Promise<GameBananaSection[]>;
     getGameBananaCategories: (args: GetCategoriesArgs) => Promise<GameBananaCategoryNode[]>;

--- a/src/types/gamebanana.ts
+++ b/src/types/gamebanana.ts
@@ -41,6 +41,17 @@ export interface GameBananaSubmitter {
   kofiUrl?: string;
 }
 
+/** A social/contact link from an artist's GameBanana profile (Bluesky, YouTube,
+ *  Discord, personal site, etc.). Fetched lazily from the member ProfilePage
+ *  since the mod's submitter payload doesn't carry these. */
+export interface GameBananaArtistLink {
+  /** Human label as configured on GameBanana, e.g. "Bluesky", "YouTube". */
+  label: string;
+  /** Lowercased platform key for icon mapping, e.g. "bluesky", "youtube". */
+  platform: string;
+  url: string;
+}
+
 export interface GameBananaPreviewMedia {
   images?: GameBananaImage[];
   metadata?: GameBananaPreviewMetadata;

--- a/src/types/gamebanana.ts
+++ b/src/types/gamebanana.ts
@@ -37,6 +37,8 @@ export interface GameBananaSubmitter {
   id: number;
   name: string;
   avatarUrl?: string;
+  profileUrl?: string;
+  kofiUrl?: string;
 }
 
 export interface GameBananaPreviewMedia {
@@ -89,6 +91,7 @@ export interface GameBananaModDetails {
   category?: GameBananaCategory;
   files?: GameBananaFile[];
   previewMedia?: GameBananaPreviewMedia;
+  submitter?: GameBananaSubmitter;
 }
 
 export interface GameBananaModFileList {


### PR DESCRIPTION
## Summary

Reworks the Browse mod-details experience and adds an artist view.

> [!NOTE]
> This branch also carries 4 pre-existing local commits that were not yet on `main` (overlay-nav polish, GameBanana Ko-fi links, installed-card alignment). The browse work depends on the Ko-fi commit, so they land together here.

### Dockable mod details sidebar
- `ModDetailsModal` gains a `variant` (`modal` | `sidebar`): one JSX tree, variant-conditional chrome. The sidebar renders inline (no portal) and forces a single-column stacked body.
- Browse wraps the grid in a flex row with a resizable `<aside>`; shrinking the `flex-1` grid drives the existing `ResizeObserver`, so the virtualized columns reflow automatically.
- Persisted `Details view` toggle (Window / Sidebar) in the View menu, plus a dock/pop-out button on each surface. Sidebar width is drag-resizable and remembered, clamped so the grid keeps >=360px; narrow windows fall back to the modal.
- Sidebar previews are a single-slot **swipe carousel** (arrows + dots + counter) in a fixed 16/9 `object-contain` box, so the arrows don't jump between differently sized images; clicking opens the existing lightbox.

### Classic small cards
- At the smallest slider sizes the classic overlay collapses to a title-only bar, revealing stats/author on hover/focus over a fuller scrim, so the art stays visible. (Keyed off real card width, since `viewMode` never resolves to `compact` for classic cards.)

### Artist socials + artist mode
- The details artist card is redesigned (avatar + monogram fallback) with an industry-standard **Ko-fi brand button**.
- Clicking the artist opens **artist mode**: the Browse grid is scoped to that submitter via GameBanana's `Generic_Submitter` filter, with a banner header (avatar, colorful brand social symbols, Ko-fi, mod count, back). Back restores the prior browse exactly.
- Artist social/contact links are fetched lazily from the member ProfilePage **only on the artist banner** (cached per member id), not on every mod open. `buildContactUrl` resolves GameBanana's `%VALUE%` href templates, handles the double-host case, and rejects non-http(s) schemes.

### Networking
- Outbound API requests now identify as `Grimoire/<version> (Deadlock mod manager; +https://grimoiremods.com)` instead of the legacy `DeadlockModManager/1.0` (GameBanana API, artist-links, archive CRC, deadlock-api stats).

## Verification
- `tsc` (app + node), `eslint`, and a full production build all pass (only pre-existing `Stats.tsx` lint warnings remain).
- The `Generic_Submitter` filter was verified against the live GameBanana API (returns only the artist's mods, confirmed at scale).
- Multi-agent review of the diff: no correctness bugs found.

> Main-process changes (artist filter, User-Agent) require a full app restart to take effect, not a renderer hot-reload.