### PR TITLE
perf(browse): smooth scrolling, docked sidebar polish, crisp card text

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Volume2,
@@ -92,7 +92,7 @@ interface ModDetailsModalProps {
   onViewArtist?: (artist: { id: number; name: string; avatarUrl?: string; profileUrl?: string; kofiUrl?: string }) => void;
 }
 
-export default function ModDetailsModal({
+function ModDetailsModal({
   mod,
   section,
   installed,
@@ -581,10 +581,10 @@ export default function ModDetailsModal({
       aria-hidden
     >
       {/* Match the real body's layout per variant: the sidebar stacks into one
-          column, so its loading skeleton must too (the modal's lg:flex-row /
-          460px image column would overflow and clip a ~440px panel). */}
-      <div className={`flex h-full min-h-0 flex-col overflow-hidden ${isSidebar ? '' : 'lg:flex-row'}`}>
-        <div className={`space-y-3 overflow-hidden ${isSidebar ? 'p-4' : 'lg:w-[460px] lg:flex-shrink-0 p-5 lg:pr-3'}`}>
+          column on a narrow dock and goes two-column past 56rem of panel
+          width (same @4xl container breakpoint as the real body below). */}
+      <div className={`flex h-full min-h-0 flex-col overflow-hidden ${isSidebar ? '@4xl:flex-row' : 'lg:flex-row'}`}>
+        <div className={`space-y-3 overflow-hidden ${isSidebar ? 'p-4 @4xl:w-[460px] @4xl:flex-shrink-0 @4xl:pr-3' : 'lg:w-[460px] lg:flex-shrink-0 p-5 lg:pr-3'}`}>
           <Skeleton className="aspect-[16/9] w-full" rounded="lg" />
           {!isSidebar && <Skeleton className="aspect-[16/10] w-full" rounded="lg" />}
           <div className="rounded-lg border border-border bg-bg-tertiary p-3">
@@ -655,23 +655,24 @@ export default function ModDetailsModal({
 
   // The sidebar shares this whole JSX tree with the modal; only the outer
   // chrome and the body layout differ. The caller's <aside> supplies the
-  // sidebar's width/height/border, so here we just fill it and force the
-  // single-column stacked body (the modal's lg:flex-row two-column layout is
-  // viewport-keyed and would overflow a ~440px panel on a wide screen).
+  // sidebar's width/height/border, so here we just fill it. The sidebar body
+  // is keyed to the PANEL's width via container queries (@container/@4xl),
+  // not the viewport: a narrow dock stacks into one column, and a dock
+  // dragged wide enough (56rem+) gets the modal's two-column layout.
   const outerClass = isSidebar
-    ? 'h-full w-full'
+    ? 'h-full w-full @container'
     : 'fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 md:px-24 z-50 animate-fade-in';
   const panelClass = isSidebar
     ? 'relative bg-bg-secondary h-full w-full overflow-hidden flex flex-col'
     : 'relative bg-bg-secondary rounded-xl w-full max-w-4xl lg:max-w-6xl h-[min(90vh,920px)] max-h-[90vh] overflow-visible flex flex-col border border-border shadow-2xl';
   const bodyContentClass = isSidebar
-    ? 'mod-details-body-content flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain'
+    ? 'mod-details-body-content flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain @4xl:flex-row @4xl:overflow-hidden'
     : 'mod-details-body-content flex h-full min-h-0 flex-col lg:flex-row overflow-y-auto overscroll-contain lg:overflow-hidden';
   const imageColClass = isSidebar
-    ? 'p-4 space-y-3'
+    ? 'p-4 space-y-3 @4xl:w-[460px] @4xl:flex-shrink-0 @4xl:overflow-y-auto @4xl:overscroll-contain @4xl:max-h-full @4xl:pr-3'
     : 'lg:w-[460px] lg:flex-shrink-0 lg:overflow-y-auto lg:overscroll-contain lg:max-h-full p-5 lg:pr-3 space-y-3';
   const detailsColClass = isSidebar
-    ? 'flex-1 min-w-0 p-4 space-y-5'
+    ? 'flex-1 min-w-0 p-4 space-y-5 @4xl:overflow-y-auto @4xl:overscroll-contain @4xl:max-h-full @4xl:pl-3'
     : 'flex-1 min-w-0 lg:overflow-y-auto lg:overscroll-contain lg:max-h-full p-5 lg:pl-3 space-y-5';
 
   const modal = (
@@ -1633,3 +1634,9 @@ export default function ModDetailsModal({
   // modal needs to escape to a body-level portal.
   return isSidebar ? modal : createPortal(modal, document.body);
 }
+
+// Memoized because the docked-sidebar variant lives inside Browse's render
+// tree, which re-renders on every virtualized-grid range change while
+// scrolling. Browse passes stable callbacks (useStableCallback) so shallow
+// prop comparison holds between those renders.
+export default memo(ModDetailsModal);

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,13 @@
   font-display: swap;
 }
 
+/* Reaver ships a single 600 face. Without this, any font-weight above 600
+   (e.g. Tailwind's font-bold) makes the browser synthesize a faux bold by
+   dilating the 600 glyphs, which reads as blurry text. */
+.font-mod-title {
+  font-synthesis: none;
+}
+
 @font-face {
   font-family: 'ValvePulp';
   src: url('/fonts/valvepulp-bold.ttf') format('truetype');
@@ -658,6 +665,24 @@ body {
   }
 }
 
+/* Docked details sidebar entrance. The aside reserves its width in one snap
+   (so the grid reflows exactly once, not per animation frame); the panel then
+   slides into the reserved gap. Transform-only, so the slide never triggers
+   layout. */
+@keyframes browseDockPanelIn {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+.browse-details-dock-panel {
+  animation: browseDockPanelIn 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 /* Locker Hero animations */
 @keyframes slideInLeft {
   from {
@@ -1144,7 +1169,8 @@ body {
   .group:focus-within .browse-sound-wave-bar,
   .sidebar-active-backdrop,
   .sidebar-active-backdrop__image,
-  .browse-result-card {
+  .browse-result-card,
+  .browse-details-dock-panel {
     animation-duration: 0.01ms;
     animation-iteration-count: 1;
   }

--- a/src/lib/useStableCallback.ts
+++ b/src/lib/useStableCallback.ts
@@ -1,0 +1,21 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Returns a function with a stable identity that always calls the latest
+ * version of `fn`. Use for callbacks passed to memoized children from
+ * components that re-render often: the child's memo stays intact while the
+ * callback still sees fresh state (no useCallback dependency auditing).
+ *
+ * The wrapper is for event handlers. Don't call it during render, and don't
+ * put the result in effect dependency arrays expecting it to change: it never
+ * does.
+ */
+export function useStableCallback<Args extends unknown[], R>(
+  fn: (...args: Args) => R
+): (...args: Args) => R {
+  const ref = useRef(fn);
+  useLayoutEffect(() => {
+    ref.current = fn;
+  });
+  return useCallback((...args: Args) => ref.current(...args), []);
+}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -65,6 +65,7 @@ import {
   backfillGameBananaFileId,
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
+import { useStableCallback } from '../lib/useStableCallback';
 import type {
   GameBananaMod,
   GameBananaModDetails,
@@ -110,7 +111,6 @@ const BROWSE_DETAILS_VIEW_STORAGE_KEY = 'browseDetailsView';
 const BROWSE_SIDEBAR_MIN_WINDOW_WIDTH = 760;
 const BROWSE_SIDEBAR_WIDTH_KEY = 'browseDetailsSidebarWidth';
 const BROWSE_SIDEBAR_WIDTH_MIN = 320;
-const BROWSE_SIDEBAR_WIDTH_MAX = 720;
 const BROWSE_SIDEBAR_WIDTH_DEFAULT = 420;
 // The grid always keeps at least this much room; the sidebar's effective width
 // is capped so a wide drag (or a small window) can't starve the browse area.
@@ -180,14 +180,24 @@ function browseSocialColor(platform: string): string {
   return BROWSE_SOCIAL_COLORS[platform] ?? '#f97316';
 }
 
-function clampSidebarWidth(value: number): number {
-  return clampNumber(value, BROWSE_SIDEBAR_WIDTH_MIN, BROWSE_SIDEBAR_WIDTH_MAX);
+// No fixed maximum width: the only hard limits are "the panel stays usable"
+// (BROWSE_SIDEBAR_WIDTH_MIN) and "the grid keeps its reserve". On a wide
+// monitor the user can drag the sidebar as wide as they like; the panel's
+// internal layout adapts via container queries (see ModDetailsModal).
+function sidebarWidthCeilingFor(windowWidth: number): number {
+  return Math.max(BROWSE_SIDEBAR_WIDTH_MIN, windowWidth - BROWSE_SIDEBAR_GRID_RESERVE);
+}
+
+function clampSidebarWidth(value: number, ceiling: number): number {
+  return clampNumber(value, BROWSE_SIDEBAR_WIDTH_MIN, Math.max(BROWSE_SIDEBAR_WIDTH_MIN, ceiling));
 }
 
 function readBrowseSidebarWidth(): number {
   if (typeof window === 'undefined') return BROWSE_SIDEBAR_WIDTH_DEFAULT;
   const stored = Number(window.localStorage.getItem(BROWSE_SIDEBAR_WIDTH_KEY));
-  return Number.isFinite(stored) && stored > 0 ? clampSidebarWidth(stored) : BROWSE_SIDEBAR_WIDTH_DEFAULT;
+  return Number.isFinite(stored) && stored > 0
+    ? clampSidebarWidth(stored, sidebarWidthCeilingFor(window.innerWidth))
+    : BROWSE_SIDEBAR_WIDTH_DEFAULT;
 }
 // Persist filter UI inputs across page navigation. The store keeps these in
 // memory so visiting Installed and coming back doesn't blow away the user's
@@ -394,13 +404,13 @@ function estimateBrowseRowHeight(
 function readableChipTone(tone: BrowseReadableChipTone = 'neutral'): string {
   switch (tone) {
     case 'accent':
-      return 'border-accent/14 bg-accent/[0.04] text-accent/72';
+      return 'border-accent/25 bg-accent/[0.08] text-accent';
     case 'danger':
-      return 'border-state-danger/20 bg-state-danger/[0.05] text-state-danger/80';
+      return 'border-state-danger/30 bg-state-danger/[0.09] text-state-danger';
     case 'info':
-      return 'border-state-info/14 bg-state-info/[0.04] text-state-info/72';
+      return 'border-state-info/25 bg-state-info/[0.08] text-state-info';
     default:
-      return 'border-white/[0.06] bg-white/[0.018] text-text-tertiary/72';
+      return 'border-white/[0.1] bg-white/[0.04] text-text-secondary';
   }
 }
 
@@ -466,7 +476,8 @@ function getReadableCardChips(mod: GameBananaMod, section: string, inferredHero:
 }
 
 function estimateReadableChipWidth(label: string): number {
-  return Math.ceil(label.length * 5.5 + 14);
+  // ~6px per character at the chip's 11px font, plus horizontal padding.
+  return Math.ceil(label.length * 6 + 14);
 }
 
 function BrowseReadableChipBadge({ chip }: { chip: BrowseReadableChip }) {
@@ -485,7 +496,7 @@ function BrowseReadableChipBadge({ chip }: { chip: BrowseReadableChip }) {
   return (
     <span
       title={chip.label}
-      className={`inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-sm border px-2 text-[10px] font-medium leading-none ${readableChipTone(
+      className={`inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-sm border px-2 text-[11px] font-medium leading-none ${readableChipTone(
         chip.tone
       )}`}
     >
@@ -535,7 +546,7 @@ function BrowseReadableChipRow({
         <div className="group/hidden relative shrink-0">
           <span
             title={`${hiddenChips.length} more`}
-            className="inline-flex h-6 items-center rounded-sm border border-white/[0.06] bg-white/[0.018] px-2 text-[10px] font-medium leading-none text-text-tertiary/72"
+            className="inline-flex h-6 items-center rounded-sm border border-white/[0.1] bg-white/[0.04] px-2 text-[11px] font-medium leading-none text-text-secondary"
           >
             +{hiddenChips.length}
           </span>
@@ -579,7 +590,7 @@ function BrowseReadableUpdatedLine({
     return (
       <p
         className={`mt-1 truncate text-[clamp(9px,3.5714cqw,11px)] font-normal leading-[1.05] ${
-          isOutdated ? 'text-state-warning/70' : 'text-text-tertiary/55'
+          isOutdated ? 'text-state-warning/85' : 'text-text-tertiary/75'
         }`}
         title={title}
       >
@@ -591,7 +602,7 @@ function BrowseReadableUpdatedLine({
   return (
     <span
       className={`inline-flex min-w-0 shrink items-center gap-0.5 truncate font-normal leading-none ${
-        isOutdated ? 'text-state-warning/80' : 'text-text-tertiary/55'
+        isOutdated ? 'text-state-warning/85' : 'text-text-tertiary/75'
       }`}
       title={title}
     >
@@ -711,8 +722,8 @@ function BrowseStatItem({
 function BrowseReadableStatsRow({ mod, density, showUpdated }: { mod: GameBananaMod; density: BrowseReadableDensity; showUpdated: boolean }) {
   const isMicro = density === 'micro';
   const groupClass = isMicro
-    ? 'grid w-full grid-cols-2 items-center text-[clamp(11px,4.3cqw,13px)] font-semibold text-text-tertiary/70'
-    : 'flex h-5 min-w-0 flex-1 items-center gap-[clamp(5px,2.5cqw,10px)] text-[clamp(11px,4.3cqw,13px)] font-semibold text-text-tertiary/60';
+    ? 'grid w-full grid-cols-2 items-center text-[clamp(11px,4.3cqw,13px)] font-semibold text-text-tertiary/85'
+    : 'flex h-5 min-w-0 flex-1 items-center gap-[clamp(5px,2.5cqw,10px)] text-[clamp(11px,4.3cqw,13px)] font-semibold text-text-tertiary/85';
   const itemEmphasis = isMicro ? 'strong' : 'muted';
 
   return (
@@ -1064,6 +1075,9 @@ export default function Browse() {
   const pendingScrollTopRef = useRef<number | null>(initialCache?.scrollTop ?? null);
   // The outer scroll container — same element with `h-full overflow-y-auto`.
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  // The virtualized grid's relative wrapper (the div sized to getTotalSize()).
+  // Used by the scroll anchor below to translate scrollTop into item space.
+  const gridWrapRef = useRef<HTMLDivElement | null>(null);
   // Live mirror of the scroll container's scrollTop. Updated from a scroll
   // listener so the unmount cleanup has a valid value to persist — by the
   // time a useEffect cleanup runs, React has already detached
@@ -1072,6 +1086,11 @@ export default function Browse() {
   const latestScrollTopRef = useRef<number>(initialCache?.scrollTop ?? 0);
   const scrollCacheFrameRef = useRef<number | null>(null);
   const scrollHoverTimeoutRef = useRef<number | null>(null);
+  // Live "user is scrolling" flag. Deliberately NOT React state: flipping
+  // state on scroll start/stop re-rendered the whole page (and busted every
+  // visible card's memo via the suppressHoverIntent prop). The scroll
+  // listener toggles the container's browse-is-scrolling class imperatively
+  // for the CSS hover suppression, and cards read this ref at event time.
   const isBrowseScrollingRef = useRef(false);
   // When local search fails (e.g. SQLite error), this flips so the main fetch
   // effect falls back to the API path. Resets whenever filter inputs change.
@@ -1080,7 +1099,6 @@ export default function Browse() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [downloadQueue, setDownloadQueue] = useState<Array<{ modId: number; fileId: number; fileName: string }>>([]);
   const [playingModId, setPlayingModId] = useState<number | null>(null);
-  const [isBrowseScrolling, setIsBrowseScrolling] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -1134,10 +1152,10 @@ export default function Browse() {
   // so the grid keeps BROWSE_SIDEBAR_GRID_RESERVE px no matter how the user drags
   // or how small the window is.
   const [browseSidebarWidth, setBrowseSidebarWidthState] = useState<number>(readBrowseSidebarWidth);
-  const sidebarWidthCeiling = browseViewportMetrics.windowWidth
-    ? Math.max(BROWSE_SIDEBAR_WIDTH_MIN, browseViewportMetrics.windowWidth - BROWSE_SIDEBAR_GRID_RESERVE)
-    : BROWSE_SIDEBAR_WIDTH_MAX;
-  const effectiveSidebarWidth = Math.min(clampSidebarWidth(browseSidebarWidth), sidebarWidthCeiling);
+  const sidebarWidthCeiling = sidebarWidthCeilingFor(
+    browseViewportMetrics.windowWidth || window.innerWidth
+  );
+  const effectiveSidebarWidth = clampSidebarWidth(browseSidebarWidth, sidebarWidthCeiling);
   // Tears down an in-flight sidebar drag (listeners + body styles). Held in a ref
   // so an unmount can finish a drag that's still mid-gesture, instead of leaking
   // the window listeners and stranding the col-resize cursor on <body>.
@@ -1147,8 +1165,7 @@ export default function Browse() {
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
     const onMove = (ev: PointerEvent) => {
-      const ceiling = Math.max(BROWSE_SIDEBAR_WIDTH_MIN, window.innerWidth - BROWSE_SIDEBAR_GRID_RESERVE);
-      const next = Math.min(clampSidebarWidth(window.innerWidth - ev.clientX), ceiling);
+      const next = clampSidebarWidth(window.innerWidth - ev.clientX, sidebarWidthCeilingFor(window.innerWidth));
       setBrowseSidebarWidthState(next);
     };
     const cleanup = () => {
@@ -1422,7 +1439,7 @@ export default function Browse() {
       latestScrollTopRef.current = nextScrollTop;
       if (!isBrowseScrollingRef.current) {
         isBrowseScrollingRef.current = true;
-        setIsBrowseScrolling(true);
+        container.classList.add('browse-is-scrolling');
       }
       if (scrollHoverTimeoutRef.current !== null) {
         window.clearTimeout(scrollHoverTimeoutRef.current);
@@ -1430,7 +1447,7 @@ export default function Browse() {
       scrollHoverTimeoutRef.current = window.setTimeout(() => {
         scrollHoverTimeoutRef.current = null;
         isBrowseScrollingRef.current = false;
-        setIsBrowseScrolling(false);
+        container.classList.remove('browse-is-scrolling');
       }, 140);
       if (scrollCacheFrameRef.current !== null) return;
       scrollCacheFrameRef.current = window.requestAnimationFrame(() => {
@@ -2161,7 +2178,7 @@ export default function Browse() {
     }
   };
 
-  const handleNavigateMod = async (mod: GameBananaMod, direction: ModDetailsNavigationDirection) => {
+  const handleNavigateMod = async (mod: GameBananaMod, direction: ModDetailsNavigationDirection): Promise<void> => {
     if (modalNavigation) return;
 
     const requestId = modalNavigationRequestRef.current + 1;
@@ -2183,7 +2200,10 @@ export default function Browse() {
     }
   };
 
-  const handleDownload = async (fileId: number, fileName: string) => {
+  // Stable identity (useStableCallback) so the memoized ModDetailsModal does
+  // not re-render every time this large component does (e.g. on every
+  // virtualizer range change while the docked sidebar is open).
+  const handleDownload = useStableCallback(async (fileId: number, fileName: string) => {
     if (!selectedMod || !activeDeadlockPath) return;
 
     // The first file claims the active slot (shows progress); additional clicks
@@ -2205,7 +2225,7 @@ export default function Browse() {
         cur && cur.modId === selectedMod.id && cur.fileId === fileId ? null : cur
       );
     }
-  };
+  });
 
   const handleQuickDownload = async (mod: GameBananaMod) => {
     if (!activeDeadlockPath) return;
@@ -2476,22 +2496,31 @@ export default function Browse() {
     selectedModIndex >= 0 && selectedModIndex < displayMods.length - 1
       ? displayMods[selectedModIndex + 1]
       : undefined;
-  const closeSelectedMod = () => {
+  // These three (plus handleDownload above) feed the memoized ModDetailsModal,
+  // so they get stable identities via useStableCallback.
+  const closeSelectedMod = useStableCallback(() => {
     modalNavigationRequestRef.current += 1;
     setModalNavigation(null);
     setSelectedMod(null);
     setSelectedModDates(null);
-  };
+  });
+
+  const navigateToPreviousMod = useStableCallback(() => {
+    if (previousSelectedMod) void handleNavigateMod(previousSelectedMod, 'previous');
+  });
+  const navigateToNextMod = useStableCallback(() => {
+    if (nextSelectedMod) void handleNavigateMod(nextSelectedMod, 'next');
+  });
 
   // Enter artist mode: scope the grid to one submitter. We leave the user's
   // search/hero/category filters untouched (artist mode ignores them in the
   // fetch) so clearing artist mode restores their prior browse exactly.
-  const viewArtist = (artist: BrowseArtistRef) => {
+  const viewArtist = useStableCallback((artist: BrowseArtistRef) => {
     if (!artist?.id) return;
     closeSelectedMod();
     setBrowseUi({ submitter: artist });
     scrollContainerRef.current?.scrollTo({ top: 0 });
-  };
+  });
   const clearArtist = () => setBrowseUi({ submitter: undefined });
 
   const readableCardTargetWidth = getReadableCardTargetWidth(browseCardSize);
@@ -2536,6 +2565,35 @@ export default function Browse() {
     rowVirtualizer.measure();
   }, [rowVirtualizer, virtualRowHeight, virtualColumnCount, gridGap, browseCardDesign]);
 
+  // Scroll anchor: when the grid's geometry changes (column count or row
+  // height, e.g. the details sidebar opening/closing or a window resize),
+  // the same scrollTop suddenly points at different mods and the view appears
+  // to jump. Re-map the scroll position so the first visible item stays put.
+  // Fractional row math (no rounding to row starts) so repeated resizes don't
+  // ratchet the position. Runs before paint, so the user never sees the
+  // un-anchored frame.
+  const gridAnchorRef = useRef<{ columnCount: number; rowHeight: number; measured: boolean } | null>(null);
+  useLayoutEffect(() => {
+    const prev = gridAnchorRef.current;
+    const measured = browseViewportMetrics !== DEFAULT_BROWSE_VIEWPORT_METRICS;
+    gridAnchorRef.current = { columnCount: virtualColumnCount, rowHeight: virtualRowHeight, measured };
+    if (!prev || !prev.measured) return; // first paint, or geometry from the pre-measure default
+    if (prev.columnCount === virtualColumnCount && prev.rowHeight === virtualRowHeight) return;
+    const container = scrollContainerRef.current;
+    const gridWrap = gridWrapRef.current;
+    if (!container || !gridWrap) return;
+    const gridTop =
+      gridWrap.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+    const scrolled = container.scrollTop - gridTop;
+    if (scrolled <= 0) return;
+    const itemOffset = (scrolled / prev.rowHeight) * prev.columnCount;
+    // Round: a fractional scrollTop rasterizes the whole grid at a subpixel
+    // offset, which blurs text until the next user scroll.
+    container.scrollTop = Math.round(gridTop + (itemOffset / virtualColumnCount) * virtualRowHeight);
+    latestScrollTopRef.current = container.scrollTop;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [virtualColumnCount, virtualRowHeight]);
+
   if (!activeDeadlockPath) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-text-secondary">
@@ -2561,7 +2619,7 @@ export default function Browse() {
         installed={installedIds.has(selectedMod.id)}
         installedFileIds={installedFileIds}
         installedFileStates={installedFileStates}
-        onEnableFile={(modId) => toggleMod(modId)}
+        onEnableFile={toggleMod}
         downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
         queuedFileIds={selectedQueuedFileIds}
         extracting={extracting}
@@ -2574,10 +2632,8 @@ export default function Browse() {
         navigationLabel={modalNavigation?.label}
         onClose={closeSelectedMod}
         onDownload={handleDownload}
-        onNavigatePrevious={
-          previousSelectedMod ? () => void handleNavigateMod(previousSelectedMod, 'previous') : undefined
-        }
-        onNavigateNext={nextSelectedMod ? () => void handleNavigateMod(nextSelectedMod, 'next') : undefined}
+        onNavigatePrevious={previousSelectedMod ? navigateToPreviousMod : undefined}
+        onNavigateNext={nextSelectedMod ? navigateToNextMod : undefined}
         previousLabel={previousSelectedMod?.name}
         nextLabel={nextSelectedMod?.name}
         onDeleteFile={deleteMod}
@@ -2587,7 +2643,10 @@ export default function Browse() {
 
   return (
     <div className="flex h-full min-h-0">
-      <div className={`flex-1 min-w-0 h-full overflow-y-auto ${isBrowseScrolling ? 'browse-is-scrolling' : ''}`} ref={scrollContainerRef}>
+      {/* The scroll listener toggles browse-is-scrolling on this element
+          imperatively; keeping it out of the className prop means scroll
+          start/stop never re-renders this (large) component. */}
+      <div className="flex-1 min-w-0 h-full overflow-y-auto" ref={scrollContainerRef}>
       {/* Header: artist banner in artist mode, otherwise the search/filter row. */}
       <div className="sticky top-0 z-40 p-4 border-b border-border bg-bg-primary">
         {artistMode && submitter ? (
@@ -3252,6 +3311,7 @@ export default function Browse() {
           const virtualRows = rowVirtualizer.getVirtualItems();
           return (
             <div
+              ref={gridWrapRef}
               className="relative w-full"
               style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
             >
@@ -3299,7 +3359,7 @@ export default function Browse() {
                             onVolumeChange={setSoundVolume}
                             hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
                             isPlaying={playingModId === mod.id}
-                            suppressHoverIntent={isBrowseScrolling}
+                            suppressHoverIntentRef={isBrowseScrollingRef}
                             enableModId={installedLocal && !installedLocal.enabled ? installedLocal.id : undefined}
                             actionContextKey={`${activeDeadlockPath ?? ''}|${section}|${effectiveCategoryId ?? ''}`}
                             onPlayingChange={(playing) => {
@@ -3375,20 +3435,25 @@ export default function Browse() {
           column count, so the grid reflows to fewer columns on its own. */}
       {selectedMod && detailsSidebarActive && (
         <aside
-          className="relative flex-shrink-0 h-full border-l border-border bg-bg-secondary overflow-hidden animate-fade-in"
+          className="relative flex-shrink-0 h-full bg-bg-primary overflow-hidden"
           style={{ width: effectiveSidebarWidth }}
         >
-          {/* Drag the left edge to resize; the width is remembered. */}
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize details sidebar"
-            onPointerDown={startSidebarResize}
-            className="group absolute inset-y-0 left-0 z-30 w-2 -ml-1 cursor-col-resize"
-          >
-            <div className="absolute inset-y-0 left-1 w-0.5 bg-transparent transition-colors group-hover:bg-accent/60" />
+          {/* The border and resize handle live on the sliding panel so the
+              dock's left edge arrives with the content instead of popping in
+              ahead of it. */}
+          <div className="browse-details-dock-panel relative h-full w-full border-l border-border bg-bg-secondary">
+            {/* Drag the left edge to resize; the width is remembered. */}
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize details sidebar"
+              onPointerDown={startSidebarResize}
+              className="group absolute inset-y-0 left-0 z-30 w-2 -ml-1 cursor-col-resize"
+            >
+              <div className="absolute inset-y-0 left-1 w-0.5 bg-transparent transition-colors group-hover:bg-accent/60" />
+            </div>
+            {renderModDetails('sidebar')}
           </div>
-          {renderModDetails('sidebar')}
         </aside>
       )}
     </div>
@@ -3409,7 +3474,7 @@ function ReadableBrowseModCard({
   onVolumeChange,
   hideNsfwPreviews,
   isPlaying,
-  suppressHoverIntent,
+  suppressHoverIntentRef,
   onPlayingChange,
   onClick,
   onQuickDownload,
@@ -3522,19 +3587,12 @@ function ReadableBrowseModCard({
     />
   );
 
-  useEffect(() => {
-    if (!suppressHoverIntent) return;
-    if (isPlaying) return;
-    const timeout = window.setTimeout(() => setAudioControlsActive(false), 0);
-    return () => window.clearTimeout(timeout);
-  }, [isPlaying, suppressHoverIntent]);
-
   return (
     <div
       onClick={onClick}
       onKeyDown={(e) => handleCardKeyDown(e, onClick)}
       onMouseEnter={() => {
-        if (!suppressHoverIntent) setAudioControlsActive(true);
+        if (!suppressHoverIntentRef?.current) setAudioControlsActive(true);
       }}
       onMouseLeave={() => {
         if (!isPlaying) setAudioControlsActive(false);
@@ -3549,7 +3607,7 @@ function ReadableBrowseModCard({
       tabIndex={0}
       aria-label={`Open details for ${mod.name}`}
       style={cardFrameStyle}
-      className={`browse-card-hover-surface browse-readable-card group flex w-full flex-col overflow-hidden rounded-md border bg-[#141414]/90 text-left shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-[border-color,transform,box-shadow] duration-150 cursor-pointer focus-visible:border-accent focus-visible:outline-none [container-type:inline-size] ${
+      className={`browse-card-hover-surface browse-readable-card group flex w-full flex-col overflow-hidden rounded-md border bg-[#141414] text-left shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-[border-color,transform,box-shadow] duration-150 cursor-pointer focus-visible:border-accent focus-visible:outline-none [container-type:inline-size] ${
         isPlaying
           ? 'border-state-danger/70 ring-2 ring-state-danger/35 shadow-lg shadow-state-danger/15'
           : downloading
@@ -3573,8 +3631,10 @@ function ReadableBrowseModCard({
         )}
 
         <div className={`${titleMarginClass} min-w-0`}>
+          {/* font-semibold, not font-bold: Reaver ships only a 600 face, so
+              bolder weights get synthetic (smeared, blurry) emboldening. */}
           <h3
-            className={`block truncate font-mod-title font-bold text-[#eee8df] ${
+            className={`block truncate font-mod-title font-semibold text-[#eee8df] ${
               isMicro
                 ? 'text-[13px] leading-4'
                 : 'text-[clamp(11px,5.3571cqw,17px)] leading-[1.28] pb-px'
@@ -3584,7 +3644,7 @@ function ReadableBrowseModCard({
             {mod.name}
           </h3>
           {showAuthor && (
-            <p className="mt-0 truncate text-[clamp(10px,4.2857cqw,13px)] font-normal leading-[1.12] text-text-secondary/64">
+            <p className="mt-0 truncate text-[clamp(10px,4.2857cqw,13px)] font-normal leading-[1.12] text-text-secondary/85">
               by {mod.submitter?.name ?? 'Unknown author'}
             </p>
           )}
@@ -3700,7 +3760,10 @@ interface ModCardProps {
   onVolumeChange: (v: number) => void;
   hideNsfwPreviews: boolean;
   isPlaying: boolean;
-  suppressHoverIntent?: boolean;
+  /** Shared "user is scrolling" flag from the grid. A ref, not a boolean, so
+   *  scroll start/stop never re-renders cards; event handlers read .current.
+   *  Hover visuals are suppressed separately in CSS via browse-is-scrolling. */
+  suppressHoverIntentRef?: React.RefObject<boolean>;
   enableModId?: string;
   actionContextKey?: string;
   onPlayingChange: (playing: boolean) => void;
@@ -3735,7 +3798,7 @@ function ModCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
   );
 }
 
-function ModCard({ mod, installed, installedDisabled, downloading, queuePosition, viewMode, cardDesign, cardSize, cardWidth, cardHeight, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, suppressHoverIntent, onPlayingChange, onClick, onQuickDownload, onEnable }: ModCardProps) {
+function ModCard({ mod, installed, installedDisabled, downloading, queuePosition, viewMode, cardDesign, cardSize, cardWidth, cardHeight, section, volume, onVolumeChange, hideNsfwPreviews, isPlaying, suppressHoverIntentRef, onPlayingChange, onClick, onQuickDownload, onEnable }: ModCardProps) {
   const thumbnail = getModThumbnail(mod);
   const audioPreview = section === 'Sound' ? getSoundPreviewUrl(mod) : undefined;
   // Compact chrome (4:3 aspect, smaller text/padding) kicks in for small cards;
@@ -3758,13 +3821,6 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
   const heroFacePos = inferredHero ? getHeroFacePosition(inferredHero) : 55;
   const [audioControlsActive, setAudioControlsActive] = useState(false);
 
-  useEffect(() => {
-    if (!suppressHoverIntent) return;
-    if (isPlaying) return;
-    const timeout = window.setTimeout(() => setAudioControlsActive(false), 0);
-    return () => window.clearTimeout(timeout);
-  }, [isPlaying, suppressHoverIntent]);
-
   // List view keeps original layout
   if (isList) {
     return (
@@ -3772,7 +3828,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
         onClick={onClick}
         onKeyDown={(e) => handleCardKeyDown(e, onClick)}
         onMouseEnter={() => {
-          if (!suppressHoverIntent) setAudioControlsActive(true);
+          if (!suppressHoverIntentRef?.current) setAudioControlsActive(true);
         }}
         onMouseLeave={() => {
           if (!isPlaying) setAudioControlsActive(false);
@@ -3909,7 +3965,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
   // Grid/Compact: overlay card — image fills card, info overlaid at bottom
   if (cardDesign === 'readable') {
     return (
-      <BrowseArtParallaxCard disabled={suppressHoverIntent}>
+      <BrowseArtParallaxCard>
         <ReadableBrowseModCard
           mod={mod}
           installed={installed}
@@ -3926,7 +3982,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
           onVolumeChange={onVolumeChange}
           hideNsfwPreviews={hideNsfwPreviews}
           isPlaying={isPlaying}
-          suppressHoverIntent={suppressHoverIntent}
+          suppressHoverIntentRef={suppressHoverIntentRef}
           onPlayingChange={onPlayingChange}
           onClick={onClick}
           onQuickDownload={onQuickDownload}
@@ -3938,12 +3994,12 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
 
   const isOutdated = mod.dateModified > 0 && isModOutdated(mod.dateModified);
   return (
-    <BrowseArtParallaxCard disabled={suppressHoverIntent}>
+    <BrowseArtParallaxCard>
       <div
         onClick={onClick}
         onKeyDown={(e) => handleCardKeyDown(e, onClick)}
         onMouseEnter={() => {
-          if (!suppressHoverIntent) setAudioControlsActive(true);
+          if (!suppressHoverIntentRef?.current) setAudioControlsActive(true);
         }}
         onMouseLeave={() => {
           if (!isPlaying) setAudioControlsActive(false);
@@ -4256,7 +4312,7 @@ const MemoizedModCard = React.memo(ModCard, (prev, next) => (
   prev.volume === next.volume &&
   prev.hideNsfwPreviews === next.hideNsfwPreviews &&
   prev.isPlaying === next.isPlaying &&
-  prev.suppressHoverIntent === next.suppressHoverIntent &&
+  prev.suppressHoverIntentRef === next.suppressHoverIntentRef &&
   prev.enableModId === next.enableModId &&
   prev.actionContextKey === next.actionContextKey
 ));


### PR DESCRIPTION
## Summary

Follow-ups from a UI smoothness audit of the Browse tab and the new docked details sidebar (#150-era feature). Three areas: scroll performance, sidebar open feel and adjustability, and card text rendering/contrast.

### Scroll performance

- **Scroll start/stop no longer re-renders anything.** The `isBrowseScrolling` React state is gone. The scroll listener toggles the `browse-is-scrolling` class on the container imperatively, and cards read a shared ref (`suppressHoverIntentRef`) at event time. Previously every scroll gesture re-rendered the whole 4.2K-line Browse component twice and busted every visible card's memo via the `suppressHoverIntent` prop. Hover visuals were already suppressed in CSS, so behavior is unchanged.
- **The docked sidebar no longer re-renders while scrolling the grid.** `ModDetailsModal` is wrapped in `React.memo`, and Browse passes it stable callbacks via a new `useStableCallback` helper (stable identity, always-fresh closure). Before this, every virtualizer range change re-rendered the entire 1.6K-line details panel.

### Docked sidebar

- **Open animation**: the aside reserves its width in one snap (grid reflows exactly once, never per animation frame) and the panel slides in with a transform-only 220ms keyframe using the app's standard easing. The border and resize handle ride on the panel. Reduced motion respected.
- **Scroll anchoring**: when grid geometry changes (sidebar open/close, resize drag, window resize), a layout effect re-maps `scrollTop` so the first visible mod stays put instead of the content jumping. Fractional row math avoids ratcheting; result is rounded to whole pixels (a fractional scrollTop rasterizes the grid at a subpixel offset and blurs text).
- **Adjustable width, no hard cap**: the fixed 720px max is removed. The panel clamps only to its 320px usable minimum and the grid's 360px reserve. The panel's internal layout is now keyed to its own width via container queries (`@container` / `@4xl`): narrow dock stacks single-column, a dock dragged past 56rem switches to the modal's two-column layout. The loading skeleton follows the same breakpoint.

### Card text

- **Blur fixes**: the card title requested `font-bold` (700) but Reaver ships only a 600 face, so Chromium synthesized a faux bold by smearing glyphs; now `font-semibold` plus `font-synthesis: none` on `.font-mod-title`. The card background was `#141414/90`; translucent backgrounds lose subpixel AA for all text on the card, so it is now opaque (visually identical over the `#0f0f0f` page bg).
- **Contrast**: author/stats/updated lines were tertiary grey at 55-72% opacity (roughly 2.4-3.5:1); raised to ~4.5-5:1 while keeping hierarchy. Chips/tags now use full-strength tone colors at 11px (width estimator updated to match) with slightly stronger borders/backgrounds.

## Testing

- `pnpm typecheck`, `pnpm lint` clean (two pre-existing Stats.tsx warnings untouched)
- `pnpm build` passes; compiled CSS confirmed to contain the container-query rules
- Manually exercised in dev: grid scrolling with and without the docked sidebar, sidebar open/close/resize, chip/title rendering