### PR TITLE
chore(release): v1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.15.3",
+  "version": "1.16.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the v1.16.0 release. Browse-themed minor: artist mode, docked details sidebar, brand icons, skin-stack preview, comments + auto-enable, IPC single-sourcing, and perf passes.

Pre-release verification (all passed):
- vpkmerge pin v0.11.0 matches the released asset sha256; no new flags since v1.15.3
- typecheck / lint / i18n:check clean
- Packaged Linux build with prod social URL baked in; smoke launch clean
- Deletion-safety review of the hero-pose cache sweeper and the auto-enable fix: no blockers