### PR TITLE
fix(crosshair): stop cards squeeze-clipping in the two-pane layout

### DIFF
--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -222,7 +222,12 @@ export default function Crosshair() {
                 nothing. Below lg the page scrolls as one. */}
             <div className="flex flex-col lg:flex-row gap-6 lg:gap-0 lg:h-full">
                 {/* Left Panel - Settings */}
-                <div className="w-full lg:w-1/3 flex flex-col gap-6 lg:min-h-0 lg:overflow-y-auto lg:p-6">
+                {/* Both columns stack cards with space-y (block layout), not
+                    flex-col: Card has overflow-hidden, and a height-bounded
+                    flex column shrink-squeezes such children to fit instead
+                    of overflowing, which clips the controls and leaves
+                    nothing for overflow-y-auto to scroll. */}
+                <div className="w-full lg:w-1/3 space-y-6 lg:min-h-0 lg:overflow-y-auto lg:p-6">
                     <Card title="Crosshair Shape">
                         <div className="space-y-6">
                             <Slider editable label="Gap" value={pipGap} min={-10} max={50} onChange={setPipGap} />
@@ -314,12 +319,14 @@ export default function Crosshair() {
                 </div>
 
                 {/* Right Panel - Preview & Actions */}
-                <div className="flex-1 flex flex-col gap-6 min-w-0 lg:min-h-0 lg:overflow-y-auto lg:p-6 lg:pl-0">
-                    {/* Top Actions Bar */}
-                    <div className="flex flex-col sm:flex-row gap-4">
+                <div className="flex-1 space-y-6 min-w-0 lg:min-h-0 lg:overflow-y-auto lg:p-6 lg:pl-0">
+                    {/* Top Actions Bar. The two cards share roughly half the
+                        page, so they only sit side by side on wide windows;
+                        contents wrap rather than clip when space runs out. */}
+                    <div className="flex flex-col 2xl:flex-row gap-4">
                         <Card className="flex-1" contentClassName="p-3">
-                            <div className="flex items-center justify-between gap-3 h-full">
-                                <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                                <div className="flex flex-wrap items-center gap-2">
                                     <Button variant="secondary" onClick={reset} icon={RotateCcw} size="sm">Reset</Button>
                                     <Button
                                         variant={imported ? 'success' : 'secondary'}
@@ -339,7 +346,7 @@ export default function Crosshair() {
                                         {copied ? 'Copied' : 'Copy Code'}
                                     </Button>
                                 </div>
-                                <div className="hidden sm:block text-xs text-text-secondary">
+                                <div className="hidden sm:block text-xs text-text-secondary whitespace-nowrap">
                                     Press F7 in-game
                                 </div>
                             </div>


### PR DESCRIPTION
## Problem

The Crosshair tab rendered with most of its controls clipped and unreachable: only 2 of 7 shape sliders visible, the Center Dot card cut mid-slider, both In-Game Behavior toggles hidden, and the preview's pin row gone. Scrolling did nothing.

## Root cause

Not in the page itself. `Card` gained `overflow-hidden` in the card-polish redesign, and per CSS that zeroes a flex item's automatic minimum size. The page's two columns are height-bounded flex containers (`lg:h-full` + `flex flex-col` + `lg:overflow-y-auto`), so instead of the columns overflowing and scrolling, every card silently shrank to fit the viewport and clipped its content. The columns then never overflowed, so `overflow-y-auto` had nothing to scroll: the two-pane scroll fix from 351a4f7 was undone without any diff to this page.

## Fix

- Stack cards in both columns with block layout (`space-y-6`) instead of `flex flex-col`, so cards keep their natural height and the columns scroll. Left a comment explaining the trap.
- Top action bar: contents wrap instead of clipping (the Copy Code button was cut off and "Press F7 in-game" wrapped one letter per line), the hint stays on one line, and the two cards only sit side by side from `2xl` since they share roughly half the page (`sm:` was far too early).

## Verified

Drove the app over CDP at 1262x676 and 1600x900: all sliders, toggles, the pin row, and the presets gallery are reachable; both columns report real overflow (left column 2037px of content in a 615px viewport) and scroll to the bottom. ESLint clean on the file.