### PR TITLE
feat(stats): opt-in match-salt contribution to deadlock-api.com

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -82,6 +82,7 @@ import './ipc/trippyEffects';
 import './ipc/locker';
 import './ipc/previewCache';
 import './ipc/discord';
+import './ipc/saltIngest';
 import './ipc/servers';
 import './ipc/performanceConfig';
 
@@ -90,6 +91,7 @@ import { runStartupRecovery } from './ipc/launch';
 import { loadSettings, saveSettings } from './services/settings';
 import { backfillMissingMetadataHashes } from './services/metadata';
 import { destroyDiscordRpc } from './services/discordRpc';
+import { startSaltIngest } from './services/saltIngest';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -377,6 +379,11 @@ if (!gotTheLock) {
         // Restore a previously-persisted social session (no-op if none, or if
         // we're on Linux without a real secret store — ADR-011).
         void hydrateSocialSession();
+
+        // Resume the opt-in match-salt contributor across restarts.
+        if (loadSettings().contributeMatchSalts) {
+            startSaltIngest();
+        }
 
         // Recover from any half-finished vanilla launch (app was closed mid-session,
         // or grimoire crashed while the user was playing vanilla), then fill in

--- a/electron/main/ipc/saltIngest.ts
+++ b/electron/main/ipc/saltIngest.ts
@@ -1,0 +1,23 @@
+import { ipcMain } from 'electron';
+import {
+    startSaltIngest,
+    stopSaltIngest,
+    getSaltIngestStatus,
+    type SaltIngestStatus,
+} from '../services/saltIngest';
+
+// salt-ingest:set-enabled - start/stop the contributor immediately when the
+// Settings toggle flips (the renderer persists the setting separately, same
+// split as the Discord RPC toggle).
+ipcMain.handle('salt-ingest:set-enabled', (_, enabled: boolean): void => {
+    if (enabled) {
+        startSaltIngest();
+    } else {
+        stopSaltIngest();
+    }
+});
+
+// salt-ingest:get-status - scan/submission counters for the Settings page.
+ipcMain.handle('salt-ingest:get-status', (): SaltIngestStatus => {
+    return getSaltIngestStatus();
+});

--- a/electron/main/services/saltIngest.ts
+++ b/electron/main/services/saltIngest.ts
@@ -1,0 +1,295 @@
+// Match-salt contribution to deadlock-api.com (opt-in, default OFF).
+//
+// Deadlock's client downloads post-match metadata from Valve's replay servers
+// via URLs like http://replay406.valve.net/1422450/<match_id>_<salt>.meta.bz2,
+// and Steam keeps those requests in its local HTTP cache. The four values in
+// the URL ("salts") are what lets the community-run deadlock-api.com fetch a
+// match's full metadata, so submitting them helps every player's stats.
+//
+// This service reimplements what the official deadlock-api-ingest tool does,
+// minus its two privacy leaks: we never send a username/account id (the field
+// is optional in the API schema) and we never ping statlocker.gg. The only
+// thing that leaves the machine is match_id, cluster_id and the two salts:
+// numbers that describe the match, not the player.
+//
+// Cache-file format note: the host and path are stored as null-separated
+// fields in a small binary header (not a literal http:// URL), always within
+// the first ~200 bytes. We read 512 to be safe and reconstruct the URL the
+// same way the official tool does.
+
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { getUserDataPath } from '../utils/paths';
+import { statsApiRateLimiter } from './rateLimiter';
+import { GRIMOIRE_USER_AGENT } from './userAgent';
+// Status shape is a wire type (crosses IPC), so it lives in the single-source
+// declaration file alongside ElectronAPI (type-only import, erased at build).
+import type { SaltIngestStatus } from '../../../src/types/electron';
+export type { SaltIngestStatus };
+
+const INGEST_URL = 'https://api.deadlock-api.com/v1/matches/salts';
+const DEADLOCK_APP_ID = '1422450';
+const HEADER_BYTES = 512;
+const RESCAN_INTERVAL_MS = 15 * 60 * 1000;
+
+export interface MatchSalts {
+    match_id: number;
+    cluster_id: number | null;
+    metadata_salt: number | null;
+    replay_salt: number | null;
+}
+
+interface PersistedState {
+    /** Keys of already-submitted salts: "<match_id>:meta" / "<match_id>:dem". */
+    submitted: string[];
+    totalSubmitted: number;
+}
+
+let rescanTimer: NodeJS.Timeout | null = null;
+let scanInFlight = false;
+const status: SaltIngestStatus = {
+    running: false,
+    lastScanAt: null,
+    lastScanFound: 0,
+    totalSubmitted: 0,
+    lastError: null,
+};
+
+function getStatePath(): string {
+    return join(getUserDataPath(), 'salt-ingest.json');
+}
+
+async function loadState(): Promise<PersistedState> {
+    try {
+        const raw = await fs.readFile(getStatePath(), 'utf-8');
+        const parsed = JSON.parse(raw) as Partial<PersistedState>;
+        return {
+            submitted: Array.isArray(parsed.submitted) ? parsed.submitted : [],
+            totalSubmitted: typeof parsed.totalSubmitted === 'number' ? parsed.totalSubmitted : 0,
+        };
+    } catch {
+        return { submitted: [], totalSubmitted: 0 };
+    }
+}
+
+async function saveState(state: PersistedState): Promise<void> {
+    const path = getStatePath();
+    const tempPath = `${path}.tmp`;
+    await fs.writeFile(tempPath, JSON.stringify(state), 'utf-8');
+    await fs.rename(tempPath, path);
+}
+
+/**
+ * Candidate Steam httpcache directories for this platform. The Linux paths
+ * are commonly symlinks to one another, so callers dedupe via realpath.
+ */
+function getCandidateCacheDirs(): string[] {
+    const home = homedir();
+    if (process.platform === 'linux') {
+        return [
+            join(home, '.local/share/Steam/appcache/httpcache'),
+            join(home, '.steam/steam/appcache/httpcache'),
+            join(home, '.var/app/com.valvesoftware.Steam/.local/share/Steam/appcache/httpcache'),
+        ];
+    }
+    if (process.platform === 'win32') {
+        return [
+            'C:\\Program Files (x86)\\Steam\\appcache\\httpcache',
+            'C:\\Program Files\\Steam\\appcache\\httpcache',
+        ];
+    }
+    return [join(home, 'Library/Application Support/Steam/appcache/httpcache')];
+}
+
+async function resolveCacheDirs(): Promise<string[]> {
+    const seen = new Set<string>();
+    for (const dir of getCandidateCacheDirs()) {
+        try {
+            seen.add(await fs.realpath(dir));
+        } catch {
+            // Directory doesn't exist on this machine; skip.
+        }
+    }
+    return [...seen];
+}
+
+function isHostChar(byte: number): boolean {
+    return (
+        (byte >= 0x30 && byte <= 0x39) || // 0-9
+        (byte >= 0x41 && byte <= 0x5a) || // A-Z
+        (byte >= 0x61 && byte <= 0x7a) || // a-z
+        byte === 0x2e // .
+    );
+}
+
+const PATH_END_MARKERS = new Set([0x20, 0x27, 0x00, 0x0a, 0x0d, 0x22]); // space ' \0 \n \r "
+const REPLAY_PATH_RE = /^\/1422450\/(\d+)_(\d+)\.(meta|dem)\.bz2$/;
+
+/**
+ * Extract replay salts from a cache-file header buffer. Mirrors the official
+ * tool: find ".valve.net", walk back over host characters, require a host
+ * starting with "replay", then take the path from the next "/" up to a
+ * terminator byte. One cache file describes one request, so first hit wins.
+ */
+export function parseSaltsFromHeader(data: Buffer): MatchSalts | null {
+    const needle = Buffer.from('.valve.net');
+    let searchFrom = 0;
+    for (;;) {
+        const idx = data.indexOf(needle, searchFrom);
+        if (idx === -1) return null;
+        searchFrom = idx + 1;
+
+        let hostStart = idx;
+        while (hostStart > 0 && isHostChar(data[hostStart - 1])) hostStart--;
+        const host = data.subarray(hostStart, idx + needle.length).toString('latin1');
+        if (!host.startsWith('replay')) continue;
+
+        const slash = data.indexOf(0x2f, idx + needle.length); // '/'
+        if (slash === -1) continue;
+        let pathEnd = slash;
+        while (pathEnd < data.length && !PATH_END_MARKERS.has(data[pathEnd])) pathEnd++;
+        let path = data.subarray(slash, pathEnd).toString('latin1');
+        if (!path.includes(DEADLOCK_APP_ID)) continue;
+
+        const queryIdx = path.indexOf('?');
+        if (queryIdx !== -1) path = path.slice(0, queryIdx);
+
+        const match = REPLAY_PATH_RE.exec(path);
+        if (!match) continue;
+
+        const matchId = Number(match[1]);
+        const salt = Number(match[2]);
+        // Plausibility only; no hardcoded ceiling (the official tool rejects
+        // match_id > 1e8, which live ids will outgrow within months).
+        if (!Number.isSafeInteger(matchId) || matchId <= 0) continue;
+        if (!Number.isSafeInteger(salt) || salt <= 0 || salt > 0xffffffff) continue;
+        const clusterId = Number(host.slice('replay'.length, -'.valve.net'.length));
+
+        return {
+            match_id: matchId,
+            cluster_id: Number.isSafeInteger(clusterId) ? clusterId : null,
+            metadata_salt: match[3] === 'meta' ? salt : null,
+            replay_salt: match[3] === 'dem' ? salt : null,
+        };
+    }
+}
+
+async function readHeader(filePath: string): Promise<Buffer | null> {
+    let handle: fs.FileHandle | null = null;
+    try {
+        handle = await fs.open(filePath, 'r');
+        const buf = Buffer.alloc(HEADER_BYTES);
+        const { bytesRead } = await handle.read(buf, 0, HEADER_BYTES, 0);
+        return buf.subarray(0, bytesRead);
+    } catch {
+        return null;
+    } finally {
+        await handle?.close().catch(() => undefined);
+    }
+}
+
+async function scanDirForSalts(dir: string, results: MatchSalts[]): Promise<void> {
+    let entries;
+    try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            await scanDirForSalts(full, results);
+        } else if (entry.isFile()) {
+            const header = await readHeader(full);
+            if (!header) continue;
+            const salts = parseSaltsFromHeader(header);
+            if (salts) results.push(salts);
+        }
+    }
+}
+
+function saltKey(s: MatchSalts): string {
+    return `${s.match_id}:${s.metadata_salt !== null ? 'meta' : 'dem'}`;
+}
+
+async function submitSalts(salts: MatchSalts[]): Promise<void> {
+    await statsApiRateLimiter.acquire();
+    const res = await fetch(INGEST_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': GRIMOIRE_USER_AGENT,
+        },
+        body: JSON.stringify(salts),
+    });
+    if (!res.ok) {
+        throw new Error(`ingest responded ${res.status}`);
+    }
+}
+
+/**
+ * One scan-and-submit pass. Failures leave the salts unmarked so the next
+ * pass retries them; nothing is ever marked submitted without a 200.
+ */
+export async function runSaltScan(): Promise<void> {
+    if (scanInFlight) return;
+    scanInFlight = true;
+    try {
+        const dirs = await resolveCacheDirs();
+        const found: MatchSalts[] = [];
+        for (const dir of dirs) {
+            await scanDirForSalts(dir, found);
+        }
+        status.lastScanAt = Date.now();
+        status.lastScanFound = found.length;
+
+        const state = await loadState();
+        const submitted = new Set(state.submitted);
+        const fresh = new Map<string, MatchSalts>();
+        for (const salts of found) {
+            const key = saltKey(salts);
+            if (!submitted.has(key)) fresh.set(key, salts);
+        }
+        if (fresh.size === 0) {
+            status.lastError = null;
+            return;
+        }
+
+        await submitSalts([...fresh.values()]);
+        for (const key of fresh.keys()) submitted.add(key);
+        state.submitted = [...submitted];
+        state.totalSubmitted += fresh.size;
+        await saveState(state);
+        status.totalSubmitted = state.totalSubmitted;
+        status.lastError = null;
+        console.log(`[SaltIngest] Contributed ${fresh.size} match salt(s) to deadlock-api.com`);
+    } catch (error) {
+        status.lastError = error instanceof Error ? error.message : String(error);
+        console.warn('[SaltIngest] Scan failed:', status.lastError);
+    } finally {
+        scanInFlight = false;
+    }
+}
+
+export function startSaltIngest(): void {
+    if (rescanTimer) return;
+    status.running = true;
+    void loadState().then((state) => {
+        status.totalSubmitted = state.totalSubmitted;
+    });
+    void runSaltScan();
+    rescanTimer = setInterval(() => void runSaltScan(), RESCAN_INTERVAL_MS);
+}
+
+export function stopSaltIngest(): void {
+    if (rescanTimer) {
+        clearInterval(rescanTimer);
+        rescanTimer = null;
+    }
+    status.running = false;
+}
+
+export function getSaltIngestStatus(): SaltIngestStatus {
+    return { ...status };
+}

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -33,6 +33,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     language: null,
     zoomFactor: 1,
     discordRpcEnabled: false,
+    contributeMatchSalts: false,
 };
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -76,6 +76,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         clear: () => ipcRenderer.invoke('discord:clear'),
     },
 
+    // Match-salt contribution to deadlock-api.com (opt-in)
+    saltIngest: {
+        setEnabled: (enabled: boolean) => ipcRenderer.invoke('salt-ingest:set-enabled', enabled),
+        getStatus: () => ipcRenderer.invoke('salt-ingest:get-status'),
+    },
+
     // Mods
     getMods: () => ipcRenderer.invoke('get-mods'),
     enableMod: (modId: string) => ipcRenderer.invoke('enable-mod', modId),

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/a
 import { DEFAULT_SIDEBAR_HERO, HERO_NAMES_SORTED, getHeroChipIconPath } from '../lib/lockerUtils';
 import SocialAccountSection from '../components/social/SocialAccountSection';
 import PerformanceConfigCard from '../components/performance/PerformanceConfigCard';
+import type { SaltIngestStatus } from '../types/electron';
 
 // GitHub Releases is the source of truth for changelogs. When we have local
 // release notes (an update is pending) we show them in-app; otherwise we link
@@ -83,6 +84,7 @@ export default function Settings() {
   const [previewConfirmOpen, setPreviewConfirmOpen] = useState(false);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [resetResult, setResetResult] = useState<string | null>(null);
+  const [saltIngestStatus, setSaltIngestStatus] = useState<SaltIngestStatus | null>(null);
   const [heroPickerOpen, setHeroPickerOpen] = useState(false);
 
   // Updater state
@@ -327,6 +329,31 @@ export default function Settings() {
   const handleDiscordRpcChange = async (checked: boolean) => {
     if (settings) {
       await saveSettings({ ...settings, discordRpcEnabled: checked });
+    }
+  };
+
+  const refreshSaltIngestStatus = useCallback(async () => {
+    try {
+      setSaltIngestStatus(await window.electronAPI.saltIngest.getStatus());
+    } catch {
+      // The status line is cosmetic; the toggle stays usable without it.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (settings?.contributeMatchSalts) {
+      void refreshSaltIngestStatus();
+    }
+  }, [settings?.contributeMatchSalts, refreshSaltIngestStatus]);
+
+  const handleContributeMatchSaltsChange = async (checked: boolean) => {
+    if (!settings) return;
+    await saveSettings({ ...settings, contributeMatchSalts: checked });
+    await window.electronAPI.saltIngest.setEnabled(checked);
+    if (checked) {
+      // The first scan usually finishes within a couple seconds; pick up its
+      // counters once it has.
+      setTimeout(() => void refreshSaltIngestStatus(), 3000);
     }
   };
 
@@ -1138,6 +1165,25 @@ export default function Settings() {
               label="Discord Rich Presence"
               description="Show what you are doing in Grimoire on your Discord profile (browsing mods, in the Locker, and so on). Talks only to your local Discord app and sends nothing to Grimoire. Off by default."
             />
+
+            <div className="h-px bg-white/5" />
+
+            <div>
+              <Toggle
+                checked={settings?.contributeMatchSalts ?? false}
+                onChange={handleContributeMatchSaltsChange}
+                label="Contribute match data to deadlock-api.com"
+                description="Help the community stats project by submitting the replay keys (salts) Steam already caches for matches whose details you view in-game. Sends only the match id, server cluster, and two download keys: no account id, no username, nothing about you or your mods. Off by default."
+              />
+              {settings?.contributeMatchSalts && saltIngestStatus && (
+                <div className="mt-2 text-xs text-text-secondary">
+                  {saltIngestStatus.totalSubmitted > 0
+                    ? `${saltIngestStatus.totalSubmitted} match salt${saltIngestStatus.totalSubmitted === 1 ? '' : 's'} contributed so far.`
+                    : 'Nothing to contribute yet. Salts appear after you view match details in-game.'}
+                  {saltIngestStatus.lastError ? ` Last attempt failed: ${saltIngestStatus.lastError}.` : ''}
+                </div>
+              )}
+            </div>
 
             <div className="h-px bg-white/5" />
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -343,6 +343,16 @@ export interface ReleaseNoteInfo {
     note: string | null;
 }
 
+export interface SaltIngestStatus {
+    running: boolean;
+    lastScanAt: number | null;
+    /** Salts found in the cache on the last scan (before dedupe). */
+    lastScanFound: number;
+    /** Total salts successfully submitted since the feature was enabled. */
+    totalSubmitted: number;
+    lastError: string | null;
+}
+
 export interface ElectronAPI {
     // Host platform ('win32', 'linux', ...), captured in the preload. The
     // renderer uses it to decide whether to draw the custom Windows title
@@ -360,6 +370,12 @@ export interface ElectronAPI {
     discord: {
         update: (ctx: { surface: string; count?: number; hero?: string }) => Promise<void>;
         clear: () => Promise<void>;
+    };
+
+    // Match-salt contribution to deadlock-api.com (opt-in)
+    saltIngest: {
+        setEnabled: (enabled: boolean) => Promise<void>;
+        getStatus: () => Promise<SaltIngestStatus>;
     };
 
     // Mods

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -765,6 +765,12 @@ export interface AppSettings {
    *  activity outward (through Discord), so it stays a deliberate choice and
    *  never sends anything to a Grimoire server. */
   discordRpcEnabled: boolean;
+  /** Contribute match salts to the community-run deadlock-api.com. Reads
+   *  replay-server URLs from Steam's local HTTP cache and submits only the
+   *  match id, cluster id, and download salts: no account id, no username,
+   *  nothing identifying. Off by default (it sends data outward, so it stays
+   *  a deliberate choice). */
+  contributeMatchSalts: boolean;
   /** Deadworks custom-server browser: list + join community dedicated servers. */
   experimentalDeadworksServers?: boolean;
   /** Advanced override for the relay the server browser queries. No UI: defaults


### PR DESCRIPTION
## What

An opt-in (default OFF) background contributor that scans Steam's local HTTP cache for Deadlock replay-server URLs and submits the parsed match salts (`match_id`, `cluster_id`, `metadata_salt`, `replay_salt`) to `POST /v1/matches/salts` on deadlock-api.com. Salts are how fresh matches enter the community stats database that the Stats tab is built on.

This is a native reimplementation of the official [deadlock-api-ingest](https://github.com/deadlock-api/deadlock-api-ingest) tool with two deliberate privacy deltas, both verified in their source:

- their tool sends `username: "ingest-tool:<steamid3>"` with every POST; we omit the field entirely (it is nullable in the API schema)
- their tool pings `statlocker.gg/api/match/{id}/populate` per match with no off switch; we don't

Nothing identifying ever leaves the machine: four numbers that describe a match, not a player.

## How it works

- Cache files store the request as null-separated host/path fields in a binary header (`replay406.valve.net\0/1422450/<match_id>_<salt>.meta.bz2`), always near the start of the file; we read the first 512 bytes and reconstruct the URL the same way the official tool does
- Entries persist for months (verified on a real cache), so a full scan at startup harvests history and a 15-minute rescan picks up new ones; no game-running gate needed
- Dedupe state lives in `userData/salt-ingest.json`; salts are marked submitted only after a 200, so failures retry on the next pass
- No hardcoded `match_id > 1e8` rejection like upstream: live match ids are already at 88M and would outgrow that cap within months
- Settings toggle sits next to Discord Rich Presence (the other deliberate outward-facing choice), with copy stating exactly what is read and what is sent, plus a contributed-count status line

## Verification

- `pnpm typecheck` and ESLint clean
- Bundled the actual service module and ran it against a real Steam cache: parser extracted 18/18 live entries with values matching a manual decode
- One full scan-and-submit pass ran end to end: the API accepted the batch with a 200 and the dedupe state file round-tripped

## Notes

- No telemetry pillar intact: default OFF, strictly opt-in, sends nothing about the user
- The same additive edits to `electron/preload/index.ts` and `src/types/electron.ts` also exist in the in-flight stats-revamp working tree; both sides have identical content so a later merge resolves cleanly