### PR TITLE
chore: single-source getActiveDeadlockPath in the settings service

### DIFF
--- a/electron/main/ipc/abilityColors.ts
+++ b/electron/main/ipc/abilityColors.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     applyHeroColor,
     applyHeroPrism,
@@ -15,14 +15,6 @@ import type {
 } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/abilitySounds.ts). */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
-
 // Per-hero ability-COLOR recolor (services/heroColors.ts). Mirrors the
 // apply/revert/get trio in ipc/abilitySounds.ts: recolor a hero's ability VFX to
 // one hue, revert it, and read back the active hue. Plus a sync support check so

--- a/electron/main/ipc/abilitySounds.ts
+++ b/electron/main/ipc/abilitySounds.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import { getHeroAbilitySlots } from '../services/abilitySounds';
 import { applyHeroSound, revertHeroSound, getActiveHeroSounds } from '../services/heroSounds';
 import type {
@@ -11,14 +11,6 @@ import type {
 } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/portraits.ts). */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
-
 // Reference data for the per-ability sound picker: the 4 ability slots (name +
 // icon) for a hero. Per-mod classifications ride on the Mod object via
 // enrichMod, so no per-mod IPC is needed here.

--- a/electron/main/ipc/conflicts.ts
+++ b/electron/main/ipc/conflicts.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings, saveSettings } from '../services/settings';
+import { loadSettings, saveSettings, getActiveDeadlockPath } from '../services/settings';
 import {
     detectConflicts,
     conflictPairKey,
@@ -8,17 +8,6 @@ import {
     type ModConflict,
 } from '../services/conflicts';
 import { scanMods } from '../services/mods';
-
-/**
- * Get the active deadlock path from settings
- */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 // get-conflicts
 ipcMain.handle('get-conflicts', async (): Promise<ModConflict[]> => {

--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     fetchSections,
     fetchCategoryTreeCached,
@@ -30,17 +30,6 @@ import type {
     GetCategoriesArgs,
 } from '../../../src/types/electron';
 import { updateModNsfw } from '../services/modDatabase';
-
-/**
- * Get the active deadlock path from settings
- */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 // browse-mods
 ipcMain.handle(

--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     launchModded,
     launchVanilla,
@@ -14,14 +14,6 @@ import {
 import { readLaunchOptions, isSteamRunning } from '../services/launchOptions';
 import { healLockerVpks } from '../services/lockerVpk';
 import { getMainWindow } from '../index';
-
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 function emitRestore(result: RestoreResult): void {
     const win = getMainWindow();

--- a/electron/main/ipc/locker.ts
+++ b/electron/main/ipc/locker.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import { listAppliedCards, clearAllHeroCards, getAppliedCardThumbnails } from '../services/heroCards';
 import { listAppliedSounds, clearAllHeroSounds } from '../services/heroSounds';
 import { clearAllHeroColors, listAppliedColors } from '../services/heroColors';
@@ -7,14 +7,6 @@ import { clearAllTrippySkins, listAppliedTrippySkins } from '../services/trippyE
 import type { LockerCardThumbnail, LockerClearScope, LockerOverview } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as the other locker IPC). */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
-
 // Cross-cutting Locker IPC: a summary of everything the Locker is currently
 // overriding (cards + ability sounds + ability colors), plus a bulk clear.
 // Drives the Installed-tab "Locker Overrides" popup (toolbar Wand2 icon).

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,7 +1,7 @@
 import { ipcMain, shell } from 'electron';
 import { promises as fs, existsSync } from 'fs';
 import { extname } from 'path';
-import { loadSettings, saveSettings } from '../services/settings';
+import { loadSettings, saveSettings, getActiveDeadlockPath } from '../services/settings';
 import {
     scanMods,
     enableMod,
@@ -39,17 +39,6 @@ const unknownDetectionControllers = new Map<string, AbortController>();
 interface UnknownCacheBulkRequest {
     modId: string;
     requestId?: string;
-}
-
-/**
- * Get the active deadlock path from settings
- */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
 }
 
 /**

--- a/electron/main/ipc/performanceConfig.ts
+++ b/electron/main/ipc/performanceConfig.ts
@@ -1,19 +1,11 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     applyPerformanceConfig,
     getPerformanceConfigStatus,
     removePerformanceConfig,
 } from '../services/performanceConfig';
 import type { PerformanceConfigStatus } from '../../../src/types/electron';
-
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 // get-performance-config-status
 ipcMain.handle('get-performance-config-status', (): PerformanceConfigStatus => {

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import { getHeroPortraits } from '../services/heroPortraits';
 import { applyHeroCard, revertHeroCard, getActiveHeroCard } from '../services/heroCards';
 import {
@@ -17,14 +17,6 @@ import type { HeroPortrait } from '../../../src/types/portrait';
 import type { ApplyHeroCardResult } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/mods.ts). */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
-
 ipcMain.handle(
     'get-hero-portraits',
     async (_, heroName: string): Promise<HeroPortrait[]> => {

--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings, saveSettings } from '../services/settings';
+import { loadSettings, saveSettings, getActiveDeadlockPath } from '../services/settings';
 import {
     loadProfiles,
     createProfile,
@@ -22,17 +22,6 @@ import type {
     PortableProfile,
     PortableResolvedMod,
 } from '../../../src/types/portableProfile';
-
-/**
- * Get the active deadlock path from settings
- */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 // get-profiles
 ipcMain.handle('get-profiles', (): Profile[] => {

--- a/electron/main/ipc/servers.ts
+++ b/electron/main/ipc/servers.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { loadSettings, getActiveDeadlockPath } from '../services/settings';
 import { getMainWindow } from '../index';
 import {
     fetchServers,
@@ -19,12 +19,6 @@ import type {
 // at the official Deadworks registry so the browser is populated out of the box.
 // Any deadworks-shaped relay works here, including our own grimoire-relay.
 const DEFAULT_RELAY_URL = 'https://api.deadworks.net';
-
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) return settings.devDeadlockPath;
-    return settings.deadlockPath;
-}
 
 function getRelayUrl(): string {
     const configured = loadSettings().deadworksRelayUrl?.trim();

--- a/electron/main/ipc/snapshots.ts
+++ b/electron/main/ipc/snapshots.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     writeSnapshot,
     listSnapshots,
@@ -8,14 +8,6 @@ import {
     type SnapshotSummary,
     type SnapshotTrigger,
 } from '../services/snapshots';
-
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
 
 // snapshot-create — capture the current installed mod set as a recovery
 // snapshot. Used automatically by the update path (trigger = "pre-update").

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -1,6 +1,6 @@
 import { ipcMain, dialog, shell, clipboard, nativeImage } from 'electron';
 import { getMainWindow } from '../index';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     getGameinfoStatus,
     fixGameinfo,
@@ -37,17 +37,6 @@ async function loadClipboardImage(source: string): Promise<Electron.NativeImage>
     }
 
     throw new Error(`Unsupported image source: ${url.protocol}`);
-}
-
-/**
- * Get the active deadlock path from settings
- */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
 }
 
 // show-open-dialog

--- a/electron/main/ipc/trippyEffects.ts
+++ b/electron/main/ipc/trippyEffects.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { loadSettings } from '../services/settings';
+import { getActiveDeadlockPath } from '../services/settings';
 import {
     applyTrippySkin,
     getActiveTrippySkin,
@@ -17,14 +17,6 @@ import type {
 } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/abilityColors.ts). */
-function getActiveDeadlockPath(): string | null {
-    const settings = loadSettings();
-    if (settings.devMode && settings.devDeadlockPath) {
-        return settings.devDeadlockPath;
-    }
-    return settings.deadlockPath;
-}
-
 // Trippy procedural effects (services/trippyEffects.ts + the trippy mode in
 // services/heroColors.ts). The preview sprite is pure pattern generation, so it
 // needs no Deadlock path: the Effects panel can show live swatches before a

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -57,6 +57,19 @@ export function loadSettings(): AppSettings {
 }
 
 /**
+ * The Deadlock path IPC handlers should act on: the dev dummy path when dev
+ * mode is active, otherwise the user's configured install. Single-sourced
+ * here; IPC modules import it instead of keeping local copies.
+ */
+export function getActiveDeadlockPath(): string | null {
+    const settings = loadSettings();
+    if (settings.devMode && settings.devDeadlockPath) {
+        return settings.devDeadlockPath;
+    }
+    return settings.deadlockPath;
+}
+
+/**
  * Save settings to disk atomically (P1 fix #8)
  * Uses write-to-temp-then-rename pattern to prevent corruption on crash
  */


### PR DESCRIPTION
## Summary

Follow-up to #162's "known debt" list. The dev-mode-aware deadlock path helper (`getActiveDeadlockPath`) was copy-pasted in 14 IPC modules. This moves the single definition into `services/settings.ts` (next to `loadSettings`, which it wraps) and imports it everywhere.

- Net -112 lines, no behavior change: all 14 copies were semantically identical (one had compressed formatting, one had a doc comment; same logic).
- Files that still use `loadSettings` for other reasons (profiles, servers, conflicts, mods) keep that import; the rest drop it.

## Verification

`pnpm typecheck` and `pnpm lint` clean (2 pre-existing Stats.tsx warnings).