### PR TITLE
perf: hero-pose cache eviction + offline-first category trees

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { SOUL_MODEL_SCHEME, registerSoulModelProtocol } from './services/soulContainerModels';
-import { HERO_POSE_SCHEME, registerHeroPoseProtocol } from './services/heroPoseModels';
+import { HERO_POSE_SCHEME, registerHeroPoseProtocol, sweepHeroPoseCache } from './services/heroPoseModels';
 
 // The `grimoire-soul:` and `grimoire-hero:` schemes serve GLBs (soul-container
 // models and posed hero stills) out of the user's library to the renderer's 3D
@@ -286,6 +286,10 @@ if (!gotTheLock) {
 
         // Serve per-hero posed stills from the user's library.
         registerHeroPoseProtocol();
+
+        // Reclaim disk from stale or least-recently-used pose entries; the
+        // cache is also swept after each export.
+        void sweepHeroPoseCache();
 
         // Default open or close DevTools by F12 in development
         app.on('browser-window-created', (_, window) => {

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron';
 import { loadSettings } from '../services/settings';
 import {
     fetchSections,
-    fetchCategoryTree,
+    fetchCategoryTreeCached,
     fetchSubmissions,
     fetchModDetails,
     fetchModFileList,
@@ -163,7 +163,7 @@ ipcMain.handle(
 ipcMain.handle(
     'get-gamebanana-categories',
     async (_, args: GetCategoriesArgs): Promise<GameBananaCategoryNode[]> => {
-        return fetchCategoryTree(args.categoryModelName);
+        return fetchCategoryTreeCached(args.categoryModelName);
     }
 );
 

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow } from 'electron';
 import { gamebananaRateLimiter } from './rateLimiter';
 import { GRIMOIRE_USER_AGENT } from './userAgent';
+import { getCachedCategoryTree, saveCachedCategoryTree } from './modDatabase';
 // The GameBanana wire types are single-sourced in src/types/gamebanana.ts
 // (the contract the renderer compiles against). Type-only import, erased at
 // build; re-exported so the many `from './gamebanana'` importers keep working.
@@ -571,6 +572,73 @@ export async function fetchCategoryTree(
     // Handle both array and object response formats
     const categories = Array.isArray(raw) ? raw : Object.values(raw);
     return categories.map(mapCategoryNode);
+}
+
+/** Refresh a cached tree once it's older than this. Category trees change
+ *  rarely (a new hero every few months), so a day of staleness is fine. */
+const CATEGORY_REFRESH_MS = 24 * 60 * 60 * 1000;
+
+/** Category models with a background refresh already running. */
+const categoryRefreshesInFlight = new Set<string>();
+
+/**
+ * Category tree with offline-first serving: return the locally cached tree
+ * immediately when one exists (kicking off a background refresh once it's
+ * older than CATEGORY_REFRESH_MS) and only block on the network when there's
+ * no cache at all. The Locker hero grid derives from this tree, so without
+ * the cache a GameBanana outage hangs the page for the full 30s timeout.
+ */
+export async function fetchCategoryTreeCached(
+    categoryModel: string
+): Promise<GameBananaCategoryNode[]> {
+    const cached = readCategoryCache(categoryModel);
+    if (cached) {
+        if (Date.now() - cached.fetchedAt > CATEGORY_REFRESH_MS) {
+            void refreshCategoryCache(categoryModel);
+        }
+        return cached.nodes;
+    }
+    const nodes = await fetchCategoryTree(categoryModel);
+    persistCategoryCache(categoryModel, nodes);
+    return nodes;
+}
+
+function readCategoryCache(
+    categoryModel: string
+): { fetchedAt: number; nodes: GameBananaCategoryNode[] } | null {
+    try {
+        const row = getCachedCategoryTree(categoryModel);
+        if (!row) return null;
+        const nodes = JSON.parse(row.payload) as GameBananaCategoryNode[];
+        if (!Array.isArray(nodes) || nodes.length === 0) return null;
+        return { fetchedAt: row.fetchedAt, nodes };
+    } catch {
+        return null; // unreadable cache = no cache; the live fetch repairs it
+    }
+}
+
+function persistCategoryCache(
+    categoryModel: string,
+    nodes: GameBananaCategoryNode[]
+): void {
+    try {
+        saveCachedCategoryTree(categoryModel, JSON.stringify(nodes));
+    } catch (err) {
+        console.warn('[fetchCategoryTreeCached] failed to persist cache:', err);
+    }
+}
+
+async function refreshCategoryCache(categoryModel: string): Promise<void> {
+    if (categoryRefreshesInFlight.has(categoryModel)) return;
+    categoryRefreshesInFlight.add(categoryModel);
+    try {
+        persistCategoryCache(categoryModel, await fetchCategoryTree(categoryModel));
+    } catch (err) {
+        // Offline or API down: keep serving the stale tree.
+        debugGameBanana('[fetchCategoryTreeCached] background refresh failed:', err);
+    } finally {
+        categoryRefreshesInFlight.delete(categoryModel);
+    }
 }
 
 /**

--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -159,8 +159,125 @@ function modelFile(key: string): string {
  */
 const POSE_CACHE_VERSION = '4';
 
+const POSE_VERSION_FILENAME = '.cache-version';
+
 function versionFile(key: string): string {
-    return join(modelDir(key), '.cache-version');
+    return join(modelDir(key), POSE_VERSION_FILENAME);
+}
+
+/**
+ * Cap on total bytes stored under hero-poses/. Each entry is a 50-95 MB GLB
+ * and every distinct hero+stack combination gets its own entry, so without a
+ * cap the cache grows unbounded as users toggle mods (observed 1.7 GB after a
+ * single day of Locker browsing). Sweeps run at startup and after each export:
+ * stale-version entries go first, then least-recently-used entries until the
+ * total is back under the cap.
+ */
+const POSE_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+
+/**
+ * Entries touched within this window are never evicted. This protects a
+ * mid-export directory (its version sidecar lands only after the GLB is fully
+ * written, so to the sweep it looks stale) and the model a viewer just
+ * requested.
+ */
+const POSE_SWEEP_MIN_AGE_MS = 5 * 60 * 1000;
+
+interface PoseCacheEntry {
+    dir: string;
+    bytes: number;
+    /** Newest file mtime in the entry dir. Export writes bump it; the protocol
+     *  handler touches the version sidecar on every serve, so this doubles as
+     *  a last-used marker for LRU eviction. */
+    lastUsedMs: number;
+    stale: boolean;
+}
+
+let poseSweepInFlight: Promise<void> | null = null;
+
+/** Sweep the pose cache: drop stale-version entries, then evict LRU entries
+ *  until the total size is under POSE_CACHE_MAX_BYTES. Concurrent calls share
+ *  one run. Never throws: a failed sweep only delays cleanup. */
+export function sweepHeroPoseCache(): Promise<void> {
+    if (!poseSweepInFlight) {
+        poseSweepInFlight = runPoseCacheSweep()
+            .catch((err) => {
+                console.warn('[heroPoseModels] pose cache sweep failed:', err);
+            })
+            .finally(() => {
+                poseSweepInFlight = null;
+            });
+    }
+    return poseSweepInFlight;
+}
+
+async function runPoseCacheSweep(): Promise<void> {
+    const root = join(app.getPath('userData'), 'hero-poses');
+    let names: string[];
+    try {
+        names = await fs.readdir(root);
+    } catch {
+        return; // no cache yet
+    }
+
+    const now = Date.now();
+    const entries: PoseCacheEntry[] = [];
+    for (const name of names) {
+        const dir = join(root, name);
+        let bytes = 0;
+        let lastUsedMs = 0;
+        try {
+            if (!(await fs.stat(dir)).isDirectory()) continue;
+            for (const file of await fs.readdir(dir)) {
+                const stat = await fs.stat(join(dir, file));
+                bytes += stat.size;
+                lastUsedMs = Math.max(lastUsedMs, stat.mtimeMs);
+            }
+        } catch {
+            continue; // raced a concurrent delete; skip
+        }
+        const version = await fs
+            .readFile(join(dir, POSE_VERSION_FILENAME), 'utf8')
+            .catch(() => '');
+        entries.push({
+            dir,
+            bytes,
+            lastUsedMs,
+            stale: version.trim() !== POSE_CACHE_VERSION,
+        });
+    }
+
+    const protectedSince = now - POSE_SWEEP_MIN_AGE_MS;
+    const doomed: PoseCacheEntry[] = [];
+    const kept: PoseCacheEntry[] = [];
+    for (const entry of entries) {
+        if (entry.stale && entry.lastUsedMs < protectedSince) {
+            doomed.push(entry);
+        } else {
+            kept.push(entry);
+        }
+    }
+
+    let total = kept.reduce((sum, entry) => sum + entry.bytes, 0);
+    if (total > POSE_CACHE_MAX_BYTES) {
+        kept.sort((a, b) => a.lastUsedMs - b.lastUsedMs);
+        for (const entry of kept) {
+            if (total <= POSE_CACHE_MAX_BYTES) break;
+            if (entry.lastUsedMs >= protectedSince) continue;
+            doomed.push(entry);
+            total -= entry.bytes;
+        }
+    }
+
+    if (doomed.length === 0) return;
+    let freed = 0;
+    for (const entry of doomed) {
+        await fs.rm(entry.dir, { recursive: true, force: true });
+        freed += entry.bytes;
+    }
+    console.log(
+        `[heroPoseModels] pose cache sweep: removed ${doomed.length} entries, freed ${Math.round(freed / 1024 / 1024)} MB`
+    );
 }
 
 /**
@@ -321,7 +438,11 @@ export async function exportHeroPose(
     const work = runHeroPoseExport(deadlockPath, heroName, normalized, fallbackSkinMetaKey);
     inFlightExports.set(requestKey, work);
     try {
-        return await work;
+        const info = await work;
+        // The cache only grows through exports; sweep opportunistically so it
+        // can't creep past the cap between app launches.
+        void sweepHeroPoseCache();
+        return info;
     } finally {
         inFlightExports.delete(requestKey);
     }
@@ -416,6 +537,12 @@ export function registerHeroPoseProtocol(): void {
             const key = decodeURIComponent(segment);
             const file = modelFile(key);
             await fs.access(file);
+            // LRU touch for the cache sweep, which uses the newest file mtime
+            // in the entry dir as last-used. Touch the tiny sidecar, not the
+            // GLB: the GLB mtime feeds the renderer's ?v= cache-buster and
+            // must keep meaning "export time".
+            const now = new Date();
+            void fs.utimes(versionFile(key), now, now).catch(() => {});
             return net.fetch(pathToFileURL(file).toString());
         } catch {
             return new Response(null, { status: 404 });

--- a/electron/main/services/modDatabase.ts
+++ b/electron/main/services/modDatabase.ts
@@ -111,6 +111,15 @@ export function initDatabase(): Database.Database {
                 pages_synced INTEGER
             );
 
+            -- GameBanana category trees (JSON), keyed by category model name
+            -- (ModCategory, SoundCategory, ...). Served offline-first so the
+            -- Locker hero grid doesn't hang on a GameBanana outage.
+            CREATE TABLE IF NOT EXISTS category_cache (
+                model TEXT PRIMARY KEY,
+                fetched_at INTEGER NOT NULL,
+                payload TEXT NOT NULL
+            );
+
             ${SEARCH_SCHEMA_SQL}
         `);
 
@@ -273,6 +282,35 @@ export function upsertMods(mods: CachedMod[]): void {
     });
 
     insertMany(mods);
+}
+
+export interface CachedCategoryTree {
+    fetchedAt: number;
+    /** JSON-serialized GameBananaCategoryNode[]. Stored opaque: the GameBanana
+     *  service owns (de)serialization and shape validation. */
+    payload: string;
+}
+
+/** Get the locally cached category tree for a category model, or null. */
+export function getCachedCategoryTree(model: string): CachedCategoryTree | null {
+    const database = initDatabase();
+    const stmt = database.prepare('SELECT fetched_at, payload FROM category_cache WHERE model = ?');
+    const row = stmt.get(model) as { fetched_at: number; payload: string } | undefined;
+    if (!row) return null;
+    return { fetchedAt: row.fetched_at, payload: row.payload };
+}
+
+/** Store (or replace) the cached category tree for a category model. */
+export function saveCachedCategoryTree(model: string, payload: string): void {
+    const database = initDatabase();
+    const stmt = database.prepare(`
+        INSERT INTO category_cache (model, fetched_at, payload)
+        VALUES (?, ?, ?)
+        ON CONFLICT(model) DO UPDATE SET
+            fetched_at = excluded.fetched_at,
+            payload = excluded.payload
+    `);
+    stmt.run(model, Date.now(), payload);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two follow-ups from investigating the packaged-build Locker lag (pre-1.16.0 smoke test). Root-causing showed the pose pipeline itself is fast (~1s export, ~1s stack merge, measured with the pinned vpkmerge against real VPKs); the real issues were unbounded pose-cache growth and the Locker's hard dependency on live GameBanana.

### 1. Hero-pose cache sweep (stale versions, then LRU past a 2 GiB cap)

Every distinct hero+stack combination stores its own 50-95 MB GLB and nothing ever deleted them: 1.7 GB across 42 entries after one day of Locker browsing, 9 of them stale-version dirs that could never be served again.

- Sweep runs at startup and after each export. Stale `.cache-version` entries go first, then least-recently-used entries until the total is under 2 GiB.
- The `grimoire-hero:` protocol handler touches the version sidecar on each serve, so recently viewed models rank as recently used. The GLB mtime stays untouched (it feeds the renderer's `?v=` cache-buster).
- Entries touched in the last 5 minutes are never evicted: protects mid-export dirs, whose sidecar lands after the GLB and would otherwise read as stale.

### 2. Offline-first category trees

The Locker hero grid derives from `fetchCategoryTree`, a live API call with a 30s timeout and no cache, so a GameBanana outage hung the page for the full timeout (exactly what happened during the 2026-06-09 API degradation). Now each category model's tree persists in a new `category_cache` table in mods-cache.db (`CREATE TABLE IF NOT EXISTS`, self-migrating like the rest of that local cache schema). The cached copy is served immediately with a deduped background refresh once it's older than 24h; only a cold cache blocks on the network. Browse gets the same benefit for every category model it requests.

No IPC surface, type, or renderer changes; same wire shapes throughout.

### Validation

- `pnpm typecheck` + `pnpm lint` clean (the 2 pre-existing Stats.tsx hook warnings only)
- End-to-end sweep test against the real built app: pointed `XDG_CONFIG_HOME` at a synthetic 3.6 GB (sparse) cache with mixed versions/ages; the startup sweep removed exactly the stale entry + the two oldest LRU entries, kept fresh/protected ones, and logged `removed 3 entries, freed 1800 MB`
- `category_cache` table verified created on a real app boot