### PR TITLE
chore(release): v1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the v1.17.0 release: Locker armory + trippy procedural effects, Deadworks server browser (experimental), perf workers, Windows dark titlebar, QoL pass.