### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {
@@ -32,7 +32,6 @@
     "package:win": "electron-vite build && electron-builder --win"
   },
   "dependencies": {
-    "7zip-bin": "^5.2.0",
     "@compai/font-unifraktur-maguntia": "^0.0.3",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -41,6 +40,7 @@
     "@react-three/fiber": "^9.6.1",
     "@tanstack/react-virtual": "^3.13.26",
     "@xhayper/discord-rpc": "^1.3.4",
+    "7zip-bin": "^5.2.0",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.5.0",
     "dompurify": "^3.3.1",


### PR DESCRIPTION
Version bump for the v1.18.0 release. 14 PRs since v1.17.0 (#162-#177): OptimizationLock performance config, crosshair overhaul, Stats rebuild + salt contribution, UI primitives, Installed nav perf, native Windows title bar.