### PR TITLE
feat(locker): custom hero-card upload (cropper, export, persistence)

### DIFF
--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -3,6 +3,14 @@ import { getActiveDeadlockPath } from '../services/settings';
 import { getHeroPortraits } from '../services/heroPortraits';
 import { applyHeroCard, revertHeroCard, getActiveHeroCard } from '../services/heroCards';
 import {
+    getCustomCardSlots,
+    applyCustomHeroCard,
+    exportCustomHeroCard,
+    getAppliedCustomCard,
+    type CustomCardVariantUpload,
+} from '../services/customHeroCards';
+import type { CustomCardSlot } from '../../../src/types/portrait';
+import {
     getSoulModelInfo,
     exportSoulModel,
     type SoulModelInfo,
@@ -50,6 +58,47 @@ ipcMain.handle(
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) return null;
         return getActiveHeroCard(deadlockPath, heroName);
+    }
+);
+
+ipcMain.handle(
+    'get-custom-card-slots',
+    async (_, heroName: string): Promise<CustomCardSlot[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) return [];
+        return getCustomCardSlots(deadlockPath, heroName);
+    }
+);
+
+ipcMain.handle(
+    'apply-custom-hero-card',
+    async (_, heroName: string, uploads: CustomCardVariantUpload[]): Promise<ApplyHeroCardResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return applyCustomHeroCard(deadlockPath, heroName, uploads);
+    }
+);
+
+ipcMain.handle(
+    'export-custom-hero-card',
+    async (
+        _,
+        heroName: string,
+        uploads: CustomCardVariantUpload[],
+        destPath: string
+    ): Promise<string> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return exportCustomHeroCard(deadlockPath, heroName, uploads, destPath);
+    }
+);
+
+ipcMain.handle(
+    'get-applied-custom-card',
+    async (_, heroName: string): Promise<{ variant: string; dataUrl: string }[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) return [];
+        return getAppliedCustomCard(deadlockPath, heroName);
     }
 );
 

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -12,7 +12,7 @@ import { healLockerVpks } from '../services/lockerVpk';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { getAddonsPath, getCitadelPath } from '../services/deadlock';
-import type { OpenDialogOptions } from '../../../src/types/electron';
+import type { OpenDialogOptions, SaveDialogOptions } from '../../../src/types/electron';
 
 async function loadClipboardImage(source: string): Promise<Electron.NativeImage> {
     if (!source) {
@@ -52,6 +52,24 @@ ipcMain.handle(
         return result.canceled ? null : result.filePaths[0] || null;
     }
 );
+
+// show-save-dialog
+ipcMain.handle(
+    'show-save-dialog',
+    async (_, options: SaveDialogOptions): Promise<string | null> => {
+        const result = await dialog.showSaveDialog({
+            title: options.title,
+            defaultPath: options.defaultPath,
+            filters: options.filters,
+        });
+        return result.canceled ? null : result.filePath || null;
+    }
+);
+
+// reveal-path: open the OS file browser with the given file selected.
+ipcMain.handle('reveal-path', async (_, targetPath: string): Promise<void> => {
+    if (targetPath) shell.showItemInFolder(targetPath);
+});
 
 // copy-image-to-clipboard
 // Writes actual image pixels to the system clipboard, not just the image URL.

--- a/electron/main/services/customHeroCards.ts
+++ b/electron/main/services/customHeroCards.ts
@@ -1,0 +1,313 @@
+/**
+ * Custom hero-card UPLOAD pipeline.
+ *
+ * The Locker "Hero Card" picker (heroCards.ts) lets a user choose card art their
+ * installed mods ship. This module adds the other source: the user's own PNGs.
+ *
+ * Deadlock card art is one `.vtex_c` per variant under
+ * `panorama/images/heroes/<codename>_<variant>_(psd or png).vtex_c`, each at a
+ * fixed size. Rather than encode a `.vtex_c` from scratch, we reuse the base
+ * game's own texture as a template: `vpkmerge icon` reads the base entry for its
+ * format and dimensions, resizes the user's PNG to match, and splices it in
+ * (see vpkmerge's `icon` subcommand / `morphic::replace_mip_chain`). The result
+ * is packed into a persistent per-hero staging VPK under userData, then folded
+ * into the single Locker cosmetics VPK by the same `rebuildLockerCosmetics` path
+ * an installed-mod card uses, so custom and mod cards compose identically.
+ */
+import { promises as fs, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { randomUUID } from 'crypto';
+import { app } from 'electron';
+import {
+    runVpkmerge,
+    vpkmergeBinaryPath,
+    verifyVpkOutput,
+} from './modMerger';
+import { codenamesForHero } from './heroPortraits';
+import {
+    baseCardPakPath,
+    customCardVpkPath,
+    currentCardSelections,
+    rebuildLockerCosmetics,
+} from './heroCards';
+import { ensureGrimoireConfigured, migrateManagedVpksToGrimoire } from './lockerVpk';
+import { invalidateVpkParseCache } from './vpk';
+import { fingerprintFile } from './fileMatch';
+import type { ApplyHeroCardResult, LockerCardSelection } from '../../../src/types/mod';
+import type { CustomCardSlot } from '../../../src/types/portrait';
+
+/** One variant slot the user fills with a PNG. `dataUrl` is a `data:image/png`
+ *  base64 URL (the cropper output, already at the variant's target aspect); an
+ *  empty/absent dataUrl means "leave this variant default". */
+export interface CustomCardVariantUpload {
+    variant: string;
+    dataUrl: string;
+}
+
+/** Largest accepted decoded image, a guard against a runaway IPC payload. Card
+ *  PNGs are a few KB, so this is generous headroom, not a real limit. */
+const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
+
+/** Decode a `data:image/png;base64,...` URL to PNG bytes, validating the shape,
+ *  the size, and the PNG magic so a bad payload fails clearly here, not deep in
+ *  vpkmerge. Returns the raw bytes for a temp file the `icon` build reads. */
+function decodePngDataUrl(dataUrl: string, variant: string): Buffer {
+    const match = /^data:image\/png;base64,(.+)$/s.exec(dataUrl);
+    if (!match) {
+        throw new Error(`The "${variant}" image must be a PNG data URL.`);
+    }
+    const bytes = Buffer.from(match[1], 'base64');
+    if (bytes.length === 0) throw new Error(`The "${variant}" image is empty.`);
+    if (bytes.length > MAX_IMAGE_BYTES) {
+        throw new Error(`The "${variant}" image is too large (max 32 MB).`);
+    }
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A.
+    const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    if (bytes.length < 8 || !bytes.subarray(0, 8).equals(sig)) {
+        throw new Error(`The "${variant}" image is not a valid PNG.`);
+    }
+    return bytes;
+}
+
+/** Display/sort order for variant slots (full card first, then by prominence). */
+const VARIANT_ORDER = ['card', 'vertical', 'card_critical', 'card_gloat', 'minimap', 'small', 'other'];
+function variantRank(variant: string): number {
+    const i = VARIANT_ORDER.indexOf(variant);
+    return i === -1 ? VARIANT_ORDER.length : i;
+}
+
+interface BasePortraitManifest {
+    portraits: Array<{
+        variant: string;
+        width: number;
+        height: number;
+        source_path: string;
+        output_path: string | null;
+    }>;
+}
+
+/**
+ * The uploadable variant slots for a hero, derived from the base game's own card
+ * art: one slot per variant `pak01_dir.vpk` ships, carrying the template entry
+ * path, the dimensions an upload will be resized to, and a decoded preview of
+ * the default art. Returns the first codename that yields art (packs use one).
+ */
+export async function getCustomCardSlots(
+    deadlockPath: string,
+    heroName: string
+): Promise<CustomCardSlot[]> {
+    vpkmergeBinaryPath(); // clear error early if the binary is missing/too old
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) return [];
+
+    const basePak = baseCardPakPath(deadlockPath);
+    if (!existsSync(basePak)) {
+        throw new Error(`Base game pak not found at ${basePak}.`);
+    }
+
+    const cacheRoot = join(app.getPath('userData'), 'custom-card-slots');
+    for (const codename of codenames) {
+        const outDir = join(cacheRoot, codename);
+        const manifestPath = join(outDir, 'manifest.json');
+        try {
+            await runVpkmerge(
+                ['portrait', basePak, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
+                60000
+            );
+            const manifest = JSON.parse(
+                await fs.readFile(manifestPath, 'utf-8')
+            ) as BasePortraitManifest;
+            const slots: CustomCardSlot[] = [];
+            for (const p of manifest.portraits) {
+                if (!p.output_path || !p.source_path) continue;
+                const png = await fs.readFile(p.output_path);
+                slots.push({
+                    variant: p.variant,
+                    entry: p.source_path,
+                    width: p.width,
+                    height: p.height,
+                    baseDataUrl: `data:image/png;base64,${png.toString('base64')}`,
+                });
+            }
+            if (slots.length > 0) {
+                return slots.sort((a, b) => variantRank(a.variant) - variantRank(b.variant));
+            }
+        } catch (err) {
+            console.warn(`[customHeroCards] base slots for ${codename}: ${String(err)}`);
+        }
+    }
+    return [];
+}
+
+/**
+ * Build a standalone custom-card addon VPK at `outPath` from `uploads` (one PNG
+ * per variant), using each variant's base-game texture as the template. Shared
+ * by apply (out = staging VPK) and export (out = a user-chosen file). Returns
+ * the variants actually written.
+ */
+async function buildCustomCardVpk(
+    deadlockPath: string,
+    heroName: string,
+    uploads: CustomCardVariantUpload[],
+    outPath: string
+): Promise<string[]> {
+    vpkmergeBinaryPath();
+    const provided = uploads.filter((u) => u.dataUrl);
+    if (provided.length === 0) throw new Error('Upload at least one card image.');
+
+    // Map each chosen variant to the base template entry (+ verifies the variant
+    // is one the base game actually ships, so the dimensions are knowable).
+    const slots = await getCustomCardSlots(deadlockPath, heroName);
+    if (slots.length === 0) {
+        throw new Error(`No base card art found for ${heroName} to use as a template.`);
+    }
+    const slotByVariant = new Map(slots.map((s) => [s.variant, s]));
+
+    const basePak = baseCardPakPath(deadlockPath);
+    await fs.mkdir(dirname(outPath), { recursive: true });
+
+    // Decode each upload to a temp PNG the `icon` build reads, then clean them
+    // up regardless of outcome. Temp files live beside the output so the build
+    // never crosses a filesystem boundary.
+    const tmpDir = join(dirname(outPath), `.build-${randomUUID()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    try {
+        const sets: string[] = [];
+        for (const u of provided) {
+            const slot = slotByVariant.get(u.variant);
+            if (!slot) throw new Error(`No base template for the "${u.variant}" card variant.`);
+            const bytes = decodePngDataUrl(u.dataUrl, u.variant);
+            const pngPath = join(tmpDir, `${u.variant}.png`);
+            await fs.writeFile(pngPath, bytes);
+            sets.push(`${slot.entry}=${pngPath}`);
+        }
+
+        const args = ['icon', '--template-vpk', basePak];
+        for (const set of sets) {
+            args.push('--set', set);
+        }
+        args.push('--encode-vpk', outPath);
+        await runVpkmerge(args, 120000);
+    } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+    await verifyVpkOutput(outPath);
+    return provided.map((u) => u.variant);
+}
+
+/**
+ * Build a custom card from `uploads` (one PNG per variant), pack it into this
+ * hero's staging VPK, register it as a custom selection, and rebuild the
+ * consolidated cosmetics VPK. Replaces any prior card (mod or custom) for the
+ * hero, exactly like applyHeroCard.
+ */
+export async function applyCustomHeroCard(
+    deadlockPath: string,
+    heroName: string,
+    uploads: CustomCardVariantUpload[]
+): Promise<ApplyHeroCardResult> {
+    ensureGrimoireConfigured(deadlockPath);
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) throw new Error(`Unknown hero: ${heroName}`);
+    const primaryCodename = codenames[0];
+    await migrateManagedVpksToGrimoire(deadlockPath);
+
+    const stagingPath = customCardVpkPath(deadlockPath, primaryCodename);
+    const variants = await buildCustomCardVpk(deadlockPath, heroName, uploads, stagingPath);
+    invalidateVpkParseCache(stagingPath);
+
+    const fp = await fingerprintFile(stagingPath);
+    const fileName = `custom:${primaryCodename}`;
+    const selection: LockerCardSelection = {
+        heroCodename: primaryCodename,
+        heroName,
+        variants,
+        source: {
+            kind: 'custom',
+            fileName,
+            modName: 'Custom upload',
+            sha256AtApplyTime: fp.sha256,
+        },
+        addedAt: new Date().toISOString(),
+    };
+
+    const current = await currentCardSelections(deadlockPath);
+    const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
+    const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    return {
+        activeSourceFileName: missing.includes(fileName) ? null : fileName,
+        missingSourceFileNames: missing,
+    };
+}
+
+/**
+ * Build the custom card as a standalone addon VPK at `destPath` (a user-chosen
+ * file), without applying it. The exported VPK is self-contained: dropping it
+ * into citadel/addons overrides those card variants in place. Returns the path.
+ */
+export async function exportCustomHeroCard(
+    deadlockPath: string,
+    heroName: string,
+    uploads: CustomCardVariantUpload[],
+    destPath: string
+): Promise<string> {
+    if (!destPath) throw new Error('No export path chosen.');
+    await buildCustomCardVpk(deadlockPath, heroName, uploads, destPath);
+    return destPath;
+}
+
+/**
+ * The images of the custom card currently applied for `heroName`, decoded back
+ * to data URLs from this hero's staging VPK on disk. Empty unless a custom card
+ * is applied. Lets the picker repopulate the user's uploaded art after an app
+ * restart (the applied card persists on disk; this re-surfaces it in the UI).
+ */
+export async function getAppliedCustomCard(
+    deadlockPath: string,
+    heroName: string
+): Promise<{ variant: string; dataUrl: string }[]> {
+    const codenames = codenamesForHero(heroName);
+    if (codenames.length === 0) return [];
+    const primaryCodename = codenames[0];
+
+    // Only surface images when a custom card is actually the active selection.
+    const selections = await currentCardSelections(deadlockPath);
+    const sel = selections.find(
+        (c) => c.heroCodename === primaryCodename && c.source.kind === 'custom'
+    );
+    if (!sel) return [];
+
+    const stagingPath = customCardVpkPath(deadlockPath, primaryCodename);
+    if (!existsSync(stagingPath)) return [];
+
+    vpkmergeBinaryPath();
+    const cacheRoot = join(app.getPath('userData'), 'custom-card-applied');
+    for (const codename of codenames) {
+        const outDir = join(cacheRoot, primaryCodename, codename);
+        const manifestPath = join(outDir, 'manifest.json');
+        try {
+            await runVpkmerge(
+                ['portrait', stagingPath, '--hero', codename, '--out', outDir, '--manifest', manifestPath],
+                60000
+            );
+            const manifest = JSON.parse(
+                await fs.readFile(manifestPath, 'utf-8')
+            ) as BasePortraitManifest;
+            const out: { variant: string; dataUrl: string }[] = [];
+            for (const p of manifest.portraits) {
+                if (!p.output_path) continue;
+                const png = await fs.readFile(p.output_path);
+                out.push({
+                    variant: p.variant,
+                    dataUrl: `data:image/png;base64,${png.toString('base64')}`,
+                });
+            }
+            if (out.length > 0) {
+                return out.sort((a, b) => variantRank(a.variant) - variantRank(b.variant));
+            }
+        } catch (err) {
+            console.warn(`[customHeroCards] applied images for ${codename}: ${String(err)}`);
+        }
+    }
+    return [];
+}

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -14,9 +14,15 @@
  */
 import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
-import { getAddonFolderPaths, getDisabledPath, getGrimoirePath, metaKeyFor } from './deadlock';
+import {
+    getAddonFolderPaths,
+    getCitadelPath,
+    getDisabledPath,
+    getGrimoirePath,
+    metaKeyFor,
+} from './deadlock';
 import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
 import {
     runVpkmerge,
@@ -48,6 +54,25 @@ const PANORAMA_HERO_PREFIX = 'panorama/images/heroes/';
  *  conventions. */
 function cardPrefix(codename: string): string {
     return `${PANORAMA_HERO_PREFIX}${codename}_`;
+}
+
+/** Base game pak that ships every hero's default card art, used as the template
+ *  source for custom uploads (each variant's `.vtex_c` lends its format/dims). */
+export function baseCardPakPath(deadlockPath: string): string {
+    return join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+}
+
+/**
+ * Persistent on-disk home for a custom-uploaded card's staging VPK, keyed by
+ * hero codename and namespaced per install. It lives under userData (NOT a
+ * mounted search path), so it never loads on its own: the rebuild splits it into
+ * the single consolidated cosmetics VPK exactly like an installed-mod source.
+ * Survives rebuilds so reverting another hero doesn't drop this hero's upload.
+ */
+export function customCardVpkPath(deadlockPath: string, codename: string): string {
+    const installKey = createHash('sha1').update(deadlockPath).digest('hex').slice(0, 12);
+    // `_dir.vpk` so vpkmerge split + the VPK parser treat it as a directory VPK.
+    return join(app.getPath('userData'), 'custom-hero-cards', installKey, `${codename}_dir.vpk`);
 }
 
 interface VpkRef {
@@ -98,7 +123,7 @@ function findCosmeticsVpk(
 /** The current card selection set, read from the synthetic key (post-migration)
  *  or, as a fallback during the pre-migration window, from an in-addons managed
  *  VPK. */
-async function currentCardSelections(deadlockPath: string): Promise<LockerCardSelection[]> {
+export async function currentCardSelections(deadlockPath: string): Promise<LockerCardSelection[]> {
     const synth = getModMetadata(LOCKER_CARDS_KEY)?.lockerCosmetics?.cards;
     if (synth) return synth;
     const vpks = await listAddonVpks(deadlockPath);
@@ -176,7 +201,7 @@ interface RebuildResult {
  * its hero's card prefix, combine the disjoint chunks into one VPK, swap it in,
  * and slot it below any enabled competitor for the same card path.
  */
-async function rebuildLockerCosmetics(
+export async function rebuildLockerCosmetics(
     deadlockPath: string,
     desired: LockerCardSelection[]
 ): Promise<RebuildResult> {
@@ -184,11 +209,27 @@ async function rebuildLockerCosmetics(
     const destPath = lockerCardsVpkPath(deadlockPath);
     const vpks = await listAddonVpks(deadlockPath);
 
+    // The resolved source path each valid selection splits from, parallel to
+    // `valid` (custom sources resolve to their staging VPK, not an addon).
+    const srcPathFor = new Map<LockerCardSelection, string>();
+
     // Resolve each selection's source (relocating by hash if renamed) and
     // confirm it still ships this hero's cards. Anything unresolved is dropped.
     const valid: LockerCardSelection[] = [];
     const missing: string[] = [];
     for (const sel of desired) {
+        // Custom uploads resolve to a persistent staging VPK keyed by codename,
+        // not an installed addon. Keep the selection's synthetic fileName as-is.
+        if (sel.source.kind === 'custom') {
+            const path = customCardVpkPath(deadlockPath, sel.heroCodename);
+            if (!existsSync(path) || heroCardPaths(path, sel.heroName).length === 0) {
+                missing.push(sel.source.fileName);
+                continue;
+            }
+            srcPathFor.set(sel, path);
+            valid.push(sel);
+            continue;
+        }
         const src = await locateSource(vpks, sel.source.fileName, sel.source.sha256AtApplyTime);
         if (!src || heroCardPaths(src.path, sel.heroName).length === 0) {
             missing.push(sel.source.fileName);
@@ -196,7 +237,9 @@ async function rebuildLockerCosmetics(
         }
         // Re-key to the located file's current metaKey so a source that moved
         // folders (overflow) or was renamed (reconcile) stays addressable.
-        valid.push({ ...sel, source: { ...sel.source, fileName: src.metaKey } });
+        const rekeyed = { ...sel, source: { ...sel.source, fileName: src.metaKey } };
+        srcPathFor.set(rekeyed, src.path);
+        valid.push(rekeyed);
     }
 
     // Empty set: tear down the cosmetics VPK entirely.
@@ -218,14 +261,14 @@ async function rebuildLockerCosmetics(
         await fs.mkdir(planDir, { recursive: true });
         for (let i = 0; i < valid.length; i++) {
             const sel = valid[i];
-            const src = vpks.find((v) => v.metaKey === sel.source.fileName)!;
+            const srcPath = srcPathFor.get(sel)!;
             const chunkPath = join(grimoireDir, `${tag}.chunk${i}.vpk`);
             const planPath = join(planDir, `plan${i}.json`);
             await fs.writeFile(
                 planPath,
                 JSON.stringify({ outputs: [{ path: chunkPath, prefixes: heroCardPrefixes(sel.heroName) }] })
             );
-            await runVpkmerge(['split', '--plan', planPath, src.path], 120000);
+            await runVpkmerge(['split', '--plan', planPath, srcPath], 120000);
             await verifyVpkOutput(chunkPath);
             chunkPaths.push(chunkPath);
         }
@@ -306,6 +349,11 @@ export async function applyHeroCard(
     const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    // A mod card replacing a prior custom upload for this hero leaves the custom
+    // staging VPK orphaned; drop it (it's unmounted, just unused).
+    if (current.some((c) => c.heroCodename === primaryCodename && c.source.kind === 'custom')) {
+        await fs.unlink(customCardVpkPath(deadlockPath, primaryCodename)).catch(() => {});
+    }
     return {
         // missing[] carries metaKeys (a selection's source key), so compare and
         // report the metaKey, which the picker round-trips as the tile identity.
@@ -328,8 +376,16 @@ export async function revertHeroCard(
     const current = await currentCardSelections(deadlockPath);
     if (current.length === 0) return { activeSourceFileName: null, missingSourceFileNames: [] };
 
+    const removed = current.filter((c) => c.heroCodename === primaryCodename);
     const next = current.filter((c) => c.heroCodename !== primaryCodename);
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    // Drop the staging VPK behind any custom upload we just reverted, so a stale
+    // PNG set doesn't linger in userData (it's not mounted, just unused).
+    for (const sel of removed) {
+        if (sel.source.kind === 'custom') {
+            await fs.unlink(customCardVpkPath(deadlockPath, sel.heroCodename)).catch(() => {});
+        }
+    }
     return { activeSourceFileName: null, missingSourceFileNames: missing };
 }
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -34,6 +34,7 @@ import type {
     DownloadModArgs,
     GetCategoriesArgs,
     OpenDialogOptions,
+    SaveDialogOptions,
     ImportCustomModArgs,
     SearchLocalModsOptions,
     CrosshairSettings,
@@ -123,6 +124,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('revert-hero-card', heroName),
     getActiveHeroCard: (heroName: string) =>
         ipcRenderer.invoke('get-active-hero-card', heroName),
+    getCustomCardSlots: (heroName: string) =>
+        ipcRenderer.invoke('get-custom-card-slots', heroName),
+    applyCustomHeroCard: (heroName: string, uploads: { variant: string; dataUrl: string }[]) =>
+        ipcRenderer.invoke('apply-custom-hero-card', heroName, uploads),
+    exportCustomHeroCard: (
+        heroName: string,
+        uploads: { variant: string; dataUrl: string }[],
+        destPath: string
+    ) => ipcRenderer.invoke('export-custom-hero-card', heroName, uploads, destPath),
+    getAppliedCustomCard: (heroName: string) =>
+        ipcRenderer.invoke('get-applied-custom-card', heroName),
     getSoulModelInfo: (key: string) =>
         ipcRenderer.invoke('get-soul-model-info', key),
     exportSoulModel: (metaKey: string) =>
@@ -260,6 +272,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     // Dialogs
     showOpenDialog: (options: OpenDialogOptions) => ipcRenderer.invoke('show-open-dialog', options),
+    showSaveDialog: (options: SaveDialogOptions) => ipcRenderer.invoke('show-save-dialog', options),
+    revealPath: (targetPath: string) => ipcRenderer.invoke('reveal-path', targetPath),
 
     // Drag & drop
     getDroppedFilePath: (file: File) => webUtils.getPathForFile(file),

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.12.0';
+const VPKMERGE_VERSION = 'v0.13.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'ac4f5ec48c01f586a24369cae1ce89f5d9587ecee1c58a7729e9e7c35f43fe72' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: 'c51cdd798fcd6052026c8af47ddc93265b08e18f6b07374e6b8691126f976e50' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '1429cab5248c71bc4d50143bfc327fb19c0289d504f8212c8d458be53f84e4de' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '49fa476ef49ed252bd418ee00c5aa4b13aa731eb4c10c406bd45fd63aa501097' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: 'aa2602b2040eef87e814a92c078a7987cd9bf8584cfb18fc6919c092ef8ea56f' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '2a5a6f4a36b8e940cc95536b2baaca19c9d6c37fc1056d046ba60caad9919006' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/src/components/locker/CardCropper.tsx
+++ b/src/components/locker/CardCropper.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, AlertCircle, Crop, ZoomIn, RotateCcw } from 'lucide-react';
+import { Modal } from '../common/Modal';
+
+interface CardCropperProps {
+  /** Source image to crop (any size), as a data URL. */
+  imageDataUrl: string;
+  /** Target output dimensions (the variant's exact size in the base game). */
+  targetWidth: number;
+  targetHeight: number;
+  /** Human label for the variant being cropped (e.g. "Card", "Minimap"). */
+  variantLabel: string;
+  onCancel: () => void;
+  /** Receives the cropped image as a PNG data URL at exactly target size. */
+  onCrop: (dataUrl: string) => void;
+}
+
+/** Longest edge of the editing viewport, in CSS px. The viewport keeps the
+ *  target aspect; the source image is scaled to cover it and pans/zooms within. */
+const BOX = 360;
+const MAX_ZOOM = 5;
+
+/**
+ * Crop-to-aspect editor for a custom hero-card upload.
+ *
+ * vpkmerge resizes the uploaded PNG to the variant's exact dimensions by a plain
+ * stretch, so any aspect mismatch distorts the art. This editor sidesteps that:
+ * the user frames the image inside a fixed viewport locked to the target aspect,
+ * and we export exactly `targetWidth x targetHeight` so the downstream resize is
+ * a clean, undistorted scale. "Cover" (zoom 1) is the default so the frame is
+ * always filled; zooming in crops tighter.
+ */
+export default function CardCropper({
+  imageDataUrl,
+  targetWidth,
+  targetHeight,
+  variantLabel,
+  onCancel,
+  onCrop,
+}: CardCropperProps) {
+  const aspect = targetWidth / targetHeight;
+  const viewW = aspect >= 1 ? BOX : Math.round(BOX * aspect);
+  const viewH = aspect >= 1 ? Math.round(BOX / aspect) : BOX;
+
+  const [img, setImg] = useState<HTMLImageElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(1);
+  // Top-left of the drawn image relative to the viewport, in CSS px (<= 0).
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const drag = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
+
+  // Scale at which the source just covers the viewport (zoom 1 == cover).
+  const coverScale = img ? Math.max(viewW / img.naturalWidth, viewH / img.naturalHeight) : 1;
+  const drawnW = img ? img.naturalWidth * coverScale * zoom : viewW;
+  const drawnH = img ? img.naturalHeight * coverScale * zoom : viewH;
+
+  const clamp = useCallback(
+    (x: number, y: number) => ({
+      x: Math.min(0, Math.max(viewW - drawnW, x)),
+      y: Math.min(0, Math.max(viewH - drawnH, y)),
+    }),
+    [viewW, viewH, drawnW, drawnH]
+  );
+
+  // Load the source image to learn its natural size, then center it at cover.
+  useEffect(() => {
+    let active = true;
+    const el = new Image();
+    el.onload = () => {
+      if (!active) return;
+      setImg(el);
+      const cs = Math.max(viewW / el.naturalWidth, viewH / el.naturalHeight);
+      setOffset({ x: (viewW - el.naturalWidth * cs) / 2, y: (viewH - el.naturalHeight * cs) / 2 });
+      setZoom(1);
+      setError(null);
+    };
+    el.onerror = () => {
+      if (active) setError('That image could not be loaded. Try a different PNG or JPG.');
+    };
+    el.src = imageDataUrl;
+    return () => {
+      active = false;
+    };
+  }, [imageDataUrl, viewW, viewH]);
+
+  // Zoom around the viewport center so the framed subject stays put.
+  const applyZoom = useCallback(
+    (nextZoom: number) => {
+      const z = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+      if (!img) {
+        setZoom(z);
+        return;
+      }
+      const cx = (viewW / 2 - offset.x) / (coverScale * zoom);
+      const cy = (viewH / 2 - offset.y) / (coverScale * zoom);
+      const nx = viewW / 2 - cx * coverScale * z;
+      const ny = viewH / 2 - cy * coverScale * z;
+      const newDrawnW = img.naturalWidth * coverScale * z;
+      const newDrawnH = img.naturalHeight * coverScale * z;
+      setZoom(z);
+      setOffset({
+        x: Math.min(0, Math.max(viewW - newDrawnW, nx)),
+        y: Math.min(0, Math.max(viewH - newDrawnH, ny)),
+      });
+    },
+    [img, offset, zoom, coverScale, viewW, viewH]
+  );
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!img) return;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    drag.current = { startX: e.clientX, startY: e.clientY, ox: offset.x, oy: offset.y };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    const next = clamp(
+      drag.current.ox + (e.clientX - drag.current.startX),
+      drag.current.oy + (e.clientY - drag.current.startY)
+    );
+    setOffset(next);
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+  };
+
+  const handleApply = () => {
+    if (!img) return;
+    const scale = coverScale * zoom;
+    // The viewport maps to this rect in source-image natural coordinates.
+    const srcX = -offset.x / scale;
+    const srcY = -offset.y / scale;
+    const srcW = viewW / scale;
+    const srcH = viewH / scale;
+    const canvas = document.createElement('canvas');
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      setError('Could not render the crop (no 2D canvas context).');
+      return;
+    }
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, targetWidth, targetHeight);
+    onCrop(canvas.toDataURL('image/png'));
+  };
+
+  return (
+    <Modal onClose={onCancel} size="none" panelClassName="max-w-xl" labelledBy="card-cropper-title">
+      <div className="flex flex-col gap-4 p-5">
+        <div className="flex items-center gap-2">
+          <Crop className="h-4 w-4 text-accent" />
+          <h2 id="card-cropper-title" className="text-sm font-semibold text-text-primary">
+            Crop {variantLabel} card
+          </h2>
+          <span className="ml-auto text-[11px] tabular-nums text-text-secondary">
+            output {targetWidth} x {targetHeight}
+          </span>
+        </div>
+
+        {error ? (
+          <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-400">
+            <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span className="break-words">{error}</span>
+          </div>
+        ) : (
+          <>
+            <div className="flex justify-center">
+              <div
+                className="relative touch-none overflow-hidden rounded-md border border-border bg-bg-primary/60 select-none"
+                style={{ width: viewW, height: viewH, cursor: img ? 'grab' : 'default' }}
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+                onPointerCancel={onPointerUp}
+                onWheel={onWheel}
+              >
+                {img ? (
+                  <img
+                    src={imageDataUrl}
+                    alt={`${variantLabel} crop source`}
+                    draggable={false}
+                    className="pointer-events-none absolute max-w-none"
+                    style={{ left: offset.x, top: offset.y, width: drawnW, height: drawnH }}
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-text-secondary">
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <ZoomIn className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+              <input
+                type="range"
+                min={1}
+                max={MAX_ZOOM}
+                step={0.01}
+                value={zoom}
+                disabled={!img}
+                onChange={(e) => applyZoom(Number(e.target.value))}
+                className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-border accent-accent disabled:cursor-not-allowed"
+              />
+              <span className="w-10 text-right text-[11px] tabular-nums text-text-secondary">
+                {zoom.toFixed(1)}x
+              </span>
+              <button
+                type="button"
+                disabled={!img}
+                onClick={() => applyZoom(1)}
+                title="Reset zoom"
+                className="cursor-pointer rounded-md border border-border/60 p-1 text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
+            {img && (img.naturalWidth < targetWidth || img.naturalHeight < targetHeight) && (
+              <p className="text-[11px] leading-snug text-amber-400/90">
+                Source is {img.naturalWidth} x {img.naturalHeight}, smaller than the {targetWidth} x{' '}
+                {targetHeight} target, so it will be upscaled and may look soft.
+              </p>
+            )}
+            <p className="text-[11px] leading-snug text-text-secondary">
+              Drag to reposition, scroll or use the slider to zoom. The frame is locked to the card's
+              aspect so the result is not stretched.
+            </p>
+          </>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="cursor-pointer rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!img || !!error}
+            onClick={handleApply}
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-accent-foreground transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Crop className="h-3.5 w-3.5" /> Use crop
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -1,8 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Images, Loader2, AlertCircle, Check } from 'lucide-react';
-import { applyHeroCard, getActiveHeroCard, getHeroPortraits, revertHeroCard } from '../../lib/api';
+import { Images, Loader2, AlertCircle, Check, Upload, X, Download } from 'lucide-react';
+import {
+  applyCustomHeroCard,
+  applyHeroCard,
+  exportCustomHeroCard,
+  getActiveHeroCard,
+  getAppliedCustomCard,
+  getCustomCardSlots,
+  getHeroPortraits,
+  readImageDataUrl,
+  revealPath,
+  revertHeroCard,
+  showOpenDialog,
+  showSaveDialog,
+} from '../../lib/api';
+import { showToast } from '../../stores/toastStore';
 import { useAppStore } from '../../stores/appStore';
-import type { HeroPortrait } from '../../types/portrait';
+import CardCropper from './CardCropper';
+import type { CustomCardSlot, HeroPortrait } from '../../types/portrait';
 
 interface HeroCardPickerProps {
   heroName: string;
@@ -25,6 +40,17 @@ const VARIANT_ORDER = ['card', 'vertical', 'card_critical', 'card_gloat', 'minim
 function variantRank(variant: string): number {
   const i = VARIANT_ORDER.indexOf(variant);
   return i === -1 ? VARIANT_ORDER.length : i;
+}
+
+/** A cheap order-independent fingerprint of the current picks, used to tell
+ *  whether the slots differ from what was last applied (drives the Apply vs
+ *  Applied vs Update button state). Length + tail avoids hashing whole data
+ *  URLs while staying collision-safe in practice. */
+function picksSignature(picks: Record<string, string>): string {
+  return Object.keys(picks)
+    .sort()
+    .map((v) => `${v}#${picks[v].length}#${picks[v].slice(-32)}`)
+    .join('|');
 }
 
 interface PortraitFileGroup {
@@ -51,16 +77,53 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
   // The source filename mid-apply/revert (drives the per-tile spinner).
   const [busySource, setBusySource] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // Custom-upload state: the base-derived variant slots, the user's chosen PNG
+  // per variant (path + preview data URL), and a busy flag during build.
+  const [slots, setSlots] = useState<CustomCardSlot[]>([]);
+  // Per-variant cropped output, keyed by variant: a PNG data URL already at the
+  // variant's exact target size (produced by the cropper).
+  const [picks, setPicks] = useState<Record<string, string>>({});
+  // Signature of the picks last applied (or restored from disk on load), so we
+  // can show Applied when nothing changed and re-enable on edit. null = unapplied.
+  const [appliedSig, setAppliedSig] = useState<string | null>(null);
+  const [customBusy, setCustomBusy] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  // The variant currently open in the cropper, with its source image + slot.
+  const [cropping, setCropping] = useState<{ slot: CustomCardSlot; sourceDataUrl: string } | null>(
+    null
+  );
+
+  const customApplied = activeSource?.startsWith('custom:') ?? false;
+  const picksSig = useMemo(() => picksSignature(picks), [picks]);
+  const hasPicks = Object.keys(picks).length > 0;
+  // Dirty == there are picks that differ from what's applied. Drives the button.
+  const dirty = hasPicks && picksSig !== appliedSig;
 
   useEffect(() => {
     let active = true;
     setLoading(true);
     setError(null);
-    Promise.all([getHeroPortraits(heroName), getActiveHeroCard(heroName)])
-      .then(([list, activeCard]) => {
+    setPicks({});
+    setAppliedSig(null);
+    Promise.all([
+      getHeroPortraits(heroName),
+      getActiveHeroCard(heroName),
+      getCustomCardSlots(heroName),
+      // Restore the user's previously-applied custom art so it persists across
+      // restarts (the applied card lives on disk; this re-decodes it to data URLs).
+      getAppliedCustomCard(heroName),
+    ])
+      .then(([list, activeCard, cardSlots, applied]) => {
         if (!active) return;
         setPortraits(list);
         setActiveSource(activeCard?.sourceFileName ?? null);
+        setSlots(cardSlots);
+        if (applied.length > 0) {
+          const restored: Record<string, string> = {};
+          for (const a of applied) restored[a.variant] = a.dataUrl;
+          setPicks(restored);
+          setAppliedSig(picksSignature(restored));
+        }
       })
       .catch((err) => {
         if (active) setError(String(err));
@@ -92,6 +155,98 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       setActionError(String(err));
     } finally {
       setBusySource(null);
+    }
+  };
+
+  const handlePickVariant = async (slot: CustomCardSlot) => {
+    if (customBusy) return;
+    try {
+      const path = await showOpenDialog({
+        title: `Choose an image for the ${VARIANT_LABEL[slot.variant] ?? slot.variant} card`,
+        filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp'] }],
+      });
+      if (!path) return;
+      const sourceDataUrl = await readImageDataUrl(path);
+      setActionError(null);
+      setCropping({ slot, sourceDataUrl });
+    } catch (err) {
+      setActionError(String(err));
+    }
+  };
+
+  const handleCropDone = (dataUrl: string) => {
+    if (!cropping) return;
+    const variant = cropping.slot.variant;
+    setPicks((prev) => ({ ...prev, [variant]: dataUrl }));
+    setCropping(null);
+  };
+
+  const handleClearVariant = (variant: string) => {
+    setPicks((prev) => {
+      const next = { ...prev };
+      delete next[variant];
+      return next;
+    });
+  };
+
+  const handleApplyCustom = async () => {
+    const uploads = Object.entries(picks).map(([variant, dataUrl]) => ({ variant, dataUrl }));
+    if (uploads.length === 0 || customBusy || !dirty) return;
+    const sigAtApply = picksSig;
+    setCustomBusy(true);
+    setActionError(null);
+    try {
+      const result = await applyCustomHeroCard(heroName, uploads);
+      setActiveSource(result.activeSourceFileName);
+      // Mark these exact picks as applied so the button reads "Applied" until
+      // the user changes a slot.
+      setAppliedSig(sigAtApply);
+      await loadMods({ silent: true });
+    } catch (err) {
+      setActionError(String(err));
+    } finally {
+      setCustomBusy(false);
+    }
+  };
+
+  const handleRevertCustom = async () => {
+    if (customBusy) return;
+    setCustomBusy(true);
+    setActionError(null);
+    try {
+      await revertHeroCard(heroName);
+      setActiveSource(null);
+      setPicks({});
+      setAppliedSig(null);
+      await loadMods({ silent: true });
+    } catch (err) {
+      setActionError(String(err));
+    } finally {
+      setCustomBusy(false);
+    }
+  };
+
+  const handleExportCustom = async () => {
+    const uploads = Object.entries(picks).map(([variant, dataUrl]) => ({ variant, dataUrl }));
+    if (uploads.length === 0 || exporting || customBusy) return;
+    setActionError(null);
+    try {
+      const safeName = heroName.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const destPath = await showSaveDialog({
+        title: `Export ${heroName} custom card`,
+        defaultPath: `${safeName}_custom_card_dir.vpk`,
+        filters: [{ name: 'VPK addon', extensions: ['vpk'] }],
+      });
+      if (!destPath) return;
+      setExporting(true);
+      const written = await exportCustomHeroCard(heroName, uploads, destPath);
+      showToast(`Exported to ${written}`, { tone: 'success', duration: 6000 });
+      // Open the OS file browser at the exported file so they can find it.
+      void revealPath(written);
+    } catch (err) {
+      setActionError(String(err));
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -219,6 +374,153 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
             );
           })}
         </div>
+      )}
+
+      {!loading && !error && slots.length > 0 && (
+        <div
+          className={`space-y-3 rounded-[10px] border p-3 backdrop-blur-sm transition-[border-color,box-shadow] duration-200 ${
+            customApplied
+              ? 'border-accent bg-accent/[0.08] shadow-[0_0_0_1px_var(--color-accent),0_0_18px_-6px_var(--color-accent)]'
+              : 'border-white/[0.08] bg-[#141414]/55'
+          }`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <Upload className="h-3.5 w-3.5 text-accent" />
+              <span className="text-xs font-semibold text-text-primary">Upload your own</span>
+            </div>
+            {customApplied ? (
+              <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-accent-foreground">
+                <Check className="h-2.5 w-2.5" /> Applied
+              </span>
+            ) : (
+              <span className="flex-shrink-0 text-[10px] uppercase tracking-wide text-text-secondary">
+                {slots.length} slot{slots.length !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+          <p className="text-[11px] leading-snug text-text-secondary">
+            Click a slot to choose an image and crop it to that variant's exact size. Fill only the
+            variants you want to change, then apply. Unfilled variants stay default.
+          </p>
+
+          {/* One tile per variant the base game ships. An empty slot shows the
+              default art dimmed with an upload hint; a filled slot shows the
+              cropped result with a clear (x) button. Each tile keeps the
+              variant's true aspect so the preview matches the in-game shape. */}
+          <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-4">
+            {slots.map((slot) => {
+              const pick = picks[slot.variant];
+              return (
+                <figure key={slot.variant} className="relative min-w-0">
+                  <button
+                    type="button"
+                    disabled={customBusy}
+                    onClick={() => handlePickVariant(slot)}
+                    title={`${VARIANT_LABEL[slot.variant] ?? slot.variant} · ${slot.width} x ${slot.height}`}
+                    style={{ aspectRatio: `${slot.width} / ${slot.height}` }}
+                    className="group relative flex w-full cursor-pointer items-center justify-center overflow-hidden rounded-md border border-border/50 bg-bg-primary/40 transition-colors hover:border-accent/50 disabled:cursor-not-allowed"
+                  >
+                    <img
+                      src={pick ?? slot.baseDataUrl}
+                      alt={`${heroName} ${VARIANT_LABEL[slot.variant] ?? slot.variant}`}
+                      className={`max-h-full max-w-full object-contain ${pick ? '' : 'opacity-30'}`}
+                    />
+                    <span className="absolute inset-0 flex items-center justify-center bg-black/0 text-white/0 transition-colors group-hover:bg-black/55 group-hover:text-white/90">
+                      <Upload className="h-4 w-4" />
+                    </span>
+                  </button>
+                  {pick && (
+                    <button
+                      type="button"
+                      disabled={customBusy}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClearVariant(slot.variant);
+                      }}
+                      title="Clear image"
+                      aria-label={`Clear ${VARIANT_LABEL[slot.variant] ?? slot.variant} image`}
+                      className="absolute right-1 top-1 z-10 cursor-pointer rounded-full bg-black/75 p-1 text-white/90 shadow-sm ring-1 ring-white/10 transition-colors hover:bg-black/90 hover:text-white disabled:cursor-not-allowed"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                  <figcaption className="mt-1 text-center">
+                    <span className="block truncate text-[9px] uppercase tracking-wide text-text-secondary">
+                      {VARIANT_LABEL[slot.variant] ?? slot.variant}
+                    </span>
+                    <span className="block text-[9px] tabular-nums text-text-secondary/70">
+                      {slot.width} x {slot.height}
+                    </span>
+                  </figcaption>
+                </figure>
+              );
+            })}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              // Clickable only when there's something new to apply. After apply
+              // it reads "Applied" and stays disabled until a slot changes.
+              disabled={customBusy || !dirty}
+              onClick={handleApplyCustom}
+              className={`inline-flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed ${
+                customApplied && !dirty
+                  ? 'bg-accent/15 text-accent ring-1 ring-accent/40'
+                  : 'bg-accent text-accent-foreground hover:bg-accent-hover disabled:opacity-50'
+              }`}
+            >
+              {customBusy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Check className="h-3.5 w-3.5" />
+              )}
+              {customBusy
+                ? 'Applying...'
+                : customApplied && !dirty
+                  ? 'Applied'
+                  : customApplied
+                    ? 'Update custom card'
+                    : 'Apply custom card'}
+            </button>
+            <button
+              type="button"
+              disabled={exporting || customBusy || !hasPicks}
+              onClick={handleExportCustom}
+              title="Save this custom card as a standalone .vpk file"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {exporting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
+              Export VPK
+            </button>
+            {customApplied && (
+              <button
+                type="button"
+                disabled={customBusy}
+                onClick={handleRevertCustom}
+                className="inline-flex cursor-pointer items-center rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Revert
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {cropping && (
+        <CardCropper
+          imageDataUrl={cropping.sourceDataUrl}
+          targetWidth={cropping.slot.width}
+          targetHeight={cropping.slot.height}
+          variantLabel={VARIANT_LABEL[cropping.slot.variant] ?? cropping.slot.variant}
+          onCancel={() => setCropping(null)}
+          onCrop={handleCropDone}
+        />
       )}
     </section>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, ActiveTrippySkin, ApplyTrippySkinResult, ApplyTrippyVfxResult, TrippySpriteOptions, TrippySpriteResult, TrippyVfxChoice, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
 import type {
   HeroPortrait,
+  CustomCardSlot,
   HeroPoseInfo,
   HeroPoseSkinSource,
   SoulModelInfo,
@@ -148,6 +149,36 @@ export async function getActiveHeroCard(
   heroName: string
 ): Promise<{ sourceFileName: string; variants: string[] } | null> {
   return window.electronAPI.getActiveHeroCard(heroName);
+}
+
+/** Uploadable card-variant slots for a hero, derived from the base game art. */
+export async function getCustomCardSlots(heroName: string): Promise<CustomCardSlot[]> {
+  return window.electronAPI.getCustomCardSlots(heroName);
+}
+
+/** Build + apply a custom card from one cropped PNG (data URL) per variant. */
+export async function applyCustomHeroCard(
+  heroName: string,
+  uploads: { variant: string; dataUrl: string }[]
+): Promise<ApplyHeroCardResult> {
+  return window.electronAPI.applyCustomHeroCard(heroName, uploads);
+}
+
+/** Export the custom card as a standalone .vpk to a chosen path; returns it. */
+export async function exportCustomHeroCard(
+  heroName: string,
+  uploads: { variant: string; dataUrl: string }[],
+  destPath: string
+): Promise<string> {
+  return window.electronAPI.exportCustomHeroCard(heroName, uploads, destPath);
+}
+
+/** Cropped images of the currently-applied custom card (empty if none), so the
+ *  picker can restore the user's uploads after an app restart. */
+export async function getAppliedCustomCard(
+  heroName: string
+): Promise<{ variant: string; dataUrl: string }[]> {
+  return window.electronAPI.getAppliedCustomCard(heroName);
 }
 
 /** Whether a soul-container mod has an exported model in the user's library (+ mtime). */
@@ -550,6 +581,18 @@ export async function showOpenDialog(options: {
   filters?: Array<{ name: string; extensions: string[] }>;
 }): Promise<string | null> {
   return window.electronAPI.showOpenDialog(options);
+}
+
+export async function showSaveDialog(options: {
+  title?: string;
+  defaultPath?: string;
+  filters?: Array<{ name: string; extensions: string[] }>;
+}): Promise<string | null> {
+  return window.electronAPI.showSaveDialog(options);
+}
+
+export async function revealPath(targetPath: string): Promise<void> {
+  return window.electronAPI.revealPath(targetPath);
 }
 
 // =====================

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -44,7 +44,7 @@ import type {
     GameBananaCommentsResponse,
     GameBananaArtistLink,
 } from './gamebanana';
-import type { HeroPortrait, SoulModelInfo, HeroPoseInfo, HeroPoseSkinSource } from './portrait';
+import type { HeroPortrait, CustomCardSlot, SoulModelInfo, HeroPoseInfo, HeroPoseSkinSource } from './portrait';
 import type {
     DeadworksServer,
     DeadworksContentItem,
@@ -132,6 +132,13 @@ export interface PerformanceConfigStatus {
 export interface OpenDialogOptions {
     directory?: boolean;
     title?: string;
+    defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+}
+
+export interface SaveDialogOptions {
+    title?: string;
+    /** Pre-filled path/filename (e.g. a suggested VPK name). */
     defaultPath?: string;
     filters?: Array<{ name: string; extensions: string[] }>;
 }
@@ -417,6 +424,19 @@ export interface ElectronAPI {
     getActiveHeroCard: (
         heroName: string
     ) => Promise<{ sourceFileName: string; variants: string[] } | null>;
+    getCustomCardSlots: (heroName: string) => Promise<CustomCardSlot[]>;
+    applyCustomHeroCard: (
+        heroName: string,
+        uploads: { variant: string; dataUrl: string }[]
+    ) => Promise<ApplyHeroCardResult>;
+    exportCustomHeroCard: (
+        heroName: string,
+        uploads: { variant: string; dataUrl: string }[],
+        destPath: string
+    ) => Promise<string>;
+    getAppliedCustomCard: (
+        heroName: string
+    ) => Promise<{ variant: string; dataUrl: string }[]>;
     getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
     exportSoulModel: (metaKey: string) => Promise<SoulModelInfo>;
     getHeroPoseInfo: (
@@ -534,6 +554,8 @@ export interface ElectronAPI {
 
     // Dialogs
     showOpenDialog: (options: OpenDialogOptions) => Promise<string | null>;
+    showSaveDialog: (options: SaveDialogOptions) => Promise<string | null>;
+    revealPath: (targetPath: string) => Promise<void>;
 
     // Drag & drop
     getDroppedFilePath: (file: File) => string;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -49,12 +49,18 @@ export interface LockerCardSelection {
    *  Informational: the split takes the whole per-hero panorama prefix. */
   variants: string[];
   source: {
+    /** Where this card came from. Absent or `"mod"` = an installed mod VPK
+     *  (the original behavior). `"custom"` = a user-uploaded PNG set, built into
+     *  a persistent staging VPK the rebuild resolves by `heroCodename` rather
+     *  than by addon lookup. */
+    kind?: 'mod' | 'custom';
     /** Folder-relative metaKey of the source VPK (bare filename for a base
      *  citadel/addons mod, "addonsN/<file>" for an overflow mod). Named
      *  `fileName` for back-compat: pre-overflow selections stored the bare
      *  filename, which IS the base mod's metaKey, so they still resolve. May
      *  drift if reconcile renames or overflow moves it; `sha256AtApplyTime` is
-     *  the content-identity fallback for relocation. */
+     *  the content-identity fallback for relocation. For a custom source this is
+     *  the synthetic id `custom:<heroCodename>`. */
     fileName: string;
     modName?: string;
     gameBananaId?: number;

--- a/src/types/portrait.ts
+++ b/src/types/portrait.ts
@@ -23,6 +23,26 @@ export interface HeroPortrait {
 }
 
 /**
+ * One uploadable hero-card variant slot, derived from the base game's own card
+ * art (`vpkmerge portrait` on `pak01_dir.vpk`). The custom-card uploader shows
+ * one slot per variant the base ships, so a user-supplied PNG is resized to the
+ * exact dimensions the game expects for that variant.
+ */
+export interface CustomCardSlot {
+  /** card | vertical | minimap | small | card_critical | card_gloat | other */
+  variant: string;
+  /** VPK entry path of the base template `.vtex_c` this slot replaces, fed
+   *  straight back into applyCustomHeroCard as the `--set ENTRY=PNG` target. */
+  entry: string;
+  /** Dimensions the uploaded PNG will be resized to (the template's own size). */
+  width: number;
+  height: number;
+  /** The base game's art for this variant, decoded to a data URL, shown dimmed
+   *  behind an empty slot so the user sees what they are replacing. */
+  baseDataUrl: string;
+}
+
+/**
  * Whether a soul-container mod has an exported 3D model in the user's library,
  * and its mtime (used to cache-bust the `grimoire-soul:` URL after a re-export).
  * Keyed per-mod by the VPK file name. The GLB itself never reaches the renderer


### PR DESCRIPTION
## What

Adds a **custom hero-card uploader** to the Locker Hero Card picker, so a user can build a Deadlock hero card from their own images, one per variant the base game ships (minimap, small, card, low-HP, gloat, vertical).

## How it works

- vpkmerge's **`icon`** subcommand (v0.13.0) reuses the base game's `.vtex_c` at each card path as a template, resizes the user PNG to that texture's exact dimensions, splices it in via `morphic::replace_mip_chain`, and packs the result so it overrides the base art in place. No encoder-from-scratch.
- `customHeroCards.ts` orchestrates it and folds the result into the existing single consolidated Locker cosmetics VPK (new `source.kind: 'custom'`), so custom and mod cards compose identically and cost one mount slot total.

## Features

- **Per-variant upload** with each slot showing its exact target dimensions.
- **Crop-to-aspect editor** (`CardCropper`): pan/zoom, exports at the variant's exact size so vpkmerge's resize never distorts. Warns when the source is smaller than the target.
- **Apply / Applied / Update** state-driven button (disabled until the picks differ from what's applied).
- **Export VPK**: save the custom card as a standalone `.vpk` to a chosen folder (native save dialog) and reveal it.
- **Persistence**: uploaded art is re-decoded from the on-disk staging VPK on load, so it survives app restarts.
- Validation in main (PNG signature + 32 MB cap), temp files cleaned up.

## New IPC

`get-custom-card-slots`, `apply-custom-hero-card`, `export-custom-hero-card`, `get-applied-custom-card`, `show-save-dialog`, `reveal-path`.

## vpkmerge pin

Includes the pin bump to **vpkmerge v0.13.0** (`scripts/fetch-vpkmerge.mjs`). Verified: release is published (not draft), all 3 CLI assets present, and the linux/macOS/Windows sha256s in the pin match the released binaries exactly (the bundled linux binary is the released asset and has `icon`). **Release gate cleared - safe to merge/package.**

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.
- vpkmerge command chain validated end to end against the real `pak01_dir.vpk`: slot enumeration, multi-variant `icon` build, split into the cosmetics VPK, decode-back round-trip, export-to-folder, and the data-URL -> temp -> icon path.