### PR TITLE
fix(installed): auto-match replaced files in Update all

### DIFF
--- a/src/lib/updateFileMatch.ts
+++ b/src/lib/updateFileMatch.ts
@@ -1,0 +1,116 @@
+import type { GameBananaFile } from '../types/gamebanana';
+
+/**
+ * Identity signals for an installed file whose GameBanana file id is no
+ * longer current (the author archived or deleted it). Used to find the
+ * replacement among the mod's current files.
+ */
+export interface UpdateMatchSignals {
+  /** The GameBanana file id Grimoire downloaded originally. */
+  installedFileId: number;
+  /** The author's per-file description ("header") captured at download time.
+   *  Survives locally even when the file row was deleted from GameBanana. */
+  fileDescription?: string;
+  /** The original archive filename captured at download time (e.g.
+   *  "galaxy_rem_gold.zip"). Like fileDescription, survives deletion. */
+  sourceFileName?: string;
+}
+
+/** Minimum share of the old filename's meaningful tokens that must reappear
+ *  in a candidate's filename before a name-based match is trusted. */
+const MIN_NAME_SCORE = 0.6;
+/** Required lead over the runner-up candidate so near-ties stay manual. */
+const MIN_NAME_MARGIN = 0.25;
+
+/**
+ * Resolve which current (non-archived) file supersedes an installed file
+ * that is no longer current. Returns null when no single candidate is a
+ * confident match: callers should fall back to a manual pick, never guess.
+ *
+ * Matching runs two signals in order:
+ * 1. The author's per-file description. Authors keep these stable across
+ *    re-uploads far more often than filenames (filenames usually gain a date
+ *    or hash suffix per upload), so an exact normalized match that is unique
+ *    among current files is decisive.
+ * 2. Filename token overlap. Tokens that exist only to version an upload
+ *    (pure numbers, "v2", hex hash suffixes) are dropped before comparing,
+ *    so "redesign_standalone_v1_5.7z" matches
+ *    "standalone_passive_items_redesign_06_04.7z" on {redesign, standalone}.
+ *
+ * @param signals identity of the installed file
+ * @param files the mod's full file list from GameBanana, archived included
+ *  (the archived entry for the installed file is the best source for its
+ *  old name and description when nothing was captured locally)
+ * @param excludeIds candidate file ids that are already spoken for (claimed
+ *  by a sibling variant in the same update run, or already installed)
+ */
+export function resolveUpdateTarget(
+  signals: UpdateMatchSignals,
+  files: GameBananaFile[],
+  excludeIds?: ReadonlySet<number>,
+): GameBananaFile | null {
+  const candidates = files.filter(
+    (f) => !f.isArchived && f.id !== signals.installedFileId && !excludeIds?.has(f.id),
+  );
+  if (candidates.length === 0) return null;
+
+  const oldEntry = files.find((f) => f.id === signals.installedFileId);
+  const oldDescription = normalizeText(signals.fileDescription ?? oldEntry?.description ?? '');
+  const oldName = signals.sourceFileName || oldEntry?.fileName || '';
+
+  if (oldDescription) {
+    const descMatches = candidates.filter(
+      (f) => normalizeText(f.description ?? '') === oldDescription,
+    );
+    if (descMatches.length === 1) return descMatches[0];
+    // Zero or several description matches: fall through to filename matching
+    // rather than guessing between identically-described files.
+  }
+
+  const oldTokens = tokenizeFileName(oldName);
+  if (oldTokens.size === 0) return null;
+
+  const scored = candidates
+    .map((file) => {
+      const tokens = tokenizeFileName(file.fileName);
+      let overlap = 0;
+      for (const token of oldTokens) {
+        if (tokens.has(token)) overlap += 1;
+      }
+      return { file, score: overlap / oldTokens.size };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const best = scored[0];
+  const runnerUp = scored[1];
+  if (best.score >= MIN_NAME_SCORE && (!runnerUp || best.score - runnerUp.score >= MIN_NAME_MARGIN)) {
+    return best.file;
+  }
+  return null;
+}
+
+/** Lowercase, strip punctuation, collapse whitespace. "Current/Max Health"
+ *  and "current max health" compare equal. */
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Split a filename into the tokens that identify the variant, dropping the
+ *  archive extension and tokens that only version an upload: pure numbers
+ *  (dates, counters), "v"-prefixed versions, hex hash suffixes like "8388e",
+ *  and single characters. */
+function tokenizeFileName(fileName: string): Set<string> {
+  const stem = fileName.replace(/\.(zip|rar|7z|vpk|gz|tar)$/i, '');
+  const tokens = new Set<string>();
+  for (const raw of stem.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length < 2) continue;
+    if (/^\d+$/.test(raw)) continue;
+    if (/^v\d+$/.test(raw)) continue;
+    if (/^[0-9a-f]+$/.test(raw) && /\d/.test(raw)) continue;
+    tokens.add(raw);
+  }
+  return tokens;
+}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -81,6 +81,7 @@ import PriorityEditor from '../components/PriorityEditor';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { formatBytes } from '../lib/formatBytes';
+import { resolveUpdateTarget } from '../lib/updateFileMatch';
 import { Button, Tag } from '../components/common/ui';
 import { LockerOverridesModal } from '../components/LockerOverridesModal';
 import { ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
@@ -737,6 +738,11 @@ export default function Installed() {
   const [updateAllConfirmOpen, setUpdateAllConfirmOpen] = useState(false);
   const [updateAllProgress, setUpdateAllProgress] = useState<{ done: number; total: number } | null>(null);
   const [updateAllError, setUpdateAllError] = useState<string | null>(null);
+  // Mods whose replacement file couldn't be auto-matched during an update run
+  // (author replaced their files and several current files could be the
+  // successor). The installs are kept untouched; a toast offers a manual pick
+  // via the details modal, which already handles the delete + re-enable flow.
+  const [updatePickQueue, setUpdatePickQueue] = useState<{ id: string; name: string }[]>([]);
   const installedScrollRef = useRef<HTMLDivElement | null>(null);
   const latestInstalledScrollTopRef = useRef(
     installedPageScrollTop || useAppStore.getState().installedScrollTop
@@ -1291,16 +1297,20 @@ export default function Installed() {
    * Update-all button reflects per-group updates too.
    */
   const runUpdate = async (targets: typeof mods) => {
+    setUpdatePickQueue([]);
     const snapshots = targets
       .filter((m) => m.gameBananaId && typeof m.gameBananaFileId === 'number')
       .map((m) => ({
         oldId: m.id,
+        modName: m.name,
         gameBananaId: m.gameBananaId!,
         gameBananaFileId: m.gameBananaFileId!,
         fileName: m.fileName,
         section: m.sourceSection ?? 'Mod',
         categoryId: m.categoryId ?? 0,
         wasEnabled: m.enabled,
+        fileDescription: m.fileDescription,
+        sourceFileName: m.sourceFileName,
       }));
     if (snapshots.length === 0) return;
 
@@ -1317,6 +1327,9 @@ export default function Installed() {
 
     setUpdateAllProgress({ done: 0, total: snapshots.length });
     const failures: string[] = [];
+    // Rows needing a manual file pick. Their installs are left untouched, so
+    // they stay flagged and the details modal's update path can finish the job.
+    const needsPick: { id: string; name: string }[] = [];
     // Track the (gameBananaId, fileId) actually downloaded so re-enable can
     // still find the new install even when we redirected a stale snapshot.
     const completed: { gameBananaId: number; gameBananaFileId: number; wasEnabled: boolean; fileName: string }[] = [];
@@ -1353,14 +1366,27 @@ export default function Installed() {
       //
       // Pass 1: rows whose stored fileId is still a current file on GameBanana
       // (genuine multi-file mods stay 1:1).
-      // Pass 2: rows whose fileId is gone or archived. Fall back to a
-      // single-file consolidation only when the mod now ships exactly one
-      // current file and no other row already claimed it.
+      // Pass 2: rows whose fileId is gone or archived. First try to identify
+      // the replacement by the author's per-file description and filename
+      // token overlap (resolveUpdateTarget); then fall back to a single-file
+      // consolidation when the mod now ships exactly one current file. Rows
+      // with no confident match go to the manual-pick queue instead of being
+      // guessed at.
       type Resolution =
         | { ok: true; snapshot: (typeof snapshots)[number]; fileId: number; fileName: string }
         | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };
       const resolutions: Resolution[] = [];
+      // Seed claims with live files already installed as siblings outside this
+      // run, so neither the fuzzy match nor the single-file fallback
+      // re-downloads a variant the user already has.
+      const groupOldIds = new Set(group.map((s) => s.oldId));
       const claimedIds = new Set<number>();
+      for (const m of mods) {
+        if (m.gameBananaId !== group[0].gameBananaId || groupOldIds.has(m.id)) continue;
+        if (typeof m.gameBananaFileId === 'number' && liveFileIds.has(m.gameBananaFileId)) {
+          claimedIds.add(m.gameBananaFileId);
+        }
+      }
       for (const s of group) {
         if (liveFileIds.has(s.gameBananaFileId)) {
           resolutions.push({ ok: true, snapshot: s, fileId: s.gameBananaFileId, fileName: s.fileName });
@@ -1369,14 +1395,26 @@ export default function Installed() {
       }
       for (const s of group) {
         if (liveFileIds.has(s.gameBananaFileId)) continue;
-        if (liveFiles.length === 1 && !claimedIds.has(liveFiles[0].id)) {
+        const match = resolveUpdateTarget(
+          {
+            installedFileId: s.gameBananaFileId,
+            fileDescription: s.fileDescription,
+            sourceFileName: s.sourceFileName,
+          },
+          details.files ?? [],
+          claimedIds,
+        );
+        if (match) {
+          resolutions.push({ ok: true, snapshot: s, fileId: match.id, fileName: match.fileName });
+          claimedIds.add(match.id);
+        } else if (liveFiles.length === 1 && !claimedIds.has(liveFiles[0].id)) {
           resolutions.push({ ok: true, snapshot: s, fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
           claimedIds.add(liveFiles[0].id);
         } else {
           resolutions.push({
             ok: false,
             snapshot: s,
-            reason: 'file no longer on GameBanana; mod files changed. Reinstall from Browse.',
+            reason: 'stored file is no longer current on GameBanana and no clear replacement match exists',
           });
         }
       }
@@ -1397,7 +1435,8 @@ export default function Installed() {
 
       for (const r of resolutions) {
         if (!r.ok) {
-          failures.push(`${r.snapshot.fileName}: ${r.reason}`);
+          needsPick.push({ id: r.snapshot.oldId, name: r.snapshot.modName });
+          console.warn(`[Update] ${r.snapshot.fileName}: ${r.reason}`);
         } else {
           try {
             await deleteMod(r.snapshot.oldId);
@@ -1452,10 +1491,32 @@ export default function Installed() {
       }
     }
     setUpdateAllProgress(null);
+    if (needsPick.length > 0) {
+      setUpdatePickQueue(needsPick);
+    }
     if (failures.length > 0) {
       setUpdateAllError(`${failures.length} mod${failures.length === 1 ? '' : 's'} failed to update. See console for details.`);
       console.warn('[Update] failures:', failures);
     }
+  };
+
+  /**
+   * Walk the manual-pick queue: open the details modal for the next mod that
+   * still exists so the user can choose the replacement file. The modal's
+   * update path (handleDetailsDownload) handles delete + re-enable.
+   */
+  const openNextUpdatePick = () => {
+    const queue = [...updatePickQueue];
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      const mod = mods.find((m) => m.id === next.id);
+      if (mod) {
+        setUpdatePickQueue(queue);
+        void openModDetails(mod);
+        return;
+      }
+    }
+    setUpdatePickQueue([]);
   };
 
   const handleUpdateAll = async () => {
@@ -3002,22 +3063,53 @@ export default function Installed() {
         onCancel={() => setUpdateAllConfirmOpen(false)}
       />
 
-      {updateAllError && (
-        <div
-          role="alert"
-          aria-live="polite"
-          className="fixed bottom-4 right-4 z-50 max-w-md bg-state-danger/10 border border-state-danger/40 text-state-danger rounded-sm px-4 py-3 shadow-lg flex items-start gap-3 animate-fade-in"
-        >
-          <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-          <div className="flex-1 text-sm text-text-primary">{updateAllError}</div>
-          <button
-            type="button"
-            onClick={() => setUpdateAllError(null)}
-            className="text-state-danger hover:text-text-primary p-1 -m-1 cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-state-danger"
-            aria-label="Dismiss update error"
-          >
-            <X className="w-4 h-4" />
-          </button>
+      {(updateAllError || updatePickQueue.length > 0) && (
+        <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
+          {updateAllError && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="max-w-md bg-state-danger/10 border border-state-danger/40 text-state-danger rounded-sm px-4 py-3 shadow-lg flex items-start gap-3 animate-fade-in"
+            >
+              <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              <div className="flex-1 text-sm text-text-primary">{updateAllError}</div>
+              <button
+                type="button"
+                onClick={() => setUpdateAllError(null)}
+                className="text-state-danger hover:text-text-primary p-1 -m-1 cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-state-danger"
+                aria-label="Dismiss update error"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+          {updatePickQueue.length > 0 && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="max-w-md bg-bg-secondary border border-accent/40 rounded-sm px-4 py-3 shadow-lg flex items-start gap-3 animate-fade-in"
+            >
+              <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0 text-accent" />
+              <div className="flex-1 text-sm text-text-primary">
+                <p>
+                  {updatePickQueue.length === 1
+                    ? `${updatePickQueue[0].name} needs a manual file pick: the author replaced their files and no clear match exists. The installed version was kept.`
+                    : `${updatePickQueue.length} mods need a manual file pick: the authors replaced their files and no clear match exists. The installed versions were kept.`}
+                </p>
+                <Button size="sm" variant="primary" className="mt-2" onClick={openNextUpdatePick}>
+                  {updatePickQueue.length === 1 ? 'Pick replacement' : `Pick replacements (${updatePickQueue.length})`}
+                </Button>
+              </div>
+              <button
+                type="button"
+                onClick={() => setUpdatePickQueue([])}
+                className="text-text-muted hover:text-text-primary p-1 -m-1 cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                aria-label="Dismiss manual pick notice"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Problem

Update all failed for any mod whose author archived or deleted the installed file and now ships multiple current files. The resolver in `runUpdate` only knew two ways to pick a replacement: the stored file id is still live (never true for a flagged mod), or the mod has exactly one current file. Everything else failed with "file no longer on GameBanana; mod files changed. Reinstall from Browse."

Since archive-old-upload-new is how most active GameBanana authors ship updates, this made Update all fail repeatedly. Reproduced against the live API: both mods flagged on my install (gb 601444 Always Show Passive Items, gb 637275 Numeric Health v2) hit this exact path, failing 2/2 on every run.

## Fix

New pure module `src/lib/updateFileMatch.ts` with `resolveUpdateTarget()`, run as a new pass before the existing single-file fallback. It identifies the replacement among current files using two conservative signals, in order:

1. **The author's per-file description**, captured locally at download time (survives even when GameBanana deleted the old file row). An exact normalized match that is unique among current files is decisive. Authors keep these stable across re-uploads far more often than filenames.
2. **Filename token overlap**, after dropping upload-versioning noise (pure numbers, v-prefixed versions, hex hash suffixes like `8388e`). Requires a minimum score plus a clear margin over the runner-up.

It never guesses: ambiguity or missing signals return null, and those rows now go to a manual-pick queue instead of the failure toast. The pick toast opens the details modal, where the existing update path (`handleDetailsDownload`) already handles delete + download + re-enable. The installed version is kept untouched until the user picks.

## Hardening

- Candidate claims are seeded with live files already installed as sibling variants, so neither the matcher nor the single-file fallback can re-download a variant the user already owns.
- Resolution still completes before any delete runs, preserving the invariant that an unresolvable row keeps its existing install. The pre-update recovery snapshot is unchanged.

## Verification

- Matcher tested against the live GameBanana API: both real failing installs resolve to the correct replacement file (`standalone_passive_items_redesign_06_04.7z` via name tokens, `singlebarcurrentmax_8388e.zip` via unique description match).
- Negative controls: no-signal and tied-score inputs correctly return null; excluded (claimed) candidates are skipped.
- `pnpm typecheck` and `pnpm lint` clean.