### PR TITLE
feat(windows): dark styled title bar

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, session, protocol } from 'electron';
+import { app, BrowserWindow, shell, session, protocol, nativeTheme } from 'electron';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -19,6 +19,11 @@ protocol.registerSchemesAsPrivileged([
         privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true },
     },
 ]);
+
+// The app is dark-only, so pin Chromium and the OS chrome to dark regardless
+// of the system theme. On Windows this stops the native frame/menus rendering
+// light, and it makes prefers-color-scheme report dark in the renderer.
+nativeTheme.themeSource = 'dark';
 
 // Initialize the file logger before anything else so console.* calls in IPC
 // and service modules (imported below) flow into the rolling log file from
@@ -134,8 +139,23 @@ function createWindow(): void {
         minHeight: 600,
         title: 'Grimoire',
         show: false, // Don't show until ready to prevent white flash
-        backgroundColor: '#1e1e2e', // Dark background matching app theme
+        backgroundColor: '#0f0f0f', // Dark background matching app theme
         autoHideMenuBar: true,
+        // On Windows the native frame draws a light title bar that clashes
+        // with the dark UI. Hide it and let the OS paint only the
+        // min/max/close controls (the overlay) in app colors; the renderer
+        // supplies the drag region and title via WindowsTitleBar. Linux
+        // keeps its window-manager frame.
+        ...(process.platform === 'win32'
+            ? {
+                  titleBarStyle: 'hidden' as const,
+                  titleBarOverlay: {
+                      color: '#0f0f0f',
+                      symbolColor: '#a1a1aa',
+                      height: 36,
+                  },
+              }
+            : {}),
         webPreferences: {
             preload: join(__dirname, '../preload/index.cjs'),
             contextIsolation: true,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -56,6 +56,8 @@ import type {
 
 // Expose the API to the renderer process
 contextBridge.exposeInMainWorld('electronAPI', {
+    platform: process.platform,
+
     // Settings
     detectDeadlock: () => ipcRenderer.invoke('detect-deadlock'),
     validateDeadlockPath: (path: string) => ipcRenderer.invoke('validate-deadlock-path', path),

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import { useAppStore } from '../stores/appStore';
 import type { OneClickSuspiciousFilesData, MultiVpkPickData } from '../types/electron';
 import MultiVpkPickerModal from './MultiVpkPickerModal';
 import DiscordPresence from './DiscordPresence';
+import WindowsTitleBar from './WindowsTitleBar';
 
 export default function Layout() {
   const navigate = useNavigate();
@@ -201,7 +202,10 @@ export default function Layout() {
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen flex-col">
+      {/* Windows-only drag strip; renders nothing on other platforms. */}
+      <WindowsTitleBar />
+      <div className="flex min-h-0 flex-1">
       {/* Headless: drives opt-in Discord Rich Presence from the active route. */}
       <DiscordPresence />
       <Sidebar />
@@ -228,6 +232,7 @@ export default function Layout() {
           <Outlet />
         </div>
       </main>
+      </div>
       {/* Status indicators stack in the bottom-right corner. */}
       <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
         <DownloadQueueIndicator />

--- a/src/components/WindowsTitleBar.tsx
+++ b/src/components/WindowsTitleBar.tsx
@@ -1,0 +1,33 @@
+import type { CSSProperties } from 'react';
+import { getAssetPath } from '../lib/assetPath';
+
+const TITLE_ICON = getAssetPath('/grimoire-title-icon.svg');
+
+// Matches the titleBarOverlay height set in electron/main/index.ts. The OS
+// draws the min/max/close controls over the right edge of this strip; the
+// strip itself provides the drag region and title the hidden frame used to.
+const TITLE_BAR_HEIGHT = 36;
+
+const dragStyle: CSSProperties & { WebkitAppRegion: string } = {
+    height: TITLE_BAR_HEIGHT,
+    WebkitAppRegion: 'drag',
+};
+
+export default function WindowsTitleBar() {
+    if (window.electronAPI.platform !== 'win32') return null;
+    return (
+        <header
+            style={dragStyle}
+            className="flex flex-shrink-0 select-none items-center gap-2 border-b border-border bg-bg-primary px-3"
+        >
+            <img
+                src={TITLE_ICON}
+                alt=""
+                aria-hidden
+                draggable={false}
+                className="h-4 w-4 flex-shrink-0 opacity-80"
+            />
+            <span className="text-xs font-medium tracking-wide text-text-secondary">Grimoire</span>
+        </header>
+    );
+}

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -298,6 +298,11 @@ export interface ReleaseNoteInfo {
 }
 
 export interface ElectronAPI {
+    // Host platform ('win32', 'linux', ...), captured in the preload. The
+    // renderer uses it to decide whether to draw the custom Windows title
+    // bar strip (the native frame is hidden on Windows only).
+    platform: string;
+
     // Settings
     detectDeadlock: () => Promise<string | null>;
     validateDeadlockPath: (path: string) => Promise<boolean>;


### PR DESCRIPTION
## Summary

The native Windows frame draws a white title bar by default, clashing with the dark UI. This PR makes the Windows chrome fully dark and styled to the app palette.

- Pin `nativeTheme.themeSource = 'dark'` at startup so Chromium and native chrome (menus, scrollbars, dialogs) render dark regardless of the system theme
- Windows only: hide the native frame (`titleBarStyle: 'hidden'`) and draw min/max/close via `titleBarOverlay` in app colors (bar `#0f0f0f`, symbols `#a1a1aa`, 36px)
- New `WindowsTitleBar` renderer strip provides the drag region, icon, and title; returns null on other platforms, so Linux keeps its window-manager frame
- Fix the pre-paint `backgroundColor` from stale `#1e1e2e` to the actual theme background `#0f0f0f`
- Expose `platform` on the preload bridge, added to the `ElectronAPI` contract in `src/types/electron.ts`

## Notes

- Double-click-to-maximize works through the drag region (handled natively)
- Known tradeoff of overlay-style title bars: while a full-screen modal is open it covers the strip, so the window cannot be dragged (same as VS Code/Discord)
- Verified: `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass on Linux. The overlay itself needs a visual check on a Windows build before release.