### PR TITLE
perf: parse VPK trees in worker threads (conflict scan + get-mods pre-warm)

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -16,7 +16,7 @@ import {
 import { metaKeyFor } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
-import { inferHeroFromVpk, classifyGlobalModFromVpk, GLOBAL_CLASSIFIER_VERSION, parseVpkDirectory } from '../services/vpk';
+import { inferHeroFromVpk, classifyGlobalModFromVpk, GLOBAL_CLASSIFIER_VERSION, parseVpkDirectory, parseVpkDirectoriesAsync } from '../services/vpk';
 import { classifyAbilitySoundsFromVpk } from '../services/abilitySounds';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 import { isLockerManaged } from '../services/lockerVpk';
@@ -221,6 +221,29 @@ function enrichMod(mod: Mod): WireMod {
     return { ...mod, isUnknown, globalType: globalType ?? undefined, lockerHero, lockerHeroSource };
 }
 
+/**
+ * Will enrichMod crack open this mod's VPK? Mirrors (conservatively
+ * over-approximates) the lazy-classification predicates above: globalType not
+ * yet classified at the current version, abilitySounds never checked, a Sound
+ * mod with no hero tag yet (the parse only happens when title inference fails,
+ * which we don't pre-compute; a wasted warm parse is harmless), or an unknown
+ * mod whose tree hasn't been hero-checked. Every positive persists to
+ * metadata, so this is a first-scan-only cost per mod.
+ */
+function needsVpkParseForEnrich(mod: Mod): boolean {
+    const metadata = getModMetadata(mod.metaKey);
+    const globalTypeStamped = metadata?.globalTypeClassifierVersion ?? 0;
+    if (metadata?.globalType === undefined) return true;
+    if (metadata.globalType === null && globalTypeStamped < GLOBAL_CLASSIFIER_VERSION) return true;
+    if (metadata.abilitySounds === undefined) return true;
+    if (!metadata.lockerHero && metadata.sourceSection === 'Sound') return true;
+    const isUnknown =
+        !metadata.gameBananaId &&
+        !(typeof metadata.modName === 'string' && metadata.modName.trim().length > 0);
+    if (isUnknown && !metadata.lockerHero && !metadata.lockerHeroVpkChecked) return true;
+    return false;
+}
+
 function sameKeys(a: string[], b: string[]): boolean {
     return a.length === b.length && a.every((key, index) => key === b[index]);
 }
@@ -258,7 +281,17 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     // the front of the load order (services/lockerVpk.ts), so surfacing them in
     // the Installed list would only let the user disable or reorder them and
     // silently break their applied cosmetics.
-    return mods.filter((m) => !isLockerManaged(m.metaKey)).map(enrichMod);
+    const visible = mods.filter((m) => !isLockerManaged(m.metaKey));
+    // Pre-warm the VPK parse cache across the worker pool for mods whose lazy
+    // classifications will parse inside enrichMod below. enrichMod stays sync;
+    // its parseVpkDirectoryCached calls hit the warmed cache instead of
+    // sequentially pinning the main process (worst case: first scan after
+    // importing a large collection).
+    const warmPaths = visible.filter(needsVpkParseForEnrich).map((m) => m.path);
+    if (warmPaths.length > 0) {
+        await parseVpkDirectoriesAsync(warmPaths);
+    }
+    return visible.map(enrichMod);
 });
 
 // enable-mod

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -1,5 +1,5 @@
 import { scanMods, type Mod } from './mods';
-import { parseVpkDirectoryCached, type VpkParseStats } from './vpk';
+import { parseVpkDirectoriesAsync, type VpkParseStats } from './vpk';
 import { loadSettings } from './settings';
 import { getModMetadata } from './metadata';
 
@@ -198,10 +198,16 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         }
     }
 
-    // Parse VPK file lists
+    // Parse VPK file lists. Cache misses are parsed concurrently across the
+    // worker pool instead of sequentially on the main process, which is what
+    // used to pin the event loop for hundreds of ms on a cold cache.
+    const parsedVpks = await parseVpkDirectoriesAsync(
+        enabledMods.map((mod) => mod.path),
+        { stats: vpkStats }
+    );
     const modFileLists = new Map<string, Set<string>>();
     for (const mod of enabledMods) {
-        const files = parseVpkDirectoryCached(mod.path, vpkStats);
+        const files = parsedVpks.get(mod.path);
         if (files && files.length > 0) {
             modFileLists.set(mod.id, new Set(files));
         }
@@ -241,7 +247,7 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
 
     // Strip out any pairs the user has explicitly dismissed. We do this at
     // the end rather than inside the loops so the ignored list stays a clean
-    // post-filter — easy to reason about and easy to disable later.
+    // post-filter: easy to reason about and easy to disable later.
     const settings = loadSettings();
     if (settings.ignoreConflictsByDefault) {
         return [];

--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -55,6 +55,20 @@ function emitProgress(progress: SyncProgress): void {
     }
 }
 
+// Instrumentation for the "move sync writes to a DB worker" decision: each
+// page is one synchronous better-sqlite3 transaction (50 upserts + FTS
+// triggers) on the main process. If these routinely exceed ~30ms in the wild
+// (or [event-loop] warnings correlate with sync), the worker is justified;
+// if they stay in single digits, it is not worth the complexity.
+function timedUpsert(section: string, page: number, mods: CachedMod[]): void {
+    const start = Date.now();
+    upsertMods(mods);
+    const tookMs = Date.now() - start;
+    if (tookMs >= 20) {
+        console.log(`[SyncService] ${section} page ${page}: upsert of ${mods.length} rows took ${tookMs}ms`);
+    }
+}
+
 /**
  * Convert GameBananaMod to CachedMod
  */
@@ -106,7 +120,7 @@ async function syncSection(section: SectionType): Promise<void> {
 
         // Process first page
         const cachedMods = first.records.map(mod => mapToCache(mod, section));
-        upsertMods(cachedMods);
+        timedUpsert(section, 1, cachedMods);
         modsProcessed += cachedMods.length;
 
         emitProgress({
@@ -122,7 +136,7 @@ async function syncSection(section: SectionType): Promise<void> {
         for (page = 2; page <= totalPages; page++) {
             const response = await fetchSubmissions(section, page, SYNC_PER_PAGE);
             const mods = response.records.map(mod => mapToCache(mod, section));
-            upsertMods(mods);
+            timedUpsert(section, page, mods);
             modsProcessed += mods.length;
 
             emitProgress({

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -1,5 +1,6 @@
 import { openSync, readSync, closeSync, existsSync, statSync } from 'fs';
 import { heroForSoundCodename } from './heroSoundCodenames';
+import { parseVpksInWorkers } from './workers';
 import type { GlobalModType } from '../../../src/types/mod';
 
 /**
@@ -42,11 +43,28 @@ interface VpkCacheEntry {
 }
 const vpkParseCache = new Map<string, VpkCacheEntry>();
 
+// Invalidation epochs guard the async (worker) parse path against a stale
+// write-back: a VPK rewritten while a worker parse is in flight, to the same
+// size within the same mtime tick, would otherwise land in the cache as if
+// current (the Locker card/color/sound writers rewrite VPKs in place and then
+// call invalidateVpkParseCache, which is exactly that shape). A worker result
+// is only cached when both the per-path epoch and the global epoch still match
+// their values at dispatch time. The sync path needs no guard: it parses
+// current disk content by definition.
+const cacheEpochs = new Map<string, number>();
+let globalEpoch = 0;
+
+// Dedupes concurrent async parses of the same path (e.g. a conflict scan and a
+// get-mods pre-warm racing): the second caller awaits the first's result.
+const inflightParses = new Map<string, Promise<string[] | null>>();
+
 export function invalidateVpkParseCache(vpkPath?: string): void {
     if (vpkPath) {
         vpkParseCache.delete(vpkPath);
+        cacheEpochs.set(vpkPath, (cacheEpochs.get(vpkPath) ?? 0) + 1);
     } else {
         vpkParseCache.clear();
+        globalEpoch++;
     }
 }
 
@@ -82,6 +100,113 @@ export function parseVpkDirectoryCached(vpkPath: string, stats?: VpkParseStats):
     const paths = parseVpkDirectory(vpkPath);
     vpkParseCache.set(vpkPath, { mtimeMs: stat.mtimeMs, size: stat.size, paths });
     return paths;
+}
+
+/**
+ * Parse a batch of VPKs without blocking the main process: cache hits resolve
+ * immediately, misses are parsed concurrently across the worker pool, and
+ * results are written back into the shared cache so subsequent sync
+ * parseVpkDirectoryCached calls hit for free.
+ *
+ * Failure handling degrades to exactly the pre-worker behavior: a per-file
+ * worker error (e.g. file deleted mid-scan) and a wholesale pool failure
+ * (including abort) both fall back to the sync parser on the main thread, so
+ * callers always get the same results they would have gotten before this
+ * function existed.
+ */
+export async function parseVpkDirectoriesAsync(
+    vpkPaths: string[],
+    options: { signal?: AbortSignal; stats?: VpkParseStats } = {}
+): Promise<Map<string, string[] | null>> {
+    const { signal, stats } = options;
+    const results = new Map<string, string[] | null>();
+    const pending: Array<Promise<void>> = [];
+    const misses: string[] = [];
+
+    for (const vpkPath of vpkPaths) {
+        if (results.has(vpkPath) || misses.includes(vpkPath)) continue;
+
+        let stat;
+        try {
+            stat = statSync(vpkPath);
+        } catch {
+            vpkParseCache.delete(vpkPath);
+            results.set(vpkPath, null);
+            continue;
+        }
+
+        const cached = vpkParseCache.get(vpkPath);
+        if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+            if (stats) stats.hits++;
+            results.set(vpkPath, cached.paths);
+            continue;
+        }
+        if (stats) stats.misses++;
+
+        const inflight = inflightParses.get(vpkPath);
+        if (inflight) {
+            pending.push(inflight.then((paths) => { results.set(vpkPath, paths); }));
+            continue;
+        }
+        misses.push(vpkPath);
+    }
+
+    if (misses.length > 0) {
+        const globalEpochAtDispatch = globalEpoch;
+        const epochsAtDispatch = new Map<string, number>();
+        const resolvers = new Map<string, (paths: string[] | null) => void>();
+        for (const vpkPath of misses) {
+            epochsAtDispatch.set(vpkPath, cacheEpochs.get(vpkPath) ?? 0);
+            const promise = new Promise<string[] | null>((resolve) => {
+                resolvers.set(vpkPath, resolve);
+            });
+            inflightParses.set(vpkPath, promise);
+            pending.push(promise.then((paths) => { results.set(vpkPath, paths); }));
+        }
+
+        // Settle one path: optionally cache (worker results only, and only when
+        // no invalidation happened since dispatch), then release waiters.
+        const finish = (
+            vpkPath: string,
+            paths: string[] | null,
+            workerStat?: { mtimeMs: number; size: number }
+        ): void => {
+            if (
+                workerStat &&
+                globalEpoch === globalEpochAtDispatch &&
+                (cacheEpochs.get(vpkPath) ?? 0) === epochsAtDispatch.get(vpkPath)
+            ) {
+                vpkParseCache.set(vpkPath, { mtimeMs: workerStat.mtimeMs, size: workerStat.size, paths });
+            }
+            inflightParses.delete(vpkPath);
+            resolvers.get(vpkPath)?.(paths);
+            resolvers.delete(vpkPath);
+        };
+
+        try {
+            const workerResults = await parseVpksInWorkers(
+                misses.map((vpkPath) => ({ id: vpkPath, vpkPath })),
+                { signal }
+            );
+            for (const result of workerResults) {
+                if (result.error) {
+                    // Same cost as before this function existed, for this one file.
+                    finish(result.vpkPath, parseVpkDirectoryCached(result.vpkPath));
+                } else {
+                    finish(result.vpkPath, result.paths, { mtimeMs: result.mtimeMs, size: result.size });
+                }
+            }
+        } catch (error) {
+            console.warn('[parseVpkDirectoriesAsync] worker pool failed, falling back to sync parse:', error);
+            for (const vpkPath of misses) {
+                if (!resolvers.has(vpkPath)) continue;
+                finish(vpkPath, parseVpkDirectoryCached(vpkPath));
+            }
+        }
+    }
+
+    await Promise.all(pending);
+    return results;
 }
 
 /**

--- a/electron/main/services/workers.ts
+++ b/electron/main/services/workers.ts
@@ -170,3 +170,264 @@ export async function fingerprintFileInWorker(
     const [result] = await fingerprintFilesInWorkers([task], { concurrency: 1, signal });
     return result;
 }
+
+export interface VpkParseTask {
+    id: string;
+    vpkPath: string;
+}
+
+export interface VpkParseResult {
+    id: string;
+    vpkPath: string;
+    /** Stat captured BEFORE the read, so a cache entry keyed on it can only be
+     *  older-or-equal to the parsed content, never newer. */
+    mtimeMs: number;
+    size: number;
+    /** null = stat succeeded but the file is not a parseable VPK (matches the
+     *  sync parseVpkDirectory contract). */
+    paths: string[] | null;
+    /** Set when stat/read threw (e.g. file deleted mid-scan). */
+    error?: string;
+}
+
+export interface VpkParseWorkerOptions {
+    concurrency?: number;
+    signal?: AbortSignal;
+    onResult?: (result: VpkParseResult) => void;
+}
+
+// Long-lived worker mirroring FINGERPRINT_WORKER_SCRIPT's lifecycle: one VPK
+// parse per task message, threads reused across the batch.
+//
+// The tree parser below is a mechanical copy of parseVpkDirectory in vpk.ts
+// (keep in sync with vpk.ts). It cannot be imported because this script is
+// eval'd inside the worker; eval is the proven packaged-build path (a bundled
+// worker entry file would need asar-aware resolution).
+//
+// console.warn calls inside the parser still reach the terminal (worker
+// stdout/stderr is piped to the parent) but without main-process log context.
+const VPK_PARSE_WORKER_SCRIPT = String.raw`
+const { parentPort } = require('worker_threads');
+const { openSync, readSync, closeSync, statSync } = require('fs');
+
+const VPK_SIGNATURE = 0x55AA1234;
+
+function readNullTerminatedString(buffer, offset) {
+  let end = offset;
+  while (end < buffer.length && buffer[end] !== 0) {
+    end++;
+  }
+  const str = buffer.slice(offset, end).toString('utf-8');
+  return { str, bytesRead: end - offset + 1 };
+}
+
+function parseVpkDirectory(vpkPath) {
+  try {
+    const fd = openSync(vpkPath, 'r');
+
+    const headerBuffer = Buffer.alloc(12);
+    readSync(fd, headerBuffer, 0, 12, 0);
+
+    const signature = headerBuffer.readUInt32LE(0);
+    if (signature !== VPK_SIGNATURE) {
+      closeSync(fd);
+      return null;
+    }
+
+    const version = headerBuffer.readUInt32LE(4);
+    const treeSize = headerBuffer.readUInt32LE(8);
+    const headerSize = version === 2 ? 28 : 12;
+
+    const treeBuffer = Buffer.alloc(treeSize);
+    readSync(fd, treeBuffer, 0, treeSize, headerSize);
+    closeSync(fd);
+
+    const paths = [];
+    let offset = 0;
+    let properlyTerminated = false;
+
+    while (offset < treeBuffer.length) {
+      const extResult = readNullTerminatedString(treeBuffer, offset);
+      offset += extResult.bytesRead;
+
+      if (extResult.str === '') {
+        properlyTerminated = true;
+        break;
+      }
+
+      const extension = extResult.str;
+      let extensionProperlyTerminated = false;
+
+      while (offset < treeBuffer.length) {
+        const pathResult = readNullTerminatedString(treeBuffer, offset);
+        offset += pathResult.bytesRead;
+
+        if (pathResult.str === '') {
+          extensionProperlyTerminated = true;
+          break;
+        }
+
+        const dirPath = pathResult.str === ' ' ? '' : pathResult.str;
+        let pathProperlyTerminated = false;
+
+        while (offset < treeBuffer.length) {
+          const nameResult = readNullTerminatedString(treeBuffer, offset);
+          offset += nameResult.bytesRead;
+
+          if (nameResult.str === '') {
+            pathProperlyTerminated = true;
+            break;
+          }
+
+          const filename = nameResult.str;
+          const fullPath = dirPath
+            ? dirPath + '/' + filename + '.' + extension
+            : filename + '.' + extension;
+          paths.push(fullPath);
+
+          offset += 18;
+
+          if (offset - 14 >= 0 && offset - 14 < treeBuffer.length - 1) {
+            const preloadBytes = treeBuffer.readUInt16LE(offset - 14);
+            offset += preloadBytes;
+          }
+        }
+
+        if (!pathProperlyTerminated) {
+          console.warn('[parseVpkDirectory:worker] Warning: Filename section for path "' + dirPath + '" (ext: ' + extension + ') did not terminate properly - buffer exhausted at offset ' + offset + '/' + treeBuffer.length);
+        }
+      }
+
+      if (!extensionProperlyTerminated) {
+        console.warn('[parseVpkDirectory:worker] Warning: Path section for extension "' + extension + '" did not terminate properly - buffer exhausted at offset ' + offset + '/' + treeBuffer.length);
+      }
+    }
+
+    if (!properlyTerminated) {
+      console.warn('[parseVpkDirectory:worker] ' + vpkPath + ': tree did not terminate properly (offset ' + offset + '/' + treeBuffer.length + '). Some files may be missing from conflict detection.');
+    }
+
+    if (properlyTerminated && offset < treeBuffer.length) {
+      const remainingBytes = treeBuffer.length - offset;
+      if (remainingBytes > 16) {
+        console.warn('[parseVpkDirectory:worker] ' + vpkPath + ': ' + remainingBytes + ' bytes remaining after tree termination.');
+      }
+    }
+
+    return paths;
+  } catch (error) {
+    console.error('[parseVpkDirectory:worker] Error parsing ' + vpkPath + ':', error);
+    return null;
+  }
+}
+
+parentPort.on('message', (task) => {
+  try {
+    const stats = statSync(task.vpkPath);
+    const paths = parseVpkDirectory(task.vpkPath);
+    parentPort.postMessage({
+      id: task.id,
+      vpkPath: task.vpkPath,
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+      paths,
+    });
+  } catch (err) {
+    parentPort.postMessage({
+      id: task.id,
+      vpkPath: task.vpkPath,
+      mtimeMs: 0,
+      size: 0,
+      paths: null,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+`;
+
+/**
+ * Parse a batch of VPK directory trees across a small pool of reused worker
+ * threads. Results are returned in task order. Per-file stat/read errors come
+ * back on the individual result's `error` field; the returned promise only
+ * rejects on abort or a catastrophic worker failure.
+ *
+ * Deliberately a clone of fingerprintFilesInWorkers rather than a shared
+ * generic pool, so the shipped fingerprint path stays untouched.
+ */
+export function parseVpksInWorkers(
+    tasks: VpkParseTask[],
+    options: VpkParseWorkerOptions = {}
+): Promise<VpkParseResult[]> {
+    if (tasks.length === 0) return Promise.resolve([]);
+
+    const concurrency = Math.max(1, Math.min(options.concurrency ?? DEFAULT_WORKER_CONCURRENCY, tasks.length));
+    const results = new Array<VpkParseResult>(tasks.length);
+
+    return new Promise<VpkParseResult[]>((resolve, reject) => {
+        const { signal } = options;
+        const workers: Worker[] = [];
+        const inFlight = new Map<Worker, number>();
+        let nextIndex = 0;
+        let completed = 0;
+        let settled = false;
+
+        const cleanup = (): void => {
+            signal?.removeEventListener('abort', onAbort);
+            for (const worker of workers) void worker.terminate();
+        };
+        const fail = (err: Error): void => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(err);
+        };
+        const succeed = (): void => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve(results);
+        };
+        const onAbort = (): void => fail(new Error('VPK parse worker cancelled'));
+
+        if (signal?.aborted) {
+            reject(new Error('VPK parse worker cancelled'));
+            return;
+        }
+        signal?.addEventListener('abort', onAbort, { once: true });
+
+        const dispatch = (worker: Worker): void => {
+            if (settled || nextIndex >= tasks.length) return;
+            const index = nextIndex++;
+            inFlight.set(worker, index);
+            worker.postMessage(tasks[index]);
+        };
+
+        for (let i = 0; i < concurrency; i++) {
+            const worker = new Worker(VPK_PARSE_WORKER_SCRIPT, { eval: true });
+            workers.push(worker);
+
+            worker.on('message', (result: VpkParseResult) => {
+                const index = inFlight.get(worker);
+                inFlight.delete(worker);
+                if (typeof index === 'number') {
+                    results[index] = result;
+                    options.onResult?.(result);
+                    completed++;
+                }
+                if (completed >= tasks.length) {
+                    succeed();
+                    return;
+                }
+                dispatch(worker);
+            });
+            worker.on('error', (err) => fail(err));
+            worker.on('exit', (code) => {
+                if (!settled && code !== 0) {
+                    fail(new Error(`VPK parse worker exited with code ${code}`));
+                }
+            });
+
+            dispatch(worker);
+        }
+    });
+}


### PR DESCRIPTION
## What

Conflict scans and first-scan mod enrichment parsed every VPK directory tree synchronously and sequentially on the main process, pinning the event loop (hundreds of ms to seconds on a cold cache with a large mod set). This offloads cache-miss parsing to a worker_threads pool.

- workers.ts: VPK parse worker (eval script, mechanical copy of the vpk.ts tree parser, stat-before-read) + parseVpksInWorkers, a deliberate clone of the fingerprint pool so the shipped fingerprint path stays untouched
- vpk.ts: parseVpkDirectoriesAsync batch API. Cache hits resolve immediately; misses fan out across the pool and write back into the shared vpkParseCache, so all ~15 sync parseVpkDirectoryCached callers benefit for free. Invalidation epochs block a stale write-back from a parse in flight across an in-place VPK rewrite (Locker card/color/sound writers). In-flight map dedupes concurrent batches.
- conflicts.ts: detectConflicts parses via the batch call (sync API untouched everywhere else)
- ipc/mods.ts (second commit, independently revertible): get-mods pre-warms the cache for mods whose lazy classifications would parse inside enrichMod; first scan after importing a large collection no longer freezes the window
- syncService.ts: per-page upsert duration log (>=20ms), phase 0 of the catalog-sync DB worker decision

## Failure behavior

Any worker error (per-file or whole-pool) falls back to the sync parser on the main thread: exactly the pre-PR behavior. No IPC surface, wire type, or renderer changes.

## Verification

- pnpm typecheck + pnpm lint clean; production bundles build
- Sync-vs-worker equivalence on real VPKs: byte-identical path lists including the game's pak01_dir.vpk (129,773 paths), chunk archives (null), and a deleted-file path; cold batch parses in workers, warm batch is 100% cache hits; mid-flight invalidation correctly prevents the stale write-back; concurrent batches dedupe
- Remaining manual checks (need the GUI): cold-cache Conflicts page scan in dev + packaged AppImage, watch the [detectConflicts] vpkCache/took log line and the absence of [event-loop] warnings