### PR TITLE
fix: post-merge review follow-ups for #146 and #147

### DIFF
--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -583,10 +583,9 @@ async function enableInstalledVpks(
 ): Promise<void> {
     if (installedVpks.length === 0) return;
 
-    const installedSet = new Set(installedVpks);
     const refreshed = await scanMods(deadlockPath);
     for (const vpkFileName of installedVpks) {
-        const newMod = refreshed.find((m) => installedSet.has(m.fileName) && m.fileName === vpkFileName);
+        const newMod = refreshed.find((m) => m.fileName === vpkFileName);
         if (!newMod || newMod.enabled) continue;
         try {
             await enableMod(deadlockPath, newMod.id);
@@ -939,7 +938,14 @@ async function executeDownload(
     }
 
     if (settings.autoEnableDownloads === true && !enabledInstalledVpks) {
-        await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
+        // The install already succeeded; an enable failure (e.g. scanMods
+        // hitting a transient FS error) must not reject the download promise
+        // and report the whole download as failed.
+        try {
+            await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
+        } catch (err) {
+            console.warn(`[downloadMod] Failed to auto-enable new downloads:`, err);
+        }
     }
 
     // Notify completion
@@ -1403,7 +1409,13 @@ async function executeOneClickDownload(
     }
 
     if (settings.autoEnableDownloads === true && !enabledInstalledVpks) {
-        await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
+        // Same as executeDownload: the install already succeeded, so an
+        // enable failure must not reject the download promise.
+        try {
+            await enableInstalledVpks(deadlockPath, installedVpks, 'auto-enable-downloads');
+        } catch (err) {
+            console.warn(`[oneClickInstall] Failed to auto-enable new downloads:`, err);
+        }
     }
 
     mainWindow?.webContents.send('download-complete', { modId, fileId });

--- a/src/components/common/BrandIcons.tsx
+++ b/src/components/common/BrandIcons.tsx
@@ -10,7 +10,7 @@ export type BrandIcon = (props: SVGProps<SVGSVGElement>) => ReactElement;
 
 function brandIcon(displayName: string, d: string): BrandIcon {
   const Icon = (props: SVGProps<SVGSVGElement>) => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
       <path d={d} />
     </svg>
   );


### PR DESCRIPTION
## Summary

Applies the review findings flagged while merging #146, #147, and #148:

- **download.ts**: both `autoEnableDownloads` call sites awaited `enableInstalledVpks` bare; its internal `scanMods` can reject, which would report a failed download to the renderer after a fully successful install. Wrapped in try/catch, mirroring the adjacent sibling-variant path. Also dropped a redundant `installedSet` lookup.
- **BrandIcons.tsx**: the factory SVG had no intrinsic size, so an icon rendered without a `className` would get the browser's 300x150 default. Set 24x24 before the props spread so call-site sizing still overrides.

## Test plan

- `pnpm typecheck` and `pnpm lint` pass (typecheck now covers electron/ after #148)