### PR TITLE
feat(updates): global app-update banner + Discord link in update modal

### DIFF
--- a/src/components/AppUpdateBanner.tsx
+++ b/src/components/AppUpdateBanner.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { ArrowUpCircle, Download, X } from 'lucide-react';
+import { Button } from './common/ui';
+import UpdateModal from './UpdateModal';
+import type { UpdateStatus } from '../types/electron';
+
+// Dismissed for this session (until the app relaunches). Module-scoped, not
+// React state, so navigating between pages doesn't resurrect a banner the user
+// already waved off. A new launch reloads the module and the flag resets.
+let appUpdateBannerDismissed = false;
+
+/**
+ * Global call-out for an available Grimoire app update (the Electron
+ * auto-updater, not mod updates). Mounted once in Layout so it rides above
+ * every page. The action opens the existing UpdateModal, which owns the
+ * download / release-notes / install-and-restart flow.
+ */
+export default function AppUpdateBanner() {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [managed, setManaged] = useState(false);
+  const [dismissed, setDismissed] = useState(appUpdateBannerDismissed);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    // Package-manager installs (apt / AUR / snap / flatpak) own their own
+    // updates and the auto-updater is disabled there, so never nag with a
+    // banner; the user updates through their package manager.
+    window.electronAPI.updater
+      .getInstallSource()
+      .then((src) => setManaged(src === 'managed'))
+      .catch(() => {});
+    window.electronAPI.updater.getStatus().then(setStatus).catch(() => {});
+    return window.electronAPI.updater.onStatus(setStatus);
+  }, []);
+
+  const downloaded = !!status?.downloaded;
+  const updateReady = !!status && (status.available || status.downloaded);
+  const showBanner = updateReady && !managed && !dismissed;
+  const version = status?.updateInfo?.version;
+
+  return (
+    <>
+      {showBanner && (
+        <div className="px-4 pt-3 sm:px-6">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex flex-wrap items-center gap-3 overflow-hidden rounded-xl border border-accent/30 bg-accent/10 px-4 py-3"
+          >
+            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-accent/20 text-accent">
+              <ArrowUpCircle className="h-5 w-5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold text-text-primary">
+                {downloaded
+                  ? `Grimoire ${version ? `${version} ` : ''}is ready to install`
+                  : `Grimoire update available${version ? ` (${version})` : ''}`}
+              </div>
+              <div className="text-xs text-text-secondary">
+                {downloaded
+                  ? 'Restart to finish updating. Your mods and settings stay untouched.'
+                  : 'A newer version is ready. View the release notes and download it.'}
+              </div>
+            </div>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setModalOpen(true)}
+              icon={Download}
+              className="flex-shrink-0"
+            >
+              {downloaded ? 'Install' : 'View update'}
+            </Button>
+            <button
+              type="button"
+              onClick={() => {
+                appUpdateBannerDismissed = true;
+                setDismissed(true);
+              }}
+              aria-label="Hide update banner until next launch"
+              title="Hide until next launch"
+              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary cursor-pointer"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+      {modalOpen && <UpdateModal onClose={() => setModalOpen(false)} />}
+    </>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import Sidebar from './Sidebar';
 import WelcomeModal from './WelcomeModal';
 import SyncIndicator from './SyncIndicator';
 import DownloadQueueIndicator from './DownloadQueueIndicator';
+import AppUpdateBanner from './AppUpdateBanner';
 import { Button } from './common/ui';
 import { ConfirmModal } from './common/PageComponents';
 import { ToastStack } from './common/ToastStack';
@@ -216,6 +217,7 @@ export default function Layout() {
             </div>
           </div>
         )}
+        <AppUpdateBanner />
         <div key={outletKey} className="min-h-0 flex-1 overflow-auto animate-fade-in">
           <Outlet />
         </div>

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -161,9 +161,18 @@ function ModDetailsModal({
   const [deleteCandidate, setDeleteCandidate] = useState<{ modId: string; fileName: string } | null>(null);
   const [deleteInProgress, setDeleteInProgress] = useState(false);
 
+  // Default the archived section open when the file you currently have installed
+  // lives there. That's the common update case: an author archives the old
+  // version and uploads a new current file, so your installed file drops into
+  // the (collapsed) archived list while the new "Update" target shows above.
+  // Leaving it collapsed hid which row you actually have, giving no anchor for
+  // what you're replacing.
+  const installedFileIsArchived = (mod.files ?? []).some(
+    (f) => f.isArchived && installedFileIds.has(f.id),
+  );
   useEffect(() => {
-    setArchivedFilesOpen(false);
-  }, [mod.id]);
+    setArchivedFilesOpen(installedFileIsArchived);
+  }, [mod.id, installedFileIsArchived]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1455,6 +1464,11 @@ function ModDetailsModal({
                               <ChevronRight className="w-4 h-4 flex-shrink-0" />
                             )}
                             <span className="font-medium truncate">Archived files</span>
+                            {installedFileIsArchived && (
+                              <span className="flex-shrink-0 rounded-full border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
+                                Your version
+                              </span>
+                            )}
                           </span>
                           <span className="flex-shrink-0 text-[11px] leading-none text-text-tertiary">
                             ({archivedFiles.length})

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -187,28 +187,41 @@ export default function UpdateModal({ onClose }: Props) {
                     )}
                 </div>
 
-                <div className="flex justify-end gap-3 p-6 border-t border-white/10">
-                    <Button onClick={onClose} variant="secondary">
-                        Close
-                    </Button>
-                    {installSource === 'managed' ? null : status?.downloaded ? (
-                        <Button onClick={handleInstall} icon={ArrowDownCircle}>
-                            Install &amp; Restart
+                <div className="flex items-center justify-between gap-3 p-6 border-t border-white/10">
+                    <a
+                        href="https://discord.gg/KgYGHEMq2P"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium border border-brand-discord/40 bg-brand-discord/10 text-text-primary hover:bg-brand-discord/20 hover:border-brand-discord/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-discord/60 whitespace-nowrap"
+                    >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" className="w-4 h-4 fill-current">
+                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                        </svg>
+                        Join Discord
+                    </a>
+                    <div className="flex items-center gap-3">
+                        <Button onClick={onClose} variant="secondary">
+                            Close
                         </Button>
-                    ) : status?.available && !status.downloading ? (
-                        <Button onClick={handleDownload} icon={Download}>
-                            Download Update
-                        </Button>
-                    ) : (
-                        <Button
-                            onClick={handleCheck}
-                            disabled={status?.checking || status?.downloading}
-                            isLoading={status?.checking}
-                            icon={RefreshCw}
-                        >
-                            {status?.checking ? 'Checking…' : 'Check for Updates'}
-                        </Button>
-                    )}
+                        {installSource === 'managed' ? null : status?.downloaded ? (
+                            <Button onClick={handleInstall} icon={ArrowDownCircle}>
+                                Install &amp; Restart
+                            </Button>
+                        ) : status?.available && !status.downloading ? (
+                            <Button onClick={handleDownload} icon={Download}>
+                                Download Update
+                            </Button>
+                        ) : (
+                            <Button
+                                onClick={handleCheck}
+                                disabled={status?.checking || status?.downloading}
+                                isLoading={status?.checking}
+                                icon={RefreshCw}
+                            >
+                                {status?.checking ? 'Checking…' : 'Check for Updates'}
+                            </Button>
+                        )}
+                    </div>
                 </div>
         </Modal>
     );


### PR DESCRIPTION
## What

Surfaces available **Grimoire app updates** (the Electron auto-updater, not mod updates) as a global banner, and adds a Discord link to the update modal.

### Changes
- **`AppUpdateBanner`** (new): mounted once in `Layout` so it rides above every page. Subscribes to the existing `updater.onStatus` IPC and shows when an update is `available`/`downloaded`. The action opens the existing `UpdateModal` (release notes / download / install & restart). Includes:
  - a dismiss **X** that hides it until the next launch (module-scoped, survives navigation),
  - automatic suppression for **package-manager-managed installs** (apt/AUR/snap/flatpak), where the auto-updater is disabled.
- **`UpdateModal`**: adds a **Join Discord** button to the footer (`discord.gg` invite), styled with the existing `brand-discord` tokens used on the Settings page. Opens in the user's browser.
- **`ModDetailsModal`**: when the file you currently have installed has been **archived** on GameBanana (the common update case: author archives the old file and uploads a new one), auto-expand the archived section and flag it with a **"Your version"** badge, so the file-picker shows which row you actually have instead of hiding it in a collapsed list.

## Notes
- The app-update banner is **production-only** in effect: the auto-updater is gated behind `!is.dev`, so it does not render under `pnpm dev` without a real release to detect.
- The existing sidebar update badge still shows alongside the banner; left as-is for now (can remove in a follow-up if the banner should be the single surface).

## Test
- `eslint` clean on all changed files.
- Verified the banner + modal (incl. Discord button) render via a throwaway CDP instance.