### PR TITLE
feat(crosshair): match the current in-game convar surface and overhaul the tab

### DIFF
--- a/docs/profile-spec.md
+++ b/docs/profile-spec.md
@@ -189,10 +189,10 @@ Rules:
 
 | Field | Type | Notes |
 |---|---|---|
-| `crosshair` | object | Citadel crosshair settings (10 numeric / boolean fields). Source 2 console variables. |
+| `crosshair` | object | Citadel crosshair settings. Source 2 console variables. |
 | `autoexecCommands` | string[] | Console command lines to write to `autoexec.cfg`. Importers MUST show these to the user before applying. |
 
-The full crosshair shape is defined in Grimoire's `ProfileCrosshairSettings` interface.
+The full crosshair shape is defined in Grimoire's `PortableCrosshairSettings` interface (`src/types/portableProfile.ts`). The original 10 fields (`pipGap`, `pipHeight`, `pipWidth`, `pipOpacity`, `pipBorder`, `dotOpacity`, `dotOutlineOpacity`, `colorR/G/B`) are always present. Grimoire 1.18 added optional fields for the game's outline system (`pipGapStatic`, `pipOutlineBorder/Gap/Opacity`, `dotSize`, `dotOutlineBorder/Gap`, `outlineColorR/G/B`, `disableHeroSpecificCrosshairs`); exporters keep writing `pipBorder` (derived from `pipOutlineBorder > 0`) so older importers stay compatible, and importers fill missing optional fields with defaults.
 
 ## Security notes for implementers
 

--- a/electron/main/ipc/crosshairPresets.ts
+++ b/electron/main/ipc/crosshairPresets.ts
@@ -4,6 +4,12 @@ import * as path from 'path';
 // Wire types are single-sourced in src/types/electron.ts; re-exported to
 // keep this module's surface unchanged.
 import type { CrosshairSettings, CrosshairPreset } from '../../../src/types/electron';
+import {
+    generateCrosshairCommands,
+    normalizeCrosshairSettings,
+    parseMachineConvarsCrosshair,
+} from '../../../src/lib/crosshair';
+import { readAutoexec, writeAutoexec, getAutoexecPath } from '../services/autoexec';
 export type { CrosshairSettings, CrosshairPreset };
 
 interface PresetsData {
@@ -17,7 +23,16 @@ function loadPresetsData(): PresetsData {
     try {
         if (fs.existsSync(PRESETS_FILE)) {
             const data = fs.readFileSync(PRESETS_FILE, 'utf-8');
-            return JSON.parse(data);
+            const parsed = JSON.parse(data) as PresetsData;
+            // Migrate legacy presets (pre outline system) to the full settings
+            // shape so the renderer only ever sees current-model settings.
+            return {
+                presets: (parsed.presets || []).map(p => ({
+                    ...p,
+                    settings: normalizeCrosshairSettings(p.settings),
+                })),
+                activePresetId: parsed.activePresetId ?? null,
+            };
         }
     } catch (error) {
         console.error('[CrosshairPresets] Error loading presets:', error);
@@ -38,22 +53,6 @@ function generateId(): string {
     return `preset_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 }
 
-function generateCommands(settings: CrosshairSettings): string {
-    const commands = [
-        `citadel_crosshair_pip_gap ${settings.pipGap}`,
-        `citadel_crosshair_pip_height ${settings.pipHeight}`,
-        `citadel_crosshair_pip_width ${settings.pipWidth}`,
-        `citadel_crosshair_pip_opacity ${settings.pipOpacity.toFixed(2)}`,
-        `citadel_crosshair_pip_border ${settings.pipBorder}`,
-        `citadel_crosshair_dot_opacity ${settings.dotOpacity.toFixed(2)}`,
-        `citadel_crosshair_dot_outline_opacity ${settings.dotOutlineOpacity.toFixed(2)}`,
-        `citadel_crosshair_color_r ${settings.colorR}`,
-        `citadel_crosshair_color_g ${settings.colorG}`,
-        `citadel_crosshair_color_b ${settings.colorB}`,
-    ];
-    return commands.join('\n');
-}
-
 // Get all presets
 ipcMain.handle('crosshair:getPresets', async () => {
     const data = loadPresetsData();
@@ -66,7 +65,7 @@ ipcMain.handle('crosshair:savePreset', async (_event, name: string, settings: Cr
     const preset: CrosshairPreset = {
         id: generateId(),
         name,
-        settings,
+        settings: normalizeCrosshairSettings(settings),
         thumbnail,
         createdAt: new Date().toISOString(),
     };
@@ -86,7 +85,9 @@ ipcMain.handle('crosshair:deletePreset', async (_event, id: string) => {
     return true;
 });
 
-// Apply preset to autoexec.cfg
+// Apply preset to autoexec.cfg (always via the shared marker-section format;
+// the old marker-less format written here pre-1.18 was silently dropped by
+// every other autoexec writer)
 ipcMain.handle('crosshair:applyPreset', async (_event, presetId: string, gamePath: string) => {
     const data = loadPresetsData();
     const preset = data.presets.find(p => p.id === presetId);
@@ -99,48 +100,18 @@ ipcMain.handle('crosshair:applyPreset', async (_event, presetId: string, gamePat
         throw new Error('Game path not configured');
     }
 
-    // Path to autoexec.cfg
-    const cfgDir = path.join(gamePath, 'game', 'citadel', 'cfg');
-    const autoexecPath = path.join(cfgDir, 'autoexec.cfg');
-
-    // Ensure cfg directory exists
-    if (!fs.existsSync(cfgDir)) {
-        fs.mkdirSync(cfgDir, { recursive: true });
-    }
-
-    // Generate crosshair commands
-    const crosshairCommands = generateCommands(preset.settings);
-
-    // Read existing autoexec or create new
-    let existingContent = '';
-    if (fs.existsSync(autoexecPath)) {
-        existingContent = fs.readFileSync(autoexecPath, 'utf-8');
-    }
-
-    // Remove any existing crosshair commands
-    const lines = existingContent.split('\n').filter(line =>
-        !line.trim().startsWith('citadel_crosshair_')
-    );
-
-    // Add header comment and new crosshair commands
-    const crosshairSection = [
-        '',
-        '// Crosshair settings from Deadlock Mod Manager',
+    const autoexec = readAutoexec(gamePath);
+    autoexec.crosshair = [
         `// Preset: ${preset.name}`,
-        crosshairCommands,
-        '',
+        generateCrosshairCommands(preset.settings),
     ].join('\n');
-
-    // Combine: existing (without crosshair) + new crosshair section
-    const newContent = lines.join('\n').trim() + crosshairSection;
-
-    fs.writeFileSync(autoexecPath, newContent);
+    writeAutoexec(gamePath, autoexec);
 
     // Update active preset
     data.activePresetId = presetId;
     savePresetsData(data);
 
-    return { success: true, path: autoexecPath };
+    return { success: true, path: getAutoexecPath(gamePath) };
 });
 
 // Clear autoexec crosshair settings
@@ -149,17 +120,10 @@ ipcMain.handle('crosshair:clearAutoexec', async (_event, gamePath: string) => {
         throw new Error('Game path not configured');
     }
 
-    const autoexecPath = path.join(gamePath, 'game', 'citadel', 'cfg', 'autoexec.cfg');
-
-    if (fs.existsSync(autoexecPath)) {
-        const content = fs.readFileSync(autoexecPath, 'utf-8');
-        // Remove crosshair lines and comments
-        const lines = content.split('\n').filter(line =>
-            !line.trim().startsWith('citadel_crosshair_') &&
-            !line.includes('Crosshair settings from Deadlock Mod Manager') &&
-            !line.includes('// Preset:')
-        );
-        fs.writeFileSync(autoexecPath, lines.join('\n'));
+    if (fs.existsSync(getAutoexecPath(gamePath))) {
+        const autoexec = readAutoexec(gamePath);
+        autoexec.crosshair = null;
+        writeAutoexec(gamePath, autoexec);
     }
 
     const data = loadPresetsData();
@@ -175,7 +139,7 @@ ipcMain.handle('crosshair:getAutoexecStatus', async (_event, gamePath: string) =
         return { exists: false, path: null, hasLaunchOption: false };
     }
 
-    const autoexecPath = path.join(gamePath, 'game', 'citadel', 'cfg', 'autoexec.cfg');
+    const autoexecPath = getAutoexecPath(gamePath);
     const exists = fs.existsSync(autoexecPath);
 
     let hasCrosshairSettings = false;
@@ -197,8 +161,8 @@ ipcMain.handle('crosshair:createAutoexec', async (_event, gamePath: string) => {
         throw new Error('Game path not configured');
     }
 
-    const cfgDir = path.join(gamePath, 'game', 'citadel', 'cfg');
-    const autoexecPath = path.join(cfgDir, 'autoexec.cfg');
+    const autoexecPath = getAutoexecPath(gamePath);
+    const cfgDir = path.dirname(autoexecPath);
 
     // Ensure cfg directory exists
     if (!fs.existsSync(cfgDir)) {
@@ -208,10 +172,10 @@ ipcMain.handle('crosshair:createAutoexec', async (_event, gamePath: string) => {
     // Create with a header comment
     const content = `// Deadlock autoexec.cfg
 // Created by Deadlock Mod Manager
-// 
+//
 // This file is executed when you start the game.
 // Add your custom commands below.
-// 
+//
 // TIP: Make sure to add "+exec autoexec" to your Steam launch options:
 // Right-click Deadlock in Steam > Properties > Launch Options > add: +exec autoexec
 
@@ -222,92 +186,29 @@ ipcMain.handle('crosshair:createAutoexec', async (_event, gamePath: string) => {
     return { success: true, path: autoexecPath };
 });
 
-// Section markers for autoexec
-const CROSSHAIR_START = '// === CROSSHAIR SETTINGS (Mod Manager) ===';
-const CROSSHAIR_END = '// === END CROSSHAIR ===';
-const COMMANDS_START = '// === AUTOEXEC COMMANDS (Mod Manager) ===';
-const COMMANDS_END = '// === END COMMANDS ===';
+// Import the player's live in-game crosshair from machine_convars.vcfg (the
+// KV file where the game persists settings changed in its own UI)
+ipcMain.handle('crosshair:importFromGame', async (_event, gamePath: string) => {
+    if (!gamePath) {
+        return { found: false, settings: null };
+    }
 
-// Helper to parse autoexec into sections
-function parseAutoexec(content: string): { header: string; crosshair: string; commands: string[]; other: string } {
-    const lines = content.split('\n');
-    const header: string[] = [];
-    const crosshair: string[] = [];
-    const commands: string[] = [];
-    const other: string[] = [];
+    const vcfgPath = path.join(gamePath, 'game', 'citadel', 'cfg', 'machine_convars.vcfg');
+    if (!fs.existsSync(vcfgPath)) {
+        return { found: false, settings: null };
+    }
 
-    let section: 'header' | 'crosshair' | 'commands' | 'other' = 'header';
-
-    for (const line of lines) {
-        if (line.includes(CROSSHAIR_START)) {
-            section = 'crosshair';
-            continue;
-        } else if (line.includes(CROSSHAIR_END)) {
-            section = 'other';
-            continue;
-        } else if (line.includes(COMMANDS_START)) {
-            section = 'commands';
-            continue;
-        } else if (line.includes(COMMANDS_END)) {
-            section = 'other';
-            continue;
+    try {
+        const partial = parseMachineConvarsCrosshair(fs.readFileSync(vcfgPath, 'utf-8'));
+        if (Object.keys(partial).length === 0) {
+            return { found: false, settings: null };
         }
-
-        if (section === 'header' && !line.includes('Mod Manager') && !line.trim().startsWith('citadel_crosshair_')) {
-            header.push(line);
-        } else if (section === 'crosshair') {
-            crosshair.push(line);
-        } else if (section === 'commands') {
-            if (line.trim()) commands.push(line.trim());
-        } else if (section === 'other') {
-            // Check if it's an old-style crosshair command (before sections were added)
-            if (!line.trim().startsWith('citadel_crosshair_') &&
-                !line.includes('Crosshair settings from Deadlock Mod Manager') &&
-                !line.includes('// Preset:')) {
-                other.push(line);
-            }
-        }
+        return { found: true, settings: normalizeCrosshairSettings(partial) };
+    } catch (error) {
+        console.error('[CrosshairPresets] Error reading machine_convars.vcfg:', error);
+        return { found: false, settings: null };
     }
-
-    return {
-        header: header.join('\n').trim(),
-        crosshair: crosshair.join('\n').trim(),
-        commands,
-        other: other.join('\n').trim(),
-    };
-}
-
-// Helper to build autoexec content from sections
-function buildAutoexec(header: string, crosshairContent: string | null, commands: string[]): string {
-    const parts: string[] = [];
-
-    // Header (user's manual content)
-    if (header) {
-        parts.push(header);
-    } else {
-        parts.push('// Deadlock autoexec.cfg');
-        parts.push('// Managed by Deadlock Mod Manager');
-        parts.push('// Add +exec autoexec to Steam launch options');
-    }
-
-    // Commands section
-    if (commands.length > 0) {
-        parts.push('');
-        parts.push(COMMANDS_START);
-        parts.push(...commands);
-        parts.push(COMMANDS_END);
-    }
-
-    // Crosshair section
-    if (crosshairContent) {
-        parts.push('');
-        parts.push(CROSSHAIR_START);
-        parts.push(crosshairContent);
-        parts.push(CROSSHAIR_END);
-    }
-
-    return parts.join('\n') + '\n';
-}
+});
 
 // Get autoexec commands (non-crosshair)
 ipcMain.handle('autoexec:getCommands', async (_event, gamePath: string) => {
@@ -315,46 +216,24 @@ ipcMain.handle('autoexec:getCommands', async (_event, gamePath: string) => {
         return { commands: [], exists: false };
     }
 
-    const autoexecPath = path.join(gamePath, 'game', 'citadel', 'cfg', 'autoexec.cfg');
-
-    if (!fs.existsSync(autoexecPath)) {
+    if (!fs.existsSync(getAutoexecPath(gamePath))) {
         return { commands: [], exists: false };
     }
 
-    const content = fs.readFileSync(autoexecPath, 'utf-8');
-    const parsed = parseAutoexec(content);
-
-    return { commands: parsed.commands, exists: true };
+    const autoexec = readAutoexec(gamePath);
+    return { commands: autoexec.commands, exists: true };
 });
 
-// Save autoexec commands (preserves crosshair section)
+// Save autoexec commands (preserves the crosshair section and any manual
+// content before/after the managed sections)
 ipcMain.handle('autoexec:saveCommands', async (_event, gamePath: string, commands: string[]) => {
     if (!gamePath) {
         throw new Error('Game path not configured');
     }
 
-    const cfgDir = path.join(gamePath, 'game', 'citadel', 'cfg');
-    const autoexecPath = path.join(cfgDir, 'autoexec.cfg');
+    const autoexec = readAutoexec(gamePath);
+    autoexec.commands = commands;
+    writeAutoexec(gamePath, autoexec);
 
-    // Ensure cfg directory exists
-    if (!fs.existsSync(cfgDir)) {
-        fs.mkdirSync(cfgDir, { recursive: true });
-    }
-
-    // Parse existing content to preserve crosshair settings
-    let crosshairContent: string | null = null;
-    let header = '';
-
-    if (fs.existsSync(autoexecPath)) {
-        const content = fs.readFileSync(autoexecPath, 'utf-8');
-        const parsed = parseAutoexec(content);
-        crosshairContent = parsed.crosshair || null;
-        header = parsed.header;
-    }
-
-    // Build new content
-    const newContent = buildAutoexec(header, crosshairContent, commands);
-    fs.writeFileSync(autoexecPath, newContent);
-
-    return { success: true, path: autoexecPath };
+    return { success: true, path: getAutoexecPath(gamePath) };
 });

--- a/electron/main/services/autoexec.ts
+++ b/electron/main/services/autoexec.ts
@@ -39,16 +39,23 @@ export function parseAutoexec(content: string): AutoexecData {
             continue;
         }
 
-        if (section === 'header' && !line.includes('Mod Manager') && !line.trim().startsWith('citadel_crosshair_')) {
-            header.push(line);
+        if (section === 'header') {
+            // Old-style crosshair commands (written without section markers by
+            // pre-1.18 applyPreset) are rescued into the crosshair section so a
+            // rewrite upgrades them instead of silently deleting them.
+            if (line.trim().startsWith('citadel_crosshair_') || line.trim().startsWith('// Preset:')) {
+                crosshair.push(line);
+            } else if (!line.includes('Mod Manager')) {
+                header.push(line);
+            }
         } else if (section === 'crosshair') {
             crosshair.push(line);
         } else if (section === 'commands') {
             if (line.trim()) commands.push(line.trim());
         } else if (section === 'other') {
-            // Check if it's an old-style crosshair command (before sections were added)
-            if (!line.trim().startsWith('citadel_crosshair_') &&
-                !line.includes('Crosshair settings from Deadlock Mod Manager') &&
+            if (line.trim().startsWith('citadel_crosshair_')) {
+                crosshair.push(line);
+            } else if (!line.includes('Crosshair settings from Deadlock Mod Manager') &&
                 !line.includes('// Preset:')) {
                 other.push(line);
             }
@@ -64,12 +71,12 @@ export function parseAutoexec(content: string): AutoexecData {
 }
 
 // Helper to build autoexec content from sections
-export function buildAutoexec(header: string, crosshairContent: string | null, commands: string[]): string {
+export function buildAutoexec(data: AutoexecData): string {
     const parts: string[] = [];
 
     // Header (user's manual content)
-    if (header) {
-        parts.push(header);
+    if (data.header) {
+        parts.push(data.header);
     } else {
         parts.push('// Deadlock autoexec.cfg');
         parts.push('// Managed by Deadlock Mod Manager');
@@ -77,19 +84,26 @@ export function buildAutoexec(header: string, crosshairContent: string | null, c
     }
 
     // Commands section
-    if (commands.length > 0) {
+    if (data.commands.length > 0) {
         parts.push('');
         parts.push(COMMANDS_START);
-        parts.push(...commands);
+        parts.push(...data.commands);
         parts.push(COMMANDS_END);
     }
 
     // Crosshair section
-    if (crosshairContent) {
+    if (data.crosshair) {
         parts.push('');
         parts.push(CROSSHAIR_START);
-        parts.push(crosshairContent);
+        parts.push(data.crosshair);
         parts.push(CROSSHAIR_END);
+    }
+
+    // User content that lived after the managed sections. Dropping this used
+    // to silently destroy manual edits on every managed rewrite.
+    if (data.other) {
+        parts.push('');
+        parts.push(data.other);
     }
 
     return parts.join('\n') + '\n';
@@ -121,7 +135,7 @@ export function writeAutoexec(gamePath: string, data: AutoexecData): void {
         fs.mkdirSync(cfgDir, { recursive: true });
     }
 
-    const content = buildAutoexec(data.header, data.crosshair, data.commands);
+    const content = buildAutoexec(data);
 
     try {
         fs.writeFileSync(tempPath, content);

--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -5,6 +5,7 @@ import { scanMods } from './mods';
 import { getModMetadata } from './metadata';
 import { isLockerManaged } from './lockerVpk';
 import { fetchModDetails } from './gamebanana';
+import { normalizeCrosshairSettings } from '../../../src/lib/crosshair';
 import type {
     PortableProfile,
     PortableModEntry,
@@ -553,7 +554,11 @@ export async function createProfileFromPortable(
         id: generateProfileId(),
         name: portable.profile.name,
         mods: profileMods,
-        crosshair: portable.extensions?.grimoire?.crosshair,
+        // Older exports carry the legacy 10-field shape; fill the outline/dot
+        // fields with defaults so the stored profile is always current-model.
+        crosshair: portable.extensions?.grimoire?.crosshair
+            ? normalizeCrosshairSettings(portable.extensions.grimoire.crosshair)
+            : undefined,
         autoexecCommands: portable.extensions?.grimoire?.autoexecCommands,
         createdAt: now,
         updatedAt: now,

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -5,6 +5,7 @@ import { scanMods, enableMod, disableMod, reorderMods } from './mods';
 import { getModMetadata } from './metadata';
 import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
+import { generateCrosshairCommands, normalizeCrosshairSettings } from '../../../src/lib/crosshair';
 
 // The Profile wire types are single-sourced in src/types/electron.ts
 // (docstrings included); re-exported because portableProfile.ts and the
@@ -99,7 +100,7 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
         id: generateProfileId(),
         name,
         mods: enabledMods.map(mod => toProfileMod(mod, true)),
-        crosshair: crosshairSettings,
+        crosshair: crosshairSettings ? normalizeCrosshairSettings(crosshairSettings) : undefined,
         autoexecCommands: autoexecData.commands,
         createdAt: now,
         updatedAt: now,
@@ -204,29 +205,13 @@ export async function updateProfile(deadlockPath: string, profileId: string, cro
         mods: enabledMods.map(mod => toProfileMod(mod, true)),
         // If crosshairSettings is passed, use it. If undefined/null, remove crosshair from profile.
         // This allows the frontend to explicitly control whether crosshair is included based on feature toggle.
-        crosshair: crosshairSettings,
+        crosshair: crosshairSettings ? normalizeCrosshairSettings(crosshairSettings) : undefined,
         autoexecCommands: autoexecData.commands,
         updatedAt: new Date().toISOString(),
     };
 
     saveProfiles(profiles);
     return profiles[index];
-}
-
-function generateCrosshairCommands(settings: ProfileCrosshairSettings): string {
-    const commands = [
-        `citadel_crosshair_pip_gap ${settings.pipGap}`,
-        `citadel_crosshair_pip_height ${settings.pipHeight}`,
-        `citadel_crosshair_pip_width ${settings.pipWidth}`,
-        `citadel_crosshair_pip_opacity ${settings.pipOpacity.toFixed(2)}`,
-        `citadel_crosshair_pip_border ${settings.pipBorder}`,
-        `citadel_crosshair_dot_opacity ${settings.dotOpacity.toFixed(2)}`,
-        `citadel_crosshair_dot_outline_opacity ${settings.dotOutlineOpacity.toFixed(2)}`,
-        `citadel_crosshair_color_r ${settings.colorR}`,
-        `citadel_crosshair_color_g ${settings.colorG}`,
-        `citadel_crosshair_color_b ${settings.colorB}`,
-    ];
-    return commands.join('\n');
 }
 
 /** Outcome of resolving one ProfileMod against the current scan. The `via`

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -385,6 +385,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     clearCrosshairAutoexec: (gamePath: string) => ipcRenderer.invoke('crosshair:clearAutoexec', gamePath),
     getAutoexecStatus: (gamePath: string) => ipcRenderer.invoke('crosshair:getAutoexecStatus', gamePath),
     createAutoexec: (gamePath: string) => ipcRenderer.invoke('crosshair:createAutoexec', gamePath),
+    importCrosshairFromGame: (gamePath: string) => ipcRenderer.invoke('crosshair:importFromGame', gamePath),
     getAutoexecCommands: (gamePath: string) => ipcRenderer.invoke('autoexec:getCommands', gamePath),
     saveAutoexecCommands: (gamePath: string, commands: string[]) => ipcRenderer.invoke('autoexec:saveCommands', gamePath, commands),
 

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Check, type LucideIcon } from 'lucide-react';
 
 interface CardProps {
@@ -168,6 +168,50 @@ interface SliderProps {
     showValue?: boolean;
     className?: string;
     formatValue?: (val: number) => string;
+    /** Render the value badge as a typed number input (commit on blur/Enter,
+     *  clamped to min/max) for exact entry alongside the slider. */
+    editable?: boolean;
+}
+
+function SliderValueInput({ value, min, max, step, onChange }: {
+    value: number;
+    min: number;
+    max: number;
+    step: number;
+    onChange: (value: number) => void;
+}) {
+    const [text, setText] = useState(String(value));
+    useEffect(() => { setText(String(value)); }, [value]);
+
+    const commit = () => {
+        const n = parseFloat(text);
+        if (Number.isFinite(n)) {
+            const clamped = Math.min(max, Math.max(min, n));
+            onChange(clamped);
+            setText(String(clamped));
+        } else {
+            setText(String(value));
+        }
+    };
+
+    return (
+        <input
+            type="number"
+            value={text}
+            min={min}
+            max={max}
+            step={step}
+            onChange={(e) => setText(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    commit();
+                    e.currentTarget.blur();
+                }
+            }}
+            className="w-16 text-right text-xs font-mono text-text-primary bg-bg-tertiary px-1.5 py-0.5 rounded-sm border border-transparent focus:border-accent focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+    );
 }
 
 export function Slider({
@@ -179,19 +223,24 @@ export function Slider({
     label,
     showValue = true,
     className = '',
-    formatValue
+    formatValue,
+    editable = false
 }: SliderProps) {
-    const percentage = ((value - min) / (max - min)) * 100;
+    // Clamp so out-of-range values (e.g. imported from external config) can't
+    // push the thumb outside the track.
+    const percentage = Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
 
     return (
         <div className={`space-y-2 ${className}`}>
             <div className="flex justify-between items-center">
                 {label && <label className="text-sm font-medium text-text-secondary">{label}</label>}
-                {showValue && (
+                {showValue && (editable ? (
+                    <SliderValueInput value={value} min={min} max={max} step={step} onChange={onChange} />
+                ) : (
                     <span className="text-xs font-mono text-text-primary bg-bg-tertiary px-1.5 py-0.5 rounded-sm">
                         {formatValue ? formatValue(value) : value}
                     </span>
-                )}
+                ))}
             </div>
             <div className="relative h-6 flex items-center group">
                 <div className="absolute w-full h-1.5 bg-bg-tertiary rounded-full overflow-hidden">

--- a/src/components/crosshair/CrosshairPreview.tsx
+++ b/src/components/crosshair/CrosshairPreview.tsx
@@ -1,140 +1,45 @@
+import { useEffect, useRef } from 'react';
+import type { CrosshairSettings } from '../../types/electron';
 import { useCrosshairStore } from '../../stores/crosshairStore';
-
-export interface CrosshairSettings {
-    pipGap: number;
-    pipHeight: number;
-    pipWidth: number;
-    pipOpacity: number;
-    pipBorder: boolean;
-    dotOpacity: number;
-    dotOutlineOpacity: number;
-    colorR: number;
-    colorG: number;
-    colorB: number;
-}
+import { drawCrosshair } from './drawCrosshair';
 
 interface CrosshairPreviewProps {
     size?: number;
     scale?: number;
-    // Optional override settings (for displaying saved profiles)
-    settings?: CrosshairSettings;
+    // Optional override settings (for displaying saved presets/profiles;
+    // legacy shapes are normalized inside the renderer)
+    settings?: Partial<CrosshairSettings>;
     // Render with transparent background instead of gray
     transparent?: boolean;
 }
 
-// Based on https://github.com/mcipenuks/deadlock-crosshair with adjusted gap formula
-
 export default function CrosshairPreview({ size = 200, scale = 1, settings, transparent }: CrosshairPreviewProps) {
     const storeSettings = useCrosshairStore();
+    const canvasRef = useRef<HTMLCanvasElement>(null);
 
-    // Use provided settings or fall back to store
-    const {
-        pipGap,
-        pipHeight,
-        pipWidth,
-        pipOpacity,
-        pipBorder,
-        dotOpacity,
-        dotOutlineOpacity,
-        colorR,
-        colorG,
-        colorB,
-    } = settings || storeSettings;
+    // Use provided settings or fall back to the live editor state
+    const s = settings || storeSettings;
 
-    const crosshairColor = `rgba(${colorR}, ${colorG}, ${colorB}, ${pipOpacity})`;
-    const dotColor = `rgba(${colorR}, ${colorG}, ${colorB}, ${dotOpacity})`;
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
 
-    // Gap formula - calibrated to match in-game behavior
-    const baseGap = 9;
-    const gapMultiplier = 2.5;
-    const lineGap = (baseGap + pipGap * gapMultiplier) * scale;
-    const lineWidth = pipWidth * scale;
-    const lineHeight = pipHeight * scale;
-    const noWidthOrHeight = pipWidth === 0 || pipHeight === 0;
+        // Backing store at device resolution so the crosshair stays crisp
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.round(size * dpr);
+        canvas.height = Math.round(size * dpr);
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-    // Pip style with box-sizing: border-box so border is INSIDE the dimensions
-    const pipStyle = (width: number, height: number): React.CSSProperties => ({
-        display: noWidthOrHeight ? 'none' : 'block',
-        boxSizing: 'border-box',
-        width,
-        height,
-        background: crosshairColor,
-        border: pipBorder ? '1px solid black' : 'none',
-    });
-
-    // Dot dimensions - in-game dot is about 2x2px (smaller than before)
-    const dotSize = 2 * scale;
-    // Outline is about 7x7 in-game - renders BEHIND the pips
-    const outlineSize = 7 * scale;
+        drawCrosshair(ctx, s, { size, scale, background: transparent ? null : '#555' });
+    }, [s, size, scale, transparent]);
 
     return (
-        <div
-            className="relative rounded-lg overflow-hidden"
-            style={{
-                width: size,
-                height: size,
-                backgroundColor: transparent ? 'transparent' : '#555',
-            }}
-        >
-            {/* Center container for crosshair */}
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-                {/* Dot outline - BOTTOM LAYER (behind pips) - z-index 0 */}
-                {dotOutlineOpacity > 0 && (
-                    <div
-                        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"
-                        style={{
-                            zIndex: 0,
-                            width: outlineSize,
-                            height: outlineSize,
-                            background: `rgba(0,0,0,${dotOutlineOpacity})`,
-                        }}
-                    />
-                )}
-
-                {/* Pip container - MIDDLE LAYER - z-index 1 */}
-                <div
-                    className="relative flex justify-center items-center"
-                    style={{
-                        zIndex: 1,
-                        height: lineGap,
-                        width: lineGap,
-                    }}
-                >
-                    {/* Bottom pip */}
-                    <div
-                        className="absolute top-full left-1/2 -translate-x-1/2 -translate-y-1/2"
-                        style={pipStyle(lineWidth, lineHeight)}
-                    />
-                    {/* Right pip */}
-                    <div
-                        className="absolute left-full top-1/2 -translate-y-1/2 -translate-x-1/2"
-                        style={pipStyle(lineHeight, lineWidth)}
-                    />
-                    {/* Left pip */}
-                    <div
-                        className="absolute right-full top-1/2 -translate-y-1/2 translate-x-1/2"
-                        style={pipStyle(lineHeight, lineWidth)}
-                    />
-                    {/* Top pip */}
-                    <div
-                        className="absolute bottom-full left-1/2 -translate-x-1/2 translate-y-1/2"
-                        style={pipStyle(lineWidth, lineHeight)}
-                    />
-                </div>
-
-                {/* Center dot - TOP LAYER - z-index 2 */}
-                {dotOpacity > 0 && (
-                    <div
-                        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"
-                        style={{
-                            zIndex: 2,
-                            width: dotSize,
-                            height: dotSize,
-                            background: dotColor,
-                        }}
-                    />
-                )}
-            </div>
-        </div>
+        <canvas
+            ref={canvasRef}
+            className="rounded-lg"
+            style={{ width: size, height: size }}
+        />
     );
 }

--- a/src/components/crosshair/drawCrosshair.ts
+++ b/src/components/crosshair/drawCrosshair.ts
@@ -1,0 +1,124 @@
+// Single canvas renderer for the crosshair: the live preview, the preset
+// gallery tiles, and saved thumbnails all draw through here, so they can
+// never drift apart (the old DOM preview and SVG thumbnail disagreed on dot
+// size and outline z-order).
+//
+// Geometry is computed in 1080p-reference pixels (the same unit the
+// citadel_crosshair_* convars use) and multiplied by `scale`
+// (display resolution height / 1080, times any preview zoom).
+
+import type { CrosshairSettings } from '../../types/electron';
+import { normalizeCrosshairSettings } from '../../lib/crosshair';
+
+export interface DrawCrosshairOptions {
+    /** Canvas logical (CSS) size in px; the crosshair is centered in it. */
+    size: number;
+    /** 1080p-px to display-px multiplier. */
+    scale: number;
+    /** Background fill; null/undefined leaves the canvas transparent. */
+    background?: string | null;
+}
+
+interface Rect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+export function drawCrosshair(
+    ctx: CanvasRenderingContext2D,
+    raw: Partial<CrosshairSettings>,
+    opts: DrawCrosshairOptions
+): void {
+    const s = normalizeCrosshairSettings(raw);
+    const { size, scale } = opts;
+
+    ctx.clearRect(0, 0, size, size);
+    if (opts.background) {
+        ctx.fillStyle = opts.background;
+        ctx.fillRect(0, 0, size, size);
+    }
+
+    const cx = size / 2;
+    const cy = size / 2;
+    const px = (v: number) => v * scale;
+
+    // Gap formula carried over from the previous DOM preview (calibrated
+    // against the game; re-verify after any in-game crosshair update).
+    // D = distance from screen center to each pip's center line.
+    const D = Math.max(0, (9 + s.pipGap * 2.5) / 2);
+
+    // Pip rects in 1080p units, relative to center; pips are centered on the
+    // gap boundary (half extends inward, half outward), matching the game.
+    const pips: Rect[] =
+        s.pipWidth > 0 && s.pipHeight > 0
+            ? [
+                  { x: -s.pipWidth / 2, y: -D - s.pipHeight / 2, w: s.pipWidth, h: s.pipHeight }, // top
+                  { x: -s.pipWidth / 2, y: D - s.pipHeight / 2, w: s.pipWidth, h: s.pipHeight }, // bottom
+                  { x: -D - s.pipHeight / 2, y: -s.pipWidth / 2, w: s.pipHeight, h: s.pipWidth }, // left
+                  { x: D - s.pipHeight / 2, y: -s.pipWidth / 2, w: s.pipHeight, h: s.pipWidth }, // right
+              ]
+            : [];
+
+    const fillColor = `rgba(${s.colorR}, ${s.colorG}, ${s.colorB}, ${s.pipOpacity})`;
+    const dotColor = `rgba(${s.colorR}, ${s.colorG}, ${s.colorB}, ${s.dotOpacity})`;
+    const outlineColor = (opacity: number) =>
+        `rgba(${s.outlineColorR}, ${s.outlineColorG}, ${s.outlineColorB}, ${opacity})`;
+
+    // 1. Pip outlines (stroked fully outside the pip, offset by the gap)
+    if (s.pipOutlineBorder > 0 && s.pipOutlineOpacity > 0) {
+        ctx.strokeStyle = outlineColor(s.pipOutlineOpacity);
+        ctx.lineWidth = px(s.pipOutlineBorder);
+        const off = s.pipOutlineGap + s.pipOutlineBorder / 2;
+        for (const r of pips) {
+            ctx.strokeRect(
+                cx + px(r.x - off),
+                cy + px(r.y - off),
+                px(r.w + 2 * off),
+                px(r.h + 2 * off)
+            );
+        }
+    }
+
+    // 2. Dot outline ring (outside the dot, offset by the gap)
+    if (s.dotOutlineBorder > 0 && s.dotOutlineOpacity > 0) {
+        ctx.strokeStyle = outlineColor(s.dotOutlineOpacity);
+        ctx.lineWidth = px(s.dotOutlineBorder);
+        ctx.beginPath();
+        ctx.arc(cx, cy, px(s.dotSize / 2 + s.dotOutlineGap + s.dotOutlineBorder / 2), 0, Math.PI * 2);
+        ctx.stroke();
+    }
+
+    // 3. Pips
+    if (s.pipOpacity > 0) {
+        ctx.fillStyle = fillColor;
+        for (const r of pips) {
+            ctx.fillRect(cx + px(r.x), cy + px(r.y), px(r.w), px(r.h));
+        }
+    }
+
+    // 4. Center dot (top layer)
+    if (s.dotOpacity > 0 && s.dotSize > 0) {
+        ctx.fillStyle = dotColor;
+        ctx.beginPath();
+        ctx.arc(cx, cy, px(s.dotSize / 2), 0, Math.PI * 2);
+        ctx.fill();
+    }
+}
+
+/** Render a preset thumbnail PNG (data URL) with the same renderer the live
+ *  preview uses. 1.333 scale = 1440p, the gallery's reference look. */
+export function renderCrosshairThumbnail(
+    settings: Partial<CrosshairSettings>,
+    size = 100,
+    scale = 1440 / 1080
+): string {
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return '';
+    drawCrosshair(ctx, settings, { size, scale, background: '#555' });
+    return canvas.toDataURL('image/png');
+}

--- a/src/lib/crosshair.ts
+++ b/src/lib/crosshair.ts
@@ -1,0 +1,174 @@
+// Shared crosshair settings model: single source for defaults, legacy-preset
+// migration, console-command generation, and machine_convars.vcfg parsing.
+// Imported by BOTH the renderer (store, preview) and the main process
+// (crosshairPresets ipc, profiles service), so keep it dependency-free and
+// DOM-free.
+//
+// The convar surface below was verified against the current client.dll:
+// the old `citadel_crosshair_pip_border` bool no longer exists; pip and dot
+// outlines are now (border width, gap, opacity) triples sharing an outline
+// color, and the dot gained an explicit size.
+
+import type { CrosshairSettings } from '../types/electron';
+
+export const CROSSHAIR_DEFAULTS: CrosshairSettings = {
+    pipGap: 5,
+    pipGapStatic: true,
+    pipHeight: 10,
+    pipWidth: 2,
+    pipOpacity: 1,
+    pipOutlineBorder: 1,
+    pipOutlineGap: 0,
+    pipOutlineOpacity: 1,
+    dotOpacity: 0,
+    dotSize: 8,
+    dotOutlineBorder: 2,
+    dotOutlineGap: 0,
+    dotOutlineOpacity: 0,
+    colorR: 0,
+    colorG: 255,
+    colorB: 0,
+    outlineColorR: 0,
+    outlineColorG: 0,
+    outlineColorB: 0,
+    disableHeroSpecificCrosshairs: false,
+    pipBorder: true,
+};
+
+const num = (v: unknown, fallback: number): number =>
+    typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+const bool = (v: unknown, fallback: boolean): boolean =>
+    typeof v === 'boolean' ? v : fallback;
+
+/**
+ * Fill defaults and migrate legacy shapes (pre outline system, where the only
+ * border control was the `pipBorder` bool). Always returns a complete,
+ * self-consistent settings object whose `pipBorder` is re-derived so older
+ * Grimoire builds importing a shared profile/preset still see a sane value.
+ */
+export function normalizeCrosshairSettings(
+    raw: Partial<CrosshairSettings> | undefined | null
+): CrosshairSettings {
+    const r = raw ?? {};
+    const d = CROSSHAIR_DEFAULTS;
+
+    // Legacy presets carry pipBorder but none of the outline fields: map the
+    // bool onto the new outline-border width before defaulting the rest.
+    const legacyBorder =
+        typeof r.pipBorder === 'boolean' && r.pipOutlineBorder === undefined
+            ? (r.pipBorder ? 1 : 0)
+            : undefined;
+
+    const s: CrosshairSettings = {
+        pipGap: num(r.pipGap, d.pipGap),
+        pipGapStatic: bool(r.pipGapStatic, d.pipGapStatic),
+        pipHeight: num(r.pipHeight, d.pipHeight),
+        pipWidth: num(r.pipWidth, d.pipWidth),
+        pipOpacity: num(r.pipOpacity, d.pipOpacity),
+        pipOutlineBorder: legacyBorder ?? num(r.pipOutlineBorder, d.pipOutlineBorder),
+        pipOutlineGap: num(r.pipOutlineGap, d.pipOutlineGap),
+        pipOutlineOpacity: num(r.pipOutlineOpacity, d.pipOutlineOpacity),
+        dotOpacity: num(r.dotOpacity, d.dotOpacity),
+        dotSize: num(r.dotSize, d.dotSize),
+        dotOutlineBorder: num(r.dotOutlineBorder, d.dotOutlineBorder),
+        dotOutlineGap: num(r.dotOutlineGap, d.dotOutlineGap),
+        dotOutlineOpacity: num(r.dotOutlineOpacity, d.dotOutlineOpacity),
+        colorR: num(r.colorR, d.colorR),
+        colorG: num(r.colorG, d.colorG),
+        colorB: num(r.colorB, d.colorB),
+        outlineColorR: num(r.outlineColorR, d.outlineColorR),
+        outlineColorG: num(r.outlineColorG, d.outlineColorG),
+        outlineColorB: num(r.outlineColorB, d.outlineColorB),
+        disableHeroSpecificCrosshairs: bool(
+            r.disableHeroSpecificCrosshairs,
+            d.disableHeroSpecificCrosshairs
+        ),
+        pipBorder: false,
+    };
+    s.pipBorder = s.pipOutlineBorder > 0 && s.pipOutlineOpacity > 0;
+    return s;
+}
+
+/**
+ * Emit the FULL convar set the game reads for crosshair shape, so applying a
+ * preset fully overrides whatever was last set in the in-game editor (partial
+ * writes were why presets never looked the same in game).
+ */
+export function generateCrosshairCommands(raw: Partial<CrosshairSettings>): string {
+    const s = normalizeCrosshairSettings(raw);
+    return [
+        `citadel_crosshair_pip_gap ${s.pipGap}`,
+        `citadel_crosshair_pip_gap_static ${s.pipGapStatic}`,
+        `citadel_crosshair_pip_height ${s.pipHeight}`,
+        `citadel_crosshair_pip_width ${s.pipWidth}`,
+        `citadel_crosshair_pip_opacity ${s.pipOpacity.toFixed(2)}`,
+        `citadel_crosshair_pip_outline_border ${s.pipOutlineBorder}`,
+        `citadel_crosshair_pip_outline_gap ${s.pipOutlineGap}`,
+        `citadel_crosshair_pip_outline_opacity ${s.pipOutlineOpacity.toFixed(2)}`,
+        `citadel_crosshair_dot_size ${s.dotSize}`,
+        `citadel_crosshair_dot_opacity ${s.dotOpacity.toFixed(2)}`,
+        `citadel_crosshair_dot_outline_border ${s.dotOutlineBorder}`,
+        `citadel_crosshair_dot_outline_gap ${s.dotOutlineGap}`,
+        `citadel_crosshair_dot_outline_opacity ${s.dotOutlineOpacity.toFixed(2)}`,
+        `citadel_crosshair_color_r ${s.colorR}`,
+        `citadel_crosshair_color_g ${s.colorG}`,
+        `citadel_crosshair_color_b ${s.colorB}`,
+        `citadel_crosshair_outline_color_r ${s.outlineColorR}`,
+        `citadel_crosshair_outline_color_g ${s.outlineColorG}`,
+        `citadel_crosshair_outline_color_b ${s.outlineColorB}`,
+        `citadel_crosshair_disable_hero_specific_crosshairs ${s.disableHeroSpecificCrosshairs}`,
+    ].join('\n');
+}
+
+/** Convar -> settings field, used to import the player's live in-game
+ *  crosshair from game/citadel/cfg/machine_convars.vcfg. */
+const CONVAR_FIELDS: Array<[string, keyof CrosshairSettings, 'number' | 'boolean']> = [
+    ['citadel_crosshair_pip_gap', 'pipGap', 'number'],
+    ['citadel_crosshair_pip_gap_static', 'pipGapStatic', 'boolean'],
+    ['citadel_crosshair_pip_height', 'pipHeight', 'number'],
+    ['citadel_crosshair_pip_width', 'pipWidth', 'number'],
+    ['citadel_crosshair_pip_opacity', 'pipOpacity', 'number'],
+    ['citadel_crosshair_pip_outline_border', 'pipOutlineBorder', 'number'],
+    ['citadel_crosshair_pip_outline_gap', 'pipOutlineGap', 'number'],
+    ['citadel_crosshair_pip_outline_opacity', 'pipOutlineOpacity', 'number'],
+    ['citadel_crosshair_dot_size', 'dotSize', 'number'],
+    ['citadel_crosshair_dot_opacity', 'dotOpacity', 'number'],
+    ['citadel_crosshair_dot_outline_border', 'dotOutlineBorder', 'number'],
+    ['citadel_crosshair_dot_outline_gap', 'dotOutlineGap', 'number'],
+    ['citadel_crosshair_dot_outline_opacity', 'dotOutlineOpacity', 'number'],
+    ['citadel_crosshair_color_r', 'colorR', 'number'],
+    ['citadel_crosshair_color_g', 'colorG', 'number'],
+    ['citadel_crosshair_color_b', 'colorB', 'number'],
+    ['citadel_crosshair_outline_color_r', 'outlineColorR', 'number'],
+    ['citadel_crosshair_outline_color_g', 'outlineColorG', 'number'],
+    ['citadel_crosshair_outline_color_b', 'outlineColorB', 'number'],
+    ['citadel_crosshair_disable_hero_specific_crosshairs', 'disableHeroSpecificCrosshairs', 'boolean'],
+];
+
+/**
+ * Extract crosshair convars from machine_convars.vcfg content (the KV file
+ * where the game persists in-game settings). Returns only the fields actually
+ * present so callers can tell "file had no crosshair data" from defaults.
+ */
+export function parseMachineConvarsCrosshair(content: string): Partial<CrosshairSettings> {
+    const values = new Map<string, string>();
+    for (const m of content.matchAll(/"(citadel_crosshair_[a-z_]+)"\s*"([^"]*)"/g)) {
+        values.set(m[1], m[2]);
+    }
+
+    const out: Partial<CrosshairSettings> = {};
+    const target = out as Record<string, number | boolean>;
+    for (const [convar, field, kind] of CONVAR_FIELDS) {
+        const v = values.get(convar);
+        if (v === undefined) continue;
+        if (kind === 'boolean') {
+            target[field] = v === 'true' || v === '1';
+        } else {
+            const n = parseFloat(v);
+            // The in-game sliders persist raw floats (e.g. dot_size 8.301266);
+            // 2 decimals is visually identical and keeps the editor clean.
+            if (Number.isFinite(n)) target[field] = Math.round(n * 100) / 100;
+        }
+    }
+    return out;
+}

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Copy, Check, RotateCcw, Save, Trash2, Play, Pin, XCircle, Download } from 'lucide-react';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
@@ -30,7 +30,6 @@ export default function Crosshair() {
     const [isSaving, setIsSaving] = useState(false);
     const [showSaveInput, setShowSaveInput] = useState(false);
     const [gamePath, setGamePath] = useState<string | null>(null);
-    const previewRef = useRef<HTMLDivElement>(null);
     const [alwaysOnTop, setAlwaysOnTop] = useState(false);
 
     const {
@@ -93,21 +92,6 @@ export default function Crosshair() {
         // Load always on top state
         window.electronAPI.getAlwaysOnTop().then(setAlwaysOnTop);
     }, [loadPresets]);
-
-    // Wheel-to-zoom over the preview. Attached natively with passive: false
-    // because React's root-delegated onWheel is passive, so preventDefault()
-    // there is a no-op and the wheel would zoom AND scroll the column.
-    useEffect(() => {
-        const el = previewRef.current;
-        if (!el) return;
-        const onWheel = (e: WheelEvent) => {
-            e.preventDefault();
-            const delta = e.deltaY > 0 ? -0.1 : 0.1;
-            setPreviewZoom((prev) => Math.min(3, Math.max(0.5, prev + delta)));
-        };
-        el.addEventListener('wheel', onWheel, { passive: false });
-        return () => el.removeEventListener('wheel', onWheel);
-    }, []);
 
     const handleAlwaysOnTop = async (enabled: boolean) => {
         const result = await window.electronAPI.setAlwaysOnTop(enabled);
@@ -228,13 +212,15 @@ export default function Crosshair() {
     };
 
     return (
-        <div className="p-6 lg:h-full">
+        <div className="p-6 lg:p-0 lg:h-full">
             {/* On lg+ the page fills the viewport and each column scrolls
                 independently, so the preview stays reachable while the long
-                settings list scrolls. Below lg the page scrolls as one. */}
-            <div className="flex flex-col lg:flex-row gap-6 lg:h-full">
+                settings list scrolls. The columns carry the page padding so
+                they tile the full area: no dead zones where the wheel does
+                nothing. Below lg the page scrolls as one. */}
+            <div className="flex flex-col lg:flex-row gap-6 lg:gap-0 lg:h-full">
                 {/* Left Panel - Settings */}
-                <div className="w-full lg:w-1/3 flex flex-col gap-6 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+                <div className="w-full lg:w-1/3 flex flex-col gap-6 lg:min-h-0 lg:overflow-y-auto lg:p-6">
                     <Card title="Crosshair Shape">
                         <div className="space-y-6">
                             <Slider editable label="Gap" value={pipGap} min={-10} max={50} onChange={setPipGap} />
@@ -326,7 +312,7 @@ export default function Crosshair() {
                 </div>
 
                 {/* Right Panel - Preview & Actions */}
-                <div className="flex-1 flex flex-col gap-6 min-w-0 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+                <div className="flex-1 flex flex-col gap-6 min-w-0 lg:min-h-0 lg:overflow-y-auto lg:p-6 lg:pl-0">
                     {/* Top Actions Bar */}
                     <div className="flex flex-col sm:flex-row gap-4">
                         <Card className="flex-1" contentClassName="p-3">
@@ -430,10 +416,7 @@ export default function Crosshair() {
                             <span className="font-mono text-xs w-8">{previewZoom.toFixed(1)}x</span>
                         </div>
 
-                        <div
-                            className="flex items-center justify-center bg-gradient-to-br from-bg-tertiary/50 to-bg-secondary/50 rounded-xl aspect-video lg:h-[420px] w-full overflow-hidden"
-                            ref={previewRef}
-                        >
+                        <div className="flex items-center justify-center bg-gradient-to-br from-bg-tertiary/50 to-bg-secondary/50 rounded-xl aspect-video lg:h-[420px] w-full overflow-hidden">
                             <CrosshairPreview size={400} scale={(resolution / 1080) * previewZoom} />
                         </div>
 

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -1,13 +1,31 @@
 import { useState, useEffect, useRef } from 'react';
-import { Copy, Check, RotateCcw, Save, Trash2, Play, Pin, XCircle } from 'lucide-react';
+import { Copy, Check, RotateCcw, Save, Trash2, Play, Pin, XCircle, Download } from 'lucide-react';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
+import { renderCrosshairThumbnail } from '../components/crosshair/drawCrosshair';
 import { getSettings } from '../lib/api';
 import { Card, Slider, Toggle, Button } from '../components/common/ui';
 
+// The in-game crosshair is authored in 1080p-reference px and scaled by
+// screen height, so the preview multiplies by (resolution / 1080).
+const RESOLUTIONS = [
+    { label: '1080p', height: 1080 },
+    { label: '1440p', height: 1440 },
+    { label: '4K', height: 2160 },
+];
+
+function detectResolutionHeight(): number {
+    const h = window.screen.height * (window.devicePixelRatio || 1);
+    if (h >= 2160) return 2160;
+    if (h >= 1440) return 1440;
+    return 1080;
+}
+
 export default function Crosshair() {
     const [copied, setCopied] = useState(false);
-    const [previewScale, setPreviewScale] = useState(1.3); // 1.3 matches 1440p in-game
+    const [imported, setImported] = useState(false);
+    const [resolution, setResolution] = useState(detectResolutionHeight);
+    const [previewZoom, setPreviewZoom] = useState(1);
     const [presetName, setPresetName] = useState('');
     const [isSaving, setIsSaving] = useState(false);
     const [showSaveInput, setShowSaveInput] = useState(false);
@@ -17,27 +35,47 @@ export default function Crosshair() {
 
     const {
         pipGap,
+        pipGapStatic,
         pipHeight,
         pipWidth,
         pipOpacity,
-        pipBorder,
+        pipOutlineBorder,
+        pipOutlineGap,
+        pipOutlineOpacity,
         dotOpacity,
+        dotSize,
+        dotOutlineBorder,
+        dotOutlineGap,
         dotOutlineOpacity,
         colorR,
         colorG,
         colorB,
+        outlineColorR,
+        outlineColorG,
+        outlineColorB,
+        disableHeroSpecificCrosshairs,
         setPipGap,
+        setPipGapStatic,
         setPipHeight,
         setPipWidth,
         setPipOpacity,
-        setPipBorder,
+        setPipOutlineBorder,
+        setPipOutlineGap,
+        setPipOutlineOpacity,
         setDotOpacity,
+        setDotSize,
+        setDotOutlineBorder,
+        setDotOutlineGap,
         setDotOutlineOpacity,
         setColorR,
         setColorG,
         setColorB,
+        setOutlineColor,
+        setDisableHeroSpecificCrosshairs,
         reset,
         generateCommands,
+        getSettings: getCrosshairSettings,
+        importFromGame,
         presets,
         activePresetId,
         loadPresets,
@@ -55,6 +93,21 @@ export default function Crosshair() {
         // Load always on top state
         window.electronAPI.getAlwaysOnTop().then(setAlwaysOnTop);
     }, [loadPresets]);
+
+    // Wheel-to-zoom over the preview. Attached natively with passive: false
+    // because React's root-delegated onWheel is passive, so preventDefault()
+    // there is a no-op and the wheel would zoom AND scroll the column.
+    useEffect(() => {
+        const el = previewRef.current;
+        if (!el) return;
+        const onWheel = (e: WheelEvent) => {
+            e.preventDefault();
+            const delta = e.deltaY > 0 ? -0.1 : 0.1;
+            setPreviewZoom((prev) => Math.min(3, Math.max(0.5, prev + delta)));
+        };
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, []);
 
     const handleAlwaysOnTop = async (enabled: boolean) => {
         const result = await window.electronAPI.setAlwaysOnTop(enabled);
@@ -91,47 +144,37 @@ export default function Crosshair() {
         }
     };
 
-    const generateThumbnail = (): string => {
-        // Create thumbnail using same formula as CrosshairPreview
-        // Scale proportionally: preview is 400px, thumbnail viewBox is 100
-        const baseGap = 9;
-        const gapMultiplier = 2.5;
-        const scale = 1.3;
-        const scaleFactor = 100 / 400; // Match proportions of 400px preview
+    const handleOutlineColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const rgb = hexToRgb(e.target.value);
+        if (rgb) {
+            setOutlineColor(rgb.r, rgb.g, rgb.b);
+        }
+    };
 
-        const lineGap = (baseGap + pipGap * gapMultiplier) * scale * scaleFactor;
-        const lineWidth = pipWidth * scale * scaleFactor;
-        const lineHeight = pipHeight * scale * scaleFactor;
-        const halfGap = lineGap / 2;
-        const center = 50;
-
-        // Use rgba like CrosshairPreview does
-        const pipColor = `rgba(${colorR}, ${colorG}, ${colorB}, ${pipOpacity})`;
-        const dotFillColor = `rgba(${colorR}, ${colorG}, ${colorB}, ${dotOpacity})`;
-
-        const svg = `
-            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
-                <rect width="100" height="100" fill="#555"/>
-                <!-- Top pip - centered at (center, center - halfGap) -->
-                <rect x="${center - lineWidth / 2}" y="${center - halfGap - lineHeight / 2}" width="${lineWidth}" height="${lineHeight}" fill="${pipColor}"${pipBorder ? ' stroke="black" stroke-width="0.25"' : ''}/>
-                <!-- Bottom pip - centered at (center, center + halfGap) -->
-                <rect x="${center - lineWidth / 2}" y="${center + halfGap - lineHeight / 2}" width="${lineWidth}" height="${lineHeight}" fill="${pipColor}"${pipBorder ? ' stroke="black" stroke-width="0.25"' : ''}/>
-                <!-- Left pip - centered at (center - halfGap, center) -->
-                <rect x="${center - halfGap - lineHeight / 2}" y="${center - lineWidth / 2}" width="${lineHeight}" height="${lineWidth}" fill="${pipColor}"${pipBorder ? ' stroke="black" stroke-width="0.25"' : ''}/>
-                <!-- Right pip - centered at (center + halfGap, center) -->
-                <rect x="${center + halfGap - lineHeight / 2}" y="${center - lineWidth / 2}" width="${lineHeight}" height="${lineWidth}" fill="${pipColor}"${pipBorder ? ' stroke="black" stroke-width="0.25"' : ''}/>
-                ${dotOpacity > 0 ? `<circle cx="${center}" cy="${center}" r="${2 * scale * scaleFactor}" fill="${dotFillColor}"/>` : ''}
-                ${dotOutlineOpacity > 0 ? `<circle cx="${center}" cy="${center}" r="${7 * scale * scaleFactor / 2}" fill="rgba(0,0,0,${dotOutlineOpacity})"/>` : ''}
-            </svg>
-        `;
-        return `data:image/svg+xml;base64,${btoa(svg)}`;
+    const handleImportFromGame = async () => {
+        if (!gamePath) {
+            alert('Please configure your Deadlock game path in Settings first.');
+            return;
+        }
+        try {
+            const found = await importFromGame(gamePath);
+            if (found) {
+                setImported(true);
+                setTimeout(() => setImported(false), 2000);
+            } else {
+                alert('No crosshair settings found in the game config. Change any crosshair setting in-game once, then try again.');
+            }
+        } catch (error) {
+            console.error('Failed to import crosshair from game:', error);
+            alert('Failed to read the game config. Check the game path in Settings.');
+        }
     };
 
     const handleSavePreset = async () => {
         if (!presetName.trim()) return;
         setIsSaving(true);
         try {
-            const thumbnail = generateThumbnail();
+            const thumbnail = renderCrosshairThumbnail(getCrosshairSettings());
             await savePreset(presetName.trim(), thumbnail);
             setPresetName('');
             setShowSaveInput(false);
@@ -185,24 +228,49 @@ export default function Crosshair() {
     };
 
     return (
-        <div className="p-6 space-y-6">
-            <div className="flex flex-col lg:flex-row gap-6">
+        <div className="p-6 lg:h-full">
+            {/* On lg+ the page fills the viewport and each column scrolls
+                independently, so the preview stays reachable while the long
+                settings list scrolls. Below lg the page scrolls as one. */}
+            <div className="flex flex-col lg:flex-row gap-6 lg:h-full">
                 {/* Left Panel - Settings */}
-                <div className="w-full lg:w-1/3 flex flex-col gap-6">
+                <div className="w-full lg:w-1/3 flex flex-col gap-6 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
                     <Card title="Crosshair Shape">
                         <div className="space-y-6">
-                            <Slider label="Gap" value={pipGap} min={-10} max={50} onChange={setPipGap} />
-                            <Slider label="Height" value={pipHeight} min={0} max={50} onChange={setPipHeight} />
-                            <Slider label="Width" value={pipWidth} min={0} max={10} step={0.5} onChange={setPipWidth} />
-                            <Slider label="Opacity" value={pipOpacity} min={0} max={1} step={0.05} onChange={setPipOpacity} />
-                            <Toggle label="Outline Border" checked={pipBorder} onChange={setPipBorder} />
+                            <Slider editable label="Gap" value={pipGap} min={-10} max={50} onChange={setPipGap} />
+                            <Slider editable label="Height" value={pipHeight} min={0} max={50} onChange={setPipHeight} />
+                            <Slider editable label="Width" value={pipWidth} min={0} max={10} step={0.5} onChange={setPipWidth} />
+                            <Slider editable label="Opacity" value={pipOpacity} min={0} max={1} step={0.05} onChange={setPipOpacity} />
+                            <Slider editable label="Outline Width" value={pipOutlineBorder} min={0} max={5} onChange={setPipOutlineBorder} />
+                            <Slider editable label="Outline Gap" value={pipOutlineGap} min={0} max={10} step={0.5} onChange={setPipOutlineGap} />
+                            <Slider editable label="Outline Opacity" value={pipOutlineOpacity} min={0} max={1} step={0.05} onChange={setPipOutlineOpacity} />
                         </div>
                     </Card>
 
                     <Card title="Center Dot">
                         <div className="space-y-6">
-                            <Slider label="Opacity" value={dotOpacity} min={0} max={1} step={0.05} onChange={setDotOpacity} />
-                            <Slider label="Outline Opacity" value={dotOutlineOpacity} min={0} max={1} step={0.05} onChange={setDotOutlineOpacity} />
+                            <Slider editable label="Size" value={dotSize} min={0} max={20} step={0.5} onChange={setDotSize} />
+                            <Slider editable label="Opacity" value={dotOpacity} min={0} max={1} step={0.05} onChange={setDotOpacity} />
+                            <Slider editable label="Outline Width" value={dotOutlineBorder} min={0} max={5} onChange={setDotOutlineBorder} />
+                            <Slider editable label="Outline Gap" value={dotOutlineGap} min={0} max={10} step={0.5} onChange={setDotOutlineGap} />
+                            <Slider editable label="Outline Opacity" value={dotOutlineOpacity} min={0} max={1} step={0.05} onChange={setDotOutlineOpacity} />
+                        </div>
+                    </Card>
+
+                    <Card title="In-Game Behavior">
+                        <div className="space-y-4">
+                            <Toggle
+                                label="Static Gap"
+                                description="Keep the gap fixed. When off, the in-game gap expands with weapon spread (not simulated in the preview)."
+                                checked={pipGapStatic}
+                                onChange={setPipGapStatic}
+                            />
+                            <Toggle
+                                label="Disable Hero Crosshairs"
+                                description="Some heroes override the crosshair with their own. Turn this on so your custom crosshair always wins."
+                                checked={disableHeroSpecificCrosshairs}
+                                onChange={setDisableHeroSpecificCrosshairs}
+                            />
                         </div>
                     </Card>
 
@@ -238,21 +306,42 @@ export default function Crosshair() {
                                     />
                                 ))}
                             </div>
-                            <Slider label="Red" value={colorR} min={0} max={255} onChange={setColorR} className="accent-red-500" />
-                            <Slider label="Green" value={colorG} min={0} max={255} onChange={setColorG} className="accent-green-500" />
-                            <Slider label="Blue" value={colorB} min={0} max={255} onChange={setColorB} className="accent-blue-500" />
+                            <Slider editable label="Red" value={colorR} min={0} max={255} onChange={setColorR} className="accent-red-500" />
+                            <Slider editable label="Green" value={colorG} min={0} max={255} onChange={setColorG} className="accent-green-500" />
+                            <Slider editable label="Blue" value={colorB} min={0} max={255} onChange={setColorB} className="accent-blue-500" />
+                            <div className="flex items-center gap-4 p-3 bg-black/20 rounded-lg">
+                                <input
+                                    type="color"
+                                    value={rgbToHex(outlineColorR, outlineColorG, outlineColorB)}
+                                    onChange={handleOutlineColorChange}
+                                    className="w-8 h-8 rounded cursor-pointer bg-transparent border-none"
+                                />
+                                <div className="text-xs text-text-secondary">
+                                    Outline color
+                                    <span className="ml-2 font-mono">RGB({outlineColorR}, {outlineColorG}, {outlineColorB})</span>
+                                </div>
+                            </div>
                         </div>
                     </Card>
                 </div>
 
                 {/* Right Panel - Preview & Actions */}
-                <div className="flex-1 flex flex-col gap-6 min-w-0">
+                <div className="flex-1 flex flex-col gap-6 min-w-0 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
                     {/* Top Actions Bar */}
                     <div className="flex flex-col sm:flex-row gap-4">
                         <Card className="flex-1" contentClassName="p-3">
                             <div className="flex items-center justify-between gap-3 h-full">
                                 <div className="flex items-center gap-2">
                                     <Button variant="secondary" onClick={reset} icon={RotateCcw} size="sm">Reset</Button>
+                                    <Button
+                                        variant={imported ? 'success' : 'secondary'}
+                                        onClick={handleImportFromGame}
+                                        icon={imported ? Check : Download}
+                                        size="sm"
+                                        title="Load your current in-game crosshair settings into the editor"
+                                    >
+                                        {imported ? 'Imported' : 'Import from Game'}
+                                    </Button>
                                     <Button
                                         variant={copied ? 'success' : 'primary'}
                                         onClick={handleCopy}
@@ -306,12 +395,22 @@ export default function Crosshair() {
                     {/* Preview Area */}
                     <Card className="relative w-full" contentClassName="p-0">
                         <div className="absolute top-4 right-4 z-10 flex items-center gap-3 bg-black/40 backdrop-blur-md rounded-full px-3 py-1.5 border border-white/5">
-                            <span className="text-xs text-text-secondary">Scale:</span>
+                            <select
+                                value={resolution}
+                                onChange={(e) => setResolution(parseInt(e.target.value, 10))}
+                                title="Render the preview at this display resolution's in-game size"
+                                className="bg-transparent text-xs text-text-secondary focus:outline-none cursor-pointer [&>option]:bg-bg-tertiary"
+                            >
+                                {RESOLUTIONS.map((r) => (
+                                    <option key={r.height} value={r.height}>{r.label}</option>
+                                ))}
+                            </select>
+                            <span className="text-xs text-text-secondary">Zoom:</span>
                             <div className="relative w-20 h-4 flex items-center">
                                 <div className="absolute w-full h-1 bg-bg-tertiary rounded-full overflow-hidden">
                                     <div
                                         className="h-full bg-accent"
-                                        style={{ width: `${((previewScale - 0.5) / 2.5) * 100}%` }}
+                                        style={{ width: `${((previewZoom - 0.5) / 2.5) * 100}%` }}
                                     />
                                 </div>
                                 <input
@@ -319,33 +418,28 @@ export default function Crosshair() {
                                     min={0.5}
                                     max={3}
                                     step={0.1}
-                                    value={previewScale}
-                                    onChange={(e) => setPreviewScale(parseFloat(e.target.value))}
+                                    value={previewZoom}
+                                    onChange={(e) => setPreviewZoom(parseFloat(e.target.value))}
                                     className="absolute w-full h-full opacity-0 cursor-pointer"
                                 />
                                 <div
                                     className="absolute h-3 w-3 bg-white rounded-full shadow-lg border border-accent pointer-events-none"
-                                    style={{ left: `calc(${((previewScale - 0.5) / 2.5) * 100}% - 6px)` }}
+                                    style={{ left: `calc(${((previewZoom - 0.5) / 2.5) * 100}% - 6px)` }}
                                 />
                             </div>
-                            <span className="font-mono text-xs w-8">{previewScale.toFixed(1)}x</span>
+                            <span className="font-mono text-xs w-8">{previewZoom.toFixed(1)}x</span>
                         </div>
 
                         <div
                             className="flex items-center justify-center bg-gradient-to-br from-bg-tertiary/50 to-bg-secondary/50 rounded-xl aspect-video lg:h-[420px] w-full overflow-hidden"
                             ref={previewRef}
-                            onWheel={(e) => {
-                                e.preventDefault();
-                                const delta = e.deltaY > 0 ? -0.1 : 0.1;
-                                setPreviewScale((prev) => Math.min(3, Math.max(0.5, prev + delta)));
-                            }}
                         >
-                            <CrosshairPreview size={400} scale={previewScale} />
+                            <CrosshairPreview size={400} scale={(resolution / 1080) * previewZoom} />
                         </div>
 
                         {/* Pin Window Control */}
                         <div className="p-4 border-t border-border flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-                            <p className="text-[10px] text-text-secondary italic">Using verified formula from deadlock-crosshair project</p>
+                            <p className="text-[10px] text-text-secondary italic">Preview approximates the in-game crosshair at the selected resolution. Dynamic spread bloom is not simulated.</p>
                             <Button
                                 variant={alwaysOnTop ? 'primary' : 'secondary'}
                                 size="sm"
@@ -383,7 +477,7 @@ export default function Crosshair() {
                                             }`}
                                     >
                                         <div className="w-full h-full flex items-center justify-center">
-                                            <CrosshairPreview size={80} scale={1.3} settings={preset.settings} transparent />
+                                            <CrosshairPreview size={80} scale={1440 / 1080} settings={preset.settings} transparent />
                                         </div>
 
                                         <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex flex-col items-center justify-center gap-2 p-2">

--- a/src/stores/crosshairStore.ts
+++ b/src/stores/crosshairStore.ts
@@ -1,30 +1,12 @@
 import { create } from 'zustand';
+import type { CrosshairSettings, CrosshairPreset } from '../types/electron';
+import {
+    CROSSHAIR_DEFAULTS,
+    generateCrosshairCommands,
+    normalizeCrosshairSettings,
+} from '../lib/crosshair';
 
-export interface CrosshairSettings {
-    // Pip settings
-    pipGap: number;
-    pipHeight: number;
-    pipWidth: number;
-    pipOpacity: number;
-    pipBorder: boolean;
-
-    // Dot settings
-    dotOpacity: number;
-    dotOutlineOpacity: number;
-
-    // Color settings (RGB 0-255)
-    colorR: number;
-    colorG: number;
-    colorB: number;
-}
-
-export interface CrosshairPreset {
-    id: string;
-    name: string;
-    settings: CrosshairSettings;
-    thumbnail: string;
-    createdAt: string;
-}
+export type { CrosshairSettings, CrosshairPreset };
 
 interface CrosshairStore extends CrosshairSettings {
     // Presets
@@ -32,23 +14,38 @@ interface CrosshairStore extends CrosshairSettings {
     activePresetId: string | null;
     isLoading: boolean;
 
-    // Setters
+    // Pip setters
     setPipGap: (value: number) => void;
+    setPipGapStatic: (value: boolean) => void;
     setPipHeight: (value: number) => void;
     setPipWidth: (value: number) => void;
     setPipOpacity: (value: number) => void;
-    setPipBorder: (value: boolean) => void;
+    setPipOutlineBorder: (value: number) => void;
+    setPipOutlineGap: (value: number) => void;
+    setPipOutlineOpacity: (value: number) => void;
+
+    // Dot setters
     setDotOpacity: (value: number) => void;
+    setDotSize: (value: number) => void;
+    setDotOutlineBorder: (value: number) => void;
+    setDotOutlineGap: (value: number) => void;
     setDotOutlineOpacity: (value: number) => void;
+
+    // Color setters
     setColorR: (value: number) => void;
     setColorG: (value: number) => void;
     setColorB: (value: number) => void;
     setColor: (r: number, g: number, b: number) => void;
+    setOutlineColor: (r: number, g: number, b: number) => void;
+
+    // Behavior setters
+    setDisableHeroSpecificCrosshairs: (value: boolean) => void;
 
     // Actions
     reset: () => void;
     generateCommands: () => string;
     getSettings: () => CrosshairSettings;
+    importFromGame: (gamePath: string) => Promise<boolean>;
 
     // Preset actions
     loadPresets: () => Promise<void>;
@@ -59,34 +56,27 @@ interface CrosshairStore extends CrosshairSettings {
     clearAutoexec: (gamePath: string) => Promise<void>;
 }
 
-const defaultSettings: CrosshairSettings = {
-    pipGap: 5,
-    pipHeight: 10,
-    pipWidth: 2,
-    pipOpacity: 1,
-    pipBorder: true,
-    dotOpacity: 0,
-    dotOutlineOpacity: 0,
-    colorR: 0,
-    colorG: 255,
-    colorB: 0,
-};
-
 export const useCrosshairStore = create<CrosshairStore>((set, get) => ({
-    ...defaultSettings,
+    ...CROSSHAIR_DEFAULTS,
     presets: [],
     activePresetId: null,
     isLoading: false,
 
     // Pip setters
     setPipGap: (value) => set({ pipGap: value }),
+    setPipGapStatic: (value) => set({ pipGapStatic: value }),
     setPipHeight: (value) => set({ pipHeight: value }),
     setPipWidth: (value) => set({ pipWidth: value }),
     setPipOpacity: (value) => set({ pipOpacity: value }),
-    setPipBorder: (value) => set({ pipBorder: value }),
+    setPipOutlineBorder: (value) => set({ pipOutlineBorder: value }),
+    setPipOutlineGap: (value) => set({ pipOutlineGap: value }),
+    setPipOutlineOpacity: (value) => set({ pipOutlineOpacity: value }),
 
     // Dot setters
     setDotOpacity: (value) => set({ dotOpacity: value }),
+    setDotSize: (value) => set({ dotSize: value }),
+    setDotOutlineBorder: (value) => set({ dotOutlineBorder: value }),
+    setDotOutlineGap: (value) => set({ dotOutlineGap: value }),
     setDotOutlineOpacity: (value) => set({ dotOutlineOpacity: value }),
 
     // Color setters
@@ -94,43 +84,28 @@ export const useCrosshairStore = create<CrosshairStore>((set, get) => ({
     setColorG: (value) => set({ colorG: value }),
     setColorB: (value) => set({ colorB: value }),
     setColor: (r, g, b) => set({ colorR: r, colorG: g, colorB: b }),
+    setOutlineColor: (r, g, b) => set({ outlineColorR: r, outlineColorG: g, outlineColorB: b }),
+
+    // Behavior setters
+    setDisableHeroSpecificCrosshairs: (value) => set({ disableHeroSpecificCrosshairs: value }),
 
     // Reset to defaults
-    reset: () => set(defaultSettings),
+    reset: () => set(CROSSHAIR_DEFAULTS),
 
-    // Get current settings
-    getSettings: () => {
-        const state = get();
-        return {
-            pipGap: state.pipGap,
-            pipHeight: state.pipHeight,
-            pipWidth: state.pipWidth,
-            pipOpacity: state.pipOpacity,
-            pipBorder: state.pipBorder,
-            dotOpacity: state.dotOpacity,
-            dotOutlineOpacity: state.dotOutlineOpacity,
-            colorR: state.colorR,
-            colorG: state.colorG,
-            colorB: state.colorB,
-        };
-    },
+    // Get current settings (normalized, with the legacy pipBorder flag derived)
+    getSettings: () => normalizeCrosshairSettings(get()),
 
     // Generate console commands
-    generateCommands: () => {
-        const state = get();
-        const commands = [
-            `citadel_crosshair_pip_gap ${state.pipGap}`,
-            `citadel_crosshair_pip_height ${state.pipHeight}`,
-            `citadel_crosshair_pip_width ${state.pipWidth}`,
-            `citadel_crosshair_pip_opacity ${state.pipOpacity.toFixed(2)}`,
-            `citadel_crosshair_pip_border ${state.pipBorder}`,
-            `citadel_crosshair_dot_opacity ${state.dotOpacity.toFixed(2)}`,
-            `citadel_crosshair_dot_outline_opacity ${state.dotOutlineOpacity.toFixed(2)}`,
-            `citadel_crosshair_color_r ${state.colorR}`,
-            `citadel_crosshair_color_g ${state.colorG}`,
-            `citadel_crosshair_color_b ${state.colorB}`,
-        ];
-        return commands.join('; ');
+    generateCommands: () => generateCrosshairCommands(get()),
+
+    // Pull the player's live in-game crosshair from machine_convars.vcfg
+    importFromGame: async (gamePath) => {
+        const result = await window.electronAPI.importCrosshairFromGame(gamePath);
+        if (result.settings) {
+            set(result.settings);
+            return true;
+        }
+        return false;
     },
 
     // Load presets from backend
@@ -169,9 +144,10 @@ export const useCrosshairStore = create<CrosshairStore>((set, get) => ({
         set({ activePresetId: id });
     },
 
-    // Load settings from a preset into the editor
+    // Load settings from a preset into the editor (normalize so legacy
+    // presets saved before the outline system fill in the new fields)
     loadSettingsFromPreset: (preset) => {
-        set(preset.settings);
+        set(normalizeCrosshairSettings(preset.settings));
     },
 
     // Clear crosshair from autoexec

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -276,17 +276,41 @@ export interface CachedMod {
     cachedAt: number;
 }
 
+/**
+ * Full crosshair model, matching the current in-game convar surface
+ * (citadel_crosshair_*). Pip and dot outlines are (border width, gap,
+ * opacity) triples sharing one outline color; the old single `pipBorder`
+ * bool convar no longer exists in the game.
+ */
 export interface CrosshairSettings {
     pipGap: number;
+    /** Keep the gap fixed in game; when false the gap blooms with weapon spread. */
+    pipGapStatic: boolean;
     pipHeight: number;
     pipWidth: number;
     pipOpacity: number;
-    pipBorder: boolean;
+    /** Outline stroke width in px; 0 disables the pip outline. */
+    pipOutlineBorder: number;
+    pipOutlineGap: number;
+    pipOutlineOpacity: number;
     dotOpacity: number;
+    /** Dot diameter in px (1080p reference). */
+    dotSize: number;
+    dotOutlineBorder: number;
+    dotOutlineGap: number;
     dotOutlineOpacity: number;
     colorR: number;
     colorG: number;
     colorB: number;
+    outlineColorR: number;
+    outlineColorG: number;
+    outlineColorB: number;
+    disableHeroSpecificCrosshairs: boolean;
+    /** Legacy pre-outline-system flag. Derived from pipOutlineBorder/Opacity
+     *  by normalizeCrosshairSettings and kept on the wire so older Grimoire
+     *  builds importing shared profiles still render a border. Never edited
+     *  directly. */
+    pipBorder: boolean;
 }
 
 export interface CrosshairPreset {
@@ -570,6 +594,9 @@ export interface ElectronAPI {
     clearCrosshairAutoexec: (gamePath: string) => Promise<{ success: boolean }>;
     getAutoexecStatus: (gamePath: string) => Promise<{ exists: boolean; path: string | null; hasCrosshairSettings: boolean }>;
     createAutoexec: (gamePath: string) => Promise<{ success: boolean; path: string }>;
+    /** Read the player's live in-game crosshair from machine_convars.vcfg.
+     *  settings is null when the file is missing or has no crosshair convars. */
+    importCrosshairFromGame: (gamePath: string) => Promise<{ found: boolean; settings: CrosshairSettings | null }>;
     getAutoexecCommands: (gamePath: string) => Promise<{ commands: string[]; exists: boolean }>;
     saveAutoexecCommands: (gamePath: string, commands: string[]) => Promise<{ success: boolean; path: string }>;
 
@@ -746,18 +773,10 @@ export interface ProfileMod {
     sha256?: string;
 }
 
-export interface ProfileCrosshairSettings {
-    pipGap: number;
-    pipHeight: number;
-    pipWidth: number;
-    pipOpacity: number;
-    pipBorder: boolean;
-    dotOpacity: number;
-    dotOutlineOpacity: number;
-    colorR: number;
-    colorG: number;
-    colorB: number;
-}
+/** Profiles embed the same crosshair model the Crosshair tab edits. Saved
+ *  profiles from older builds carry the legacy 10-field shape; normalize
+ *  with normalizeCrosshairSettings before use. */
+export type ProfileCrosshairSettings = CrosshairSettings;
 
 export interface Profile {
     id: string;

--- a/src/types/portableProfile.ts
+++ b/src/types/portableProfile.ts
@@ -60,6 +60,8 @@ export interface PortableModEntry {
 }
 
 export interface PortableCrosshairSettings {
+  // v1 fields: always present, so exports stay readable by older Grimoire
+  // builds (pipBorder is derived from the outline fields on export).
   pipGap: number;
   pipHeight: number;
   pipWidth: number;
@@ -70,6 +72,19 @@ export interface PortableCrosshairSettings {
   colorR: number;
   colorG: number;
   colorB: number;
+  // Additive fields (outline system, dot size). Optional: older exports omit
+  // them and importers fill defaults via normalizeCrosshairSettings.
+  pipGapStatic?: boolean;
+  pipOutlineBorder?: number;
+  pipOutlineGap?: number;
+  pipOutlineOpacity?: number;
+  dotSize?: number;
+  dotOutlineBorder?: number;
+  dotOutlineGap?: number;
+  outlineColorR?: number;
+  outlineColorG?: number;
+  outlineColorB?: number;
+  disableHeroSpecificCrosshairs?: boolean;
 }
 
 export interface GrimoireExtension {


### PR DESCRIPTION
## Why

The Crosshair tab was built against an old game build. Verified against the current client.dll:

- It wrote `citadel_crosshair_pip_border`, which no longer exists (replaced by the outline system).
- It wrote only ~half the convars the game reads for crosshair shape (`dot_size`, `pip_gap_static`, the pip/dot outline border/gap/opacity trios, `outline_color_r/g/b`, `disable_hero_specific_crosshairs` were all missing), so whatever was last set in the in-game editor leaked through and applied presets never matched in-game.
- Applying a preset wrote a marker-less autoexec format that the Autoexec tab and profile apply silently deleted.

## What

- **Full convar model**: presets now write the complete 20-convar shape set. `src/lib/crosshair.ts` is the single source for defaults, legacy migration, command generation, and `machine_convars.vcfg` parsing (replaces 3 duplicated generators and 2 duplicated autoexec parsers).
- **Unified autoexec writing**: `services/autoexec.ts` is the only writer (atomic temp-and-rename). Legacy marker-less crosshair lines are rescued into the marker section; user content after the managed sections is preserved instead of dropped.
- **One canvas renderer** for live preview, gallery tiles, and saved thumbnails (the old SVG thumbnails drew a double-size dot with inverted outline z-order). Models outlines as real outside strokes with width/gap/color and the dot at its actual size.
- **Import from Game**: loads the live in-game crosshair from `machine_convars.vcfg` into the editor (values rounded to 2dp).
- **UI**: resolution picker (1080p/1440p/4K, auto-detected) replaces the magic 1.3 scale; independent left/right column scrolling on lg+; wheel-zoom scoped to the preview via a native non-passive listener; crosshair sliders accept typed values (new opt-in `editable` prop on the shared Slider).
- **Compatibility**: legacy presets/profiles/share codes migrate on load; exports keep a derived `pipBorder` so older importers keep working. `docs/profile-spec.md` updated additively.

## Verification

- `pnpm typecheck`, `pnpm lint` (errors shown by lint are from the untracked in-progress stats work on the local tree, not this branch), `pnpm build` all pass.
- Logic verified by script: legacy migration both directions, full command emission, real `machine_convars.vcfg` import round-trip, legacy autoexec rescue, marker round-trip stability, trailing-content preservation.
- Applied a preset end-to-end in the app; autoexec.cfg now carries the full convar set in the marker format.

## Known follow-up

The preview gap formula (pip center at `(9 + gap*2.5)/2` px, 1080p reference) is carried over from the old preview and not yet re-calibrated against the current game; needs a side-by-side screenshot check. Spread bloom is intentionally not simulated (noted in the UI).