### PR TITLE
chore(release): v1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Bumps version to `1.19.0` for release.

Ships since v1.18.0:
- Custom hero-card upload with cropper/export/persistence (#183)
- Global app-update banner + Discord link in update modal (#182)
- Floating 3D model panel + live Trippy preview, Locker (#181)
- Installed toolbar view controls collapsed into a dropdown (#180)
- Trippy mode on the ability VFX recolor surface (#179)
- perf-config recovers from an emptied gameinfo.gi

vpkmerge pinned to v0.13.0 (published). Local 1.19.0 Linux build verified working. typecheck + lint clean.