### PR TITLE
feat(performance): Edit File button with editor picker for config hand-tuning

### DIFF
--- a/electron/main/ipc/performanceConfig.ts
+++ b/electron/main/ipc/performanceConfig.ts
@@ -1,11 +1,14 @@
 import { ipcMain } from 'electron';
-import { getActiveDeadlockPath } from '../services/settings';
+import { existsSync } from 'fs';
+import { getActiveDeadlockPath, loadSettings } from '../services/settings';
+import { getGameinfoPath } from '../services/deadlock';
+import { listEditorCandidates, openInEditor } from '../services/externalEditor';
 import {
     applyPerformanceConfig,
     getPerformanceConfigStatus,
     removePerformanceConfig,
 } from '../services/performanceConfig';
-import type { PerformanceConfigStatus } from '../../../src/types/electron';
+import type { EditorCandidate, PerformanceConfigStatus } from '../../../src/types/electron';
 
 // get-performance-config-status
 ipcMain.handle('get-performance-config-status', (): PerformanceConfigStatus => {
@@ -20,4 +23,24 @@ ipcMain.handle('apply-performance-config', (): PerformanceConfigStatus => {
 // remove-performance-config
 ipcMain.handle('remove-performance-config', (): PerformanceConfigStatus => {
     return removePerformanceConfig(getActiveDeadlockPath());
+});
+
+// open-performance-config-file (power users hand-tune the applied preset in
+// the editor they picked; the editor path is read from settings here, never
+// passed in from the renderer)
+ipcMain.handle('open-performance-config-file', async (): Promise<void> => {
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        throw new Error('No Deadlock path configured');
+    }
+    const gameinfoPath = getGameinfoPath(deadlockPath);
+    if (!existsSync(gameinfoPath)) {
+        throw new Error('gameinfo.gi not found');
+    }
+    await openInEditor(gameinfoPath, loadSettings().externalEditorPath);
+});
+
+// list-editor-candidates
+ipcMain.handle('list-editor-candidates', (): EditorCandidate[] => {
+    return listEditorCandidates();
 });

--- a/electron/main/ipc/performanceConfig.ts
+++ b/electron/main/ipc/performanceConfig.ts
@@ -7,6 +7,7 @@ import {
     applyPerformanceConfig,
     getPerformanceConfigStatus,
     removePerformanceConfig,
+    resetPerformanceConfigOverrides,
 } from '../services/performanceConfig';
 import type { EditorCandidate, PerformanceConfigStatus } from '../../../src/types/electron';
 
@@ -23,6 +24,12 @@ ipcMain.handle('apply-performance-config', (): PerformanceConfigStatus => {
 // remove-performance-config
 ipcMain.handle('remove-performance-config', (): PerformanceConfigStatus => {
     return removePerformanceConfig(getActiveDeadlockPath());
+});
+
+// reset-performance-config-overrides (reapply the pure preset, dropping the
+// user's saved hand-edit overrides)
+ipcMain.handle('reset-performance-config-overrides', (): PerformanceConfigStatus => {
+    return resetPerformanceConfigOverrides(getActiveDeadlockPath());
 });
 
 // open-performance-config-file (power users hand-tune the applied preset in

--- a/electron/main/services/externalEditor.ts
+++ b/electron/main/services/externalEditor.ts
@@ -1,0 +1,100 @@
+// Open a file in the user's chosen text editor. The OS default-app route
+// (shell.openPath) is a poor fit for gameinfo.gi: .gi resolves to text/plain,
+// which on many desktops maps to a word processor (LibreOffice Writer), so
+// the user picks an editor once (stored in settings.externalEditorPath) and
+// we spawn it directly. Only real executables are offered: Windows launcher
+// shims like code.cmd need a shell and break on paths with spaces.
+import { spawn } from 'child_process';
+import { accessSync, constants, existsSync } from 'fs';
+import { delimiter, join } from 'path';
+import { shell } from 'electron';
+import type { EditorCandidate } from '../../../src/types/electron';
+
+function which(cmd: string): string | null {
+    for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+        if (!dir) continue;
+        const full = join(dir, cmd);
+        try {
+            accessSync(full, constants.X_OK);
+            return full;
+        } catch {
+            // not here; keep scanning
+        }
+    }
+    return null;
+}
+
+const LINUX_CANDIDATES: Array<[command: string, name: string]> = [
+    ['gnome-text-editor', 'GNOME Text Editor'],
+    ['gedit', 'gedit'],
+    ['kate', 'Kate'],
+    ['kwrite', 'KWrite'],
+    ['mousepad', 'Mousepad'],
+    ['pluma', 'Pluma'],
+    ['geany', 'Geany'],
+    ['code', 'Visual Studio Code'],
+    ['codium', 'VSCodium'],
+    ['cursor', 'Cursor'],
+    ['subl', 'Sublime Text'],
+];
+
+function windowsCandidates(): Array<[path: string, name: string]> {
+    const programFiles = process.env['ProgramFiles'] ?? 'C:\\Program Files';
+    const programFilesX86 = process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)';
+    const localAppData = process.env['LOCALAPPDATA'] ?? '';
+    const winDir = process.env['WINDIR'] ?? 'C:\\Windows';
+    return [
+        [join(winDir, 'System32', 'notepad.exe'), 'Notepad'],
+        [join(programFiles, 'Notepad++', 'notepad++.exe'), 'Notepad++'],
+        [join(programFilesX86, 'Notepad++', 'notepad++.exe'), 'Notepad++'],
+        [join(localAppData, 'Programs', 'Microsoft VS Code', 'Code.exe'), 'Visual Studio Code'],
+        [join(programFiles, 'Microsoft VS Code', 'Code.exe'), 'Visual Studio Code'],
+        [join(programFiles, 'Sublime Text', 'sublime_text.exe'), 'Sublime Text'],
+    ];
+}
+
+export function listEditorCandidates(): EditorCandidate[] {
+    const found: EditorCandidate[] = [];
+    if (process.platform === 'win32') {
+        for (const [path, name] of windowsCandidates()) {
+            if (existsSync(path)) found.push({ name, path });
+        }
+    } else {
+        for (const [command, name] of LINUX_CANDIDATES) {
+            const path = which(command);
+            if (path) found.push({ name, path });
+        }
+    }
+    // The same editor can be detected at two install paths; keep the first.
+    const seen = new Set<string>();
+    return found.filter((c) => !seen.has(c.name) && seen.add(c.name));
+}
+
+/** Open filePath with the chosen editor binary, or the OS default app when
+ *  editorPath is null/undefined. Throws with a user-facing message. */
+export async function openInEditor(
+    filePath: string,
+    editorPath: string | null | undefined
+): Promise<void> {
+    if (editorPath) {
+        if (!existsSync(editorPath)) {
+            throw new Error(
+                'The configured editor no longer exists. Pick a different one via "change editor".'
+            );
+        }
+        await new Promise<void>((resolve, reject) => {
+            const child = spawn(editorPath, [filePath], { detached: true, stdio: 'ignore' });
+            child.once('spawn', () => {
+                child.unref();
+                resolve();
+            });
+            child.once('error', (err) => reject(new Error(`Could not launch editor: ${err.message}`)));
+        });
+        return;
+    }
+    const error = await shell.openPath(filePath);
+    if (error) {
+        // No association for the file type: at least reveal it.
+        shell.showItemInFolder(filePath);
+    }
+}

--- a/electron/main/services/performanceConfig.ts
+++ b/electron/main/services/performanceConfig.ts
@@ -31,7 +31,18 @@ const GAMEINFO_BACKUP_SUFFIX = '.grimoire-bak';
 // in-file BEGIN marker is how we detect "a game update wiped the config".
 // Deliberately NOT named gameinfo.*: system.ts's findGameinfoCandidates
 // surfaces gameinfo.* files as restore candidates and this is not one.
+// Besides wiped-detection it carries the user's overrides: hand edits to
+// preset-managed lines, harvested on reapply and layered onto every apply,
+// so power-user tweaks survive reapplies, preset updates, and game-update
+// wipes. Markers always record stock values (never override values), so
+// Remove restores the original file regardless of overrides.
 const STATE_FILENAME = 'grimoire-performance.json';
+
+/** A user deviation from the preset for one managed key: a different value,
+ *  or omit (the user deleted / commented out the preset line). Keys are
+ *  `<section path>/<key>`, e.g. `ConVars/citadel_unit_status_use_new`. */
+type OverrideEntry = { value?: string; omit?: boolean };
+type Overrides = Record<string, OverrideEntry>;
 
 function statePath(gameinfoPath: string): string {
     return join(dirname(gameinfoPath), STATE_FILENAME);
@@ -128,6 +139,94 @@ function entryKey(line: string): string | null {
 }
 
 const quote = (v: string) => `"${v.replace(/^"|"$/g, '')}"`;
+const unquote = (v: string) => v.replace(/^"|"$/g, '');
+
+// ---------------------------------------------------------------------------
+// Overrides: harvest hand edits so they survive reapply and wipes
+// ---------------------------------------------------------------------------
+
+// Bare key -> preset value + override key. null marks a bare key that appears
+// more than once in the preset (ambiguous: harvesting it could attribute a
+// value to the wrong section, so we skip it). Remove-type ops carry no value
+// and are not overridable.
+function presetKeyIndex(): Map<string, { okey: string; value: string } | null> {
+    const idx = new Map<string, { okey: string; value: string } | null>();
+    const put = (bare: string, okey: string, value: string) => {
+        idx.set(bare, idx.has(bare) ? null : { okey, value });
+    };
+    for (const [key, value] of CONVARS) put(key, `ConVars/${key}`, value);
+    for (const op of SECTION_OPS) {
+        if (!op.remove) put(op.key, `${op.path.join('/')}/${op.key}`, op.value!);
+    }
+    return idx;
+}
+
+// Read the user's deviations out of an applied file (LF-normalized): edits to
+// marker-tagged lines, commented-out or deleted preset convars, and the
+// user's own convars added inside the marked block. Runs on every reapply, so
+// the result is a complete snapshot (reverting a line back to the preset
+// value drops its override). Deletions are only detected for ConVars block
+// keys: a missing section-op key usually means a game update restructured
+// the section, not user intent.
+function harvestOverrides(content: string): Overrides {
+    const idx = presetKeyIndex();
+    const overrides: Overrides = {};
+    const addedToken = `// ${MARKER} added`;
+    const wasRe = new RegExp(`^(.*?) // ${MARKER} was ("[^"]*"|\\S+)\\s*$`);
+
+    for (const line of content.split('\n')) {
+        const addedAt = line.indexOf(addedToken);
+        if (addedAt >= 0) {
+            const body = line.slice(0, addedAt);
+            const isCommented = /^[ \t]*\/\//.test(body);
+            const active = isCommented ? body.replace(/^[ \t]*\/\/[ \t]*/, '') : body;
+            const key = entryKey(active);
+            if (!key) continue;
+            const entry = matchEntryLine(active, key);
+            const preset = idx.get(key);
+            if (preset === null) continue; // ambiguous bare key
+            if (!preset) {
+                // Not in the preset: the user's own convar inside our block.
+                if (!isCommented && entry) {
+                    overrides[`ConVars/${key}`] = { value: unquote(entry.value) };
+                }
+                continue;
+            }
+            if (isCommented) overrides[preset.okey] = { omit: true };
+            else if (entry && unquote(entry.value) !== preset.value) {
+                overrides[preset.okey] = { value: unquote(entry.value) };
+            }
+            continue;
+        }
+        const was = wasRe.exec(line);
+        if (was) {
+            const key = entryKey(was[1]);
+            const entry = key ? matchEntryLine(was[1], key) : null;
+            const preset = key ? idx.get(key) : null;
+            if (preset && entry && unquote(entry.value) !== preset.value) {
+                overrides[preset.okey] = { value: unquote(entry.value) };
+            }
+        }
+    }
+
+    // Deleted preset convars: every CONVARS key is present after an apply
+    // (edited in place or injected), so one with no active entry left in the
+    // ConVars section was removed by the user.
+    const convarRange = findSectionByPath(content, ['ConVars']);
+    if (convarRange) {
+        const activeKeys = new Set(
+            content
+                .slice(convarRange.bodyStart, convarRange.bodyEnd)
+                .split('\n')
+                .map(entryKey)
+                .filter(Boolean)
+        );
+        for (const [key] of CONVARS) {
+            if (!activeKeys.has(key)) overrides[`ConVars/${key}`] = { omit: true };
+        }
+    }
+    return overrides;
+}
 
 // ---------------------------------------------------------------------------
 // Apply
@@ -170,7 +269,10 @@ function applyOp(content: string, op: SectionOp): string | null {
     return content.slice(0, range.bodyStart) + added + content.slice(range.bodyStart);
 }
 
-export function applyPerformanceConfig(deadlockPath: string | null): PerformanceConfigStatus {
+export function applyPerformanceConfig(
+    deadlockPath: string | null,
+    opts?: { resetOverrides?: boolean }
+): PerformanceConfigStatus {
     if (!deadlockPath) return status('error', 'Deadlock path not configured.');
     const gameinfoPath = getGameinfoPath(deadlockPath);
     if (!existsSync(gameinfoPath)) {
@@ -183,6 +285,15 @@ export function applyPerformanceConfig(deadlockPath: string | null): Performance
 
         // Work in LF-space (see header comment), restore the EOL style on write.
         let content = crlf ? original.split('\r\n').join('\n') : original;
+        // User overrides: harvested fresh from the file when a config is
+        // present (so hand edits made since the last apply are captured), or
+        // carried over from the sidecar when a game update wiped the file.
+        let overrides: Overrides = {};
+        if (!opts?.resetOverrides) {
+            overrides = BEGIN_RE.test(content)
+                ? harvestOverrides(content)
+                : (readAppliedState(gameinfoPath)?.overrides ?? {});
+        }
         // Reapplying (e.g. after a preset data update) starts from a clean base.
         if (BEGIN_RE.test(content)) content = removeMarkers(content);
 
@@ -199,8 +310,15 @@ export function applyPerformanceConfig(deadlockPath: string | null): Performance
 
         const skipped: string[] = [];
         for (const op of SECTION_OPS) {
-            const next = applyOp(content, op);
-            if (next === null) skipped.push(`${op.path.join('/')}/${op.key}`);
+            const okey = `${op.path.join('/')}/${op.key}`;
+            const override = overrides[okey];
+            if (override?.omit) continue;
+            const effective =
+                override?.value !== undefined && !op.remove
+                    ? { ...op, value: override.value }
+                    : op;
+            const next = applyOp(content, effective);
+            if (next === null) skipped.push(okey);
             else content = next;
         }
 
@@ -221,10 +339,26 @@ export function applyPerformanceConfig(deadlockPath: string | null): Performance
         );
         const toInject: Array<readonly [string, string]> = [];
         for (const [key, value] of CONVARS) {
+            const override = overrides[`ConVars/${key}`];
+            if (override?.omit) continue;
+            const effective = override?.value ?? value;
             if (existingKeys.has(key)) {
-                content = applyOp(content, { path: ['ConVars'], key, value })!;
+                content = applyOp(content, { path: ['ConVars'], key, value: effective })!;
             } else {
-                toInject.push([key, value]);
+                toInject.push([key, effective]);
+            }
+        }
+        // The user's own convars (added inside the marked block by hand and
+        // harvested as overrides) ride along in the injected block.
+        const presetConvarKeys = new Set(CONVARS.map(([key]) => key));
+        for (const [okey, override] of Object.entries(overrides)) {
+            if (!okey.startsWith('ConVars/') || override.value === undefined) continue;
+            const key = okey.slice('ConVars/'.length);
+            if (presetConvarKeys.has(key)) continue;
+            if (existingKeys.has(key)) {
+                content = applyOp(content, { path: ['ConVars'], key, value: override.value })!;
+            } else {
+                toInject.push([key, override.value]);
             }
         }
         convarRange = findSectionByPath(content, ['ConVars'])!;
@@ -247,15 +381,26 @@ export function applyPerformanceConfig(deadlockPath: string | null): Performance
 
         const finalText = crlf ? content.split('\n').join('\r\n') : content;
         writeFileSync(gameinfoPath, finalText, 'utf-8');
-        writeAppliedState(gameinfoPath, true, sha256(finalText));
+        writeAppliedState(gameinfoPath, true, sha256(finalText), overrides);
 
+        const kept = Object.keys(overrides).length;
+        const keptNote = kept
+            ? ` Kept ${kept} of your override${kept === 1 ? '' : 's'}.`
+            : '';
         const note = skipped.length
             ? ` (${skipped.length} setting${skipped.length === 1 ? '' : 's'} skipped: section not found, likely changed by a game update)`
             : '';
-        return status('applied', `Performance config v${PRESET_VERSION} applied${note}.`);
+        return status('applied', `Performance config v${PRESET_VERSION} applied${note}.${keptNote}`, kept);
     } catch (err) {
         return status('error', `Failed to apply performance config: ${err}`);
     }
+}
+
+/** Reapply the pure preset, discarding the user's saved overrides. */
+export function resetPerformanceConfigOverrides(
+    deadlockPath: string | null
+): PerformanceConfigStatus {
+    return applyPerformanceConfig(deadlockPath, { resetOverrides: true });
 }
 
 function braceCount(content: string): number {
@@ -347,24 +492,38 @@ export function getPerformanceConfigStatus(deadlockPath: string | null): Perform
             const sidecar = readAppliedState(gameinfoPath);
             const handEdited =
                 typeof sidecar?.contentHash === 'string' && sidecar.contentHash !== sha256(content);
+            const overrideCount = Object.keys(sidecar?.overrides ?? {}).length;
             const base =
                 begin[2] === PRESET_VERSION
                     ? `Performance config v${begin[2]} is applied.`
                     : `Performance config v${begin[2]} is applied; v${PRESET_VERSION} is available (reapply to update).`;
+            const overrideNote = overrideCount
+                ? ` Keeping ${overrideCount} of your override${overrideCount === 1 ? '' : 's'}.`
+                : '';
             return {
                 state: 'applied',
                 appliedVersion: begin[2],
                 bundledVersion: PRESET_VERSION,
                 handEdited,
+                overrideCount,
                 message: handEdited
-                    ? `${base} The file has manual edits: Reapply overwrites values on preset-managed lines.`
-                    : base,
+                    ? `${base}${overrideNote} The file has manual edits: Reapply folds them into your overrides.`
+                    : `${base}${overrideNote}`,
             };
         }
         // Applied before, but the markers are gone: a game update replaced
         // gameinfo.gi (Valve resets it on major patches).
-        if (readAppliedState(gameinfoPath)) {
-            return status('wiped', 'A game update reset gameinfo.gi and removed the performance config. Reapply to restore it.');
+        const wipedSidecar = readAppliedState(gameinfoPath);
+        if (wipedSidecar) {
+            const savedOverrides = Object.keys(wipedSidecar.overrides ?? {}).length;
+            const restoreNote = savedOverrides
+                ? ` Your ${savedOverrides} saved override${savedOverrides === 1 ? '' : 's'} will be restored too.`
+                : '';
+            return status(
+                'wiped',
+                `A game update reset gameinfo.gi and removed the performance config. Reapply to restore it.${restoreNote}`,
+                savedOverrides
+            );
         }
         return status('not-applied', 'Performance config is not applied.');
     } catch (err) {
@@ -374,12 +533,14 @@ export function getPerformanceConfigStatus(deadlockPath: string | null): Perform
 
 function status(
     state: PerformanceConfigStatus['state'],
-    message: string
+    message: string,
+    overrideCount = 0
 ): PerformanceConfigStatus {
     return {
         state,
         appliedVersion: state === 'applied' ? PRESET_VERSION : null,
         bundledVersion: PRESET_VERSION,
+        overrideCount,
         message,
     };
 }
@@ -388,9 +549,14 @@ function sha256(text: string): string {
     return createHash('sha256').update(text, 'utf-8').digest('hex');
 }
 
-function readAppliedState(
-    gameinfoPath: string
-): { presetId: string; version: string; contentHash?: string } | null {
+interface AppliedState {
+    presetId: string;
+    version: string;
+    contentHash?: string;
+    overrides?: Overrides;
+}
+
+function readAppliedState(gameinfoPath: string): AppliedState | null {
     try {
         const raw = readFileSync(statePath(gameinfoPath), 'utf-8');
         const parsed = JSON.parse(raw);
@@ -400,15 +566,18 @@ function readAppliedState(
     }
 }
 
-function writeAppliedState(gameinfoPath: string, applied: boolean, contentHash?: string): void {
+function writeAppliedState(
+    gameinfoPath: string,
+    applied: boolean,
+    contentHash?: string,
+    overrides?: Overrides
+): void {
     const file = statePath(gameinfoPath);
     try {
         if (applied) {
-            writeFileSync(
-                file,
-                JSON.stringify({ presetId: PRESET_ID, version: PRESET_VERSION, contentHash }),
-                'utf-8'
-            );
+            const state: AppliedState = { presetId: PRESET_ID, version: PRESET_VERSION, contentHash };
+            if (overrides && Object.keys(overrides).length) state.overrides = overrides;
+            writeFileSync(file, JSON.stringify(state), 'utf-8');
         } else if (existsSync(file)) {
             unlinkSync(file);
         }

--- a/electron/main/services/performanceConfig.ts
+++ b/electron/main/services/performanceConfig.ts
@@ -9,6 +9,7 @@
 // is restored on write: line-based regexes silently fail on CR-terminated
 // lines otherwise (JS `.` does not match \r), which would inject duplicate
 // convars with ambiguous engine precedence on Windows CRLF files.
+import { createHash } from 'crypto';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { getGameinfoPath } from './deadlock';
@@ -244,8 +245,9 @@ export function applyPerformanceConfig(deadlockPath: string | null): Performance
             return status('error', 'Patch produced an unbalanced gameinfo.gi; no changes were written.');
         }
 
-        writeFileSync(gameinfoPath, crlf ? content.split('\n').join('\r\n') : content, 'utf-8');
-        writeAppliedState(gameinfoPath, true);
+        const finalText = crlf ? content.split('\n').join('\r\n') : content;
+        writeFileSync(gameinfoPath, finalText, 'utf-8');
+        writeAppliedState(gameinfoPath, true, sha256(finalText));
 
         const note = skipped.length
             ? ` (${skipped.length} setting${skipped.length === 1 ? '' : 's'} skipped: section not found, likely changed by a game update)`
@@ -339,14 +341,24 @@ export function getPerformanceConfigStatus(deadlockPath: string | null): Perform
         const content = readFileSync(gameinfoPath, 'utf-8');
         const begin = BEGIN_RE.exec(content);
         if (begin) {
+            // The sidecar records a hash of the exact bytes Grimoire wrote, so
+            // a mismatch while the markers are intact means hand edits. Old
+            // sidecars without a hash just never set the flag.
+            const sidecar = readAppliedState(gameinfoPath);
+            const handEdited =
+                typeof sidecar?.contentHash === 'string' && sidecar.contentHash !== sha256(content);
+            const base =
+                begin[2] === PRESET_VERSION
+                    ? `Performance config v${begin[2]} is applied.`
+                    : `Performance config v${begin[2]} is applied; v${PRESET_VERSION} is available (reapply to update).`;
             return {
                 state: 'applied',
                 appliedVersion: begin[2],
                 bundledVersion: PRESET_VERSION,
-                message:
-                    begin[2] === PRESET_VERSION
-                        ? `Performance config v${begin[2]} is applied.`
-                        : `Performance config v${begin[2]} is applied; v${PRESET_VERSION} is available (reapply to update).`,
+                handEdited,
+                message: handEdited
+                    ? `${base} The file has manual edits: Reapply overwrites values on preset-managed lines.`
+                    : base,
             };
         }
         // Applied before, but the markers are gone: a game update replaced
@@ -372,7 +384,13 @@ function status(
     };
 }
 
-function readAppliedState(gameinfoPath: string): { presetId: string; version: string } | null {
+function sha256(text: string): string {
+    return createHash('sha256').update(text, 'utf-8').digest('hex');
+}
+
+function readAppliedState(
+    gameinfoPath: string
+): { presetId: string; version: string; contentHash?: string } | null {
     try {
         const raw = readFileSync(statePath(gameinfoPath), 'utf-8');
         const parsed = JSON.parse(raw);
@@ -382,11 +400,15 @@ function readAppliedState(gameinfoPath: string): { presetId: string; version: st
     }
 }
 
-function writeAppliedState(gameinfoPath: string, applied: boolean): void {
+function writeAppliedState(gameinfoPath: string, applied: boolean, contentHash?: string): void {
     const file = statePath(gameinfoPath);
     try {
         if (applied) {
-            writeFileSync(file, JSON.stringify({ presetId: PRESET_ID, version: PRESET_VERSION }), 'utf-8');
+            writeFileSync(
+                file,
+                JSON.stringify({ presetId: PRESET_ID, version: PRESET_VERSION, contentHash }),
+                'utf-8'
+            );
         } else if (existsSync(file)) {
             unlinkSync(file);
         }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -247,6 +247,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getPerformanceConfigStatus: () => ipcRenderer.invoke('get-performance-config-status'),
     applyPerformanceConfig: () => ipcRenderer.invoke('apply-performance-config'),
     removePerformanceConfig: () => ipcRenderer.invoke('remove-performance-config'),
+    resetPerformanceConfigOverrides: () => ipcRenderer.invoke('reset-performance-config-overrides'),
     openPerformanceConfigFile: () => ipcRenderer.invoke('open-performance-config-file'),
     listEditorCandidates: () => ipcRenderer.invoke('list-editor-candidates'),
     openModsFolder: () => ipcRenderer.invoke('open-mods-folder'),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -247,6 +247,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getPerformanceConfigStatus: () => ipcRenderer.invoke('get-performance-config-status'),
     applyPerformanceConfig: () => ipcRenderer.invoke('apply-performance-config'),
     removePerformanceConfig: () => ipcRenderer.invoke('remove-performance-config'),
+    openPerformanceConfigFile: () => ipcRenderer.invoke('open-performance-config-file'),
+    listEditorCandidates: () => ipcRenderer.invoke('list-editor-candidates'),
     openModsFolder: () => ipcRenderer.invoke('open-mods-folder'),
     openGameFolder: () => ipcRenderer.invoke('open-game-folder'),
 

--- a/src/components/performance/EditorPickerModal.tsx
+++ b/src/components/performance/EditorPickerModal.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { AppWindow, FolderOpen, MonitorCog, X } from 'lucide-react';
+import { listEditorCandidates, showOpenDialog } from '../../lib/api';
+import type { EditorCandidate } from '../../types/electron';
+
+interface Props {
+  onClose: () => void;
+  /** null = OS default app; a string = path to the chosen editor binary. */
+  onChoose: (editorPath: string | null) => void;
+}
+
+// Picker for which application opens gameinfo.gi. Shown the first time the
+// user clicks Edit File (and from the "change editor" link): the OS default
+// for .gi is text/plain, which often resolves to a word processor, so users
+// pick a real editor once and Grimoire remembers it.
+export default function EditorPickerModal({ onClose, onChoose }: Props) {
+  const [candidates, setCandidates] = useState<EditorCandidate[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    listEditorCandidates()
+      .then((found) => {
+        if (!cancelled) setCandidates(found);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const browse = async () => {
+    const path = await showOpenDialog({
+      title: 'Choose an editor application',
+      filters: navigator.platform.startsWith('Win')
+        ? [{ name: 'Applications', extensions: ['exe'] }]
+        : undefined,
+    });
+    if (path) onChoose(path);
+  };
+
+  const rowClass =
+    'w-full flex items-center gap-3 text-left px-3 py-2 rounded-lg border border-white/10 bg-bg-tertiary hover:border-accent transition-colors cursor-pointer';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="editor-picker-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-md shadow-2xl p-5 space-y-4"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 id="editor-picker-title" className="text-base font-semibold text-text-primary">
+              Open gameinfo.gi with
+            </h2>
+            <p className="text-xs text-text-secondary mt-1">
+              Pick the editor for config tweaks. Grimoire remembers this; use the change editor
+              link on the Performance Config card to switch later.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="space-y-2">
+          <button type="button" className={rowClass} onClick={() => onChoose(null)}>
+            <MonitorCog className="w-4 h-4 text-text-secondary shrink-0" aria-hidden="true" />
+            <span className="min-w-0">
+              <span className="block text-sm text-text-primary">System default</span>
+              <span className="block text-xs text-text-secondary">
+                Whatever your OS opens text files with
+              </span>
+            </span>
+          </button>
+          {candidates.map((candidate) => (
+            <button
+              key={candidate.path}
+              type="button"
+              className={rowClass}
+              onClick={() => onChoose(candidate.path)}
+            >
+              <AppWindow className="w-4 h-4 text-text-secondary shrink-0" aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block text-sm text-text-primary">{candidate.name}</span>
+                <span className="block text-xs text-text-secondary truncate">{candidate.path}</span>
+              </span>
+            </button>
+          ))}
+          <button type="button" className={rowClass} onClick={() => void browse()}>
+            <FolderOpen className="w-4 h-4 text-text-secondary shrink-0" aria-hidden="true" />
+            <span className="block text-sm text-text-primary">Browse for an application...</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/performance/PerformanceConfigCard.tsx
+++ b/src/components/performance/PerformanceConfigCard.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Gauge, ExternalLink, RefreshCw } from 'lucide-react';
+import { Gauge, ExternalLink, RefreshCw, SquarePen } from 'lucide-react';
 import { Card, Badge, Button } from '../common/ui';
+import EditorPickerModal from './EditorPickerModal';
+import { useAppStore } from '../../stores/appStore';
 import {
   applyPerformanceConfig,
   getPerformanceConfigStatus,
+  openPerformanceConfigFile,
   removePerformanceConfig,
 } from '../../lib/api';
 import type { PerformanceConfigStatus } from '../../types/electron';
@@ -17,6 +20,9 @@ const SQOOKY_KOFI_URL = 'https://ko-fi.com/sqooky';
 export default function PerformanceConfigCard() {
   const [status, setStatus] = useState<PerformanceConfigStatus | null>(null);
   const [busy, setBusy] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const { settings, saveSettings } = useAppStore();
 
   const refresh = useCallback(async () => {
     try {
@@ -35,6 +41,14 @@ export default function PerformanceConfigCard() {
     void refresh();
   }, [refresh]);
 
+  // Re-check when the window regains focus so hand edits made in an external
+  // editor show up as the "edited" badge without a restart.
+  useEffect(() => {
+    const onFocus = () => void refresh();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [refresh]);
+
   const run = async (action: () => Promise<PerformanceConfigStatus>) => {
     setBusy(true);
     try {
@@ -44,6 +58,29 @@ export default function PerformanceConfigCard() {
     } finally {
       setBusy(false);
     }
+  };
+
+  const openFile = async () => {
+    setOpenError(null);
+    try {
+      await openPerformanceConfigFile();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      setOpenError(detail.replace(/^Error invoking remote method '[^']+': (Error: )?/, ''));
+    }
+  };
+
+  const onEditFile = () => {
+    // First use: ask which app to open with (.gi maps to text/plain, which
+    // often resolves to a word processor). The choice persists in settings.
+    if (settings?.externalEditorPath === undefined) setPickerOpen(true);
+    else void openFile();
+  };
+
+  const onChooseEditor = async (editorPath: string | null) => {
+    setPickerOpen(false);
+    if (settings) await saveSettings({ ...settings, externalEditorPath: editorPath });
+    void openFile();
   };
 
   const applied = status?.state === 'applied';
@@ -57,8 +94,10 @@ export default function PerformanceConfigCard() {
       description="Sqooky's community fps preset (OptimizationLock), applied without touching your mods."
       action={
         status && (
-          <Badge variant={applied ? 'success' : wiped ? 'warning' : status.state === 'error' ? 'error' : 'neutral'}>
-            {applied ? `Applied v${status.appliedVersion}` : wiped ? 'Wiped by game update' : status.state === 'error' ? 'Error' : 'Not applied'}
+          <Badge variant={applied ? (status.handEdited ? 'info' : 'success') : wiped ? 'warning' : status.state === 'error' ? 'error' : 'neutral'}>
+            {applied
+              ? `Applied v${status.appliedVersion}${status.handEdited ? ' (edited)' : ''}`
+              : wiped ? 'Wiped by game update' : status.state === 'error' ? 'Error' : 'Not applied'}
           </Badge>
         )
       }
@@ -89,6 +128,21 @@ export default function PerformanceConfigCard() {
             </a>
             .
           </p>
+          {applied && (
+            <p className="text-xs text-text-secondary">
+              Power users: Edit File opens gameinfo.gi to tweak values (
+              <button
+                type="button"
+                className="text-accent hover:underline"
+                onClick={() => setPickerOpen(true)}
+              >
+                change editor
+              </button>
+              ). Leave the grimoire-perf comment markers alone so Remove can restore your file
+              cleanly.
+            </p>
+          )}
+          {openError && <p className="text-xs text-red-400">{openError}</p>}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button
@@ -104,8 +158,19 @@ export default function PerformanceConfigCard() {
               Remove
             </Button>
           )}
+          {applied && (
+            <Button onClick={onEditFile} disabled={busy} variant="ghost" size="sm" icon={SquarePen}>
+              Edit File
+            </Button>
+          )}
         </div>
       </div>
+      {pickerOpen && (
+        <EditorPickerModal
+          onClose={() => setPickerOpen(false)}
+          onChoose={(editorPath) => void onChooseEditor(editorPath)}
+        />
+      )}
     </Card>
   );
 }

--- a/src/components/performance/PerformanceConfigCard.tsx
+++ b/src/components/performance/PerformanceConfigCard.tsx
@@ -8,6 +8,7 @@ import {
   getPerformanceConfigStatus,
   openPerformanceConfigFile,
   removePerformanceConfig,
+  resetPerformanceConfigOverrides,
 } from '../../lib/api';
 import type { PerformanceConfigStatus } from '../../types/electron';
 
@@ -138,8 +139,9 @@ export default function PerformanceConfigCard() {
               >
                 change editor
               </button>
-              ). Leave the grimoire-perf comment markers alone so Remove can restore your file
-              cleanly.
+              ). Your edits to preset lines are kept as overrides across Reapply and game
+              updates. Leave the grimoire-perf comment markers alone so Remove can restore your
+              file cleanly.
             </p>
           )}
           {openError && <p className="text-xs text-red-400">{openError}</p>}
@@ -161,6 +163,16 @@ export default function PerformanceConfigCard() {
           {applied && (
             <Button onClick={onEditFile} disabled={busy} variant="ghost" size="sm" icon={SquarePen}>
               Edit File
+            </Button>
+          )}
+          {applied && (status?.overrideCount ?? 0) > 0 && (
+            <Button
+              onClick={() => run(resetPerformanceConfigOverrides)}
+              disabled={busy}
+              variant="ghost"
+              size="sm"
+            >
+              Reset Overrides
             </Button>
           )}
         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -510,6 +510,14 @@ export async function removePerformanceConfig(): Promise<PerformanceConfigStatus
   return window.electronAPI.removePerformanceConfig();
 }
 
+export async function openPerformanceConfigFile(): Promise<void> {
+  return window.electronAPI.openPerformanceConfigFile();
+}
+
+export async function listEditorCandidates(): Promise<EditorCandidate[]> {
+  return window.electronAPI.listEditorCandidates();
+}
+
 export async function openModsFolder(): Promise<void> {
   return window.electronAPI.openModsFolder();
 }
@@ -595,7 +603,7 @@ export function conflictPairKey(a: string, b: string): string {
 // Profile wire types are single-sourced in types/electron.ts; re-exported
 // here to preserve this module's existing import surface.
 export type { Profile, ProfileMod, ProfileCrosshairSettings } from '../types/electron';
-import type { Profile, ProfileCrosshairSettings, PerformanceConfigStatus } from '../types/electron';
+import type { Profile, ProfileCrosshairSettings, PerformanceConfigStatus, EditorCandidate } from '../types/electron';
 
 export async function getProfiles(): Promise<Profile[]> {
   return window.electronAPI.getProfiles();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -510,6 +510,10 @@ export async function removePerformanceConfig(): Promise<PerformanceConfigStatus
   return window.electronAPI.removePerformanceConfig();
 }
 
+export async function resetPerformanceConfigOverrides(): Promise<PerformanceConfigStatus> {
+  return window.electronAPI.resetPerformanceConfigOverrides();
+}
+
 export async function openPerformanceConfigFile(): Promise<void> {
   return window.electronAPI.openPerformanceConfigFile();
 }

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -105,12 +105,20 @@ export interface GameinfoStatus {
     candidates: string[];
 }
 
+/** A text editor detected on this machine (for the Edit File picker). */
+export interface EditorCandidate {
+    name: string;
+    path: string;
+}
+
 /** State of the OptimizationLock performance preset in gameinfo.gi.
  *  'wiped' means it was applied before but a game update reset the file. */
 export interface PerformanceConfigStatus {
     state: 'not-applied' | 'applied' | 'wiped' | 'error';
     appliedVersion: string | null;
     bundledVersion: string;
+    /** Applied, but the file no longer matches what Grimoire wrote (hand edits). */
+    handEdited?: boolean;
     message: string;
 }
 
@@ -506,6 +514,8 @@ export interface ElectronAPI {
     getPerformanceConfigStatus: () => Promise<PerformanceConfigStatus>;
     applyPerformanceConfig: () => Promise<PerformanceConfigStatus>;
     removePerformanceConfig: () => Promise<PerformanceConfigStatus>;
+    openPerformanceConfigFile: () => Promise<void>;
+    listEditorCandidates: () => Promise<EditorCandidate[]>;
     openModsFolder: () => Promise<void>;
     openGameFolder: () => Promise<void>;
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -119,6 +119,9 @@ export interface PerformanceConfigStatus {
     bundledVersion: string;
     /** Applied, but the file no longer matches what Grimoire wrote (hand edits). */
     handEdited?: boolean;
+    /** Saved user deviations from the preset (hand edits harvested on reapply,
+     *  layered onto every apply, surviving game-update wipes). */
+    overrideCount?: number;
     message: string;
 }
 
@@ -514,6 +517,7 @@ export interface ElectronAPI {
     getPerformanceConfigStatus: () => Promise<PerformanceConfigStatus>;
     applyPerformanceConfig: () => Promise<PerformanceConfigStatus>;
     removePerformanceConfig: () => Promise<PerformanceConfigStatus>;
+    resetPerformanceConfigOverrides: () => Promise<PerformanceConfigStatus>;
     openPerformanceConfigFile: () => Promise<void>;
     listEditorCandidates: () => Promise<EditorCandidate[]>;
     openModsFolder: () => Promise<void>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -782,4 +782,9 @@ export interface AppSettings {
    *  file next to gameinfo.gi (main-process owned), not in settings, so a
    *  renderer settings save can never clobber it. */
   experimentalPerformanceConfig?: boolean;
+  /** Editor binary used to open gameinfo.gi for hand edits. null = the OS
+   *  default app; undefined = never chosen, so the picker is shown first.
+   *  (.gi maps to text/plain, which often resolves to a word processor, so
+   *  "default" alone makes a bad Edit File experience.) */
+  externalEditorPath?: string | null;
 }


### PR DESCRIPTION
## What

Power-user support for the OptimizationLock performance config, prompted by Discord feature-request feedback (hand edits for the old HP bar, FOV, mip bias).

### Edit File + editor picker (commit 1)

- **Edit File** button on the Performance Config card opens gameinfo.gi for hand edits.
- First click shows an **editor picker**: system default, editors detected on the machine, or browse to any binary. The choice persists as `settings.externalEditorPath` and a *change editor* link reopens the picker. Rationale: `.gi` maps to `text/plain`, whose OS default is often a word processor (LibreOffice Writer on Linux).
- The chosen editor is **spawned by the main process**, which reads the path from settings (never from the renderer). Only real executables are offered; Windows `.cmd` shims are skipped in favor of actual exes.
- Status refreshes on window focus; open failures surface on the card instead of being swallowed.

### Hand edits persist as overrides (commit 2)

- **Reapply harvests the user's deviations** from the marked lines: changed values, deleted or commented-out preset convars, and the user's own convars added inside the block. They're stored as an `overrides` map in the existing sidecar and **layered onto every apply**.
- **Game-update wipes restore preset plus overrides** (the sidecar survives the wipe).
- **Preset bumps keep user intent**: overrides are keyed per `section/key`, so the user's choices win on those keys and the new preset wins everywhere else.
- Markers always record **stock** values, never override values, so **Remove stays a byte-for-byte round-trip** regardless of overrides.
- **Reset Overrides** button reapplies the pure preset. Card shows "Keeping N of your overrides".
- Hand-edit detection via a sha256 of the written file in the sidecar; the `Applied vX (edited)` badge invites a Reapply, which now folds edits in instead of overwriting them.

## Testing

- `pnpm typecheck` and eslint clean on all touched files.
- 25-step scenario test against Sqooky's clean stock gameinfo.gi (bundled service run under node): fresh apply, four kinds of hand edits harvested on reapply, wipe detection + restore with overrides, section-op override (`Engine2/SinglePlayerAsyncRendering`), Reset Overrides, byte-identical Remove round-trip, and idempotent no-edit reapply.
- Verified `shell.openPath` behavior on Linux (opens LibreOffice via xdg, hence the picker) and editor detection (Kate/KWrite found on KDE).
- Manual flow needs a dev restart to load the new main/preload code.