### PR TITLE
feat(locker): floating 3D model panel + live trippy body preview

### DIFF
--- a/src/components/locker/FloatingModelPanel.tsx
+++ b/src/components/locker/FloatingModelPanel.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { GripHorizontal, X } from 'lucide-react';
+
+/**
+ * A draggable, resizable floating panel for the Locker's live 3D hero model.
+ *
+ * The model used to live in a fixed strip whose left offset was hardcoded to
+ * the rail + selection-column widths (780/880px), so it only worked on wide
+ * windows and collapsed to a sliver at the lg breakpoint. A floating panel
+ * decouples the viewer from panel widths entirely: it floats over the 2D
+ * portrait backdrop at any window size, and the user parks/sizes it wherever
+ * they like. Geometry persists to localStorage so it stays put across heroes
+ * and sessions.
+ *
+ * Positioned `absolute` inside the LockerHero overlay root (its offset parent),
+ * so left/top are relative to that container and `overflow-hidden` on the root
+ * clips it to the overlay. Both drag and resize clamp the panel inside the
+ * parent and re-clamp on window/overlay resize.
+ */
+
+interface Geom {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const STORAGE_KEY = 'grimoire.locker.modelPanel.geom';
+const DEFAULT_SIZE = { w: 360, h: 460 };
+const MIN = { w: 240, h: 260 };
+const MARGIN = 12;
+
+function readStored(): Geom | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const v = JSON.parse(raw) as Partial<Geom>;
+    if (
+      typeof v?.x === 'number' &&
+      typeof v?.y === 'number' &&
+      typeof v?.w === 'number' &&
+      typeof v?.h === 'number'
+    ) {
+      return v as Geom;
+    }
+  } catch {
+    /* ignore malformed storage */
+  }
+  return null;
+}
+
+function clampGeom(g: Geom, pw: number, ph: number): Geom {
+  const w = Math.max(MIN.w, Math.min(g.w, pw - MARGIN * 2));
+  const h = Math.max(MIN.h, Math.min(g.h, ph - MARGIN * 2));
+  const x = Math.min(Math.max(g.x, MARGIN), Math.max(MARGIN, pw - w - MARGIN));
+  const y = Math.min(Math.max(g.y, MARGIN), Math.max(MARGIN, ph - h - MARGIN));
+  return { x, y, w, h };
+}
+
+export default function FloatingModelPanel({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [geom, setGeom] = useState<Geom | null>(() => readStored());
+
+  const parentSize = useCallback(() => {
+    const parent = ref.current?.parentElement;
+    if (!parent) return null;
+    return { w: parent.clientWidth, h: parent.clientHeight };
+  }, []);
+
+  // Seed default (bottom-right) on first open when nothing is stored, and
+  // re-clamp whenever the overlay/window resizes so the panel never drifts off
+  // screen at a smaller size.
+  useLayoutEffect(() => {
+    const parent = ref.current?.parentElement;
+    if (!parent) return;
+    const apply = () => {
+      const pw = parent.clientWidth;
+      const ph = parent.clientHeight;
+      if (pw === 0 || ph === 0) return;
+      setGeom((g) => {
+        if (g) return clampGeom(g, pw, ph);
+        const w = Math.min(DEFAULT_SIZE.w, pw - MARGIN * 2);
+        const h = Math.min(DEFAULT_SIZE.h, ph - MARGIN * 2);
+        return clampGeom({ w, h, x: pw - w - MARGIN, y: ph - h - MARGIN }, pw, ph);
+      });
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(parent);
+    return () => ro.disconnect();
+  }, []);
+
+  // Persist geometry so the panel stays where the user parked it.
+  useEffect(() => {
+    if (!geom) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(geom));
+    } catch {
+      /* ignore quota/availability errors */
+    }
+  }, [geom]);
+
+  const beginGesture = useCallback(
+    (
+      e: React.PointerEvent,
+      compute: (base: Geom, dx: number, dy: number) => Geom
+    ) => {
+      e.preventDefault();
+      const ps = parentSize();
+      if (!ps || !geom) return;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const base = geom;
+      const onMove = (ev: PointerEvent) => {
+        setGeom(clampGeom(compute(base, ev.clientX - startX, ev.clientY - startY), ps.w, ps.h));
+      };
+      const onUp = () => {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+      };
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+    },
+    [geom, parentSize]
+  );
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent) =>
+      beginGesture(e, (base, dx, dy) => ({ ...base, x: base.x + dx, y: base.y + dy })),
+    [beginGesture]
+  );
+
+  const startResize = useCallback(
+    (e: React.PointerEvent) => {
+      e.stopPropagation();
+      beginGesture(e, (base, dx, dy) => ({ ...base, w: base.w + dx, h: base.h + dy }));
+    },
+    [beginGesture]
+  );
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-30 flex flex-col overflow-hidden rounded-xl border border-border/70 bg-bg-secondary/95 shadow-2xl backdrop-blur-md"
+      // Park off-screen until the layout effect measures the parent and seeds a
+      // real position, so the panel never flashes at 0,0.
+      style={
+        geom
+          ? { left: geom.x, top: geom.y, width: geom.w, height: geom.h }
+          : { left: -9999, top: -9999, width: DEFAULT_SIZE.w, height: DEFAULT_SIZE.h }
+      }
+    >
+      <div
+        onPointerDown={startDrag}
+        className="flex cursor-grab select-none items-center gap-2 border-b border-border/60 bg-bg-tertiary/60 px-3 py-2 active:cursor-grabbing"
+      >
+        <GripHorizontal className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+        <span className="min-w-0 flex-1 truncate text-xs font-semibold text-text-primary">
+          {title}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close 3D model"
+          aria-label="Close 3D model"
+          className="-mr-1 flex-shrink-0 cursor-pointer rounded p-0.5 text-text-secondary transition-colors hover:text-text-primary"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Body. `relative` so the viewer's absolute inset-0 states fill it. */}
+      <div className="relative flex-1 bg-bg-primary/40">{children}</div>
+
+      {/* Bottom-right resize handle. */}
+      <div
+        onPointerDown={startResize}
+        title="Resize"
+        className="absolute bottom-0 right-0 flex h-4 w-4 cursor-nwse-resize items-end justify-end p-0.5"
+      >
+        <svg viewBox="0 0 10 10" aria-hidden className="h-2.5 w-2.5 text-text-secondary/60">
+          <path d="M9 1 L1 9 M9 5 L5 9" stroke="currentColor" strokeWidth="1.2" fill="none" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/components/locker/HeroEffectsPanel.tsx
+++ b/src/components/locker/HeroEffectsPanel.tsx
@@ -108,7 +108,11 @@ export default function HeroEffectsPanel({ heroName }: HeroEffectsPanelProps) {
             <HeroColorPicker heroName={heroName} onAppliedChange={setAbilitiesApplied} />
           </div>
           <div className={surface === 'skin' ? 'space-y-3' : 'hidden'}>
-            <TrippySkinPanel heroName={heroName} onAppliedChange={setSkinApplied} />
+            <TrippySkinPanel
+              heroName={heroName}
+              active={surface === 'skin'}
+              onAppliedChange={setSkinApplied}
+            />
           </div>
         </>
       )}

--- a/src/components/locker/HeroPoseViewer.tsx
+++ b/src/components/locker/HeroPoseViewer.tsx
@@ -3,9 +3,11 @@ import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { Loader2 } from 'lucide-react';
-import { getHeroPoseInfo, exportHeroPose } from '../../lib/api';
+import { getHeroPoseInfo, exportHeroPose, previewTrippySprite } from '../../lib/api';
 import { loadGltfPreview } from '../../lib/loadGltfPreview';
 import type { HeroPoseSkinSource } from '../../types/portrait';
+import type { TrippySpriteResult } from '../../types/mod';
+import type { TrippyPreview } from '../../stores/trippyPreviewStore';
 
 /**
  * Live 3D preview of a hero's menu pose for the Locker's per-hero view.
@@ -103,21 +105,167 @@ function Controls() {
   return null;
 }
 
+/** Live trippy-skin preview: paints the body meshes with the trippy pattern and
+ *  animates it. The sprite from `previewTrippySprite` is a horizontal frame
+ *  strip (the same asset the 2D swatch flipbooks); we draw the current frame
+ *  onto an offscreen canvas and feed it as a tiling CanvasTexture, so the paint
+ *  flows on the model. This is an approximation of the engine's UV-scroll shader
+ *  (body only; the GLB carries no weapon mesh), not the exact bake.
+ *
+ *  Originals are captured per material and restored on unmount, so toggling the
+ *  preview off (or closing the panel) returns the model to its real skin. */
+function TrippyPaint({
+  scene,
+  sprite,
+  fps = 12,
+  repeat = 2,
+}: {
+  scene: THREE.Object3D;
+  sprite: TrippySpriteResult;
+  fps?: number;
+  repeat?: number;
+}) {
+  const texRef = useRef<THREE.CanvasTexture | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const startRef = useRef<number | null>(null);
+  const lastFrameRef = useRef(-1);
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = sprite.size;
+    canvas.height = sprite.size;
+    canvasRef.current = canvas;
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat, repeat);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    texRef.current = tex;
+
+    const img = new Image();
+    img.src = sprite.dataUrl;
+    imgRef.current = img;
+
+    // Unique materials so meshes sharing one material are touched once.
+    const originals = new Map<THREE.MeshStandardMaterial, { map: THREE.Texture | null; color: number }>();
+    scene.traverse((obj) => {
+      const mesh = obj as THREE.Mesh;
+      if (!mesh.isMesh) return;
+      const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      for (const m of mats) {
+        const sm = m as THREE.MeshStandardMaterial;
+        if (!sm || originals.has(sm)) continue;
+        originals.set(sm, { map: sm.map ?? null, color: sm.color?.getHex() ?? 0xffffff });
+        sm.map = tex;
+        sm.color?.setHex(0xffffff);
+        sm.needsUpdate = true;
+      }
+    });
+
+    return () => {
+      for (const [sm, original] of originals) {
+        sm.map = original.map;
+        sm.color?.setHex(original.color);
+        sm.needsUpdate = true;
+      }
+      originals.clear();
+      tex.dispose();
+      startRef.current = null;
+      lastFrameRef.current = -1;
+    };
+  }, [scene, sprite, repeat]);
+
+  useFrame((state) => {
+    const tex = texRef.current;
+    const canvas = canvasRef.current;
+    const img = imgRef.current;
+    if (!tex || !canvas || !img || !img.complete || img.naturalWidth === 0) return;
+    const now = state.clock.elapsedTime;
+    if (startRef.current === null) startRef.current = now;
+    const frame = Math.floor((now - startRef.current) * fps) % sprite.frames;
+    if (frame === lastFrameRef.current) return;
+    lastFrameRef.current = frame;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(
+      img,
+      frame * sprite.size,
+      0,
+      sprite.size,
+      sprite.size,
+      0,
+      0,
+      sprite.size,
+      sprite.size
+    );
+    tex.needsUpdate = true;
+  });
+
+  return null;
+}
+
+const q = (x: number): number => Math.round(x * 100) / 100;
+
 export default function HeroPoseViewer({
   heroName,
   skinSources = [],
   fallbackSkinMetaKey,
+  trippyPreview,
 }: {
   heroName: string;
   /** Active visual VPK stack for this hero, ordered by the main process before export. */
   skinSources?: HeroPoseSkinSource[];
   /** Single-skin fallback when a multi-source preview stack cannot be exported. */
   fallbackSkinMetaKey?: string;
+  /** Live Body + Gun trippy params to paint on the body in real time, or
+   *  undefined for the plain skin. */
+  trippyPreview?: TrippyPreview;
 }) {
   const [scene, setScene] = useState<THREE.Object3D | null>(null);
   const [generating, setGenerating] = useState(false);
   const [failed, setFailed] = useState(false);
   const sourceKey = skinSources.map((source) => `${source.priority}:${source.metaKey}`).join('|');
+
+  // The pose GLB has no weapon mesh, so a weapons-only paint has nothing to show
+  // here, and intensity 0 is "no paint". Otherwise fetch the pattern as an
+  // animated sprite strip (debounced) and flipbook it onto the body materials.
+  const showTrippy =
+    !!trippyPreview && trippyPreview.targets !== 'weapons' && trippyPreview.intensity > 0;
+  const trippyKey = showTrippy
+    ? `${trippyPreview.style}:${q(trippyPreview.intensity)}:${q(trippyPreview.phase)}:${q(trippyPreview.scroll)}`
+    : null;
+  const [trippySprite, setTrippySprite] = useState<TrippySpriteResult | null>(null);
+  useEffect(() => {
+    if (!showTrippy || !trippyPreview) {
+      setTrippySprite(null);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      previewTrippySprite({
+        style: trippyPreview.style,
+        phase: q(trippyPreview.phase),
+        scroll: q(trippyPreview.scroll),
+        intensity: q(trippyPreview.intensity),
+        frames: 24,
+        size: 128,
+      })
+        .then((sprite) => {
+          if (!cancelled) setTrippySprite(sprite);
+        })
+        .catch(() => {
+          if (!cancelled) setTrippySprite(null);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+    // trippyKey encodes the params that change the sprite.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trippyKey]);
 
   useEffect(() => {
     // The caller remounts this component (via a hero+skin `key`) when the
@@ -197,6 +345,7 @@ export default function HeroPoseViewer({
         <directionalLight position={[3, 5, 4]} intensity={1.4} />
         <directionalLight position={[-4, 2, -3]} intensity={0.6} />
         <PosedModel scene={scene} />
+        {trippySprite && <TrippyPaint scene={scene} sprite={trippySprite} />}
         <Controls />
       </Canvas>
     </div>

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -35,11 +35,20 @@ function groupVariants(mods: Mod[]): SkinGroup[] {
     if (!byKey.has(key)) byKey.set(key, []);
     byKey.get(key)!.push(mod);
   }
-  return Array.from(byKey.entries()).map(([key, variants]) => {
+  const built = Array.from(byKey.entries()).map(([key, variants]) => {
     variants.sort((a, b) => a.priority - b.priority);
     const primary = variants.find((v) => v.enabled) ?? variants[0];
     return { key, variants, primary };
   });
+  // Pin active groups (any enabled variant) to the top so the selected skin is
+  // always the first card/row in the panel. Array.sort is stable in V8, so the
+  // active and inactive partitions each keep their original relative order.
+  built.sort((a, b) => {
+    const aActive = a.variants.some((v) => v.enabled) ? 0 : 1;
+    const bActive = b.variants.some((v) => v.enabled) ? 0 : 1;
+    return aActive - bActive;
+  });
+  return built;
 }
 
 interface HeroSkinsPanelProps {
@@ -115,7 +124,7 @@ function SkinGroupCard({
     <div
       className={`group/card relative flex flex-col rounded-[10px] border p-2.5 transition-[border-color,background-color,box-shadow] duration-200 ${
         groupActive
-          ? 'border-accent bg-accent/[0.08] shadow-[0_0_0_1px_var(--color-accent),0_0_18px_-6px_var(--color-accent)] hover:bg-accent/[0.12]'
+          ? 'border-accent bg-white/[0.02] hover:bg-white/[0.04]'
           : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
       }`}
     >

--- a/src/components/locker/TrippySkinPanel.tsx
+++ b/src/components/locker/TrippySkinPanel.tsx
@@ -8,10 +8,15 @@ import {
 } from '../../lib/api';
 import { TRIPPY_STYLE_LABELS } from '../../lib/trippy';
 import TrippyPatternPicker from './TrippyPatternPicker';
+import { useTrippyPreviewStore } from '../../stores/trippyPreviewStore';
 import type { ActiveTrippySkin, TrippySkinTargets, TrippyStyleName } from '../../types/mod';
 
 interface TrippySkinPanelProps {
   heroName: string;
+  /** Whether the Body + Gun surface is the one on screen. The panel stays
+   *  mounted while hidden (to keep in-flight slider state), so this gates the
+   *  live 3D preview push: only the visible surface should paint the model. */
+  active?: boolean;
   /** Lets the parent surface toggle show an applied dot for this surface. */
   onAppliedChange?: (applied: boolean) => void;
 }
@@ -37,7 +42,11 @@ const segBtn = (selected: boolean) =>
  * surface has applied (color, gradient, prism, or trippy VFX).
  * Rendered only when the parent has confirmed hero support.
  */
-export default function TrippySkinPanel({ heroName, onAppliedChange }: TrippySkinPanelProps) {
+export default function TrippySkinPanel({
+  heroName,
+  active = true,
+  onAppliedChange,
+}: TrippySkinPanelProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -91,6 +100,31 @@ export default function TrippySkinPanel({ heroName, onAppliedChange }: TrippySki
   useEffect(() => {
     onAppliedChange?.(applied);
   }, [applied, onAppliedChange]);
+
+  // Feed the live slider state to the floating 3D viewer so it can preview the
+  // paint animated on the body in real time. Cleared when the panel unmounts
+  // (user leaves the Body + Gun trippy surface) so the model snaps back.
+  const setTrippyPreview = useTrippyPreviewStore((s) => s.setPreview);
+  const clearTrippyPreview = useTrippyPreviewStore((s) => s.clearPreview);
+  useEffect(() => {
+    if (loading || !active) {
+      clearTrippyPreview();
+      return;
+    }
+    setTrippyPreview({ heroName, style, intensity, phase, scroll, targets });
+  }, [
+    active,
+    loading,
+    heroName,
+    style,
+    intensity,
+    phase,
+    scroll,
+    targets,
+    setTrippyPreview,
+    clearTrippyPreview,
+  ]);
+  useEffect(() => clearTrippyPreview, [clearTrippyPreview]);
 
   const refreshGameRunning = async () => {
     try {

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -14,8 +14,10 @@ import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import HeroCardPicker from '../components/locker/HeroCardPicker';
 import HeroSoundPicker from '../components/locker/HeroSoundPicker';
 import HeroEffectsPanel from '../components/locker/HeroEffectsPanel';
+import FloatingModelPanel from '../components/locker/FloatingModelPanel';
 // three.js viewer is heavy; only pull the chunk when the user flips to 3D.
 const HeroPoseViewer = lazy(() => import('../components/locker/HeroPoseViewer'));
+import { useTrippyPreviewStore } from '../stores/trippyPreviewStore';
 import type { Mod } from '../types/mod';
 import type { HeroPoseSkinSource } from '../types/portrait';
 import {
@@ -103,6 +105,13 @@ export function LockerHeroView({
   const activeSkinSourceKey =
     activeSkinSources.map((source) => `${source.priority}:${source.metaKey}`).join('|') ||
     'vanilla';
+
+  // Live Body + Gun trippy params, pushed by TrippySkinPanel. Only feed the
+  // viewer when it targets the hero currently shown so a stale entry from
+  // another hero never paints the wrong model.
+  const trippyPreview = useTrippyPreviewStore((s) => s.preview);
+  const matchedTrippyPreview =
+    trippyPreview && trippyPreview.heroName === hero.name ? trippyPreview : undefined;
   const hasSounds = soundList.length > 0;
   // If the active section runs out of mods (e.g. user deleted their last
   // sound for this hero) drop back to skins so the panel isn't stuck empty.
@@ -219,30 +228,7 @@ export function LockerHeroView({
           bg-primary, which the frosted overlay reads as a dark frosted panel:
           same look as if the portrait extended that far. */}
       <div className="hidden lg:block absolute inset-0 bg-bg-primary animate-hero-zoom-in overflow-hidden">
-        {view3d ? (
-          /* Confine the viewer (model, spinner, and failure text alike) to the
-             strip right of the rail + selection column (300+480 at lg,
-             340+540 at xl). The viewer centers its content, so giving it the
-             full backdrop puts the model at the overlay's center: behind the
-             selection column and heavy glass on anything narrower than an
-             ultrawide, which reads as "3D shows nothing". */
-          <div className="absolute inset-y-0 right-0 left-[780px] xl:left-[880px]">
-            <Suspense
-              fallback={
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <Loader2 className="h-6 w-6 animate-spin text-white/80" />
-                </div>
-              }
-            >
-              <HeroPoseViewer
-                key={`${hero.name}:${activeSkinSourceKey}:${fallbackPoseSkinMetaKey ?? ''}`}
-                heroName={hero.name}
-                skinSources={activeSkinSources}
-                fallbackSkinMetaKey={fallbackPoseSkinMetaKey}
-              />
-            </Suspense>
-          </div>
-        ) : renderSrc ? (
+        {renderSrc ? (
           <img
             src={renderSrc}
             alt={hero.name}
@@ -254,27 +240,27 @@ export function LockerHeroView({
             {hero.name}
           </div>
         )}
-        {/* Bottom gradient for depth (2D only; the 3D viewer owns its frame) */}
-        {!view3d && (
-          <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
-        )}
+        {/* Bottom gradient for depth. */}
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
       </div>
 
-      {/* 2D portrait <-> live 3D pose toggle. lg+ only, matching the backdrop;
-          sits above the frosted panels so it's always clickable. */}
+      {/* Live 3D model toggle. Opens/closes the floating model panel rather than
+          swapping the backdrop, so the 2D portrait stays put and the model can
+          float over it at any window size. Shown at every width (the floating
+          panel works without the lg+ backdrop too). */}
       <button
         type="button"
         onClick={() => setView3d((v) => !v)}
         aria-pressed={view3d}
-        title={view3d ? 'Show 2D portrait' : 'Show live 3D pose'}
-        className={`hidden lg:flex absolute top-4 right-4 z-20 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors cursor-pointer ${
+        title={view3d ? 'Hide 3D model' : 'Show live 3D model'}
+        className={`absolute top-4 right-4 z-20 flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors cursor-pointer ${
           view3d
             ? 'border-accent/60 bg-accent/20 text-text-primary'
             : 'border-border/70 bg-bg-secondary/70 text-text-secondary hover:text-text-primary backdrop-blur'
         }`}
       >
         <Box className="h-3.5 w-3.5" />
-        {view3d ? '2D' : '3D'}
+        3D
       </button>
 
       {/* Progressive frosted-glass background — every layer (including the
@@ -411,6 +397,28 @@ export function LockerHeroView({
           {selectionPanel}
         </div>
       </div>
+
+      {/* Live 3D model: a floating, draggable panel over the portrait backdrop.
+          Mounted only while open so the heavy three.js chunk loads on demand. */}
+      {view3d && (
+        <FloatingModelPanel title={`${hero.name} 3D model`} onClose={() => setView3d(false)}>
+          <Suspense
+            fallback={
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Loader2 className="h-6 w-6 animate-spin text-white/80" />
+              </div>
+            }
+          >
+            <HeroPoseViewer
+              key={`${hero.name}:${activeSkinSourceKey}:${fallbackPoseSkinMetaKey ?? ''}`}
+              heroName={hero.name}
+              skinSources={activeSkinSources}
+              fallbackSkinMetaKey={fallbackPoseSkinMetaKey}
+              trippyPreview={matchedTrippyPreview}
+            />
+          </Suspense>
+        </FloatingModelPanel>
+      )}
     </div>
   );
 }

--- a/src/stores/trippyPreviewStore.ts
+++ b/src/stores/trippyPreviewStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import type { TrippyStyleName, TrippySkinTargets } from '../types/mod';
+
+/**
+ * Live (unsaved) trippy-skin params, shared from the Body + Gun paint panel to
+ * the Locker's floating 3D model viewer so it can preview the pattern animated
+ * on the hero body in real time. This is a preview-only side channel: the
+ * actual bake/apply still goes through `applyTrippySkin`. The panel pushes its
+ * slider state here on change and clears it on unmount; the viewer reads the
+ * entry that matches the hero it is currently showing.
+ *
+ * Body only: the pose GLB carries no weapon mesh, so a `weapons`-only paint has
+ * nothing to show here (the viewer ignores it). The model materials are also an
+ * approximation of the engine's UV-scroll shader, not the exact bake.
+ */
+export interface TrippyPreview {
+  heroName: string;
+  style: TrippyStyleName;
+  /** Pattern strength 0..1; 0 means no overlay. */
+  intensity: number;
+  phase: number;
+  /** UV-scroll speed scale; drives the flipbook loop speed. */
+  scroll: number;
+  targets: TrippySkinTargets;
+}
+
+interface TrippyPreviewStore {
+  preview: TrippyPreview | null;
+  setPreview: (preview: TrippyPreview) => void;
+  clearPreview: () => void;
+}
+
+export const useTrippyPreviewStore = create<TrippyPreviewStore>((set) => ({
+  preview: null,
+  setPreview: (preview) => set({ preview }),
+  clearPreview: () => set({ preview: null }),
+}));


### PR DESCRIPTION
Reworks the hero detail view's 3D and skin surfaces.

## Floating 3D model panel
- 3D model moves into a draggable, resizable floating panel (`FloatingModelPanel`) that floats over the 2D portrait backdrop and works at any window size, replacing the brittle right-side strip whose left offset was hardcoded to the rail+pane widths (780/880px) and hidden below `lg`.
- Geometry persists to `localStorage`; the 3D toggle now opens/closes the panel instead of swapping the backdrop.

## Cleaner selected skin cards
- Selected skin cards drop the orange glow + bg tint (`SkinGroupCard`) and pin to the top of their group (`groupVariants` stable sort), so the active skin is the first card/row and reads cleanly via the badge + inactive dimming rather than a competing glow.

## Live trippy body preview (Path B)
- Live Body + Gun trippy preview on the body in the 3D viewer: `TrippyPaint` flipbooks the `previewTrippySprite` frame strip as a tiling `CanvasTexture` over the body materials, animated per frame.
- Live params flow `TrippySkinPanel -> trippyPreviewStore -> LockerHero -> viewer`, gated on the Body+Gun surface being active and skipped for weapons-only / intensity 0.
- Body only (the pose GLB carries no weapon mesh) and an approximation of the engine UV-scroll shader, not the bake.

## Files
- `src/components/locker/FloatingModelPanel.tsx` (new)
- `src/stores/trippyPreviewStore.ts` (new)
- `src/components/locker/HeroPoseViewer.tsx`
- `src/components/locker/LockerHero.tsx` (`src/pages/LockerHero.tsx`)
- `src/components/locker/TrippySkinPanel.tsx`
- `src/components/locker/HeroSkinsPanel.tsx`
- `src/components/locker/HeroEffectsPanel.tsx`