### PR TITLE
Preview active hero skin stack in Locker 3D

### DIFF
--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -12,6 +12,7 @@ import {
     getHeroPoseInfo,
     exportHeroPose,
     type HeroPoseInfo,
+    type HeroPoseSkinSource,
 } from '../services/heroPoseModels';
 import type { HeroPortrait } from '../../../src/types/portrait';
 import type { ApplyHeroCardResult } from '../../../src/types/mod';
@@ -86,16 +87,21 @@ ipcMain.handle(
 
 ipcMain.handle(
     'get-hero-pose-info',
-    async (_, heroName: string, skinMetaKey?: string): Promise<HeroPoseInfo> => {
-        return getHeroPoseInfo(heroName, skinMetaKey);
+    async (_, heroName: string, skinSources?: HeroPoseSkinSource[]): Promise<HeroPoseInfo> => {
+        return getHeroPoseInfo(heroName, skinSources);
     }
 );
 
 ipcMain.handle(
     'export-hero-pose',
-    async (_, heroName: string, skinMetaKey?: string): Promise<HeroPoseInfo> => {
+    async (
+        _,
+        heroName: string,
+        skinSources?: HeroPoseSkinSource[],
+        fallbackSkinMetaKey?: string
+    ): Promise<HeroPoseInfo> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return exportHeroPose(deadlockPath, heroName, skinMetaKey);
+        return exportHeroPose(deadlockPath, heroName, skinSources, fallbackSkinMetaKey);
     }
 );

--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -24,9 +24,10 @@
  */
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 import { app, protocol, net } from 'electron';
-import { runVpkmerge } from './modMerger';
+import { runVpkmerge, verifyVpkOutput } from './modMerger';
 import { codenamesForHero } from './heroPortraits';
 import { getCitadelPath, getAddonsPath, getDisabledPath } from './deadlock';
 
@@ -68,7 +69,10 @@ const MODEL_CODENAME_OVERRIDES: Readonly<Record<string, string[]>> = {
  * a community reporter (#bugs "3D Preview pulling wrong model"): each entry
  * decodes, carries a real menu pose, and is the current model. Viscous is a
  * no-op today (`--hero viscous` already resolves here) but pinned for the same
- * skin-path robustness. Deliberately NOT pinned: Infernus (its current
+ * skin-path robustness. Rem is pinned to `familiar_wip`: the plain
+ * `familiar.vmdl_c` exports a live skeleton/clip with every rendered vertex
+ * weighted to pelvis, so the mixer advances while the mesh stays effectively
+ * bind-posed. Deliberately NOT pinned: Infernus (its current
  * `heroes_wip/inferno` ships no menu/idle pose clip, so `--require-pose` would
  * drop it to a 2D portrait; `--hero inferno` already resolves to a poseable
  * same-size model) and Billy (`punkgoat` ships the rig but no pose clip and
@@ -80,6 +84,7 @@ const MODEL_ENTRY_OVERRIDES: Readonly<Record<string, string>> = {
     Pocket: 'models/heroes_wip/pocket/pocket.vmdl_c',
     Ivy: 'models/heroes_wip/ivy/ivy.vmdl_c',
     'Lady Geist': 'models/heroes_wip/geist/geist.vmdl_c',
+    Rem: 'models/heroes_wip/familiar/familiar_wip.vmdl_c',
     Viscous: 'models/heroes_staging/viscous/viscous.vmdl_c',
 };
 
@@ -111,8 +116,18 @@ function sanitize(value: string): string {
  *  (a skin metaKey, or `vanilla` for the base look) so each skin caches its own
  *  still. Lowercased because the skin half is a VPK name, unique case-
  *  insensitively. */
-function poseKey(heroName: string, skinMetaKey?: string): string {
-    return `${heroName}::${skinMetaKey ?? 'vanilla'}`;
+export interface HeroPoseSkinSource {
+    metaKey: string;
+    priority: number;
+}
+
+function poseKey(heroName: string, skinSources: HeroPoseSkinSource[] = []): string {
+    if (skinSources.length === 0) return `${heroName}::vanilla`;
+    if (skinSources.length === 1) return `${heroName}::${skinSources[0].metaKey}`;
+    const stack = skinSources
+        .map((source) => `${source.priority}:${source.metaKey}`)
+        .join('+');
+    return `${heroName}::stack::${stack}`;
 }
 
 function modelDir(key: string): string {
@@ -138,8 +153,11 @@ function modelFile(key: string): string {
  * v3: reworked heroes (Abrams, McGinnis, Pocket, Ivy, Lady Geist, ...) now pin
  * their exact current `heroes_wip` entry instead of `--hero` discovery, which had
  * been resolving to the stale pre-rework body. Pre-v3 GLBs cached the wrong model.
+ *
+ * v4: Rem now pins `familiar_wip.vmdl_c`; old cached Familiar GLBs targeted
+ * `familiar.vmdl_c`, whose rendered vertices are all pelvis-weighted.
  */
-const POSE_CACHE_VERSION = '3';
+const POSE_CACHE_VERSION = '4';
 
 function versionFile(key: string): string {
     return join(modelDir(key), '.cache-version');
@@ -169,6 +187,68 @@ async function resolveSkinVpk(deadlockPath: string, metaKey: string): Promise<st
         }
     }
     return null;
+}
+
+function normalizeSkinSources(skinSources: HeroPoseSkinSource[] = []): HeroPoseSkinSource[] {
+    const byKey = new Map<string, HeroPoseSkinSource>();
+    for (const source of skinSources) {
+        const metaKey = source.metaKey.trim();
+        if (!metaKey) continue;
+        byKey.set(metaKey, {
+            metaKey,
+            priority: Number.isFinite(source.priority) ? source.priority : 0,
+        });
+    }
+    return [...byKey.values()].sort(
+        (a, b) => b.priority - a.priority || a.metaKey.localeCompare(b.metaKey)
+    );
+}
+
+interface PoseSource {
+    vpk: string;
+    sources: HeroPoseSkinSource[];
+    tempDir?: string;
+}
+
+async function resolvePoseSource(
+    deadlockPath: string,
+    pak01: string,
+    skinSources: HeroPoseSkinSource[]
+): Promise<PoseSource> {
+    const resolved: Array<HeroPoseSkinSource & { path: string }> = [];
+    for (const source of skinSources) {
+        const path = await resolveSkinVpk(deadlockPath, source.metaKey);
+        if (path) resolved.push({ ...source, path });
+    }
+
+    if (resolved.length === 0) {
+        return { vpk: pak01, sources: [] };
+    }
+
+    if (resolved.length === 1) {
+        return {
+            vpk: resolved[0].path,
+            sources: [{ metaKey: resolved[0].metaKey, priority: resolved[0].priority }],
+        };
+    }
+
+    const tempDir = await fs.mkdtemp(join(tmpdir(), 'grimoire-hero-pose-'));
+    const merged = join(tempDir, 'stack_dir.vpk');
+    try {
+        await runVpkmerge([merged, ...resolved.map((source) => source.path)], 120000);
+        await verifyVpkOutput(merged);
+        return {
+            vpk: merged,
+            tempDir,
+            sources: resolved.map((source) => ({
+                metaKey: source.metaKey,
+                priority: source.priority,
+            })),
+        };
+    } catch (err) {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        throw err;
+    }
 }
 
 export interface HeroPoseInfo {
@@ -201,9 +281,9 @@ async function infoForKey(key: string): Promise<HeroPoseInfo> {
  *  and storage key. */
 export async function getHeroPoseInfo(
     heroName: string,
-    skinMetaKey?: string
+    skinSources?: HeroPoseSkinSource[]
 ): Promise<HeroPoseInfo> {
-    return infoForKey(poseKey(heroName, skinMetaKey));
+    return infoForKey(poseKey(heroName, normalizeSkinSources(skinSources)));
 }
 
 /**
@@ -230,13 +310,15 @@ const inFlightExports = new Map<string, Promise<HeroPoseInfo>>();
 export async function exportHeroPose(
     deadlockPath: string,
     heroName: string,
-    skinMetaKey?: string
+    skinSources?: HeroPoseSkinSource[],
+    fallbackSkinMetaKey?: string
 ): Promise<HeroPoseInfo> {
-    const requestKey = poseKey(heroName, skinMetaKey);
+    const normalized = normalizeSkinSources(skinSources);
+    const requestKey = poseKey(heroName, normalized);
     const existing = inFlightExports.get(requestKey);
     if (existing) return existing;
 
-    const work = runHeroPoseExport(deadlockPath, heroName, skinMetaKey);
+    const work = runHeroPoseExport(deadlockPath, heroName, normalized, fallbackSkinMetaKey);
     inFlightExports.set(requestKey, work);
     try {
         return await work;
@@ -248,7 +330,26 @@ export async function exportHeroPose(
 async function runHeroPoseExport(
     deadlockPath: string,
     heroName: string,
-    skinMetaKey?: string
+    skinSources: HeroPoseSkinSource[],
+    fallbackSkinMetaKey?: string
+): Promise<HeroPoseInfo> {
+    try {
+        return await runHeroPoseExportForSources(deadlockPath, heroName, skinSources);
+    } catch (err) {
+        if (skinSources.length <= 1 || !fallbackSkinMetaKey) throw err;
+        const fallback =
+            skinSources.find((source) => source.metaKey === fallbackSkinMetaKey) ?? {
+                metaKey: fallbackSkinMetaKey,
+                priority: 0,
+            };
+        return runHeroPoseExportForSources(deadlockPath, heroName, [fallback]);
+    }
+}
+
+async function runHeroPoseExportForSources(
+    deadlockPath: string,
+    heroName: string,
+    skinSources: HeroPoseSkinSource[]
 ): Promise<HeroPoseInfo> {
     const selectors = modelSelectorsForHero(heroName);
     if (selectors.length === 0) {
@@ -256,44 +357,46 @@ async function runHeroPoseExport(
     }
 
     const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
-    const skinVpk = skinMetaKey ? await resolveSkinVpk(deadlockPath, skinMetaKey) : null;
-    const sourceVpk = skinVpk ?? pak01;
-    // Key reflects what actually sourced the pose: the skin only when its VPK
-    // resolved, else vanilla. The renderer reads the key off the returned info.
-    const key = poseKey(heroName, skinVpk ? skinMetaKey : undefined);
+    const source = await resolvePoseSource(deadlockPath, pak01, skinSources);
+    try {
+        const key = poseKey(heroName, source.sources);
+        const dir = modelDir(key);
+        await fs.mkdir(dir, { recursive: true });
+        const out = modelFile(key);
 
-    const dir = modelDir(key);
-    await fs.mkdir(dir, { recursive: true });
-    const out = modelFile(key);
-
-    let lastError: unknown;
-    for (const selector of selectors) {
-        try {
-            await runVpkmerge([
-                'model',
-                'export',
-                '--vpk',
-                sourceVpk,
-                ...selector,
-                '--base',
-                pak01,
-                '--pose',
-                // Refuse to bake a static bind/T-pose: a clipless WIP hero
-                // (Apollo, Billy, Celeste, Mina, Paige, Rem) errors here and the
-                // Locker falls back to the 2D portrait instead of an unposed model.
-                '--require-pose',
-                '--out',
-                out,
-            ]);
-            await fs.writeFile(versionFile(key), POSE_CACHE_VERSION);
-            return infoForKey(key);
-        } catch (err) {
-            lastError = err;
+        let lastError: unknown;
+        for (const selector of selectors) {
+            try {
+                await runVpkmerge([
+                    'model',
+                    'export',
+                    '--vpk',
+                    source.vpk,
+                    ...selector,
+                    '--base',
+                    pak01,
+                    '--pose',
+                    // Refuse to bake a static bind/T-pose: a clipless WIP hero
+                    // (Apollo, Billy, Celeste, Mina, Paige, Rem) errors here and the
+                    // Locker falls back to the 2D portrait instead of an unposed model.
+                    '--require-pose',
+                    '--out',
+                    out,
+                ]);
+                await fs.writeFile(versionFile(key), POSE_CACHE_VERSION);
+                return infoForKey(key);
+            } catch (err) {
+                lastError = err;
+            }
+        }
+        throw lastError instanceof Error
+            ? lastError
+            : new Error(`Failed to export pose for "${heroName}".`);
+    } finally {
+        if (source.tempDir) {
+            await fs.rm(source.tempDir, { recursive: true, force: true });
         }
     }
-    throw lastError instanceof Error
-        ? lastError
-        : new Error(`Failed to export pose for "${heroName}".`);
 }
 
 /**

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -1,5 +1,5 @@
 import { promises as fs, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
@@ -33,12 +33,37 @@ const VPKMERGE_BINARY_BY_PLATFORM: Record<SupportedPlatform, string> = {
     'win32-x64':    'vpkmerge-windows-x86_64.exe',
 };
 
+function firstExistingPath(paths: string[]): string | null {
+    for (const path of paths) {
+        if (existsSync(path)) return path;
+    }
+    return null;
+}
+
+function devVpkmergeBinaryPath(): string | null {
+    const explicit = process.env['VPKMERGE_BINARY'];
+    if (explicit && existsSync(explicit)) return explicit;
+
+    const repoRoot = app.getAppPath();
+    const siblingRoot = resolve(repoRoot, '..', 'vpkmerge', 'target');
+    const exeName = process.platform === 'win32' ? 'vpkmerge.exe' : 'vpkmerge';
+    return firstExistingPath([
+        join(siblingRoot, 'release', exeName),
+        join(siblingRoot, 'debug', exeName),
+    ]);
+}
+
 /**
  * Resolve the bundled vpkmerge binary path. In dev the binary lives under
  * the repo's resources/; in a packaged build electron-builder's
  * extraResources places it at process.resourcesPath/vpkmerge/.
  */
 export function vpkmergeBinaryPath(): string {
+    if (!app.isPackaged) {
+        const local = devVpkmergeBinaryPath();
+        if (local) return local;
+    }
+
     const key = `${process.platform}-${process.arch}` as SupportedPlatform;
     const assetName = VPKMERGE_BINARY_BY_PLATFORM[key];
     if (!assetName) {

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -26,6 +26,7 @@ import { runVpkmerge } from './modMerger';
 import { getCitadelPath, getAddonsPath, getDisabledPath } from './deadlock';
 
 export const SOUL_MODEL_SCHEME = 'grimoire-soul';
+const SOUL_CACHE_VERSION = '2';
 
 /**
  * Canonical soul-container model entry. Present in the base pak01 and in the
@@ -50,6 +51,10 @@ function modelDir(key: string): string {
 
 function modelFile(key: string): string {
     return join(modelDir(key), 'model.glb');
+}
+
+function versionFile(key: string): string {
+    return join(modelDir(key), '.cache-version');
 }
 
 /**
@@ -139,6 +144,10 @@ export interface SoulModelInfo {
 export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
     try {
         const stat = await fs.stat(modelFile(key));
+        const version = await fs.readFile(versionFile(key), 'utf8').catch(() => '');
+        if (version.trim() !== SOUL_CACHE_VERSION) {
+            return { hasModel: false, mtimeMs: null };
+        }
         return { hasModel: true, mtimeMs: stat.mtimeMs };
     } catch {
         return { hasModel: false, mtimeMs: null };
@@ -177,11 +186,12 @@ export async function exportSoulModel(
         out,
     ]);
 
-    // Drop the degenerate skin morphic emits on these static props so three.js
-    // loads them as plain meshes (see stripGlbSkins).
+    // Current vpkmerge avoids degenerate static skins, but keep this as a
+    // compatibility no-op/fallback for older local binaries or stale outputs.
     const raw = await fs.readFile(out);
     const patched = stripGlbSkins(raw);
     if (patched !== raw) await fs.writeFile(out, patched);
+    await fs.writeFile(versionFile(metaKey), SOUL_CACHE_VERSION);
 
     return getSoulModelInfo(metaKey);
 }

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -26,7 +26,10 @@ import { runVpkmerge } from './modMerger';
 import { getCitadelPath, getAddonsPath, getDisabledPath } from './deadlock';
 
 export const SOUL_MODEL_SCHEME = 'grimoire-soul';
-const SOUL_CACHE_VERSION = '2';
+// v1: the original pipeline (vpkmerge export + stripGlbSkins patch). Pre-sidecar
+// GLBs are treated as v1 in getSoulModelInfo, so introducing the sidecar did not
+// invalidate existing caches.
+const SOUL_CACHE_VERSION = '1';
 
 /**
  * Canonical soul-container model entry. Present in the base pak01 and in the
@@ -144,8 +147,14 @@ export interface SoulModelInfo {
 export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
     try {
         const stat = await fs.stat(modelFile(key));
-        const version = await fs.readFile(versionFile(key), 'utf8').catch(() => '');
-        if (version.trim() !== SOUL_CACHE_VERSION) {
+        // A GLB without a sidecar predates cache versioning and counts as v1:
+        // the export pipeline is unchanged since those were written (vpkmerge
+        // v0.11.0 still emits the degenerate static skin, which stripGlbSkins
+        // already patched at write time), so they stay valid. Bump
+        // SOUL_CACHE_VERSION only when the export output actually changes.
+        const raw = await fs.readFile(versionFile(key), 'utf8').catch(() => '');
+        const version = raw.trim() || '1';
+        if (version !== SOUL_CACHE_VERSION) {
             return { hasModel: false, mtimeMs: null };
         }
         return { hasModel: true, mtimeMs: stat.mtimeMs };
@@ -186,8 +195,10 @@ export async function exportSoulModel(
         out,
     ]);
 
-    // Current vpkmerge avoids degenerate static skins, but keep this as a
-    // compatibility no-op/fallback for older local binaries or stale outputs.
+    // Drop the degenerate skin emitted on this static prop so three.js loads
+    // it as a plain mesh (see stripGlbSkins). Still required: as of vpkmerge
+    // v0.11.0 the export carries 1 skin and 0 animations (verified 2026-06-09
+    // against both the bundled and a fresh release build).
     const raw = await fs.readFile(out);
     const patched = stripGlbSkins(raw);
     if (patched !== raw) await fs.writeFile(out, patched);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -846,10 +846,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('export-soul-model', metaKey),
     clearSoulModel: (key: string) =>
         ipcRenderer.invoke('clear-soul-model', key),
-    getHeroPoseInfo: (heroName: string, skinMetaKey?: string) =>
-        ipcRenderer.invoke('get-hero-pose-info', heroName, skinMetaKey),
-    exportHeroPose: (heroName: string, skinMetaKey?: string) =>
-        ipcRenderer.invoke('export-hero-pose', heroName, skinMetaKey),
+    getHeroPoseInfo: (heroName: string, skinSources?: unknown[]) =>
+        ipcRenderer.invoke('get-hero-pose-info', heroName, skinSources),
+    exportHeroPose: (heroName: string, skinSources?: unknown[], fallbackSkinMetaKey?: string) =>
+        ipcRenderer.invoke('export-hero-pose', heroName, skinSources, fallbackSkinMetaKey),
     getPreviewCacheSize: () =>
         ipcRenderer.invoke('get-preview-cache-size'),
     clearPreviewCache: () =>

--- a/src/components/locker/HeroPoseViewer.tsx
+++ b/src/components/locker/HeroPoseViewer.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { Loader2 } from 'lucide-react';
 import { getHeroPoseInfo, exportHeroPose } from '../../lib/api';
+import { loadGltfPreview } from '../../lib/loadGltfPreview';
+import type { HeroPoseSkinSource } from '../../types/portrait';
 
 /**
  * Live 3D preview of a hero's menu pose for the Locker's per-hero view.
@@ -104,15 +105,19 @@ function Controls() {
 
 export default function HeroPoseViewer({
   heroName,
-  skinMetaKey,
+  skinSources = [],
+  fallbackSkinMetaKey,
 }: {
   heroName: string;
-  /** metaKey of the hero's active skin VPK; omit for a vanilla pose. */
-  skinMetaKey?: string;
+  /** Active visual VPK stack for this hero, ordered by the main process before export. */
+  skinSources?: HeroPoseSkinSource[];
+  /** Single-skin fallback when a multi-source preview stack cannot be exported. */
+  fallbackSkinMetaKey?: string;
 }) {
   const [scene, setScene] = useState<THREE.Object3D | null>(null);
   const [generating, setGenerating] = useState(false);
   const [failed, setFailed] = useState(false);
+  const sourceKey = skinSources.map((source) => `${source.priority}:${source.metaKey}`).join('|');
 
   useEffect(() => {
     // The caller remounts this component (via a hero+skin `key`) when the
@@ -122,11 +127,11 @@ export default function HeroPoseViewer({
 
     (async () => {
       try {
-        let info = await getHeroPoseInfo(heroName, skinMetaKey);
+        let info = await getHeroPoseInfo(heroName, skinSources);
         if (!info.hasModel) {
           if (cancelled) return;
           setGenerating(true);
-          info = await exportHeroPose(heroName, skinMetaKey);
+          info = await exportHeroPose(heroName, skinSources, fallbackSkinMetaKey);
           if (cancelled) return;
           setGenerating(false);
         }
@@ -135,9 +140,7 @@ export default function HeroPoseViewer({
           return;
         }
         const url = meshUrlFor(info.key, info.mtimeMs);
-        const gltf = await new Promise<GLTF>((resolve, reject) => {
-          new GLTFLoader().load(url, resolve, undefined, reject);
-        });
+        const gltf = await loadGltfPreview(url);
         if (cancelled) {
           disposeScene(gltf.scene);
           return;
@@ -156,7 +159,7 @@ export default function HeroPoseViewer({
       cancelled = true;
       if (loaded) disposeScene(loaded);
     };
-  }, [heroName, skinMetaKey]);
+  }, [heroName, sourceKey, fallbackSkinMetaKey, skinSources]);
 
   if (failed) {
     return (
@@ -173,7 +176,10 @@ export default function HeroPoseViewer({
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
         <Loader2 className="h-6 w-6 animate-spin text-white/80" />
         {generating && (
-          <p className="text-xs text-text-secondary">Posing {heroName}...</p>
+          <p className="text-xs text-text-secondary">
+            Posing {heroName}
+            {skinSources.length > 1 ? ` with ${skinSources.length} active mods` : ''}...
+          </p>
         )}
       </div>
     );

--- a/src/components/locker/HeroPoseViewer.tsx
+++ b/src/components/locker/HeroPoseViewer.tsx
@@ -159,7 +159,12 @@ export default function HeroPoseViewer({
       cancelled = true;
       if (loaded) disposeScene(loaded);
     };
-  }, [heroName, sourceKey, fallbackSkinMetaKey, skinSources]);
+    // `skinSources` is deliberately not a dependency: `sourceKey` already
+    // encodes its contents, and the array reference changes on every parent
+    // mods refresh, which would tear down and re-fetch the GLB for an
+    // identical stack (visible viewer churn on unrelated toggles).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroName, sourceKey, fallbackSkinMetaKey]);
 
   if (failed) {
     return (

--- a/src/components/locker/SoulContainerViewer.tsx
+++ b/src/components/locker/SoulContainerViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { Loader2 } from 'lucide-react';
 import { getSoulModelInfo, exportSoulModel } from '../../lib/api';
+import { loadGltfPreview } from '../../lib/loadGltfPreview';
 
 /**
  * Live 3D preview of a soul-container mod, for the Locker's Global view.
@@ -112,9 +112,7 @@ export default function SoulContainerViewer({
           return;
         }
         const url = meshUrlFor(modKey, info.mtimeMs);
-        const gltf = await new Promise<GLTF>((resolve, reject) => {
-          new GLTFLoader().load(url, resolve, undefined, reject);
-        });
+        const gltf = await loadGltfPreview(url);
         if (cancelled) {
           disposeScene(gltf.scene);
           return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,10 @@
 import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
-import type { HeroPortrait, SoulModelInfo, HeroPoseInfo } from '../types/portrait';
+import type {
+  HeroPortrait,
+  HeroPoseInfo,
+  HeroPoseSkinSource,
+  SoulModelInfo,
+} from '../types/portrait';
 import type {
   GameBananaModsResponse,
   GameBananaModDetails,
@@ -156,21 +161,22 @@ export async function clearSoulModel(key: string): Promise<void> {
   return window.electronAPI.clearSoulModel(key);
 }
 
-/** Whether a hero's posed 3D still exists for the given active skin (+ mtime, key). */
+/** Whether a hero's posed 3D still exists for the given active skin stack (+ mtime, key). */
 export async function getHeroPoseInfo(
   heroName: string,
-  skinMetaKey?: string
+  skinSources?: HeroPoseSkinSource[]
 ): Promise<HeroPoseInfo> {
-  return window.electronAPI.getHeroPoseInfo(heroName, skinMetaKey);
+  return window.electronAPI.getHeroPoseInfo(heroName, skinSources);
 }
 
 /** Generate a hero's posed 3D still via the bundled vpkmerge `--pose` exporter.
- *  Pass the active skin's metaKey to pose that skin; omit for a vanilla pose. */
+ *  Pass the active skin stack to pose the current equipped look; omit for vanilla. */
 export async function exportHeroPose(
   heroName: string,
-  skinMetaKey?: string
+  skinSources?: HeroPoseSkinSource[],
+  fallbackSkinMetaKey?: string
 ): Promise<HeroPoseInfo> {
-  return window.electronAPI.exportHeroPose(heroName, skinMetaKey);
+  return window.electronAPI.exportHeroPose(heroName, skinSources, fallbackSkinMetaKey);
 }
 
 export async function applyHeroSound(

--- a/src/lib/loadGltfPreview.ts
+++ b/src/lib/loadGltfPreview.ts
@@ -1,0 +1,50 @@
+import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+type CreateImageBitmapFunction = Window['createImageBitmap'];
+
+let disableDepth = 0;
+let hadCreateImageBitmap = false;
+let savedCreateImageBitmap: CreateImageBitmapFunction | undefined;
+
+function defineCreateImageBitmap(value: CreateImageBitmapFunction | undefined): void {
+  Object.defineProperty(globalThis, 'createImageBitmap', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function disableImageBitmapLoader(): void {
+  if (disableDepth === 0) {
+    hadCreateImageBitmap = 'createImageBitmap' in globalThis;
+    savedCreateImageBitmap = globalThis.createImageBitmap;
+    defineCreateImageBitmap(undefined);
+  }
+  disableDepth += 1;
+}
+
+function restoreImageBitmapLoader(): void {
+  if (disableDepth === 0) return;
+  disableDepth -= 1;
+  if (disableDepth > 0) return;
+
+  if (hadCreateImageBitmap) {
+    defineCreateImageBitmap(savedCreateImageBitmap);
+  } else {
+    delete (globalThis as { createImageBitmap?: CreateImageBitmapFunction }).createImageBitmap;
+  }
+
+  hadCreateImageBitmap = false;
+  savedCreateImageBitmap = undefined;
+}
+
+export async function loadGltfPreview(url: string): Promise<GLTF> {
+  disableImageBitmapLoader();
+  try {
+    return await new Promise<GLTF>((resolve, reject) => {
+      new GLTFLoader().load(url, resolve, undefined, reject);
+    });
+  } finally {
+    restoreImageBitmapLoader();
+  }
+}

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -18,6 +18,7 @@ import HeroColorPicker from '../components/locker/HeroColorPicker';
 const HeroPoseViewer = lazy(() => import('../components/locker/HeroPoseViewer'));
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { Mod } from '../types/mod';
+import type { HeroPoseSkinSource } from '../types/portrait';
 import {
   FAVORITE_HEROES_KEY,
   MINA_ARCHIVE_DEFAULT,
@@ -393,15 +394,29 @@ export function LockerHeroView({
   const selectedPoseSkinKey =
     poseSkinSelection?.heroId === hero.id ? poseSkinSelection.key : null;
 
-  // The skin to pose: prefer the last skin the user enabled in this view, then
-  // fall back to the first enabled skin. Multiple enabled skin VPKs can layer,
-  // so "first enabled" alone can keep showing an older skin after a new pick.
-  const activeSkinMetaKey = useMemo(() => {
+  // Single-skin fallback: prefer the last skin the user enabled in this view,
+  // then fall back to the first enabled skin.
+  const fallbackPoseSkinMetaKey = useMemo(() => {
     const selected = selectedPoseSkinKey
       ? skinList.find((mod) => poseSkinSelectionKey(mod) === selectedPoseSkinKey && mod.enabled)
       : null;
     return (selected ?? skinList.find((mod) => mod.enabled))?.metaKey;
   }, [skinList, selectedPoseSkinKey]);
+
+  // Default 3D preview source: every currently enabled visual VPK for this hero.
+  // The main process uses priority to build a preview merge that matches game
+  // load order, and falls back to fallbackPoseSkinMetaKey if the stack cannot export.
+  const activeSkinSources = useMemo<HeroPoseSkinSource[]>(
+    () =>
+      skinList
+        .filter((mod) => mod.enabled)
+        .map((mod) => ({ metaKey: mod.metaKey, priority: mod.priority }))
+        .sort((a, b) => b.priority - a.priority || a.metaKey.localeCompare(b.metaKey)),
+    [skinList]
+  );
+  const activeSkinSourceKey =
+    activeSkinSources.map((source) => `${source.priority}:${source.metaKey}`).join('|') ||
+    'vanilla';
   const hasSounds = soundList.length > 0;
   // If the active section runs out of mods (e.g. user deleted their last
   // sound for this hero) drop back to skins so the panel isn't stuck empty.
@@ -476,9 +491,10 @@ export function LockerHeroView({
             }
           >
             <HeroPoseViewer
-              key={`${hero.name}:${activeSkinMetaKey ?? 'vanilla'}`}
+              key={`${hero.name}:${activeSkinSourceKey}:${fallbackPoseSkinMetaKey ?? ''}`}
               heroName={hero.name}
-              skinMetaKey={activeSkinMetaKey}
+              skinSources={activeSkinSources}
+              fallbackSkinMetaKey={fallbackPoseSkinMetaKey}
             />
           </Suspense>
         ) : renderSrc ? (

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -36,7 +36,7 @@ import type {
     GameBananaCollection,
     GameBananaCollectionItemsResponse,
 } from './gamebanana';
-import type { HeroPortrait, SoulModelInfo, HeroPoseInfo } from './portrait';
+import type { HeroPortrait, SoulModelInfo, HeroPoseInfo, HeroPoseSkinSource } from './portrait';
 
 export interface BrowseModsArgs {
     page: number;
@@ -338,8 +338,15 @@ export interface ElectronAPI {
     getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
     exportSoulModel: (metaKey: string) => Promise<SoulModelInfo>;
     clearSoulModel: (key: string) => Promise<void>;
-    getHeroPoseInfo: (heroName: string, skinMetaKey?: string) => Promise<HeroPoseInfo>;
-    exportHeroPose: (heroName: string, skinMetaKey?: string) => Promise<HeroPoseInfo>;
+    getHeroPoseInfo: (
+        heroName: string,
+        skinSources?: HeroPoseSkinSource[]
+    ) => Promise<HeroPoseInfo>;
+    exportHeroPose: (
+        heroName: string,
+        skinSources?: HeroPoseSkinSource[],
+        fallbackSkinMetaKey?: string
+    ) => Promise<HeroPoseInfo>;
     getPreviewCacheSize: () => Promise<{ bytes: number }>;
     clearPreviewCache: () => Promise<{ bytesFreed: number }>;
     applyHeroSound: (

--- a/src/types/portrait.ts
+++ b/src/types/portrait.ts
@@ -33,9 +33,14 @@ export interface SoulModelInfo {
   mtimeMs: number | null;
 }
 
+export interface HeroPoseSkinSource {
+  metaKey: string;
+  priority: number;
+}
+
 /**
  * Whether a hero's posed 3D still exists in the user's library (for the given
- * active skin), its mtime (to cache-bust the `grimoire-hero:` URL after a
+ * active skin stack), its mtime (to cache-bust the `grimoire-hero:` URL after a
  * re-export), and the storage `key` the renderer builds that URL from. The key
  * is returned rather than recomputed because export can fall back from a skin
  * to a vanilla pose, which changes it.


### PR DESCRIPTION
## Summary
- make Locker 3D hero previews use the full active visual skin stack instead of only the most recently enabled skin
- build a temporary preview VPK for multi-mod stacks, cache posed GLBs by stack, and fall back to the previous single-skin export path on failure
- share the Electron GLB loading workaround across hero and soul-container viewers
- prefer sibling vpkmerge release builds in dev and refresh stale 3D preview caches

## Verification
- pnpm lint (passes with existing Stats.tsx hook dependency warnings)
- GRIMOIRE_SOCIAL_BASE_URL=https://example.com pnpm build
- smoke-tested two-VPK Abrams preview stack: temporary merge + posed GLB export completed successfully