### PR TITLE
feat(sidebar): per-hero calibrated backdrop positioning

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback, useRef, useLayoutEffect } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef, useLayoutEffect, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -43,7 +43,7 @@ import {
 } from '../lib/api';
 
 import { getAssetPath } from '../lib/assetPath';
-import { DEFAULT_SIDEBAR_HERO, getHeroFacePosition, getHeroRenderPath } from '../lib/lockerUtils';
+import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath } from '../lib/lockerUtils';
 import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
 
@@ -117,10 +117,10 @@ function GrimoireTitleIcon() {
 
 function SidebarActiveBackdrop({
   heroSrc,
-  heroPositionX,
+  heroImageStyle,
 }: {
   heroSrc: string | null;
-  heroPositionX: number;
+  heroImageStyle: CSSProperties;
 }) {
   if (heroSrc) {
     return (
@@ -129,7 +129,7 @@ function SidebarActiveBackdrop({
           src={heroSrc}
           alt=""
           className="sidebar-active-backdrop__image h-full w-full object-cover opacity-75"
-          style={{ objectPosition: `${heroPositionX}% 18%` }}
+          style={heroImageStyle}
         />
         <span className="absolute inset-0 bg-gradient-to-r from-bg-primary/90 via-bg-primary/55 to-bg-primary/20" />
         <span className="absolute inset-0 bg-black/20" />
@@ -304,9 +304,7 @@ export default function Sidebar() {
   const sidebarHeroHighlightSrc = sidebarHeroHighlight
     ? getHeroRenderPath(sidebarHeroHighlight)
     : null;
-  const sidebarHeroHighlightX = sidebarHeroHighlight
-    ? getHeroFacePosition(sidebarHeroHighlight)
-    : 55;
+  const sidebarHeroImageStyle = getSidebarHeroImageStyle(sidebarHeroHighlight);
   const settingsActive = location.pathname.startsWith('/settings');
   const discoverActive = location.pathname.startsWith('/discover');
 
@@ -745,7 +743,7 @@ export default function Sidebar() {
             >
               <SidebarActiveBackdrop
                 heroSrc={sidebarHeroHighlightSrc}
-                heroPositionX={sidebarHeroHighlightX}
+                heroImageStyle={sidebarHeroImageStyle}
               />
             </div>
           )}
@@ -1108,7 +1106,7 @@ export default function Sidebar() {
           {settingsActive && (
             <SidebarActiveBackdrop
               heroSrc={sidebarHeroHighlightSrc}
-              heroPositionX={sidebarHeroHighlightX}
+              heroImageStyle={sidebarHeroImageStyle}
             />
           )}
           <span className={`relative z-10 ${actionIconClass}`}>

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { GlobalModType, Mod } from '../types/mod';
 import { getAssetPath } from './assetPath';
@@ -37,47 +38,80 @@ export function readStoredFavorites(): number[] {
 }
 
 /**
- * Per-hero portrait X positioning (percentage) for gallery cards based on face location.
- * The value represents where the face is located horizontally in the image.
- * Default is 55% which works for most heroes.
+ * Per-hero portrait positioning for hero-render backdrops, based on where the
+ * face sits in the image.
+ *
+ * x is the object-position crop percent shared by the gallery-style surfaces
+ * (Locker, Browse, Installed), each of which pairs it with its own hardcoded
+ * y. y and shiftX are SIDEBAR-ONLY, calibrated against the sidebar active card
+ * via tools/hero-position-calibrator.html: the sidebar card is so wide that
+ * object-cover leaves no horizontal slack (x does nothing there), so shiftX
+ * slides the whole image by a percentage of the card width (negative = left,
+ * positive = right) and may deliberately push the art past the edge, leaving
+ * blank card background. Default is { x: 55, y: 18 } with no shift.
  */
-export const HERO_FACE_POSITION: Record<string, number> = {
-  Abrams: 0,
-  Bebop: 81,
-  Billy: 73,
-  Calico: 80,
-  Doorman: 40,
-  Drifter: 93,
-  Dynamo: 68,
-  'Grey Talon': 77,
-  Haze: 78,
-  Holliday: 26,
-  Infernus: 100,
-  Ivy: 72,
-  Kelvin: 47,
-  'Lady Geist': 87,
-  Lash: 54,
-  McGinnis: 22,
-  Mina: 54,
-  Mirage: 65,
-  'Mo & Krill': 100,
-  Paige: 42,
-  Paradox: 59,
-  Pocket: 61,
-  Seven: 57,
-  Shiv: 68,
-  Sinclair: 61,
-  Victor: 45,
-  Vindicta: 83,
-  Viscous: 72,
-  Vyper: 48,
-  Warden: 55,
-  Wraith: 56,
-  Yamato: 56,
+export type HeroFacePosition = { x: number; y: number; shiftX?: number };
+
+export const HERO_FACE_POSITION: Record<string, HeroFacePosition> = {
+  Abrams: { x: 0, y: 12, shiftX: 24 },
+  Apollo: { x: 55, y: 12, shiftX: 16 },
+  Bebop: { x: 81, y: 1.5, shiftX: 5 },
+  Billy: { x: 73, y: 18, shiftX: 6.5 },
+  Calico: { x: 80, y: 19, shiftX: 11.5 },
+  Celeste: { x: 55, y: 9.5, shiftX: 16.5 },
+  Doorman: { x: 40, y: 19, shiftX: 35.5 },
+  Drifter: { x: 93, y: 18, shiftX: 20.5 },
+  Dynamo: { x: 68, y: 13.5, shiftX: 19.5 },
+  Graves: { x: 55, y: 21.5, shiftX: 26 },
+  'Grey Talon': { x: 77, y: 12, shiftX: 20 },
+  Haze: { x: 50, y: 9, shiftX: 22 },
+  Holliday: { x: 26, y: 17, shiftX: 29 },
+  Infernus: { x: 100, y: 8.5, shiftX: 5.5 },
+  Ivy: { x: 72, y: 24, shiftX: 9.5 },
+  Kelvin: { x: 47, y: 16, shiftX: 16.5 },
+  'Lady Geist': { x: 87, y: 14.5, shiftX: 15.5 },
+  Lash: { x: 54, y: 10.5, shiftX: 21.5 },
+  McGinnis: { x: 22, y: 17, shiftX: 35 },
+  Mina: { x: 54, y: 16.5, shiftX: 14 },
+  Mirage: { x: 65, y: 16.5, shiftX: 23.5 },
+  'Mo & Krill': { x: 100, y: 25.5, shiftX: 3.5 },
+  Paige: { x: 42, y: 18, shiftX: 31.5 },
+  Paradox: { x: 59, y: 18, shiftX: 3.5 },
+  Pocket: { x: 61, y: 12.5, shiftX: 10.5 },
+  Rem: { x: 55, y: 25, shiftX: 29 },
+  Seven: { x: 57, y: 12.5, shiftX: 18.5 },
+  Shiv: { x: 68, y: 7.5, shiftX: 0.5 },
+  Silver: { x: 55, y: 21, shiftX: 21.5 },
+  Sinclair: { x: 61, y: 12, shiftX: 17.5 },
+  Venator: { x: 55, y: 10, shiftX: 1 },
+  Victor: { x: 45, y: 9.5, shiftX: 28 },
+  Vindicta: { x: 83, y: 3.5, shiftX: 8.5 },
+  Viscous: { x: 72, y: 9, shiftX: 14.5 },
+  Vyper: { x: 48, y: 22.5, shiftX: 22 },
+  Warden: { x: 55, y: 15.5, shiftX: 24 },
+  Wraith: { x: 56, y: 20, shiftX: 32.5 },
+  Yamato: { x: 56, y: 11.5, shiftX: 29.5 },
 };
 
-export function getHeroFacePosition(name: string): number {
-  return HERO_FACE_POSITION[name] ?? 55;
+const DEFAULT_FACE_POSITION: Required<HeroFacePosition> = { x: 55, y: 18, shiftX: 0 };
+
+export function getHeroFacePosition(name: string | null | undefined): Required<HeroFacePosition> {
+  const position = name ? HERO_FACE_POSITION[name] : undefined;
+  return position ? { shiftX: 0, ...position } : DEFAULT_FACE_POSITION;
+}
+
+/**
+ * Inline style for the SIDEBAR active-card hero backdrop: the object-position
+ * crop plus the shiftX horizontal slide (a margin so it stays a percentage of
+ * the card width). It can push the image past the card edge on purpose,
+ * leaving blank card background. Other surfaces intentionally do not use this:
+ * they pair the x crop percent with their own hardcoded y.
+ */
+export function getSidebarHeroImageStyle(name: string | null | undefined): CSSProperties {
+  const { x, y, shiftX } = getHeroFacePosition(name);
+  const style: CSSProperties = { objectPosition: `${x}% ${y}%` };
+  if (shiftX) style.marginLeft = `${shiftX}%`;
+  return style;
 }
 
 /**

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3486,7 +3486,7 @@ function ReadableBrowseModCard({
   const hasAudioPreview = Boolean(audioPreview);
   const inferredHero = inferHeroFromTitle(mod.name);
   const heroRenderUrl = isSoundSection && inferredHero ? getHeroRenderPath(inferredHero) : undefined;
-  const heroFacePos = inferredHero ? getHeroFacePosition(inferredHero) : 55;
+  const heroFacePosX = getHeroFacePosition(inferredHero).x;
   const shouldHideNsfw = Boolean(mod.nsfw && hideNsfwPreviews);
   const readableCardWidth = cardWidth ?? getReadableCardTargetWidth(cardSize);
   const readableDensity = getReadableDensity(readableCardWidth);
@@ -3539,7 +3539,7 @@ function ReadableBrowseModCard({
             loading="lazy"
             decoding="async"
             className="browse-card-media-zoom h-full w-full object-cover scale-105 blur-lg saturate-75"
-            style={{ objectPosition: `${heroFacePos}% 20%` }}
+            style={{ objectPosition: `${heroFacePosX}% 20%` }}
           />
         ) : (
           <ImageContextMenu src={heroRenderUrl} alt={inferredHero ?? mod.name}>
@@ -3549,7 +3549,7 @@ function ReadableBrowseModCard({
               loading="lazy"
               decoding="async"
               className="browse-card-media-zoom h-full w-full object-cover"
-              style={{ objectPosition: `${heroFacePos}% 20%` }}
+              style={{ objectPosition: `${heroFacePosX}% 20%` }}
             />
           </ImageContextMenu>
         )
@@ -3818,7 +3818,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
   // Used to swap in the locker hero portrait as the card backdrop.
   const inferredHero = isSoundSection ? inferHeroFromTitle(mod.name) : null;
   const heroRenderUrl = inferredHero ? getHeroRenderPath(inferredHero) : undefined;
-  const heroFacePos = inferredHero ? getHeroFacePosition(inferredHero) : 55;
+  const heroFacePosX = getHeroFacePosition(inferredHero).x;
   const [audioControlsActive, setAudioControlsActive] = useState(false);
 
   // List view keeps original layout
@@ -3858,7 +3858,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
                   loading="lazy"
                   decoding="async"
                   className="browse-card-media-zoom w-full h-full object-cover"
-                  style={{ objectPosition: `${heroFacePos}% 25%` }}
+                  style={{ objectPosition: `${heroFacePosX}% 25%` }}
                 />
               </ImageContextMenu>
             ) : thumbnail ? (
@@ -4035,7 +4035,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
                   loading="lazy"
                   decoding="async"
                   className="browse-card-media-zoom w-full h-full object-cover"
-                  style={{ objectPosition: `${heroFacePos}% 20%` }}
+                  style={{ objectPosition: `${heroFacePosX}% 20%` }}
                 />
               </ImageContextMenu>
             ) : thumbnail ? (

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -4965,7 +4965,7 @@ function ModMediaPreview({
     ? mod.lockerHero ?? inferHeroFromTitle(mod.name)
     : null;
   const soundHeroRenderUrl = soundHeroName ? getHeroRenderPath(soundHeroName) : null;
-  const soundHeroFacePos = soundHeroName ? getHeroFacePosition(soundHeroName) : 50;
+  const soundHeroFacePosX = soundHeroName ? getHeroFacePosition(soundHeroName).x : 50;
   const image = (
     <ModThumbnail
       src={mod.thumbnailUrl}
@@ -4985,7 +4985,7 @@ function ModMediaPreview({
         alt={soundHeroName ?? mod.name}
         draggable={false}
         className="block h-full w-full object-cover origin-center transform-gpu will-change-transform transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
-        style={{ objectPosition: `${soundHeroFacePos}% 25%` }}
+        style={{ objectPosition: `${soundHeroFacePosX}% 25%` }}
       />
     </ImageContextMenu>
   ) : (
@@ -5229,7 +5229,7 @@ function ModListRowContent({
     ? mod.lockerHero ?? inferHeroFromTitle(mod.name)
     : null;
   const listHeroRenderUrl = listHeroName ? getHeroRenderPath(listHeroName) : null;
-  const listHeroFacePos = listHeroName ? getHeroFacePosition(listHeroName) : 50;
+  const listHeroFacePosX = listHeroName ? getHeroFacePosition(listHeroName).x : 50;
 
   return (
     <>
@@ -5273,7 +5273,7 @@ function ModListRowContent({
               alt={listHeroName ?? mod.name}
               draggable={false}
               className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
-              style={{ objectPosition: `${listHeroFacePos}% 25%` }}
+              style={{ objectPosition: `${listHeroFacePosX}% 25%` }}
             />
           </ImageContextMenu>
         ) : isSound && !mod.thumbnailUrl ? (

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1319,7 +1319,7 @@ function HeroGalleryCard({
   const renderLocal = getHeroRenderPath(hero.name);
   const wikiUrl = getHeroWikiUrl(hero.name);
   const namePath = getHeroNamePath(hero.name);
-  const facePositionX = getHeroFacePosition(hero.name);
+  const facePositionX = getHeroFacePosition(hero.name).x;
   const [fallbackStep, setFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
   const [, setImageCacheVersion] = useState(0);
@@ -1504,7 +1504,7 @@ function HeroCard({
 }: HeroCardProps) {
   const localUrl = getHeroRenderPath(hero.name);
   const wikiUrl = getHeroWikiUrl(hero.name);
-  const facePositionX = getHeroFacePosition(hero.name);
+  const facePositionX = getHeroFacePosition(hero.name).x;
   // Background art fallback chain mirrors the gallery card: local render ->
   // wiki render -> GameBanana icon -> none (solid panel).
   const [bgFallbackStep, setBgFallbackStep] = useState(0);

--- a/tools/hero-position-calibrator.html
+++ b/tools/hero-position-calibrator.html
@@ -1,0 +1,566 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Grimoire - Sidebar Hero Position Calibrator</title>
+<style>
+  :root {
+    --bg: #0f0f0f;
+    --card: #1a1a1a;
+    --input: #242424;
+    --accent: #f97316;
+    --text: #ffffff;
+    --muted: #a1a1aa;
+    --border: #2d2d2d;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    font-size: 14px;
+    display: grid;
+    grid-template-columns: 230px 1fr 340px;
+    height: 100vh;
+    overflow: hidden;
+  }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin: 0 0 10px; }
+
+  /* ----- hero list ----- */
+  #heroList {
+    overflow-y: auto;
+    border-right: 1px solid var(--border);
+    padding: 8px;
+  }
+  .hero-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 5px 8px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background: none;
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+    font-size: 13px;
+  }
+  .hero-row:hover { background: var(--input); }
+  .hero-row.active { border-color: rgba(249, 115, 22, 0.5); background: rgba(249, 115, 22, 0.12); }
+  .hero-row .dot {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--border);
+    flex-shrink: 0;
+  }
+  .hero-row.done .dot { background: #22c55e; }
+  .hero-row.touched:not(.done) .dot { background: var(--accent); }
+
+  /* ----- center stage ----- */
+  #stage {
+    overflow-y: auto;
+    padding: 24px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+  .preview-block { display: flex; flex-direction: column; gap: 8px; }
+  .preview-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+  .preview-rail {
+    background: var(--bg);
+    border: 1px dashed var(--border);
+    border-radius: 4px;
+    padding: 14px;
+    display: inline-flex;
+    gap: 18px;
+    align-items: flex-start;
+    width: fit-content;
+  }
+
+  /* Faithful replica of the sidebar active nav card:
+     expanded sidebar 14rem with p-2 nav padding -> 208px wide, h-10 -> 40px. */
+  .nav-card {
+    position: relative;
+    overflow: hidden;
+    border-radius: 2px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    width: 208px;
+    height: 40px;
+    cursor: grab;
+    user-select: none;
+  }
+  .nav-card:active { cursor: grabbing; }
+  .nav-card.collapsed { width: 48px; }
+  .nav-card .backdrop {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.75;
+    pointer-events: none;
+  }
+  .nav-card .grad {
+    position: absolute; inset: 0; pointer-events: none;
+    background: linear-gradient(to right,
+      rgba(15, 15, 15, 0.9) 0%,
+      rgba(15, 15, 15, 0.55) 50%,
+      rgba(15, 15, 15, 0.2) 100%);
+  }
+  .nav-card .shade { position: absolute; inset: 0; background: rgba(0, 0, 0, 0.2); pointer-events: none; }
+  .nav-card .fg {
+    position: absolute; inset: 0;
+    display: flex; align-items: center;
+    font-size: 14px; font-weight: 600;
+    pointer-events: none;
+  }
+  .nav-card .icon-slot {
+    width: 46px; height: 100%;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .nav-card.collapsed .icon-slot { width: 100%; }
+  .nav-card svg { width: 20px; height: 20px; stroke: rgba(255, 255, 255, 0.9); }
+  .zoom2 { transform: scale(2); transform-origin: top left; }
+  .zoom2-wrap { width: 420px; height: 84px; }
+
+  /* ----- minimap ----- */
+  #minimapWrap { position: relative; width: fit-content; cursor: crosshair; overflow: hidden; border-radius: 3px;
+    padding: 36px; background: repeating-conic-gradient(#161616 0% 25%, #101010 0% 50%) 0 0 / 24px 24px; }
+  #minimap { display: block; max-height: 320px; max-width: 420px; border: 1px solid var(--border); border-radius: 3px; }
+  #cropRect {
+    position: absolute;
+    border: 1.5px solid var(--accent);
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.45);
+    pointer-events: none;
+  }
+
+  /* ----- controls panel ----- */
+  #panel {
+    border-left: 1px solid var(--border);
+    padding: 18px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .ctl { display: flex; flex-direction: column; gap: 6px; }
+  .ctl label { display: flex; justify-content: space-between; color: var(--muted); font-size: 12px; }
+  .ctl label output { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+  input[type="range"] { width: 100%; accent-color: var(--accent); }
+  .btn {
+    background: var(--input);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 3px;
+    padding: 7px 10px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .btn:hover { border-color: var(--accent); }
+  .btn.primary { background: var(--accent); border-color: var(--accent); color: #0f0f0f; font-weight: 600; }
+  .btn-row { display: flex; gap: 8px; flex-wrap: wrap; }
+  .btn-row .btn { flex: 1; }
+  #exportBox {
+    width: 100%;
+    height: 220px;
+    background: var(--input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    padding: 8px;
+    white-space: pre;
+  }
+  .hint { color: var(--muted); font-size: 11px; line-height: 1.5; }
+  kbd {
+    background: var(--input); border: 1px solid var(--border); border-radius: 3px;
+    padding: 0 4px; font-size: 10px; font-family: inherit;
+  }
+  #heroTitle { font-size: 18px; font-weight: 700; margin: 0; }
+  #progress { color: var(--muted); font-size: 12px; }
+  .flash { outline: 2px solid #22c55e !important; transition: outline 0.1s; }
+</style>
+</head>
+<body>
+
+<div id="heroList"></div>
+
+<div id="stage">
+  <div>
+    <p id="heroTitle"></p>
+    <p id="progress"></p>
+  </div>
+
+  <div class="preview-block">
+    <div class="preview-label">Sidebar active card (1x, drag image to position)</div>
+    <div class="preview-rail">
+      <div class="nav-card" id="card1x">
+        <img class="backdrop" />
+        <span class="grad"></span>
+        <span class="shade"></span>
+        <span class="fg">
+          <span class="icon-slot">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/>
+            </svg>
+          </span>
+          <span class="label">Installed</span>
+        </span>
+      </div>
+      <div class="nav-card collapsed" id="cardCollapsed">
+        <img class="backdrop" />
+        <span class="grad"></span>
+        <span class="shade"></span>
+        <span class="fg">
+          <span class="icon-slot">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/>
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="preview-block">
+    <div class="preview-label">2x zoom</div>
+    <div class="preview-rail zoom2-wrap">
+      <div class="zoom2">
+        <div class="nav-card" id="card2x">
+          <img class="backdrop" />
+          <span class="grad"></span>
+          <span class="shade"></span>
+          <span class="fg">
+            <span class="icon-slot">
+              <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/>
+              </svg>
+            </span>
+            <span class="label">Installed</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="preview-block">
+    <div class="preview-label">Full render with crop region (click to center crop there)</div>
+    <div id="minimapWrap">
+      <img id="minimap" />
+      <div id="cropRect"></div>
+    </div>
+  </div>
+</div>
+
+<div id="panel">
+  <h2>Position</h2>
+  <div class="ctl">
+    <label>Shift X (% of card width; blank edges allowed) <output id="xOut"></output></label>
+    <input type="range" id="xSlider" min="-150" max="150" step="1" />
+  </div>
+  <div class="ctl">
+    <label>Y (object-position) <output id="yOut"></output></label>
+    <input type="range" id="ySlider" min="-100" max="200" step="1" />
+  </div>
+
+  <div class="btn-row">
+    <button class="btn" id="resetBtn">Reset hero</button>
+    <button class="btn" id="doneBtn">Done, next</button>
+  </div>
+  <div class="btn-row">
+    <button class="btn" id="prevBtn">&larr; Prev</button>
+    <button class="btn" id="nextBtn">Next &rarr;</button>
+  </div>
+
+  <div class="hint">
+    Arrows slide the image (hold <kbd>Shift</kbd> for 5): <kbd>&larr;</kbd><kbd>&rarr;</kbd> = Shift X, <kbd>&uarr;</kbd><kbd>&darr;</kbd> = Y.
+    <kbd>Enter</kbd> marks done and advances. <kbd>PgUp</kbd>/<kbd>PgDn</kbd> switch hero.
+    Drag the card image or click the full render. Everything autosaves to localStorage.
+  </div>
+
+  <h2>Export</h2>
+  <textarea id="exportBox" readonly spellcheck="false"></textarea>
+  <div class="btn-row">
+    <button class="btn primary" id="copyBtn">Copy HERO_FACE_POSITION map</button>
+  </div>
+  <div class="btn-row">
+    <button class="btn" id="clearBtn">Clear all saved values</button>
+  </div>
+</div>
+
+<script>
+// Seed X (object-position crop percent; only matters on portrait surfaces like
+// the Locker gallery, passed through untouched) = HERO_FACE_POSITION in
+// src/lib/lockerUtils.ts. Seed Y = 18, seed Shift X = 0.
+// Shift X is the horizontal control for this wide card: object-cover leaves no
+// horizontal slack here, so X percent does nothing; Shift X slides the whole
+// image by a percent of the card width (margin-left), blank edges allowed.
+const SEED = {
+  'Abrams': 0, 'Apollo': 55, 'Bebop': 81, 'Billy': 73, 'Calico': 80, 'Celeste': 55, 'Doorman': 40,
+  'Drifter': 93, 'Dynamo': 68, 'Graves': 55, 'Grey Talon': 77, 'Haze': 78, 'Holliday': 26,
+  'Infernus': 100, 'Ivy': 72, 'Kelvin': 47, 'Lady Geist': 87, 'Lash': 54,
+  'McGinnis': 22, 'Mina': 54, 'Mirage': 65, 'Mo & Krill': 100, 'Paige': 42,
+  'Paradox': 59, 'Pocket': 61, 'Rem': 55, 'Seven': 57, 'Shiv': 68, 'Silver': 55, 'Sinclair': 61, 'Venator': 55,
+  'Victor': 45, 'Vindicta': 83, 'Viscous': 72, 'Vyper': 48, 'Warden': 55,
+  'Wraith': 56, 'Yamato': 56,
+};
+const DEFAULT_Y = 18;
+const HEROES = Object.keys(SEED);
+const STORE_KEY = 'grimoireHeroPosCalibration';
+
+// mirrors heroAssetBaseName + getHeroRenderPath
+const renderPath = (name) => '../public/locker/heroes/' + name.trim().replace(/\s+/g, '_') + '_Render.png';
+
+let state = loadState();
+let current = state.lastHero && HEROES.includes(state.lastHero) ? state.lastHero : HEROES[0];
+
+function loadState() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+    return { heroes: raw.heroes || {}, lastHero: raw.lastHero || null };
+  } catch { return { heroes: {}, lastHero: null }; }
+}
+function saveState() {
+  state.lastHero = current;
+  localStorage.setItem(STORE_KEY, JSON.stringify(state));
+}
+function entry(name) {
+  if (!state.heroes[name]) {
+    state.heroes[name] = { x: SEED[name], y: DEFAULT_Y, shiftX: 0, done: false, touched: false };
+  }
+  if (typeof state.heroes[name].shiftX !== 'number') state.heroes[name].shiftX = 0;
+  return state.heroes[name];
+}
+
+// ---- DOM refs ----
+const xSlider = document.getElementById('xSlider');
+const ySlider = document.getElementById('ySlider');
+const xOut = document.getElementById('xOut');
+const yOut = document.getElementById('yOut');
+const heroListEl = document.getElementById('heroList');
+const minimap = document.getElementById('minimap');
+const cropRect = document.getElementById('cropRect');
+const cards = ['card1x', 'cardCollapsed', 'card2x'].map((id) => document.getElementById(id));
+const exportBox = document.getElementById('exportBox');
+
+function buildList() {
+  heroListEl.innerHTML = '';
+  for (const name of HEROES) {
+    const e = entry(name);
+    const btn = document.createElement('button');
+    btn.className = 'hero-row' + (name === current ? ' active' : '') +
+      (e.done ? ' done' : '') + (e.touched ? ' touched' : '');
+    btn.innerHTML = '<span class="dot"></span><span>' + name + '</span>';
+    btn.onclick = () => { current = name; render(); };
+    heroListEl.appendChild(btn);
+  }
+}
+
+function applyPosition() {
+  const e = entry(current);
+  xOut.value = e.shiftX + '%';
+  yOut.value = e.y + '%';
+  xSlider.value = e.shiftX;
+  ySlider.value = e.y;
+  for (const card of cards) {
+    const img = card.querySelector('.backdrop');
+    img.style.objectPosition = e.x + '% ' + e.y + '%';
+    img.style.marginLeft = e.shiftX + '%';
+  }
+  updateCropRect();
+  updateExport();
+  saveState();
+}
+
+function render() {
+  const e = entry(current);
+  document.getElementById('heroTitle').textContent = current;
+  const doneCount = HEROES.filter((h) => entry(h).done).length;
+  document.getElementById('progress').textContent =
+    doneCount + ' / ' + HEROES.length + ' done' + (e.done ? ' (this one is done)' : '');
+  const src = renderPath(current);
+  for (const card of cards) card.querySelector('.backdrop').src = src;
+  minimap.src = src;
+  buildList();
+  applyPosition();
+  const active = heroListEl.querySelector('.hero-row.active');
+  if (active) active.scrollIntoView({ block: 'nearest' });
+}
+
+// Out-of-range values are intentional: a big shift pushes the image past the
+// card edge, leaving blank card background. Generous clamp keeps numbers sane.
+function setPos(shiftX, y, markTouched = true) {
+  const e = entry(current);
+  e.shiftX = Math.round(Math.max(-300, Math.min(300, shiftX)) * 2) / 2;
+  e.y = Math.round(Math.max(-300, Math.min(400, y)) * 2) / 2;
+  if (markTouched) e.touched = true;
+  applyPosition();
+  const row = heroListEl.querySelectorAll('.hero-row')[HEROES.indexOf(current)];
+  if (row && e.touched) row.classList.add('touched');
+}
+
+// ---- crop minimap (expanded card geometry: 208x40, object-fit cover) ----
+const CARD_W = 208, CARD_H = 40;
+function coverGeometry(iw, ih) {
+  const scale = Math.max(CARD_W / iw, CARD_H / ih);
+  return { visW: CARD_W / scale, visH: CARD_H / scale };
+}
+function updateCropRect() {
+  const iw = minimap.naturalWidth, ih = minimap.naturalHeight;
+  if (!iw || !ih || !minimap.clientWidth) { cropRect.style.display = 'none'; return; }
+  cropRect.style.display = 'block';
+  const e = entry(current);
+  const { visW, visH } = coverGeometry(iw, ih);
+  // Visible window in image coords: crop slack panning (x/y percent) plus the
+  // pixel slide (shiftX percent of card width -> image coords via the scale).
+  const scale = CARD_W / visW;
+  const shiftImg = (e.shiftX / 100) * CARD_W / scale;
+  const left = (iw - visW) * e.x / 100 - shiftImg;
+  const top = (ih - visH) * e.y / 100;
+  const k = minimap.clientWidth / iw;
+  cropRect.style.left = minimap.offsetLeft + left * k + 'px';
+  cropRect.style.top = minimap.offsetTop + top * k + 'px';
+  cropRect.style.width = visW * k + 'px';
+  cropRect.style.height = visH * k + 'px';
+}
+minimap.addEventListener('load', updateCropRect);
+window.addEventListener('resize', updateCropRect);
+
+document.getElementById('minimapWrap').addEventListener('pointerdown', (ev) => {
+  const apply = (e2) => {
+    const iw = minimap.naturalWidth, ih = minimap.naturalHeight;
+    if (!iw) return;
+    const rect = minimap.getBoundingClientRect();
+    const k = iw / rect.width;
+    const px = (e2.clientX - rect.left) * k;
+    const py = (e2.clientY - rect.top) * k;
+    const e = entry(current);
+    const { visW, visH } = coverGeometry(iw, ih);
+    const scale = CARD_W / visW;
+    // Center the window on the click: window left = crop-slack term - shift.
+    const wantLeft = px - visW / 2;
+    const shiftImg = (iw - visW) * e.x / 100 - wantLeft;
+    const shiftX = shiftImg * scale / CARD_W * 100;
+    const y = (ih - visH) !== 0 ? (py - visH / 2) / (ih - visH) * 100 : 50;
+    setPos(shiftX, y);
+  };
+  apply(ev);
+  const move = (e2) => apply(e2);
+  const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+  window.addEventListener('pointermove', move);
+  window.addEventListener('pointerup', up);
+});
+
+// ---- drag on the cards ----
+for (const card of cards) {
+  const zoom = card.id === 'card2x' ? 2 : 1;
+  card.addEventListener('pointerdown', (ev) => {
+    ev.preventDefault();
+    const img = card.querySelector('.backdrop');
+    const iw = img.naturalWidth, ih = img.naturalHeight;
+    if (!iw) return;
+    const cw = card.clientWidth, ch = card.clientHeight;
+    const scale = Math.max(cw / iw, ch / ih);
+    const overY = ih * scale - ch;
+    const start = { px: ev.clientX, py: ev.clientY, shiftX: entry(current).shiftX, y: entry(current).y };
+    const move = (e2) => {
+      const dx = (e2.clientX - start.px) / zoom;
+      const dy = (e2.clientY - start.py) / zoom;
+      setPos(
+        start.shiftX + dx / cw * 100,
+        overY > 0 ? start.y - dy / overY * 100 : start.y
+      );
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  });
+}
+
+// ---- sliders / keyboard / nav ----
+xSlider.addEventListener('input', () => setPos(+xSlider.value, entry(current).y));
+ySlider.addEventListener('input', () => setPos(entry(current).x, +ySlider.value));
+
+function step(delta) { return delta * (window.__shift ? 5 : 1); }
+window.addEventListener('keydown', (ev) => {
+  if (ev.target.tagName === 'TEXTAREA') return;
+  window.__shift = ev.shiftKey;
+  const e = entry(current);
+  const s = ev.shiftKey ? 5 : 1;
+  // Arrows move the IMAGE in that direction. Y percent pans the crop window,
+  // so image-down = y-down in value terms only when slack is negative; with
+  // object-cover slack the image moves down as y decreases.
+  switch (ev.key) {
+    case 'ArrowLeft': setPos(e.shiftX - s, e.y); ev.preventDefault(); break;
+    case 'ArrowRight': setPos(e.shiftX + s, e.y); ev.preventDefault(); break;
+    case 'ArrowUp': setPos(e.shiftX, e.y + s); ev.preventDefault(); break;
+    case 'ArrowDown': setPos(e.shiftX, e.y - s); ev.preventDefault(); break;
+    case 'Enter': markDoneAndNext(); ev.preventDefault(); break;
+    case 'PageUp': go(-1); ev.preventDefault(); break;
+    case 'PageDown': go(1); ev.preventDefault(); break;
+  }
+});
+
+function go(dir) {
+  const i = HEROES.indexOf(current);
+  current = HEROES[(i + dir + HEROES.length) % HEROES.length];
+  render();
+}
+function markDoneAndNext() {
+  entry(current).done = true;
+  // jump to the next not-done hero, or just the next one
+  const i = HEROES.indexOf(current);
+  for (let k = 1; k <= HEROES.length; k++) {
+    const cand = HEROES[(i + k) % HEROES.length];
+    if (!entry(cand).done) { current = cand; render(); return; }
+  }
+  render();
+}
+
+document.getElementById('prevBtn').onclick = () => go(-1);
+document.getElementById('nextBtn').onclick = () => go(1);
+document.getElementById('doneBtn').onclick = markDoneAndNext;
+document.getElementById('resetBtn').onclick = () => {
+  state.heroes[current] = { x: SEED[current], y: DEFAULT_Y, shiftX: 0, done: false, touched: false };
+  render();
+};
+document.getElementById('clearBtn').onclick = () => {
+  if (confirm('Wipe all saved calibration values?')) {
+    state = { heroes: {}, lastHero: current };
+    localStorage.removeItem(STORE_KEY);
+    render();
+  }
+};
+
+// ---- export ----
+function fmt(n) { return Number.isInteger(n) ? String(n) : n.toFixed(1); }
+function key(name) { return /^[A-Za-z]+$/.test(name) ? name : "'" + name + "'"; }
+// Matches the HERO_FACE_POSITION shape in src/lib/lockerUtils.ts: paste the
+// body straight over the existing map.
+function combinedSnippet() {
+  const lines = HEROES.map((h) => {
+    const e = entry(h);
+    const shift = e.shiftX ? ', shiftX: ' + fmt(e.shiftX) : '';
+    return '  ' + key(h) + ': { x: ' + fmt(e.x) + ', y: ' + fmt(e.y) + shift + ' },';
+  });
+  return 'export const HERO_FACE_POSITION: Record<string, HeroFacePosition> = {\n' +
+    lines.join('\n') + '\n};';
+}
+function updateExport() { exportBox.value = combinedSnippet(); }
+
+function copy(text, btn) {
+  navigator.clipboard.writeText(text).then(() => {
+    btn.classList.add('flash');
+    setTimeout(() => btn.classList.remove('flash'), 400);
+  });
+}
+document.getElementById('copyBtn').onclick = (ev) => copy(combinedSnippet(), ev.target);
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Hand-calibrated positioning for the hero art behind the sidebar active card, for all 38 heroes.

## Why

The sidebar backdrop had a hardcoded `18%` vertical crop and a dead horizontal axis: the card is ~5.2:1 while the renders are ~1.15:1, so object-cover's scale is width-dominant and there is zero horizontal slack for `object-position` x to distribute. Heroes ended up framed by luck.

## How

- `HERO_FACE_POSITION` is now `{ x, y, shiftX? }` per hero:
  - `x` keeps its old meaning: the crop percent used by the gallery-style surfaces (Locker, Browse, Installed), each still paired with its own hardcoded y. Those surfaces are visually unchanged apart from refreshed x values.
  - `y` and `shiftX` are sidebar-only (`getSidebarHeroImageStyle`). `y` replaces the hardcoded 18%; `shiftX` slides the image by a percentage of the card width via `margin-left`, deliberately allowed to push the art past the edge and leave blank card background so the label side stays clean.
- Six heroes that previously fell back to the default now have entries: Apollo, Celeste, Graves, Rem, Silver, Venator.
- Adds `tools/hero-position-calibrator.html`: a standalone, dependency-free page that replicates the sidebar card pixel-for-pixel (expanded, collapsed, 2x zoom), with drag-to-position, a full-render crop minimap, per-hero progress saved to localStorage, and a one-click TS export matching the map shape. Open it straight from disk; it loads renders from `public/locker/heroes/` via relative paths.

## Testing

- `tsc -p tsconfig.app.json --noEmit` clean on this branch.
- Calibrator verified headless (default and shifted states render correctly, crop rect tracks past the image edge).
- All 38 heroes eyeballed in the calibrator's faithful card replica while calibrating.