### PR TITLE
Fix mod details and download auto-enable

### DIFF
--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -44,6 +44,8 @@ export interface OneClickInstallArgs {
     enrichedDetails?: GameBananaModDetails;
 }
 
+type DisabledSiblingVariant = { id: string; name: string; fileName: string };
+
 /**
  * Strip the trailing archive extension from a GameBanana filename so we keep
  * a clean stem to use as a label fallback. Case-insensitive; leaves the rest
@@ -578,6 +580,57 @@ async function renameVpksToAvoidConflicts(
     return renamedFiles;
 }
 
+async function enableInstalledVpks(
+    deadlockPath: string,
+    installedVpks: string[],
+    context: string
+): Promise<void> {
+    if (installedVpks.length === 0) return;
+
+    const installedSet = new Set(installedVpks);
+    const refreshed = await scanMods(deadlockPath);
+    for (const vpkFileName of installedVpks) {
+        const newMod = refreshed.find((m) => installedSet.has(m.fileName) && m.fileName === vpkFileName);
+        if (!newMod || newMod.enabled) continue;
+        try {
+            await enableMod(deadlockPath, newMod.id);
+        } catch (err) {
+            console.warn(`[download] Failed to auto-enable ${vpkFileName} (${context}):`, err);
+        }
+    }
+}
+
+async function disableSiblingVariants(
+    deadlockPath: string,
+    installedVpks: string[],
+    modId: number | undefined,
+    fileId: number | undefined
+): Promise<DisabledSiblingVariant[]> {
+    if (installedVpks.length === 0 || modId === undefined || modId <= 0) return [];
+
+    const installedSet = new Set(installedVpks);
+    const allMods = await scanMods(deadlockPath);
+    // scanMods returns filesystem state only; gameBananaId and gameBananaFileId
+    // live in the metadata sidecar. Read them per-mod here or the filter never
+    // matches and no sibling variants get disabled.
+    const stalePeers = allMods.filter((m) => {
+        if (!m.enabled) return false;
+        if (installedSet.has(m.fileName)) return false;
+        const meta = getModMetadata(m.metaKey);
+        return (
+            meta?.gameBananaId === modId &&
+            (fileId === undefined || meta?.gameBananaFileId !== fileId)
+        );
+    });
+    const disabledPeers: DisabledSiblingVariant[] = [];
+    for (const peer of stalePeers) {
+        console.log(`[download] Auto-disabling sibling variant: ${peer.fileName}`);
+        await disableMod(deadlockPath, peer.id);
+        disabledPeers.push({ id: peer.id, name: peer.name, fileName: peer.fileName });
+    }
+    return disabledPeers;
+}
+
 /**
  * Execute the actual download (internal, called from queue)
  */
@@ -864,29 +917,10 @@ async function executeDownload(
     // Opt-out: settings.autoDisableSiblingVariants = false keeps every variant
     // enabled (e.g. a mod page whose separate files are meant to run together).
     const settings = loadSettings();
+    let enabledInstalledVpks = false;
     if (settings.autoDisableSiblingVariants !== false) {
         try {
-            const installedSet = new Set(installedVpks);
-            const allMods = await scanMods(deadlockPath);
-            // scanMods returns filesystem state only; gameBananaId and
-            // gameBananaFileId live in the metadata sidecar (enriched at
-            // the IPC boundary by enrichMod). Read them per-mod here or the
-            // filter never matches and no sibling variants ever get disabled.
-            const stalePeers = allMods.filter((m) => {
-                if (!m.enabled) return false;
-                if (installedSet.has(m.fileName)) return false;
-                const meta = getModMetadata(m.metaKey);
-                return (
-                    meta?.gameBananaId === modId &&
-                    meta?.gameBananaFileId !== fileId
-                );
-            });
-            const disabledPeers: Array<{ id: string; name: string; fileName: string }> = [];
-            for (const peer of stalePeers) {
-                console.log(`[downloadMod] Auto-disabling sibling variant: ${peer.fileName}`);
-                await disableMod(deadlockPath, peer.id);
-                disabledPeers.push({ id: peer.id, name: peer.name, fileName: peer.fileName });
-            }
+            const disabledPeers = await disableSiblingVariants(deadlockPath, installedVpks, modId, fileId);
             // Downloads land in /disabled by default, so just disabling the
             // previously-enabled sibling would leave the mod entirely off
             // ("the newest pick is the active one" in the surrounding comment
@@ -894,17 +928,8 @@ async function executeDownload(
             // enabled variant, move the freshly-downloaded VPK(s) into the
             // addons folder so the user ends up with the new variant active.
             if (disabledPeers.length > 0 && installedVpks.length > 0) {
-                const refreshed = await scanMods(deadlockPath);
-                for (const vpkFileName of installedVpks) {
-                    const newMod = refreshed.find((m) => m.fileName === vpkFileName);
-                    if (newMod && !newMod.enabled) {
-                        try {
-                            await enableMod(deadlockPath, newMod.id);
-                        } catch (err) {
-                            console.warn(`[downloadMod] Failed to enable new variant ${vpkFileName}:`, err);
-                        }
-                    }
-                }
+                await enableInstalledVpks(deadlockPath, installedVpks, 'sibling-variant');
+                enabledInstalledVpks = true;
                 mainWindow?.webContents.send('mods-auto-disabled', {
                     reason: 'sibling-variant',
                     modId,
@@ -915,6 +940,10 @@ async function executeDownload(
         } catch (err) {
             console.warn(`[downloadMod] Failed to auto-disable sibling variants:`, err);
         }
+    }
+
+    if (settings.autoEnableDownloads === true && !enabledInstalledVpks) {
+        await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
     }
 
     // Notify completion
@@ -1350,6 +1379,35 @@ async function executeOneClickDownload(
         const vpkPath = join(targetPath, vpkFileName);
         const perVpkMetadata = stampVpkLockerHero(metadata, section, vpkPath);
         await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
+    }
+
+    const settings = loadSettings();
+    let enabledInstalledVpks = false;
+    if (settings.autoDisableSiblingVariants !== false) {
+        try {
+            const disabledPeers = await disableSiblingVariants(
+                deadlockPath,
+                installedVpks,
+                realModId,
+                resolvedFileId
+            );
+            if (disabledPeers.length > 0 && installedVpks.length > 0) {
+                await enableInstalledVpks(deadlockPath, installedVpks, 'sibling-variant');
+                enabledInstalledVpks = true;
+                mainWindow?.webContents.send('mods-auto-disabled', {
+                    reason: 'sibling-variant',
+                    modId: realModId ?? modId,
+                    fileId: resolvedFileId ?? fileId,
+                    disabled: disabledPeers,
+                });
+            }
+        } catch (err) {
+            console.warn(`[oneClickInstall] Failed to auto-disable sibling variants:`, err);
+        }
+    }
+
+    if (settings.autoEnableDownloads === true && !enabledInstalledVpks) {
+        await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
     }
 
     mainWindow?.webContents.send('download-complete', { modId, fileId });

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -10,6 +10,9 @@ export interface AppSettings {
     hideOutdatedMods: boolean;       // Hide GameBanana mods flagged as outdated in Browse
     lockerCardsExpandedByDefault: boolean; // Open Locker list-view hero cards expanded on first load
     autoDisableSiblingVariants: boolean; // Installing a different file of an already-enabled mod disables the prior variant (not about updates)
+    /** Enable newly downloaded VPKs after a successful install. Off by default
+     *  so downloads keep behaving as a staging step unless the user opts in. */
+    autoEnableDownloads: boolean;
     steamLaunchOptions: string;      // Args written to Steam's localconfig.vdf for Deadlock just before launch
     activeProfileId: string | null;  // Currently active profile
     autoSaveProfile: boolean;        // Auto-save when mods change
@@ -65,6 +68,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     hideOutdatedMods: false,
     lockerCardsExpandedByDefault: false,
     autoDisableSiblingVariants: true,
+    autoEnableDownloads: false,
     steamLaunchOptions: '',
     activeProfileId: null,
     autoSaveProfile: false,

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -309,7 +309,7 @@ export default function ModDetailsModal({
 
   const currentImage = images[currentImageIndex];
   // The lightbox loads the original GB asset for detail inspection.
-  // The inline stack uses file530 per image directly via raw <img> tags so
+  // The inline stack uses file530 per image directly via plain image elements so
   // each thumb can render and load independently as the user scrolls.
   const currentImageFullUrl = currentImage
     ? `${currentImage.baseUrl}/${currentImage.file}`
@@ -663,16 +663,16 @@ export default function ModDetailsModal({
     : 'fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 md:px-24 z-50 animate-fade-in';
   const panelClass = isSidebar
     ? 'relative bg-bg-secondary h-full w-full overflow-hidden flex flex-col'
-    : 'relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl';
+    : 'relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl h-[min(90vh,920px)] max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl';
   const bodyContentClass = isSidebar
-    ? 'mod-details-body-content flex h-full min-h-0 flex-col overflow-y-auto'
-    : 'mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto lg:overflow-hidden';
+    ? 'mod-details-body-content flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain'
+    : 'mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto overscroll-contain lg:overflow-hidden';
   const imageColClass = isSidebar
     ? 'p-4 space-y-3'
-    : 'lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pr-3 space-y-3';
+    : 'lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:overscroll-contain lg:max-h-full p-5 lg:pr-3 space-y-3';
   const detailsColClass = isSidebar
     ? 'flex-1 min-w-0 p-4 space-y-5'
-    : 'flex-1 min-w-0 lg:overflow-y-auto lg:max-h-full p-5 lg:pl-3 space-y-5';
+    : 'flex-1 min-w-0 lg:overflow-y-auto lg:overscroll-contain lg:max-h-full p-5 lg:pl-3 space-y-5';
 
   const modal = (
     <div
@@ -1470,16 +1470,25 @@ export default function ModDetailsModal({
                 </section>
               )}
               <section>
-                <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2 flex items-center gap-2">
-                  <MessageSquare className="w-3.5 h-3.5" />
-                  Comments {commentsTotalCount > 0 && <span className="normal-case tracking-normal text-text-secondary/70">({commentsTotalCount})</span>}
-                </h3>
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <h3 className="flex min-w-0 items-center gap-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                    <MessageSquare className="h-3.5 w-3.5 flex-shrink-0" />
+                    <span className="truncate">
+                      Comments {commentsTotalCount > 0 && <span className="normal-case tracking-normal text-text-secondary/70">({commentsTotalCount})</span>}
+                    </span>
+                  </h3>
+                  {!commentsLoading && commentsTotalCount > comments.length && comments.length > 0 && (
+                    <span className="flex-shrink-0 text-[11px] text-text-tertiary">
+                      Showing {comments.length.toLocaleString()} of {commentsTotalCount.toLocaleString()}
+                    </span>
+                  )}
+                </div>
                 {commentsLoading ? (
-                  <ul className="divide-y divide-border/60">
+                  <ul className="divide-y divide-border/60 rounded-lg border border-border/80 bg-bg-tertiary/30 px-3">
                     {Array.from({ length: 2 }).map((_, i) => (
-                      <li key={i} className="flex gap-3 py-3 first:pt-0">
-                        <Skeleton className="w-7 h-7 flex-shrink-0" rounded="full" />
-                        <div className="flex-1 space-y-1.5">
+                      <li key={i} className="flex gap-3 py-3">
+                        <Skeleton className="h-8 w-8 flex-shrink-0" rounded="full" />
+                        <div className="min-w-0 flex-1 space-y-1.5">
                           <div className="flex items-center gap-2">
                             <Skeleton className="h-3 w-24" />
                             <Skeleton className="h-2.5 w-16" />
@@ -1491,37 +1500,55 @@ export default function ModDetailsModal({
                     ))}
                   </ul>
                 ) : comments.length === 0 ? (
-                  <p className="text-sm text-text-secondary py-1">No comments yet</p>
+                  <div className="flex items-center gap-3 rounded-lg border border-dashed border-border bg-bg-tertiary/30 px-3 py-4 text-sm text-text-secondary">
+                    <MessageSquare className="h-4 w-4 flex-shrink-0 text-text-tertiary" />
+                    <span>No comments yet</span>
+                  </div>
                 ) : (
                   /* Flat threaded layout - no per-comment card. Files stay
                      as bordered action cards (each is something you DO);
                      comments are conversational content (something you
                      READ), so we strip the boxes and let the avatar + name
                      + divider carry the visual hierarchy instead. */
-                  <ul className="divide-y divide-border/60">
-                    {comments.map((comment) => (
-                      <li key={comment.id} className="flex gap-3 py-3 first:pt-0">
-                        {comment.poster.avatarUrl ? (
-                          <img
-                            src={comment.poster.avatarUrl}
-                            alt={comment.poster.name}
-                            className="w-7 h-7 rounded-full flex-shrink-0"
-                          />
-                        ) : (
-                          <div className="w-7 h-7 rounded-full flex-shrink-0 bg-bg-tertiary" />
-                        )}
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-baseline gap-2 mb-0.5">
-                            <span className="text-sm font-medium text-text-primary">{comment.poster.name}</span>
-                            <span className="text-[11px] text-text-tertiary">{formatDate(comment.dateAdded)}</span>
+                  <ul className="divide-y divide-border/60 rounded-lg border border-border/80 bg-bg-tertiary/30">
+                    {comments.map((comment) => {
+                      const posterInitial = comment.poster.name.trim().charAt(0).toUpperCase() || '?';
+                      return (
+                        <li key={comment.id} className="flex min-w-0 gap-3 px-3 py-3">
+                          {comment.poster.avatarUrl ? (
+                            <img
+                              src={comment.poster.avatarUrl}
+                              alt={`${comment.poster.name} avatar`}
+                              loading="lazy"
+                              referrerPolicy="no-referrer"
+                              className="h-8 w-8 flex-shrink-0 rounded-full border border-border bg-bg-secondary object-cover"
+                            />
+                          ) : (
+                            <div
+                              aria-hidden="true"
+                              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-accent/30 bg-accent/15 text-xs font-bold text-accent"
+                            >
+                              {posterInitial}
+                            </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
+                              <span className="min-w-0 max-w-full truncate text-sm font-semibold text-text-primary" title={comment.poster.name}>
+                                {comment.poster.name}
+                              </span>
+                              <span className="inline-flex flex-shrink-0 items-center gap-1 text-[11px] text-text-tertiary">
+                                <Clock className="h-3 w-3" />
+                                {formatDate(comment.dateAdded)}
+                              </span>
+                            </div>
+                            <div
+                              className="mod-comment-content mt-1"
+                              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
+                            />
                           </div>
-                          <div
-                            className="text-sm text-text-primary/90 leading-relaxed [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
-                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
-                          />
-                        </div>
-                      </li>
-                    ))}
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </section>

--- a/src/index.css
+++ b/src/index.css
@@ -995,9 +995,11 @@ body {
 }
 
 .release-notes blockquote {
-  border-left: 3px solid var(--color-border);
-  padding-left: 0.875em;
   margin: 0.75em 0;
+  padding: 0.6em 0.875em;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-tertiary);
   color: var(--color-text-secondary);
 }
 
@@ -1030,6 +1032,98 @@ body {
 .release-notes th {
   background: var(--color-bg-tertiary);
   font-weight: 600;
+}
+
+/* GameBanana comments rendered inside ModDetailsModal. Keep this compact and
+   tokenized because the source HTML can contain long URLs, images, lists, and
+   code blocks. */
+.mod-comment-content {
+  color: color-mix(in srgb, var(--color-text-primary) 90%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.mod-comment-content > :first-child { margin-top: 0; }
+.mod-comment-content > :last-child  { margin-bottom: 0; }
+
+.mod-comment-content p {
+  margin: 0.35em 0;
+}
+
+.mod-comment-content a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.mod-comment-content a:hover {
+  color: var(--color-accent-hover);
+}
+
+.mod-comment-content a:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-accent) 70%, transparent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.mod-comment-content ul,
+.mod-comment-content ol {
+  margin: 0.45em 0;
+  padding-left: 1.35em;
+}
+
+.mod-comment-content ul { list-style: disc; }
+.mod-comment-content ol { list-style: decimal; }
+
+.mod-comment-content li {
+  margin: 0.2em 0;
+}
+
+.mod-comment-content blockquote {
+  margin: 0.65em 0;
+  padding: 0.55em 0.7em;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--color-text-secondary);
+}
+
+.mod-comment-content code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  background: var(--color-bg-secondary);
+  padding: 0.12em 0.32em;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+.mod-comment-content pre {
+  margin: 0.65em 0;
+  padding: 0.65em 0.8em;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+  font-size: 0.85em;
+  line-height: 1.5;
+}
+
+.mod-comment-content pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: inherit;
+}
+
+.mod-comment-content img {
+  max-width: 100%;
+  height: auto;
+  margin: 0.5em 0;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -311,6 +311,12 @@ export default function Settings() {
     }
   };
 
+  const handleAutoEnableDownloadsChange = async (checked: boolean) => {
+    if (settings) {
+      await saveSettings({ ...settings, autoEnableDownloads: checked });
+    }
+  };
+
   const handleIgnoreConflictsByDefaultChange = async (checked: boolean) => {
     if (settings) {
       await saveSettings({ ...settings, ignoreConflictsByDefault: checked });
@@ -1094,6 +1100,15 @@ export default function Settings() {
               onChange={handleAutoDisableSiblingsChange}
               label="Switch variants instead of stacking them"
               description="When you install a different file of a mod you already have enabled, disable the previous variant so only the new one is active. Turn off to keep multiple variants of the same mod enabled at once. (Updates always replace the old file regardless of this setting.)"
+            />
+
+            <div className="h-px bg-white/5" />
+
+            <Toggle
+              checked={settings?.autoEnableDownloads ?? false}
+              onChange={handleAutoEnableDownloadsChange}
+              label="Enable mods after download"
+              description="Move newly downloaded mods into the active load order as soon as installation finishes. If no enabled slot is available, the mod stays installed and disabled."
             />
 
             <div className="h-px bg-white/5" />

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -590,6 +590,9 @@ export interface AppSettings {
   hideOutdatedMods: boolean;
   lockerCardsExpandedByDefault: boolean;
   autoDisableSiblingVariants: boolean;
+  /** After a successful GameBanana download, immediately enable the installed
+   *  VPKs instead of leaving them in the disabled library. Off by default. */
+  autoEnableDownloads: boolean;
   steamLaunchOptions: string;
   activeProfileId: string | null;
   autoSaveProfile: boolean;


### PR DESCRIPTION
## Summary
- Fix mod details modal scrolling and improve the comments/release notes presentation.
- Add a default-off setting to enable downloaded mods automatically after downloads finish.
- Reuse sibling-variant disabling for one-click installs before auto-enabling new downloads.

## Validation
- pnpm lint
- GRIMOIRE_SOCIAL_BASE_URL=https://grimoire-social.example.workers.dev pnpm build