### PR TITLE
feat(performance): Sqooky artist link + drop poweruser copy from the card

### DIFF
--- a/src/components/ImageContextMenu.tsx
+++ b/src/components/ImageContextMenu.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo, useState } from 'react';
-import * as ContextMenu from '@radix-ui/react-context-menu';
-import { Check, ExternalLink, FolderOpen, ImageDown, Link, Loader2, type LucideIcon } from 'lucide-react';
+import { Check, ExternalLink, FolderOpen, ImageDown, Link, Loader2 } from 'lucide-react';
+import { MenuContent, MenuItem, MenuLabel, MenuRoot, MenuSeparator, MenuTrigger } from './common/menu';
 
 interface ImageContextMenuProps {
   src: string;
@@ -83,28 +83,25 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
       : Link;
 
   return (
-    <ContextMenu.Root onOpenChange={(next) => {
+    <MenuRoot onOpenChange={(next) => {
       if (!next) resetTransientState();
     }}>
-      <ContextMenu.Trigger asChild>
+      <MenuTrigger asChild>
         <span
           className="contents"
           onContextMenu={(event) => event.stopPropagation()}
         >
           {children}
         </span>
-      </ContextMenu.Trigger>
-      <ContextMenu.Portal>
-        <ContextMenu.Content
-          collisionPadding={12}
-          onClick={(event) => event.stopPropagation()}
-          onPointerDown={(event) => event.stopPropagation()}
-          onContextMenu={(event) => event.stopPropagation()}
-          className="z-[80] min-w-52 rounded-lg border border-white/10 bg-bg-secondary/95 p-1.5 text-sm text-text-primary shadow-2xl shadow-black/50 backdrop-blur-md animate-fade-in"
-        >
-          <ContextMenu.Label className="max-w-64 truncate px-2 py-1 text-[11px] uppercase tracking-wide text-text-tertiary">
+      </MenuTrigger>
+      <MenuContent
+        onClick={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+        onContextMenu={(event) => event.stopPropagation()}
+      >
+          <MenuLabel>
             {alt || 'Image'}
-          </ContextMenu.Label>
+          </MenuLabel>
           <MenuItem
             icon={imageCopyIcon}
             spinning={imageCopyState === 'copying'}
@@ -141,7 +138,7 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
           </MenuItem>
           {canOpenImage && (
             <>
-              <ContextMenu.Separator className="my-1 h-px bg-white/10" />
+              <MenuSeparator />
               <MenuItem icon={ExternalLink} onSelect={openImage}>
                 Open image
               </MenuItem>
@@ -149,44 +146,14 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
           )}
           {onRevealInFolder && (
             <>
-              <ContextMenu.Separator className="my-1 h-px bg-white/10" />
+              <MenuSeparator />
               <MenuItem icon={FolderOpen} onSelect={onRevealInFolder}>
                 Reveal mod in folder
               </MenuItem>
             </>
           )}
-        </ContextMenu.Content>
-      </ContextMenu.Portal>
-    </ContextMenu.Root>
-  );
-}
-
-interface MenuItemProps {
-  children: ReactNode;
-  icon: LucideIcon;
-  spinning?: boolean;
-  tone?: 'default' | 'success' | 'danger';
-  onSelect: (event: Event) => void;
-}
-
-function MenuItem({ children, icon: Icon, spinning, tone = 'default', onSelect }: MenuItemProps) {
-  const toneClass = tone === 'success'
-    ? 'text-state-success focus:bg-state-success/10 data-[highlighted]:bg-state-success/10'
-    : tone === 'danger'
-      ? 'text-state-danger focus:bg-state-danger/10 data-[highlighted]:bg-state-danger/10'
-      : 'text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10';
-
-  return (
-    <ContextMenu.Item
-      onSelect={(event) => {
-        event.stopPropagation();
-        onSelect(event);
-      }}
-      className={`flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer ${toneClass}`}
-    >
-      <Icon className={`h-4 w-4 flex-shrink-0 text-current ${spinning ? 'animate-spin' : ''}`} />
-      <span className="min-w-0 flex-1 truncate">{children}</span>
-    </ContextMenu.Item>
+      </MenuContent>
+    </MenuRoot>
   );
 }
 

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -19,6 +19,7 @@ import {
   createProfileFromGameBananaIds,
 } from '../lib/api';
 import { Button } from './common/ui';
+import { Modal } from './common/Modal';
 import ModThumbnail from './ModThumbnail';
 import type {
   GameBananaCollection,
@@ -347,16 +348,6 @@ export default function ImportCollectionModal({
       });
     }
   }, [collection, installedBatchIds]);
-
-  // Escape closes — but only when we're not mid-submission (don't yank the
-  // modal out from under a running batch).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !submitting) onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, submitting]);
 
   // ───────── Fetching collection + items ─────────
 
@@ -787,17 +778,15 @@ export default function ImportCollectionModal({
   const batchInFlight = counts.queued + counts.downloading > 0;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="import-collection-title"
-      onClick={submitting ? undefined : onClose}
+    <Modal
+      onClose={onClose}
+      labelledBy="import-collection-title"
+      size="xl"
+      // Escape/backdrop close: but only when we're not mid-submission (don't
+      // yank the modal out from under a running batch).
+      dismissable={!submitting}
+      panelClassName="max-h-[85vh] flex flex-col overflow-hidden"
     >
-      <div
-        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-4xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
         {/* Header */}
         <div className="flex items-start justify-between p-6 border-b border-white/10">
           <div className="min-w-0 flex items-start gap-3">
@@ -1275,7 +1264,6 @@ export default function ImportCollectionModal({
             </div>
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,6 +7,8 @@ import SyncIndicator from './SyncIndicator';
 import DownloadQueueIndicator from './DownloadQueueIndicator';
 import { Button } from './common/ui';
 import { ConfirmModal } from './common/PageComponents';
+import { ToastStack } from './common/ToastStack';
+import { showToast } from '../stores/toastStore';
 import { getSettings, setSettings, getGameinfoStatus, fixGameinfo } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { applyAccentColor } from '../lib/accentColor';
@@ -26,12 +28,10 @@ export default function Layout() {
   const [isFixingGameinfo, setIsFixingGameinfo] = useState(false);
   // Normal one-click download progress is handled by DownloadQueueIndicator.
   // This only catches failures before a download can be queued.
-  const [oneClickError, setOneClickError] = useState<{ label: string; message: string } | null>(null);
   const [suspiciousPrompt, setSuspiciousPrompt] = useState<OneClickSuspiciousFilesData | null>(null);
   const [multiVpkPrompt, setMultiVpkPrompt] = useState<MultiVpkPickData | null>(null);
   // Shown when GameBanana starts returning 429s (the main process debounces the
   // event so a burst of rejected requests surfaces one warning, not a flood).
-  const [rateLimited, setRateLimited] = useState(false);
 
   // Re-theme the app whenever the stored accent color changes. We pull
   // settings into the global store on mount so the value is available before
@@ -104,20 +104,13 @@ export default function Layout() {
   useEffect(() => {
     const unsubscribe = window.electronAPI.onOneClickInstall((data) => {
       if (data.error) {
-        setOneClickError({ label: data.modName ?? 'mod', message: data.error });
+        showToast(`${data.modName ?? 'mod'}: ${data.error}`, { tone: 'error', duration: 8000 });
         return;
       }
-      setOneClickError(null);
       navigate('/');
     });
     return unsubscribe;
   }, [navigate]);
-
-  useEffect(() => {
-    if (!oneClickError) return;
-    const t = setTimeout(() => setOneClickError(null), 8000);
-    return () => clearTimeout(t);
-  }, [oneClickError]);
 
   useEffect(() => {
     const unsubscribe = window.electronAPI.onOneClickSuspiciousFiles((data) => {
@@ -138,16 +131,14 @@ export default function Layout() {
   // lives here rather than inside one page.
   useEffect(() => {
     const unsubscribe = window.electronAPI.onGameBananaRateLimited(() => {
-      setRateLimited(true);
+      showToast('GameBanana is rate-limiting Grimoire. Pause a moment before retrying.', {
+        tone: 'warning',
+        duration: 8000,
+        dismissable: true,
+      });
     });
     return unsubscribe;
   }, []);
-
-  useEffect(() => {
-    if (!rateLimited) return;
-    const t = setTimeout(() => setRateLimited(false), 8000);
-    return () => clearTimeout(t);
-  }, [rateLimited]);
 
   const respondToSuspicious = async (accepted: boolean) => {
     if (!suspiciousPrompt) return;
@@ -238,14 +229,7 @@ export default function Layout() {
         <DownloadQueueIndicator />
         <SyncIndicator />
       </div>
-      {oneClickError && (
-        <div className="fixed left-1/2 top-4 z-50 -translate-x-1/2">
-          <div className="flex w-[min(420px,calc(100vw-2rem))] items-center justify-center gap-2 px-2 py-1 text-sm font-semibold text-red-300 drop-shadow-[0_1px_2px_rgba(0,0,0,0.85)]">
-            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-            <span className="truncate">{oneClickError.label}: {oneClickError.message}</span>
-          </div>
-        </div>
-      )}
+      <ToastStack />
       <ConfirmModal
         isOpen={!!suspiciousPrompt}
         title="Suspicious files detected"
@@ -272,32 +256,14 @@ export default function Layout() {
                 )}
               </ul>
               <p className="text-xs">
-                Grimoire only extracts <code className="rounded bg-bg-tertiary px-1">.vpk</code> files
-                — these won&apos;t be installed even if you continue. Review the mod&apos;s GameBanana
+                Grimoire only extracts <code className="rounded bg-bg-tertiary px-1">.vpk</code> files:
+                these won&apos;t be installed even if you continue. Review the mod&apos;s GameBanana
                 page if anything looks off.
               </p>
             </div>
           ) : null
         }
       />
-      {rateLimited && (
-        <div className="fixed bottom-6 left-1/2 z-[60] -translate-x-1/2">
-          <div className="flex items-center gap-2 rounded-sm border border-yellow-500/40 bg-yellow-500/15 px-4 py-2 text-sm text-yellow-200 shadow-lg backdrop-blur-sm max-w-[460px]">
-            <AlertTriangle className="h-4 w-4 flex-shrink-0 text-yellow-400" />
-            <span className="flex-1">
-              GameBanana is rate-limiting Grimoire. Pause a moment before retrying.
-            </span>
-            <button
-              type="button"
-              onClick={() => setRateLimited(false)}
-              className="flex-shrink-0 text-yellow-300/70 hover:text-yellow-100"
-              aria-label="Dismiss"
-            >
-              Dismiss
-            </button>
-          </div>
-        </div>
-      )}
       {multiVpkPrompt && (
         <MultiVpkPickerModal
           key={multiVpkPrompt.requestId}

--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -14,6 +14,7 @@ import {
     Loader2,
 } from 'lucide-react';
 import { Button } from './common/ui';
+import { Modal } from './common/Modal';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
 import {
     getLockerOverview,
@@ -280,15 +281,6 @@ export function LockerOverridesModal({
 
     const busy = removing !== null || clearing !== null || savingKey !== null;
 
-    // Escape closes, but not mid-operation (don't abandon a rebuild visually).
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && !busy) onClose();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [busy, onClose]);
-
     useEffect(() => {
         const timers = commitTimers.current;
         return () => {
@@ -420,22 +412,19 @@ export function LockerOverridesModal({
     const trippySkins = overview?.trippySkins ?? [];
 
     return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 animate-fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Locker overrides"
-            onMouseDown={(e) => {
-                if (e.target === e.currentTarget && !busy) onClose();
-            }}
+        <Modal
+            onClose={onClose}
+            labelledBy="locker-overrides-title"
+            size="lg"
+            dismissable={!busy}
+            panelClassName="flex max-h-[85vh] flex-col overflow-hidden"
         >
-            <div className="flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border bg-bg-secondary shadow-2xl">
                 {/* Header */}
                 <div className="flex items-start justify-between gap-3 border-b border-border px-5 py-4">
                     <div className="flex items-center gap-2.5">
                         <Wand2 className="h-5 w-5 text-accent" />
                         <div>
-                            <h2 className="text-base font-semibold text-text-primary">Locker Overrides</h2>
+                            <h2 id="locker-overrides-title" className="text-base font-semibold text-text-primary">Locker Overrides</h2>
                             <p className="text-xs text-text-secondary">
                                 Always-on cosmetics, separate from your mod load order and the 99-slot cap.
                             </p>
@@ -841,8 +830,7 @@ export function LockerOverridesModal({
                         </Button>
                     )}
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }
 

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -3,6 +3,7 @@ import { Layers, X, AlertTriangle, Info } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
 import { Button } from './common/ui';
+import { Modal } from './common/Modal';
 
 interface Props {
   sources: Mod[];
@@ -14,7 +15,7 @@ interface Props {
 /**
  * Confirmation modal for combining multiple installed mods into a single
  * merged VPK. Sources that share a GameBanana submission (color variants,
- * preset versions, etc.) collapse into a variant picker — exactly one
+ * preset versions, etc.) collapse into a variant picker: exactly one
  * variant per group enters the merge, because variants of the same mod
  * occupy the same in-game file paths and would just override each other.
  *
@@ -80,17 +81,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="merge-mods-title"
-      onClick={onCancel}
-    >
-      <div
-        className="bg-bg-secondary border border-border rounded-xl w-full max-w-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onCancel} labelledBy="merge-mods-title" size="none" panelClassName="max-w-xl">
         <div className="flex items-center justify-between p-5 border-b border-border">
           <h3 id="merge-mods-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
             <Layers className="w-5 h-5" />
@@ -162,7 +153,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
                     {!group.mod.gameBananaId && (
                       <span
                         className="ml-auto text-[10px] uppercase tracking-wide text-text-secondary/80 px-1.5 py-0.5 rounded border border-border"
-                        title="Local mod — not in the unroll share code"
+                        title="Local mod: not in the unroll share code"
                       >
                         local
                       </span>
@@ -265,8 +256,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
             {submitting ? 'Merging…' : 'Merge'}
           </Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -283,7 +273,7 @@ type SourceGroup =
 /**
  * Group sources by GameBanana submission id so variants of the same mod
  * collapse into one pick. Local mods (no gameBananaId) and singleton GB mods
- * stay as `single` entries — there's nothing to pick.
+ * stay as `single` entries: there's nothing to pick.
  */
 function buildSourceGroups(sources: Mod[]): SourceGroup[] {
   const byGb = new Map<number, Mod[]>();
@@ -313,7 +303,7 @@ function buildSourceGroups(sources: Mod[]): SourceGroup[] {
     groups.push({
       kind: 'variants',
       gameBananaId,
-      // Use the first variant's display name — they all came from the same
+      // Use the first variant's display name: they all came from the same
       // GameBanana submission so the mod name is identical.
       modName: variants[0].name,
       variants,

--- a/src/components/MergedContentsModal.tsx
+++ b/src/components/MergedContentsModal.tsx
@@ -3,6 +3,7 @@ import { Layers, X, Share2, Scissors, Check, PackageOpen, Loader2, AlertTriangle
 import type { Mod, MergedModSource } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
 import { Button, Tag } from './common/ui';
+import { Modal } from './common/Modal';
 import { formatRelativeDate } from '../lib/dates';
 
 interface Props {
@@ -64,17 +65,7 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
   const createdLabel = formatRelativeDate(merged.createdAt) || merged.createdAt;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="merged-contents-title"
-      onClick={onClose}
-    >
-      <div
-        className="bg-bg-secondary border border-border rounded-xl w-full max-w-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} labelledBy="merged-contents-title" size="lg">
         <div className="flex items-center justify-between p-5 border-b border-border">
           <h3
             id="merged-contents-title"
@@ -230,7 +221,6 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
             Close
           </Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/MultiVpkPickerModal.tsx
+++ b/src/components/MultiVpkPickerModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { FileArchive, Check, X } from 'lucide-react';
 import type { MultiVpkPickData } from '../types/electron';
 import { formatBytes } from '../lib/formatBytes';
+import { Modal } from './common/Modal';
 
 interface Props {
     data: MultiVpkPickData;
@@ -12,7 +13,7 @@ interface Props {
 /**
  * Multi-VPK picker. Shown when an archive (Warden Remodel, etc.) yields more
  * than one .vpk after extraction. Previously the install pipeline silently
- * kept the alphabetically-first VPK and unlinked the rest — felt like data
+ * kept the alphabetically-first VPK and unlinked the rest: felt like data
  * loss to users. This modal makes the choice explicit.
  *
  * Default selection: all VPKs are checked. Most multi-VPK archives ship
@@ -21,7 +22,7 @@ interface Props {
  * remembering to check missing content.
  *
  * NOTE: the parent must mount this with a key tied to `data.requestId` so a
- * fresh request resets the selection — we deliberately avoid a syncing
+ * fresh request resets the selection: we deliberately avoid a syncing
  * useEffect here.
  */
 export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props) {
@@ -46,17 +47,7 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
     };
 
     return (
-        <div
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="multi-vpk-pick-title"
-            onClick={onCancel}
-        >
-            <div
-                className="bg-bg-secondary border border-border rounded-xl w-full max-w-lg"
-                onClick={(e) => e.stopPropagation()}
-            >
+        <Modal onClose={onCancel} labelledBy="multi-vpk-pick-title" size="md">
                 <div className="flex items-center justify-between p-5 border-b border-border">
                     <h3 id="multi-vpk-pick-title" className="text-lg font-semibold text-text-primary flex items-center gap-2">
                         <FileArchive className="w-5 h-5" />
@@ -75,7 +66,7 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
                     <p className="text-sm text-text-secondary">
                         <span className="font-medium text-text-primary">{data.modName}</span> contains{' '}
                         {data.vpkFileNames.length} <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">.vpk</code> files.
-                        Pick which ones to install — leave any unwanted ones unchecked and they&apos;ll be skipped.
+                        Pick which ones to install: leave any unwanted ones unchecked and they&apos;ll be skipped.
                     </p>
 
                     <div className="flex items-center justify-between pb-2 border-b border-border/60">
@@ -150,7 +141,6 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
                         Install {selected.size > 0 ? `${selected.size}` : ''}
                     </button>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -132,7 +132,7 @@ export default function PriorityEditor({
       )}
       {editing && popoverPos && createPortal(
         <div
-          className="fixed z-[9999] w-40 rounded-lg border border-border bg-bg-secondary p-2.5 text-left shadow-xl"
+          className="fixed z-[80] w-40 rounded-lg border border-border bg-bg-secondary p-2.5 text-left shadow-xl"
           style={{ top: popoverPos.top, left: popoverPos.left }}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
   Image,
   ImageOff,
 } from 'lucide-react';
-import * as ContextMenu from '@radix-ui/react-context-menu';
+import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from './common/menu';
 import {
   getConflicts,
   getGameRunningStatus,
@@ -902,7 +902,13 @@ export default function Sidebar() {
           </div>
         )}
 
-        <div className="space-y-1">
+        {/* flex+gap rather than space-y: the launch context-menu trigger is a
+            display:contents span around both launch buttons, so space-y's
+            direct-child margin selector skips them while flex gap still
+            applies (they participate in the parent's layout individually).
+            gap-2 matches the footer rail's space-y-2 rhythm (launch buttons,
+            update flag, and Settings all sit 8px apart). */}
+        <div className="flex flex-col gap-2">
           {showPreviewVolume && (collapsed ? (
             <button
               type="button"
@@ -970,8 +976,8 @@ export default function Sidebar() {
               )}
             </button>
           ) : (
-            <ContextMenu.Root>
-              <ContextMenu.Trigger asChild>
+            <MenuRoot>
+              <MenuTrigger asChild>
                 <span className="contents">
           <button
             onClick={handleLaunchModded}
@@ -1029,28 +1035,13 @@ export default function Sidebar() {
             )}
           </button>
                 </span>
-              </ContextMenu.Trigger>
-              <ContextMenu.Portal>
-                <ContextMenu.Content
-                  collisionPadding={12}
-                  className="z-[80] min-w-52 rounded-lg border border-white/10 bg-bg-secondary/95 p-1.5 text-sm text-text-primary shadow-2xl shadow-black/50 backdrop-blur-md animate-fade-in"
-                >
-                  <ContextMenu.Item
-                    onSelect={toggleLaunchBg}
-                    className="flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10"
-                  >
-                    {launchBgHidden ? (
-                      <Image className="h-4 w-4 flex-shrink-0" />
-                    ) : (
-                      <ImageOff className="h-4 w-4 flex-shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">
-                      {launchBgHidden ? t('sidebar.launch.showArt') : t('sidebar.launch.hideArt')}
-                    </span>
-                  </ContextMenu.Item>
-                </ContextMenu.Content>
-              </ContextMenu.Portal>
-            </ContextMenu.Root>
+              </MenuTrigger>
+              <MenuContent>
+                <MenuItem icon={launchBgHidden ? Image : ImageOff} onSelect={toggleLaunchBg}>
+                  {launchBgHidden ? t('sidebar.launch.showArt') : t('sidebar.launch.hideArt')}
+                </MenuItem>
+              </MenuContent>
+            </MenuRoot>
           )}
         </div>
 

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { X, Download, ArrowDownCircle, RefreshCw, Sparkles, AlertTriangle, Package } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { Button } from './common/ui';
+import { Modal } from './common/Modal';
 
 type InstallSource = 'managed' | 'appimage' | 'standard';
 
@@ -42,14 +43,6 @@ export default function UpdateModal({ onClose }: Props) {
         return unsub;
     }, []);
 
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') onClose();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [onClose]);
-
     const handleCheck = async () => {
         setCheckedOnce(false);
         try {
@@ -75,30 +68,25 @@ export default function UpdateModal({ onClose }: Props) {
     const hasNotes = Array.isArray(releaseNotes) ? releaseNotes.length > 0 : Boolean(releaseNotes);
 
     return (
-        <div
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="update-modal-title"
-            onClick={onClose}
+        <Modal
+            onClose={onClose}
+            labelledBy="update-modal-title"
+            size="lg"
+            panelClassName="max-h-[85vh] flex flex-col overflow-hidden"
         >
-            <div
-                className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
-                onClick={(e) => e.stopPropagation()}
-            >
                 <div className="flex items-start justify-between p-6 border-b border-white/10">
                     <div className="min-w-0">
                         <h2 id="update-modal-title" className="text-xl font-bold text-text-primary">
                             {status?.downloaded
                                 ? `v${status.updateInfo?.version} ready to install`
                                 : status?.available
-                                    ? `Update available — v${status.updateInfo?.version}`
+                                    ? `Update available: v${status.updateInfo?.version}`
                                     : 'App Updates'}
                         </h2>
                         <p className="text-sm text-text-secondary mt-1">
                             You're on <span className="font-mono text-text-primary">v{appVersion || '...'}</span>
                             {status?.updateInfo?.releaseDate && status.available && (
-                                <> — released {new Date(status.updateInfo.releaseDate).toLocaleDateString()}</>
+                                <> (released {new Date(status.updateInfo.releaseDate).toLocaleDateString()})</>
                             )}
                         </p>
                     </div>
@@ -222,7 +210,6 @@ export default function UpdateModal({ onClose }: Props) {
                         </Button>
                     )}
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -33,6 +33,7 @@ import {
 } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import { ArchivedTag, Button, CheckboxMark, Tag } from './common/ui';
+import { Modal } from './common/Modal';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { formatBytes } from '../lib/formatBytes';
 
@@ -543,17 +544,12 @@ export default function VariantPickerModal({
     };
 
     return (
-        <div
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="variant-picker-title"
-            onClick={onClose}
+        <Modal
+            onClose={onClose}
+            labelledBy="variant-picker-title"
+            size="none"
+            panelClassName="max-w-xl"
         >
-            <div
-                className="bg-bg-secondary border border-border rounded-xl w-full max-w-xl"
-                onClick={(e) => e.stopPropagation()}
-            >
                 <div className="flex items-center justify-between p-5 border-b border-border gap-3">
                     <div className="min-w-0">
                         <h3 id="variant-picker-title" className="text-lg font-semibold text-text-primary truncate">
@@ -629,7 +625,6 @@ export default function VariantPickerModal({
                         Done
                     </Button>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { FolderOpen, Wrench, Check, X, ArrowRight, Loader2, Terminal } from 'lucide-react';
 import { Button, Badge } from './common/ui';
+import { Modal } from './common/Modal';
 import {
     validateDeadlockPath,
     showOpenDialog,
@@ -136,11 +137,18 @@ export default function WelcomeModal({ onComplete }: WelcomeModalProps) {
     const canProceed = isValidPath && gameinfoConfigured;
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-            <div className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-xl overflow-hidden shadow-2xl animate-scale-in">
+        <Modal
+            onClose={() => {}}
+            dismissable={false}
+            labelledBy="welcome-modal-title"
+            size="none"
+            panelClassName="max-w-xl overflow-hidden animate-scale-in"
+            backdropClassName="backdrop-blur-sm"
+        >
                 {/* Header */}
                 <div className="p-6 pb-4 text-center">
                     <h1
+                        id="welcome-modal-title"
                         className="text-3xl text-accent mb-1"
                         style={{ fontFamily: "'IM Fell English', serif" }}
                     >
@@ -300,7 +308,6 @@ export default function WelcomeModal({ onComplete }: WelcomeModalProps) {
                         </button>
                     </div>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// Standard modal shell: portal to body, dimmed backdrop, Escape and
+// backdrop-click dismissal, focus hand-off into the panel and restore on
+// close. Sits at z-50 (see the z-index scale in index.css).
+//
+// Call sites that conditionally render (`{show && <MyModal/>}`) get no exit
+// animation, same as before. To fade out, keep the Modal mounted and drive
+// the `open` prop instead; unmount happens MODAL_EXIT_MS after open=false.
+
+const MODAL_EXIT_MS = 200;
+
+// 'none' skips the width preset; the caller supplies its own max-w via
+// panelClassName (two max-w-* utilities don't override predictably).
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'none';
+
+const SIZE_CLASSES: Record<ModalSize, string> = {
+    sm: 'max-w-md',
+    md: 'max-w-lg',
+    lg: 'max-w-2xl',
+    xl: 'max-w-4xl',
+    none: '',
+};
+
+interface ModalProps {
+    onClose: () => void;
+    open?: boolean;
+    /** id of the element labelling the dialog (usually the title heading) */
+    labelledBy?: string;
+    size?: ModalSize;
+    /** false blocks Escape and backdrop-click closing (busy states, first-run flows) */
+    dismissable?: boolean;
+    /** extra classes for the panel (layout like flex/max-h, or a width override) */
+    panelClassName?: string;
+    /** extra classes for the backdrop (e.g. backdrop-blur-sm); don't stack bg-* utilities */
+    backdropClassName?: string;
+    children: ReactNode;
+}
+
+export function Modal({
+    onClose,
+    open = true,
+    labelledBy,
+    size = 'md',
+    dismissable = true,
+    panelClassName = '',
+    backdropClassName = '',
+    children,
+}: ModalProps) {
+    const panelRef = useRef<HTMLDivElement>(null);
+    const restoreFocusRef = useRef<HTMLElement | null>(null);
+    const [mounted, setMounted] = useState(open);
+    // Render-time adjustment so opening re-mounts on the same commit.
+    if (open && !mounted) setMounted(true);
+
+    useEffect(() => {
+        if (open) return;
+        const timer = window.setTimeout(() => setMounted(false), MODAL_EXIT_MS);
+        return () => window.clearTimeout(timer);
+    }, [open]);
+
+    useEffect(() => {
+        if (!open || !dismissable) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key !== 'Escape') return;
+            e.preventDefault();
+            onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [open, dismissable, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+        const previous = document.activeElement;
+        if (previous instanceof HTMLElement) restoreFocusRef.current = previous;
+        // Move focus into the dialog unless something inside already took it
+        // (e.g. an autoFocus input rendered by the caller).
+        const panel = panelRef.current;
+        if (panel && !panel.contains(document.activeElement)) panel.focus();
+        return () => {
+            restoreFocusRef.current?.focus();
+            restoreFocusRef.current = null;
+        };
+    }, [open]);
+
+    if (!mounted) return null;
+    const closing = !open;
+
+    return createPortal(
+        <div
+            className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 ${
+                closing ? 'animate-fade-out pointer-events-none' : 'animate-fade-in'
+            } ${backdropClassName}`}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={labelledBy}
+            onClick={(e) => {
+                if (dismissable && e.target === e.currentTarget) onClose();
+            }}
+        >
+            <div
+                ref={panelRef}
+                tabIndex={-1}
+                className={`w-full ${SIZE_CLASSES[size]} bg-bg-secondary border border-border rounded-lg shadow-2xl outline-none ${panelClassName}`}
+            >
+                {children}
+            </div>
+        </div>,
+        document.body
+    );
+}

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 import { type LucideIcon } from 'lucide-react';
+import { Modal } from './Modal';
 
 // ============================================================================
 // SectionHeader - Consistent section header styling
@@ -151,42 +152,35 @@ export function ConfirmModal({
     onConfirm,
     onCancel,
 }: ConfirmModalProps) {
-    if (!isOpen) return null;
-
     const confirmClass = variant === 'danger'
         ? 'border border-red-500/40 bg-red-500/10 hover:bg-red-500/20 hover:border-red-500/60 text-red-400 focus-visible:ring-red-400'
         : 'border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary focus-visible:ring-accent';
 
     return (
-        <div
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="confirm-modal-title"
-            onClick={onCancel}
+        <Modal
+            open={isOpen}
+            onClose={onCancel}
+            labelledBy="confirm-modal-title"
+            size="sm"
+            panelClassName="relative overflow-hidden p-6"
         >
-            <div
-                className="bg-bg-secondary border border-border rounded-sm p-6 max-w-md w-full relative overflow-hidden"
-                onClick={(e) => e.stopPropagation()}
-            >
-                <span aria-hidden className={`absolute left-0 top-0 bottom-0 w-[2px] ${variant === 'danger' ? 'bg-red-500/60' : 'bg-accent/60'}`} />
-                <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
-                <div className="text-text-secondary mb-4">{message}</div>
-                <div className="flex justify-end gap-3">
-                    <button
-                        onClick={onCancel}
-                        className="px-4 py-2 bg-bg-tertiary border border-border rounded-sm hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                    >
-                        {cancelLabel}
-                    </button>
-                    <button
-                        onClick={onConfirm}
-                        className={`px-4 py-2 rounded-sm font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
-                    >
-                        {confirmLabel}
-                    </button>
-                </div>
+            <span aria-hidden className={`absolute left-0 top-0 bottom-0 w-[2px] ${variant === 'danger' ? 'bg-red-500/60' : 'bg-accent/60'}`} />
+            <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
+            <div className="text-text-secondary mb-4">{message}</div>
+            <div className="flex justify-end gap-3">
+                <button
+                    onClick={onCancel}
+                    className="px-4 py-2 bg-bg-tertiary border border-border rounded-sm hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                >
+                    {cancelLabel}
+                </button>
+                <button
+                    onClick={onConfirm}
+                    className={`px-4 py-2 rounded-sm font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
+                >
+                    {confirmLabel}
+                </button>
             </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/common/ToastStack.tsx
+++ b/src/components/common/ToastStack.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Check, Info } from 'lucide-react';
+import { useToastStore, type Toast } from '../../stores/toastStore';
+
+// Renders the toast queue bottom-center at z-60 (above modals; see the
+// z-index scale in index.css). Mounted once in Layout.
+
+const TONE_CLASSES: Record<Toast['tone'], string> = {
+  info: 'border-border bg-bg-secondary text-text-primary',
+  success: 'border-state-success/40 bg-state-success/10 text-state-success',
+  warning: 'border-yellow-500/40 bg-yellow-500/15 text-yellow-200',
+  error: 'border-red-500/40 bg-red-500/10 text-red-300',
+};
+
+const EXIT_MS = 200;
+
+export function ToastStack() {
+  const toasts = useToastStore((s) => s.toasts);
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 left-1/2 z-[60] flex w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 flex-col items-center gap-2">
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const dismissToast = useToastStore((s) => s.dismissToast);
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const fadeTimer = window.setTimeout(() => setClosing(true), Math.max(0, toast.duration - EXIT_MS));
+    const removeTimer = window.setTimeout(() => dismissToast(toast.id), toast.duration);
+    return () => {
+      window.clearTimeout(fadeTimer);
+      window.clearTimeout(removeTimer);
+    };
+  }, [toast.id, toast.duration, dismissToast]);
+
+  const icon = toast.tone === 'warning' || toast.tone === 'error'
+    ? <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+    : toast.tone === 'success'
+      ? <Check className="h-4 w-4 flex-shrink-0" />
+      : <Info className="h-4 w-4 flex-shrink-0 text-text-secondary" />;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`pointer-events-auto flex max-w-[460px] items-center gap-2 rounded-lg border px-4 py-2 text-sm shadow-lg shadow-black/40 backdrop-blur-sm ${
+        TONE_CLASSES[toast.tone]
+      } ${closing ? 'animate-fade-out' : 'animate-fade-in'}`}
+    >
+      {icon}
+      <span className="min-w-0 flex-1">{toast.message}</span>
+      {toast.dismissable && (
+        <button
+          type="button"
+          onClick={() => dismissToast(toast.id)}
+          className="flex-shrink-0 cursor-pointer opacity-70 transition-opacity hover:opacity-100"
+          aria-label="Dismiss"
+        >
+          Dismiss
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/menu.tsx
+++ b/src/components/common/menu.tsx
@@ -1,0 +1,87 @@
+import { type ReactNode } from 'react';
+import * as RadixContextMenu from '@radix-ui/react-context-menu';
+import { type LucideIcon } from 'lucide-react';
+
+// Shared right-click menu primitives (styled wrappers over Radix
+// context-menu). One source for the menu surface and item styling that was
+// previously copy-pasted between ImageContextMenu, Sidebar, and the
+// Installed card menu. Menus sit at z-[80] (see the z-index scale in
+// index.css).
+//
+// Usage:
+//   <MenuRoot>
+//     <MenuTrigger asChild>...</MenuTrigger>
+//     <MenuContent>
+//       <MenuLabel>...</MenuLabel>
+//       <MenuItem icon={FolderOpen} onSelect={...}>Reveal in folder</MenuItem>
+//       <MenuSeparator />
+//     </MenuContent>
+//   </MenuRoot>
+
+export const MenuRoot = RadixContextMenu.Root;
+export const MenuTrigger = RadixContextMenu.Trigger;
+
+export const MENU_SURFACE_CLASS =
+  'z-[80] min-w-52 rounded-lg border border-white/10 bg-bg-secondary/95 p-1.5 text-sm text-text-primary shadow-2xl shadow-black/50 backdrop-blur-md animate-fade-in';
+
+type MenuContentProps = RadixContextMenu.ContextMenuContentProps;
+
+export function MenuContent({ children, className = '', ...props }: MenuContentProps) {
+  return (
+    <RadixContextMenu.Portal>
+      <RadixContextMenu.Content
+        collisionPadding={12}
+        className={`${MENU_SURFACE_CLASS} ${className}`}
+        {...props}
+      >
+        {children}
+      </RadixContextMenu.Content>
+    </RadixContextMenu.Portal>
+  );
+}
+
+interface MenuItemProps {
+  children: ReactNode;
+  icon?: LucideIcon;
+  /** Renders the icon with animate-spin (in-flight clipboard ops etc.) */
+  spinning?: boolean;
+  tone?: 'default' | 'success' | 'danger';
+  disabled?: boolean;
+  onSelect: (event: Event) => void;
+}
+
+export function MenuItem({ children, icon: Icon, spinning, tone = 'default', disabled, onSelect }: MenuItemProps) {
+  const toneClass = tone === 'success'
+    ? 'text-state-success focus:bg-state-success/10 data-[highlighted]:bg-state-success/10'
+    : tone === 'danger'
+      ? 'text-state-danger focus:bg-state-danger/10 data-[highlighted]:bg-state-danger/10'
+      : 'text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10';
+
+  return (
+    <RadixContextMenu.Item
+      disabled={disabled}
+      onSelect={(event) => {
+        event.stopPropagation();
+        onSelect(event);
+      }}
+      className={`flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer data-[disabled]:cursor-default data-[disabled]:opacity-50 ${toneClass}`}
+    >
+      {Icon && <Icon className={`h-4 w-4 flex-shrink-0 text-current ${spinning ? 'animate-spin' : ''}`} />}
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+    </RadixContextMenu.Item>
+  );
+}
+
+export function MenuLabel({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <RadixContextMenu.Label
+      className={`max-w-64 truncate px-2 py-1 text-[11px] uppercase tracking-wide text-text-tertiary ${className}`}
+    >
+      {children}
+    </RadixContextMenu.Label>
+  );
+}
+
+export function MenuSeparator() {
+  return <RadixContextMenu.Separator className="my-1 h-px bg-white/10" />;
+}

--- a/src/components/performance/EditorPickerModal.tsx
+++ b/src/components/performance/EditorPickerModal.tsx
@@ -67,8 +67,8 @@ export default function EditorPickerModal({ onClose, onChoose }: Props) {
               Open gameinfo.gi with
             </h2>
             <p className="text-xs text-text-secondary mt-1">
-              Pick the editor for config tweaks. Grimoire remembers this; use the change editor
-              link on the Performance Config card to switch later.
+              Pick the editor for config tweaks. Grimoire remembers this; the gear button next to
+              Edit File switches it later.
             </p>
           </div>
           <button

--- a/src/components/performance/PerformanceConfigCard.tsx
+++ b/src/components/performance/PerformanceConfigCard.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Gauge, ExternalLink, RefreshCw, SquarePen } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Gauge, ExternalLink, RefreshCw, Settings2, SquarePen } from 'lucide-react';
 import { Card, Badge, Button } from '../common/ui';
 import EditorPickerModal from './EditorPickerModal';
-import { useAppStore } from '../../stores/appStore';
+import { useAppStore, type BrowseArtistRef } from '../../stores/appStore';
 import {
   applyPerformanceConfig,
   getPerformanceConfigStatus,
@@ -15,6 +16,16 @@ import type { PerformanceConfigStatus } from '../../types/electron';
 const OPTIMIZATIONLOCK_URL = 'https://github.com/Sqooky/OptimizationLock';
 const SQOOKY_KOFI_URL = 'https://ko-fi.com/sqooky';
 
+// Sqooky's GameBanana identity, so the credit opens the in-app artist view
+// (Browse scoped to their submissions) like any other artist link.
+const SQOOKY_ARTIST: BrowseArtistRef = {
+  id: 3826762,
+  name: 'Sqooky!',
+  avatarUrl: 'https://images.gamebanana.com/img/av/69f9ec7828119.png',
+  profileUrl: 'https://gamebanana.com/members/3826762',
+  kofiUrl: SQOOKY_KOFI_URL,
+};
+
 // Settings card for the OptimizationLock performance preset (experimental).
 // Applies Sqooky's community fps config onto gameinfo.gi in place, shows
 // whether a game update wiped it, and credits the upstream project.
@@ -23,7 +34,13 @@ export default function PerformanceConfigCard() {
   const [busy, setBusy] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
-  const { settings, saveSettings } = useAppStore();
+  const { settings, saveSettings, setBrowseUi } = useAppStore();
+  const navigate = useNavigate();
+
+  const viewSqookyInBrowse = () => {
+    setBrowseUi({ submitter: SQOOKY_ARTIST });
+    navigate('/browse');
+  };
 
   const refresh = useCallback(async () => {
     try {
@@ -109,13 +126,21 @@ export default function PerformanceConfigCard() {
           <p className="text-xs text-text-secondary">
             Map looks dark? Set in-game shadows to Medium or Low. Game updates wipe the config; Grimoire
             spots that here so you can reapply. By{' '}
+            <button
+              type="button"
+              onClick={viewSqookyInBrowse}
+              className="text-accent hover:underline"
+            >
+              Sqooky
+            </button>{' '}
+            and{' '}
             <a
               href={OPTIMIZATIONLOCK_URL}
               target="_blank"
               rel="noreferrer noopener"
               className="text-accent hover:underline inline-flex items-center gap-0.5"
             >
-              Sqooky and contributors
+              contributors
               <ExternalLink className="w-3 h-3" aria-hidden="true" />
             </a>
             . If it helps,{' '}
@@ -129,21 +154,6 @@ export default function PerformanceConfigCard() {
             </a>
             .
           </p>
-          {applied && (
-            <p className="text-xs text-text-secondary">
-              Power users: Edit File opens gameinfo.gi to tweak values (
-              <button
-                type="button"
-                className="text-accent hover:underline"
-                onClick={() => setPickerOpen(true)}
-              >
-                change editor
-              </button>
-              ). Your edits to preset lines are kept as overrides across Reapply and game
-              updates. Leave the grimoire-perf comment markers alone so Remove can restore your
-              file cleanly.
-            </p>
-          )}
           {openError && <p className="text-xs text-red-400">{openError}</p>}
         </div>
         <div className="flex items-center gap-2 shrink-0">
@@ -164,6 +174,18 @@ export default function PerformanceConfigCard() {
             <Button onClick={onEditFile} disabled={busy} variant="ghost" size="sm" icon={SquarePen}>
               Edit File
             </Button>
+          )}
+          {applied && settings?.externalEditorPath !== undefined && (
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              disabled={busy}
+              title="Change editor"
+              aria-label="Change editor"
+              className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary"
+            >
+              <Settings2 className="w-4 h-4" aria-hidden="true" />
+            </button>
           )}
           {applied && (status?.overrideCount ?? 0) > 0 && (
             <Button

--- a/src/components/profiles/ExportProfileModal.tsx
+++ b/src/components/profiles/ExportProfileModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { X, Download, ClipboardCopy, CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Modal } from '../common/Modal';
 import { exportPortableProfile } from '../../lib/api';
 import { PORTABLE_PROFILE_FILE_EXTENSION } from '../../types/portableProfile';
 import type { PortableExportResult } from '../../types/portableProfile';
@@ -33,12 +34,6 @@ export default function ExportProfileModal({ profileId, profileName, onClose }: 
     return () => { cancelled = true; };
   }, [profileId]);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
   const handleSaveFile = () => {
     if (!result) return;
     const blob = new Blob([result.json], { type: 'application/json' });
@@ -62,17 +57,12 @@ export default function ExportProfileModal({ profileId, profileName, onClose }: 
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="export-profile-title"
-      onClick={onClose}
+    <Modal
+      onClose={onClose}
+      labelledBy="export-profile-title"
+      size="md"
+      panelClassName="flex flex-col overflow-hidden"
     >
-      <div
-        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-lg flex flex-col overflow-hidden shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
         <div className="flex items-start justify-between p-6 border-b border-white/10">
           <div className="min-w-0">
             <h2 id="export-profile-title" className="text-xl font-bold text-text-primary">
@@ -162,7 +152,6 @@ export default function ExportProfileModal({ profileId, profileName, onClose }: 
         <div className="p-4 border-t border-white/10 flex justify-end">
           <Button variant="secondary" onClick={onClose}>Close</Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -12,6 +12,7 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { Button, CheckboxMark } from '../common/ui';
+import { Modal } from '../common/Modal';
 import ModThumbnail from '../ModThumbnail';
 import SocialProfileHeader, { type SocialProfileSeed } from '../social/SocialProfileHeader';
 import {
@@ -213,14 +214,6 @@ export default function ImportProfileDialog({
   }, [rows]);
   const trackedKeysRef = useRef(trackedKeys);
   useEffect(() => { trackedKeysRef.current = trackedKeys; }, [trackedKeys]);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !importing) onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, importing]);
 
   // Listen for download events to drive row status during import.
   useEffect(() => {
@@ -679,17 +672,13 @@ export default function ImportProfileDialog({
   const showInputForm = !socialProfileId && !showResolved && !showSkeleton;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-2 sm:p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="import-profile-title"
-      onClick={importing ? undefined : onClose}
+    <Modal
+      onClose={onClose}
+      labelledBy="import-profile-title"
+      size="none"
+      dismissable={!importing}
+      panelClassName={`${socialProfileId ? 'max-w-5xl' : 'max-w-4xl'} max-h-[92vh] flex flex-col overflow-hidden`}
     >
-      <div
-        className={`bg-bg-secondary border border-white/10 rounded-2xl w-full ${socialProfileId ? 'max-w-5xl' : 'max-w-4xl'} max-h-[92vh] flex flex-col overflow-hidden shadow-2xl`}
-        onClick={(e) => e.stopPropagation()}
-      >
         <div className={`flex items-start justify-between ${parsed || socialProfileId ? 'px-4 sm:px-6 py-3' : 'p-4 sm:p-6'} border-b border-white/10`}>
           <div className="min-w-0">
             <h2 id="import-profile-title" className="text-base sm:text-lg font-bold text-text-primary">
@@ -1266,7 +1255,6 @@ export default function ImportProfileDialog({
             </div>
           );
         })()}
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/servers/ConnectServerDialog.tsx
+++ b/src/components/servers/ConnectServerDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2, X, Download, CheckCircle2, AlertTriangle, Play } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Modal } from '../common/Modal';
 import {
   deadworksConnect,
   deadworksOnDownloadProgress,
@@ -71,13 +72,15 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
   const indeterminate = progress?.status === 'decompressing';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4" onClick={phase !== 'working' ? onClose : undefined}>
-      <div
-        className="w-full max-w-md rounded-md border border-border bg-bg-secondary shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal
+      onClose={onClose}
+      labelledBy="connect-server-title"
+      size="sm"
+      dismissable={phase !== 'working'}
+      backdropClassName="backdrop-blur-sm"
+    >
         <div className="flex items-center justify-between border-b border-border px-5 py-3">
-          <h2 className="font-reaver text-lg tracking-wide text-text-primary truncate">{server.name}</h2>
+          <h2 id="connect-server-title" className="font-reaver text-lg tracking-wide text-text-primary truncate">{server.name}</h2>
           <button
             onClick={onClose}
             disabled={phase === 'working'}
@@ -156,7 +159,6 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
             </div>
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/social/EditProfileDialog.tsx
+++ b/src/components/social/EditProfileDialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { X, AlertTriangle, CheckCircle2, Pencil } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Modal } from '../common/Modal';
 import { socialUpdateProfile, type SocialUpdateProfileResponse } from '../../lib/api';
 
 interface EditProfileDialogProps {
@@ -23,14 +24,6 @@ export default function EditProfileDialog({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !submitting) onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, submitting]);
 
   const trimmedTitle = title.trim();
   const trimmedDescription = description.trim();
@@ -67,19 +60,13 @@ export default function EditProfileDialog({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="edit-profile-title"
-      onClick={() => {
-        if (!submitting) onClose();
-      }}
+    <Modal
+      onClose={onClose}
+      labelledBy="edit-profile-title"
+      size="md"
+      dismissable={!submitting}
+      panelClassName="flex flex-col overflow-hidden"
     >
-      <div
-        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-lg flex flex-col overflow-hidden shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
         <div className="flex items-start justify-between p-6 border-b border-white/10">
           <div className="min-w-0">
             <h2
@@ -194,7 +181,6 @@ export default function EditProfileDialog({
             </>
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/social/PublishDialog.tsx
+++ b/src/components/social/PublishDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { X, AlertTriangle, Loader2, CheckCircle2, Globe } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Modal } from '../common/Modal';
 import {
   exportPortableProfile,
   socialPublish,
@@ -58,12 +59,6 @@ export default function PublishDialog({
     return () => { cancelled = true; };
   }, [profileId]);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !submitting) onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, submitting]);
-
   const trimmedTitle = title.trim();
   const trimmedDescription = description.trim();
   const titleTooLong = trimmedTitle.length > 80;
@@ -99,17 +94,13 @@ export default function PublishDialog({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="publish-profile-title"
-      onClick={() => { if (!submitting) onClose(); }}
+    <Modal
+      onClose={onClose}
+      labelledBy="publish-profile-title"
+      size="md"
+      dismissable={!submitting}
+      panelClassName="flex flex-col overflow-hidden"
     >
-      <div
-        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-lg flex flex-col overflow-hidden shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
         <div className="flex items-start justify-between p-6 border-b border-white/10">
           <div className="min-w-0">
             <h2 id="publish-profile-title" className="text-xl font-bold text-text-primary flex items-center gap-2">
@@ -271,7 +262,6 @@ export default function PublishDialog({
             </>
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/social/PublishPickerDialog.tsx
+++ b/src/components/social/PublishPickerDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { X, Loader2, AlertTriangle, Boxes, Globe, FolderOpen } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Modal } from '../common/Modal';
 import { EmptyState } from '../common/PageComponents';
 import { getProfiles, type Profile } from '../../lib/api';
 import { formatRelativeDate } from '../../lib/dates';
@@ -26,12 +27,6 @@ export default function PublishPickerDialog({ onClose, onPick }: PublishPickerDi
     return () => { cancelled = true; };
   }, []);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
   // Most recently updated first so the profile the user just finished
   // tweaking is at the top.
   const sorted = useMemo(() => {
@@ -44,17 +39,12 @@ export default function PublishPickerDialog({ onClose, onPick }: PublishPickerDi
   }, [profiles]);
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="publish-pick-title"
-      onClick={onClose}
+    <Modal
+      onClose={onClose}
+      labelledBy="publish-pick-title"
+      size="md"
+      panelClassName="max-h-[80vh] flex flex-col overflow-hidden"
     >
-      <div
-        className="bg-bg-secondary border border-white/10 rounded-2xl w-full max-w-lg max-h-[80vh] flex flex-col overflow-hidden shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
         <div className="flex items-start justify-between p-6 border-b border-white/10">
           <div className="min-w-0">
             <h2 id="publish-pick-title" className="text-xl font-bold text-text-primary flex items-center gap-2">
@@ -147,7 +137,6 @@ export default function PublishPickerDialog({ onClose, onPick }: PublishPickerDi
             Cancel
           </Button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+/* Z-index scale. New surfaces pick from this ladder instead of inventing
+   values (no more z-[9999]):
+     z-30  page-level overlays inside the content area (Locker hero/global panels)
+     z-40  sticky chrome (sidebar, titlebar)
+     z-50  modals (Modal component) and full-screen dialogs
+     z-60  surfaces that stack above a modal: toasts, ModDetailsModal
+     z-80  context menus and popovers (always top) */
+
 /* Gothic Font for Grimoire branding - loaded via Google Fonts in index.html */
 /* Grenze Gotisch: https://fonts.google.com/specimen/Grenze+Gotisch */
 
@@ -95,6 +103,9 @@
   --color-state-warning: #facc15;
   --color-state-danger:  #f87171;
   --color-state-info:    #60a5fa;
+
+  /* Third-party brand colors (buttons/links that represent the brand itself). */
+  --color-brand-discord: #5865F2;
 
   --font-radiance: 'Radiance', system-ui, sans-serif;
   --font-reaver: 'Reaver', serif;
@@ -718,6 +729,28 @@ body {
   }
 }
 
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @keyframes modDetailsContentOutLeft {
   from {
     opacity: 1;
@@ -776,6 +809,14 @@ body {
 
 .animate-fade-in {
   animation: fadeIn 0.3s ease-out forwards;
+}
+
+.animate-fade-out {
+  animation: fadeOut 0.2s ease-out forwards;
+}
+
+.animate-scale-in {
+  animation: scaleIn 0.25s ease-out forwards;
 }
 
 .mod-details-body-content,
@@ -1155,6 +1196,8 @@ body {
   .animate-slide-in-left,
   .animate-hero-zoom-in,
   .animate-fade-in,
+  .animate-fade-out,
+  .animate-scale-in,
   .mod-details-body--loading-next .mod-details-body-content,
   .mod-details-body--loading-previous .mod-details-body-content,
   .mod-details-body--loading-next .mod-details-navigation-skeleton,

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -406,7 +406,7 @@ export default function Conflicts() {
   }
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
+    <div className="p-6 max-w-5xl mx-auto animate-fade-in">
       <PageHeader
         title={`Conflicts (${conflicts.length})`}
         description={

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -60,8 +60,9 @@ import {
   FileText,
   Banana,
 } from 'lucide-react';
-import * as ContextMenu from '@radix-ui/react-context-menu';
 import { useNavigate } from 'react-router-dom';
+import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/common/menu';
+import { showToast } from '../stores/toastStore';
 import { useAppStore } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder } from '../lib/api';
@@ -577,7 +578,6 @@ export default function Installed() {
   const [unmergeResult, setUnmergeResult] = useState<{ mod: Mod; result: UnmergeModResult; copied: boolean } | null>(null);
   // Brief inline confirmation when the share code is copied. Cleared on a
   // timer; null when no recent copy.
-  const [copyToast, setCopyToast] = useState<string | null>(null);
 
   // Multi-select state. `selectedIds` always stores mod ids (variants of a
   // selected group expand to every variant id) so bulk handlers can iterate
@@ -957,7 +957,7 @@ export default function Installed() {
   // sidesteps the rate-limit pain of the CRC auto-matcher.
   const associateUnknownMatch = async (mod: Mod, args: AssociateUnknownModArgs) => {
     await associateUnknownMod(mod.id, args);
-    setCopyToast(`Linked to ${args.modName}`);
+    showToast(`Linked to ${args.modName}`, { tone: 'success', duration: 2200 });
     await finishUnknownFix(mod);
   };
 
@@ -1769,7 +1769,7 @@ export default function Installed() {
       }
     } catch (err) {
       console.error('[Installed] unmerge failed:', err);
-      setCopyToast(`Unmerge failed: ${err instanceof Error ? err.message : String(err)}`);
+      showToast(`Unmerge failed: ${err instanceof Error ? err.message : String(err)}`, { tone: 'error' });
     }
   };
 
@@ -1777,10 +1777,10 @@ export default function Installed() {
     if (!mod.merged?.shareCode) return;
     try {
       await navigator.clipboard.writeText(mod.merged.shareCode);
-      setCopyToast('Share code copied');
+      showToast('Share code copied', { tone: 'success', duration: 2200 });
     } catch (err) {
       console.error('[Installed] clipboard write failed:', err);
-      setCopyToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`);
+      showToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`, { tone: 'error' });
     }
   };
 
@@ -1794,25 +1794,19 @@ export default function Installed() {
     await loadMods({ silent: true });
     if (result.collapsed) {
       setMergedContentsMod(null);
-      setCopyToast(`Merge dissolved (extracted ${source.modName})`);
+      showToast(`Merge dissolved (extracted ${source.modName})`, { tone: 'success', duration: 2200 });
       return;
     }
     setMergedContentsMod(result.merged);
-    setCopyToast(`Extracted ${source.modName}`);
+    showToast(`Extracted ${source.modName}`, { tone: 'success', duration: 2200 });
   };
 
-  // Auto-dismiss the copy toast after a short read time.
-  useEffect(() => {
-    if (!copyToast) return;
-    const id = window.setTimeout(() => setCopyToast(null), 2200);
-    return () => window.clearTimeout(id);
-  }, [copyToast]);
 
   // Surface a non-fatal store notice (e.g. the 99-enabled cap) through the same
   // transient toast, then clear it from the store so it doesn't re-fire.
   useEffect(() => {
     if (!modsNotice) return;
-    setCopyToast(modsNotice);
+    showToast(modsNotice, { tone: 'warning' });
     clearModsNotice();
   }, [modsNotice, clearModsNotice]);
 
@@ -2683,8 +2677,11 @@ export default function Installed() {
   return (
     <div ref={installedScrollRef} className="h-full overflow-y-auto px-4 pb-5 sm:px-6">
       <div className="sticky top-0 z-30 -mx-4 mb-4 border-b border-white/5 bg-bg-primary/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-bg-primary/80 sm:-mx-6 sm:px-6">
-        <div className="flex flex-wrap items-center gap-2 lg:gap-3">
-          <div className="relative min-w-[14rem] flex-1 basis-[20rem] sm:max-w-md">
+        {/* Row 1: search + view controls. The search shrinks (min-w) instead of
+            pushing the controls onto a right-aligned orphan row, which used to
+            leave a dead gap at common window widths. */}
+        <div className="flex items-center gap-2 lg:gap-3">
+          <div className="relative min-w-[11rem] max-w-md flex-1">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary pointer-events-none" />
             <input
               type="text"
@@ -2704,7 +2701,6 @@ export default function Installed() {
               </button>
             )}
           </div>
-          {topStatusActions}
           <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
             {/* Sort + filter: load order / recent / name, GameBanana vs local
                 import, and mod-type buckets. The badge counts active
@@ -2940,9 +2936,10 @@ export default function Installed() {
 
             {/* Card-size slider: only meaningful in grid layout, so it's
                 disabled (and dimmed) while List is active rather than hidden,
-                keeping the toolbar from reflowing as you switch. */}
+                keeping the toolbar from reflowing as you switch. Dropped below
+                lg so the toolbar keeps to one row in narrow windows. */}
             <div
-              className={`order-last flex items-center gap-2 rounded-sm border border-border bg-bg-secondary px-2 py-1.5 transition-opacity ${
+              className={`order-last hidden items-center gap-2 rounded-sm border border-border bg-bg-secondary px-2 py-1.5 transition-opacity lg:flex ${
                 layout === 'list' ? 'opacity-40' : ''
               }`}
               title="Card size (drag to the small end for compact cards)"
@@ -2974,6 +2971,9 @@ export default function Installed() {
             />
           </div>
         </div>
+        {/* Row 2 (contextual): status actions get their own strip instead of
+            jostling with the search for row-1 space. */}
+        {topStatusActions && <div className="mt-2">{topStatusActions}</div>}
       </div>
 
       {lockerOverridesOpen && (
@@ -3459,16 +3459,6 @@ export default function Installed() {
         />
       )}
 
-      {copyToast && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="fixed bottom-20 left-1/2 -translate-x-1/2 z-[60] bg-bg-secondary border border-border rounded-lg shadow-lg shadow-black/40 px-4 py-2 text-sm text-text-primary animate-fade-in"
-        >
-          {copyToast}
-        </div>
-      )}
-
       {selectMode && (
         // z-40 keeps this floating bar above the page + sticky header (z-30)
         // but below modal overlays (z-50), so an open modal's backdrop dims it
@@ -3822,8 +3812,10 @@ function BulkUnknownFixModal({
   const retryableCount = unknownMods.filter(
     (mod) => !pendingIds.has(mod.id) && cache[mod.id]?.crcMatch.status === 'not-found'
   ).length;
+  const [confirmFindAll, setConfirmFindAll] = useState(false);
 
   return createPortal(
+    <>
     <div
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
       role="dialog"
@@ -3863,13 +3855,7 @@ function BulkUnknownFixModal({
                   size="sm"
                   icon={Search}
                   disabled={findableCount === 0}
-                  onClick={() => {
-                    const ok = window.confirm(
-                      `Auto-detect scans GameBanana for ${findableCount} mod${findableCount === 1 ? '' : 's'}. ` +
-                        'This can hit GameBanana rate limits. Searching manually (per mod) is faster and lighter. Continue?'
-                    );
-                    if (ok) onFindAll(unknownMods);
-                  }}
+                  onClick={() => setConfirmFindAll(true)}
                   title="Auto-detect every unknown mod that has not already been checked (heavy, may hit rate limits)"
                 >
                   Search all
@@ -3951,7 +3937,22 @@ function BulkUnknownFixModal({
           />
         </div>
       </div>
-    </div>,
+    </div>
+    {/* Sibling of the backdrop: portal events bubble through the React tree,
+        so nesting this inside the backdrop would close the whole dialog on
+        any click in the confirm. */}
+    <ConfirmModal
+      isOpen={confirmFindAll}
+      title="Search all unknown mods?"
+      message={`Auto-detect scans GameBanana for ${findableCount} mod${findableCount === 1 ? '' : 's'}. This can hit GameBanana rate limits. Searching manually (per mod) is faster and lighter.`}
+      confirmLabel="Search all"
+      onConfirm={() => {
+        setConfirmFindAll(false);
+        onFindAll(unknownMods);
+      }}
+      onCancel={() => setConfirmFindAll(false)}
+    />
+    </>,
     document.body
   );
 }
@@ -5649,7 +5650,7 @@ function ModCard({
             ref={menuPanelRef}
             role="menu"
             data-card-menu-open
-            className="z-[100] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
+            className="z-[80] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
             style={{
               position: 'fixed',
               right: Math.max(8, window.innerWidth - menuRect.right),
@@ -5872,11 +5873,11 @@ function ModCard({
     </div>
   );
   return (
-    <ContextMenu.Root>
+    <MenuRoot>
       {/* Disabled in select mode so right-click doesn't fight the full-card
           select overlay. Thumbnail right-clicks never reach here: the image
           context menu's trigger stops propagation. */}
-      <ContextMenu.Trigger asChild disabled={selectMode}>
+      <MenuTrigger asChild disabled={selectMode}>
     <div
       data-mod-entry-key={entryKey}
       className={`group/card relative rounded-[10px] border transform-gpu transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ${isList ? stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
@@ -6100,22 +6101,13 @@ function ModCard({
       </div>
 
     </div>
-      </ContextMenu.Trigger>
-      <ContextMenu.Portal>
-        <ContextMenu.Content
-          collisionPadding={12}
-          className="z-[80] min-w-52 rounded-lg border border-white/10 bg-bg-secondary/95 p-1.5 text-sm text-text-primary shadow-2xl shadow-black/50 backdrop-blur-md animate-fade-in"
-        >
-          <ContextMenu.Item
-            onSelect={handleRevealInFolder}
-            className="flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10"
-          >
-            <FolderOpen className="h-4 w-4 flex-shrink-0" />
-            <span className="min-w-0 flex-1 truncate">Reveal in folder</span>
-          </ContextMenu.Item>
-        </ContextMenu.Content>
-      </ContextMenu.Portal>
-    </ContextMenu.Root>
+      </MenuTrigger>
+      <MenuContent>
+        <MenuItem icon={FolderOpen} onSelect={handleRevealInFolder}>
+          Reveal in folder
+        </MenuItem>
+      </MenuContent>
+    </MenuRoot>
   );
 }
 

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -45,6 +45,29 @@ import {
   type HeroCategory,
 } from '../lib/lockerUtils';
 
+// Route changes flip the overlay state instantly, which unmounts the hero or
+// global panel on the next frame with no exit transition. Retain the last
+// value for the fade-out duration so the panel can animate away first.
+const OVERLAY_EXIT_MS = 200;
+
+function useOverlayExit<T>(value: T | null): { item: T | null; closing: boolean } {
+  const [retained, setRetained] = useState<T | null>(null);
+  // Render-time adjustment (not an effect) so the retained value tracks the
+  // live one without an extra commit.
+  if (value !== null && value !== retained) {
+    setRetained(value);
+  }
+  useEffect(() => {
+    if (value !== null) return;
+    const timer = window.setTimeout(() => setRetained(null), OVERLAY_EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [value]);
+  return {
+    item: value ?? retained,
+    closing: value === null && retained !== null,
+  };
+}
+
 let lockerPageScrollTop = 0;
 let lockerCategoriesCache: GameBananaCategoryNode[] | null = null;
 const lockerLoadedImageUrls = new Set<string>();
@@ -112,7 +135,6 @@ export default function Locker() {
     return stored === 'list' ? 'list' : 'gallery';
   });
   const [abilityRecolorSupport, setAbilityRecolorSupport] = useState<Record<string, boolean>>({});
-  const [showAbilityRecolorOnly, setShowAbilityRecolorOnly] = useState(false);
   // List-view accordion state. The Settings preference decides the initial
   // state; after that, manual expand/collapse stays under the user's control.
   const [expandedHeroes, setExpandedHeroes] = useState<Set<number>>(() => new Set());
@@ -328,25 +350,6 @@ export default function Locker() {
       return a.name.localeCompare(b.name);
     });
   }, [baseHeroList, favoriteHeroes, heroMods, heroSounds]);
-  const abilityRecolorSupportLoaded = useMemo(
-    () =>
-      heroNamesForColorSupport.length === 0 ||
-      heroNamesForColorSupport.every((name) =>
-        Object.prototype.hasOwnProperty.call(abilityRecolorSupport, name)
-      ),
-    [abilityRecolorSupport, heroNamesForColorSupport]
-  );
-  const abilityRecolorCount = useMemo(
-    () => heroList.filter((hero) => abilityRecolorSupport[hero.name]).length,
-    [abilityRecolorSupport, heroList]
-  );
-  const visibleHeroList = useMemo(
-    () =>
-      showAbilityRecolorOnly
-        ? heroList.filter((hero) => abilityRecolorSupport[hero.name])
-        : heroList,
-    [abilityRecolorSupport, heroList, showAbilityRecolorOnly]
-  );
   const lockerCardsExpandedByDefault = settings?.lockerCardsExpandedByDefault ?? false;
 
   useEffect(() => {
@@ -362,18 +365,22 @@ export default function Locker() {
   }, [heroList, lockerCardsExpandedByDefault]);
 
   const allExpanded =
-    visibleHeroList.length > 0 && visibleHeroList.every((hero) => expandedHeroes.has(hero.id));
+    heroList.length > 0 && heroList.every((hero) => expandedHeroes.has(hero.id));
   const toggleExpandAll = useCallback(() => {
     setExpandedHeroes((prev) => {
       const everyOpen =
-        visibleHeroList.length > 0 && visibleHeroList.every((hero) => prev.has(hero.id));
-      return everyOpen ? new Set() : new Set(visibleHeroList.map((hero) => hero.id));
+        heroList.length > 0 && heroList.every((hero) => prev.has(hero.id));
+      return everyOpen ? new Set() : new Set(heroList.map((hero) => hero.id));
     });
-  }, [visibleHeroList]);
+  }, [heroList]);
   const selectedHero = selectedHeroId === null
     ? null
     : heroList.find((hero) => hero.id === selectedHeroId) ?? null;
   const selectedHeroMissing = selectedHeroRouteParam !== null && !selectedHero;
+  const heroOverlay = useOverlayExit(selectedHero);
+  const overlayHero = heroOverlay.item;
+  const missingOverlay = useOverlayExit(selectedHeroMissing ? true : null);
+  const globalOverlay = useOverlayExit(globalSelected ? true : null);
 
   // Publish the open hero's name for Discord Rich Presence (read by
   // DiscordPresence). Clear it on unmount so leaving the Locker drops the hero.
@@ -381,13 +388,15 @@ export default function Locker() {
     setLockerHeroName(selectedHero?.name ?? null);
     return () => setLockerHeroName(null);
   }, [selectedHero, setLockerHeroName]);
+  // Keyed off the retained overlay hero (not the live route value) so the
+  // panel keeps its content while it fades out.
   const selectedHeroMods = useMemo(
-    () => (selectedHero ? heroMods.map.get(selectedHero.id) ?? [] : []),
-    [heroMods, selectedHero]
+    () => (overlayHero ? heroMods.map.get(overlayHero.id) ?? [] : []),
+    [heroMods, overlayHero]
   );
   const selectedHeroSoundList = useMemo(
-    () => (selectedHero ? heroSounds.map.get(selectedHero.id) ?? [] : []),
-    [heroSounds, selectedHero]
+    () => (overlayHero ? heroSounds.map.get(overlayHero.id) ?? [] : []),
+    [heroSounds, overlayHero]
   );
   const selectedHeroSkinCount = useMemo(
     () => countLockerSkins(selectedHeroMods),
@@ -527,9 +536,7 @@ export default function Locker() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm text-text-secondary">
           {[
-            showAbilityRecolorOnly
-              ? `${visibleHeroList.length}/${heroList.length} heroes`
-              : `${heroList.length} heroes`,
+            `${heroList.length} heroes`,
             `${installedSkinCount} skin${installedSkinCount !== 1 ? 's' : ''}`,
             installedSoundCount > 0
               ? `${installedSoundCount} sound${installedSoundCount !== 1 ? 's' : ''}`
@@ -550,27 +557,7 @@ export default function Locker() {
                 {unassignedSkins.length + unassignedSounds.length} unassigned
               </button>
             )}
-          {abilityRecolorCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowAbilityRecolorOnly((show) => !show)}
-              disabled={!abilityRecolorSupportLoaded}
-              aria-pressed={showAbilityRecolorOnly}
-              className={`flex items-center gap-1.5 self-stretch rounded-sm border px-3 text-sm transition-colors ${
-                showAbilityRecolorOnly
-                  ? 'border-accent/50 bg-accent/15 text-text-primary'
-                  : 'border-border bg-bg-secondary text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'
-              } ${abilityRecolorSupportLoaded ? 'cursor-pointer' : 'cursor-wait opacity-60'}`}
-              title="Show only heroes with ability color recoloring"
-            >
-              <RainbowPaletteIcon className="h-4 w-4" />
-              Recolorable
-              <span className="ml-0.5 rounded-sm bg-black/20 px-1.5 py-0.5 text-[11px] leading-none text-current">
-                {abilityRecolorCount}
-              </span>
-            </button>
-          )}
-          {viewMode === 'list' && visibleHeroList.length > 0 && (
+          {viewMode === 'list' && heroList.length > 0 && (
             <button
               onClick={toggleExpandAll}
               className="flex items-center gap-1.5 self-stretch rounded-sm border border-border bg-bg-secondary px-3 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
@@ -600,21 +587,16 @@ export default function Locker() {
           <Layers className="w-12 h-12 mb-3 opacity-50" />
           <p>No hero categories found.</p>
         </div>
-      ) : visibleHeroList.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-64 text-text-secondary">
-          <RainbowPaletteIcon className="w-12 h-12 mb-3 opacity-80" />
-          <p>No heroes with ability recoloring available.</p>
-        </div>
       ) : viewMode === 'gallery' ? (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-          {globalCount > 0 && !showAbilityRecolorOnly && (
+          {globalCount > 0 && (
             <GlobalGalleryCard
               count={globalCount}
               typeCount={globalTypeCount}
               onNavigate={() => navigate('/locker/global')}
             />
           )}
-          {visibleHeroList.map((hero) => (
+          {heroList.map((hero) => (
             <HeroGalleryCard
               key={hero.id}
               hero={hero}
@@ -636,7 +618,7 @@ export default function Locker() {
         </div>
       ) : (
         <div className="grid grid-cols-1 items-start gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {globalCount > 0 && !showAbilityRecolorOnly && (
+          {globalCount > 0 && (
             <button
               type="button"
               onClick={() => navigate('/locker/global')}
@@ -667,7 +649,7 @@ export default function Locker() {
               <ChevronDown className="relative z-10 h-4 w-4 -rotate-90 text-text-secondary" />
             </button>
           )}
-          {visibleHeroList.map((hero) => (
+          {heroList.map((hero) => (
             <HeroCard
               key={hero.id}
               hero={hero}
@@ -693,7 +675,7 @@ export default function Locker() {
         </div>
       )}
 
-      {viewMode === 'list' && !showAbilityRecolorOnly && (unassignedSkins.length > 0 || unassignedSounds.length > 0) && (
+      {viewMode === 'list' && (unassignedSkins.length > 0 || unassignedSounds.length > 0) && (
         <div className="space-y-3">
           <SectionHeader>Unassigned</SectionHeader>
           <p className="text-xs text-text-secondary -mt-1">
@@ -759,36 +741,40 @@ export default function Locker() {
       )}
     </div>
 
-      {selectedHero && (
+      {overlayHero && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
+          className={`fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary sidebar-offset-transition ${
+            heroOverlay.closing ? 'animate-fade-out pointer-events-none' : 'animate-fade-in'
+          }`}
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <LockerHeroView
-            key={selectedHero.id}
-            hero={selectedHero}
+            key={overlayHero.id}
+            hero={overlayHero}
             skinList={selectedHeroMods}
             soundList={selectedHeroSoundList}
             skinCount={selectedHeroSkinCount}
-            isFavorite={favoriteHeroes.includes(selectedHero.id)}
+            isFavorite={favoriteHeroes.includes(overlayHero.id)}
             onBack={() => navigate('/locker')}
             onToggleFavorite={() =>
               setFavoriteHeroes((prev) =>
-                prev.includes(selectedHero.id)
-                  ? prev.filter((id) => id !== selectedHero.id)
-                  : [...prev, selectedHero.id]
+                prev.includes(overlayHero.id)
+                  ? prev.filter((id) => id !== overlayHero.id)
+                  : [...prev, overlayHero.id]
               )
             }
-            onSelect={(modId) => setActiveSkin(selectedHero.id, modId)}
-            onToggleVariant={(modId) => toggleHeroVariant(selectedHero.id, modId)}
+            onSelect={(modId) => setActiveSkin(overlayHero.id, modId)}
+            onToggleVariant={(modId) => toggleHeroVariant(overlayHero.id, modId)}
             hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           />
         </div>
       )}
 
-      {selectedHeroMissing && (
+      {missingOverlay.item && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
+          className={`fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary sidebar-offset-transition ${
+            missingOverlay.closing ? 'animate-fade-out pointer-events-none' : 'animate-fade-in'
+          }`}
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <div className="flex h-full flex-col items-center justify-center p-6 text-text-secondary">
@@ -804,9 +790,11 @@ export default function Locker() {
           </div>
         </div>
       )}
-      {globalSelected && (
+      {globalOverlay.item && (
         <div
-          className="fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary animate-fade-in sidebar-offset-transition"
+          className={`fixed bottom-0 right-0 top-0 z-30 overflow-hidden bg-bg-primary sidebar-offset-transition ${
+            globalOverlay.closing ? 'animate-fade-out pointer-events-none' : 'animate-fade-in'
+          }`}
           style={{ left: 'var(--grimoire-sidebar-width, 14rem)' }}
         >
           <LockerGlobalView
@@ -1239,14 +1227,14 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType 
       {retagMenu && (
         <>
           <div
-            className="fixed inset-0 z-[59]"
+            className="fixed inset-0 z-[79]"
             aria-hidden
             onClick={() => setRetagMenu(null)}
           />
           <div
             role="menu"
             aria-label="Change global category"
-            className="fixed z-[60] w-52 rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
+            className="fixed z-[80] w-52 rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
             style={{ top: retagMenu.y, left: retagMenu.x }}
           >
             <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -380,7 +380,7 @@ export default function Profiles() {
   }
 
   return (
-    <div className="p-6 h-full max-w-5xl mx-auto w-full flex flex-col overflow-hidden">
+    <div className="p-6 h-full max-w-5xl mx-auto w-full flex flex-col overflow-hidden animate-fade-in">
       <div className="flex flex-col gap-6 flex-1 overflow-auto px-1">
         <div className="space-y-6 pr-1">
           {error && (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy, ChevronDown } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Ban, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy, ChevronDown } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
@@ -628,7 +628,7 @@ export default function Settings() {
   }
 
   return (
-    <div className="p-8 max-w-5xl mx-auto space-y-8">
+    <div className="p-8 max-w-5xl mx-auto space-y-8 animate-fade-in">
       <PageHeader
         title="Settings"
         description="Configure game paths, preferences, and maintenance tasks"
@@ -922,7 +922,7 @@ export default function Settings() {
                           className="h-7 w-7 object-contain"
                         />
                       ) : (
-                        <Palette className="h-4 w-4 text-accent" aria-hidden />
+                        <Ban className="h-4 w-4 text-text-secondary" aria-hidden />
                       )}
                       <ChevronDown className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5 text-text-primary/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.85)]" aria-hidden />
                     </button>
@@ -1036,7 +1036,7 @@ export default function Settings() {
                                   : 'border-white/10 bg-bg-tertiary hover:border-accent/50 hover:bg-accent/10'
                               }`}
                             >
-                              <Palette className="h-5 w-5 text-accent" aria-hidden />
+                              <Ban className="h-5 w-5 text-text-secondary" aria-hidden />
                               {selectedSidebarHero === null && (
                                 <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
                                   <Check className="h-2.5 w-2.5" aria-hidden />
@@ -1345,7 +1345,7 @@ export default function Settings() {
                   href="https://discord.gg/KgYGHEMq2P"
                   target="_blank"
                   rel="noreferrer noopener"
-                  className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60 whitespace-nowrap"
+                  className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-brand-discord/40 bg-brand-discord/10 text-text-primary hover:bg-brand-discord/20 hover:border-brand-discord/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-discord/60 whitespace-nowrap"
                 >
                   <svg
                     aria-hidden="true"
@@ -1433,7 +1433,7 @@ export default function Settings() {
                       href="https://discord.gg/KgYGHEMq2P"
                       target="_blank"
                       rel="noreferrer noopener"
-                      className="inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium border border-[#5865F2]/40 bg-[#5865F2]/10 text-text-primary hover:bg-[#5865F2]/20 hover:border-[#5865F2]/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]/60"
+                      className="inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium border border-brand-discord/40 bg-brand-discord/10 text-text-primary hover:bg-brand-discord/20 hover:border-brand-discord/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-discord/60"
                     >
                       <svg aria-hidden="true" viewBox="0 0 24 24" className="w-4 h-4 fill-current">
                         <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -117,7 +117,7 @@ export default function Stats() {
     }
 
     return (
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col h-full animate-fade-in">
             <div className="px-6 py-3 border-b border-white/5 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-3 min-w-0">
                     <BarChart3 className="w-6 h-6 text-accent shrink-0" />

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand';
+
+// App-wide toast queue. Toasts stack bottom-center (rendered by ToastStack in
+// Layout) instead of each surface hand-rolling its own floating div, so two
+// notifications no longer overwrite each other.
+
+export type ToastTone = 'info' | 'success' | 'warning' | 'error';
+
+export interface Toast {
+  id: number;
+  message: string;
+  tone: ToastTone;
+  /** ms until auto-dismiss */
+  duration: number;
+  /** show an explicit Dismiss button (sticky warnings) */
+  dismissable?: boolean;
+}
+
+interface ToastOptions {
+  tone?: ToastTone;
+  duration?: number;
+  dismissable?: boolean;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  showToast: (message: string, opts?: ToastOptions) => number;
+  dismissToast: (id: number) => void;
+}
+
+let nextToastId = 1;
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  showToast: (message, opts = {}) => {
+    const id = nextToastId++;
+    const toast: Toast = {
+      id,
+      message,
+      tone: opts.tone ?? 'info',
+      duration: opts.duration ?? 5000,
+      dismissable: opts.dismissable,
+    };
+    set((s) => ({ toasts: [...s.toasts, toast] }));
+    return id;
+  },
+  dismissToast: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));
+
+/** Imperative helper for non-component call sites. */
+export function showToast(message: string, opts?: ToastOptions): number {
+  return useToastStore.getState().showToast(message, opts);
+}


### PR DESCRIPTION
Follow-up polish on #172, both from review feedback:

- **Removed the poweruser explainer paragraph** (Edit File / overrides / markers copy) from the Performance Config card. Changing the editor moves to a small gear button next to Edit File (shown once an editor has been chosen; the first click on Edit File still opens the picker).
- **Sqooky in the credit line now opens the in-app artist view**: Browse scoped to his GameBanana submissions (member 3826762, verified to be the OptimizationLock author with 9 Deadlock submissions including "OptimizationLockV2 Important Fix :D"). The avatar and ko-fi ride along in the BrowseArtistRef so the artist banner renders without an extra fetch. "contributors" keeps the GitHub repo link.

Typecheck and eslint clean.