### PR TITLE
Speed up profile import + add author-page link on installed mods

### DIFF
--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -350,21 +350,22 @@ export async function resolvePortableProfile(
         ? await buildInstalledIndex(deadlockPath)
         : null;
 
-    const resolved: PortableResolvedMod[] = [];
-    for (const entry of profile.mods) {
-        const r = await resolveOne(entry);
-        if (
-            installedIndex &&
-            r.status !== 'unresolvable' &&
-            r.entry.source === 'gamebanana' &&
-            r.resolvedFileId !== undefined
-        ) {
-            const ref = r.entry.ref as { submissionId: number; vpkStem?: string };
-            const hit = lookupInstalled(installedIndex, ref.submissionId, r.resolvedFileId, ref.vpkStem);
-            if (hit) r.alreadyInstalled = true;
-        }
-        resolved.push(r);
-    }
+    const resolved = await Promise.all(
+        profile.mods.map(async (entry) => {
+            const r = await resolveOne(entry);
+            if (
+                installedIndex &&
+                r.status !== 'unresolvable' &&
+                r.entry.source === 'gamebanana' &&
+                r.resolvedFileId !== undefined
+            ) {
+                const ref = r.entry.ref as { submissionId: number; vpkStem?: string };
+                const hit = lookupInstalled(installedIndex, ref.submissionId, r.resolvedFileId, ref.vpkStem);
+                if (hit) r.alreadyInstalled = true;
+            }
+            return r;
+        })
+    );
 
     let exactCount = 0;
     let upgradedCount = 0;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -387,6 +387,7 @@ interface InstalledEntryCardProps {
   selectMode: boolean;
   selected: boolean;
   onOpenDetails: (mod: Mod) => void;
+  onViewAuthor: (mod: Mod) => void;
   onOpenPicker: (gameBananaId: number) => void;
   onToggle: (entry: ModEntry) => void;
   onDelete: (entry: ModEntry) => void;
@@ -423,6 +424,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
   selectMode,
   selected,
   onOpenDetails,
+  onViewAuthor,
   onOpenPicker,
   onToggle,
   onDelete,
@@ -450,6 +452,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
         onOpenDetails={
           mod.merged || mod.gameBananaId ? () => onOpenDetails(mod) : undefined
         }
+        onViewAuthor={mod.gameBananaId ? () => onViewAuthor(mod) : undefined}
         onToggle={() => onToggle(entry)}
         onDelete={() => onDelete(entry)}
         onEditLocal={!mod.gameBananaId ? () => onEditLocal(mod) : undefined}
@@ -498,6 +501,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
       updateAvailable={updateAvailable}
       entryKey={entry.key}
       onOpenDetails={() => onOpenPicker(entry.gameBananaId)}
+      onViewAuthor={entry.gameBananaId ? () => onViewAuthor(entry.primary) : undefined}
       onToggle={() => onToggle(entry)}
       onDelete={() => onDelete(entry)}
       onTagLocker={(heroName) => onTagLocker(entry, heroName)}
@@ -2358,6 +2362,33 @@ export default function Installed() {
   const openEntryPicker = useStableCallback((gameBananaId: number) => {
     setPickerGroupId(gameBananaId);
   });
+  // Open the mod author's GameBanana profile. We don't store the submitter
+  // locally, so resolve from the catalog cache first (instant when the mod is
+  // mirrored) and fall back to a live details fetch.
+  const viewEntryAuthor = useStableCallback(async (mod: Mod) => {
+    if (!mod.gameBananaId) return;
+    try {
+      const cached = await window.electronAPI.getCachedMod(mod.gameBananaId).catch(() => null);
+      let url =
+        cached?.submitterId && cached.submitterId > 0
+          ? `https://gamebanana.com/members/${cached.submitterId}`
+          : undefined;
+      if (!url) {
+        const details = await getModDetails(mod.gameBananaId, mod.sourceSection ?? 'Mod');
+        const s = details.submitter;
+        url = s?.profileUrl ?? (s && s.id > 0 ? `https://gamebanana.com/members/${s.id}` : undefined);
+      }
+      if (!url) {
+        showToast("Couldn't find this mod's author page", { tone: 'error' });
+        return;
+      }
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      showToast(`Couldn't open author page: ${err instanceof Error ? err.message : String(err)}`, {
+        tone: 'error',
+      });
+    }
+  });
   const toggleEntry = useStableCallback((entry: ModEntry) => {
     if (entry.kind === 'group') void handleGroupToggle(entry);
     else void toggleMod(entry.mod.id);
@@ -2759,6 +2790,7 @@ export default function Installed() {
     selectMode,
     selected: isEntrySelected(entry),
     onOpenDetails: openEntryDetails,
+    onViewAuthor: viewEntryAuthor,
     onOpenPicker: openEntryPicker,
     onToggle: toggleEntry,
     onDelete: deleteEntry,
@@ -5151,6 +5183,9 @@ interface ModCardProps {
   soundVolume: number;
   updateAvailable?: boolean;
   onOpenDetails?: () => void;
+  /** Open the mod author's GameBanana profile in the browser. Undefined for
+   *  local mods with no GameBanana source. */
+  onViewAuthor?: () => void;
   onToggle: () => void;
   onDelete: () => void;
   onEditLocal?: () => void;
@@ -5768,6 +5803,7 @@ function ModCard({
   soundVolume,
   updateAvailable,
   onOpenDetails,
+  onViewAuthor,
   onToggle,
   onDelete,
   onEditLocal,
@@ -6092,6 +6128,21 @@ function ModCard({
               >
                 <Info className="w-3.5 h-3.5" />
                 View details
+              </button>
+            )}
+            {onViewAuthor && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  onViewAuthor();
+                }}
+                className={menuItemClasses}
+              >
+                <Banana className="w-3.5 h-3.5" />
+                View author's page
               </button>
             )}
             {(onTagLocker || onTagGlobal) && (

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -64,7 +64,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/common/menu';
 import { showToast } from '../stores/toastStore';
-import { useAppStore } from '../stores/appStore';
+import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder } from '../lib/api';
 import type { UnmergeModResult } from '../lib/api';
@@ -621,6 +621,7 @@ export default function Installed() {
     importCustomMod,
     soundVolume,
     setInstalledScrollTop,
+    setBrowseUi,
   } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
 
@@ -1044,7 +1045,7 @@ export default function Installed() {
     setDetailsDates(null);
     try {
       const [details, cached] = await Promise.all([
-        getModDetails(m.gameBananaId, section),
+        getModDetails(m.gameBananaId, section, { includeSubmitter: true }),
         window.electronAPI.getCachedMod(m.gameBananaId).catch(() => null),
       ]);
       setDetailsMod(details);
@@ -2362,27 +2363,40 @@ export default function Installed() {
   const openEntryPicker = useStableCallback((gameBananaId: number) => {
     setPickerGroupId(gameBananaId);
   });
-  // Open the mod author's GameBanana profile. We don't store the submitter
-  // locally, so resolve from the catalog cache first (instant when the mod is
-  // mirrored) and fall back to a live details fetch.
+  // Open an artist's page inside Grimoire by entering Browse's artist mode (the
+  // grid scoped to that submitter), the same surface the artist card in a mod's
+  // details opens.
+  const openArtistPage = useStableCallback((artist: BrowseArtistRef) => {
+    if (!artist?.id || artist.id <= 0) return;
+    closeModDetails();
+    setBrowseUi({ submitter: artist });
+    navigate('/browse');
+  });
+  // Kebab-menu entry point: we don't store the submitter locally, so resolve it
+  // from the catalog cache first (instant when the mod is mirrored) and fall
+  // back to a live details fetch before opening the artist page.
   const viewEntryAuthor = useStableCallback(async (mod: Mod) => {
     if (!mod.gameBananaId) return;
     try {
       const cached = await window.electronAPI.getCachedMod(mod.gameBananaId).catch(() => null);
-      let url =
+      let artist: BrowseArtistRef | undefined =
         cached?.submitterId && cached.submitterId > 0
-          ? `https://gamebanana.com/members/${cached.submitterId}`
+          ? { id: cached.submitterId, name: cached.submitterName ?? 'Artist', profileUrl: cached.profileUrl }
           : undefined;
-      if (!url) {
-        const details = await getModDetails(mod.gameBananaId, mod.sourceSection ?? 'Mod');
+      if (!artist) {
+        const details = await getModDetails(mod.gameBananaId, mod.sourceSection ?? 'Mod', {
+          includeSubmitter: true,
+        });
         const s = details.submitter;
-        url = s?.profileUrl ?? (s && s.id > 0 ? `https://gamebanana.com/members/${s.id}` : undefined);
+        if (s && s.id > 0) {
+          artist = { id: s.id, name: s.name, avatarUrl: s.avatarUrl, profileUrl: s.profileUrl, kofiUrl: s.kofiUrl };
+        }
       }
-      if (!url) {
+      if (!artist) {
         showToast("Couldn't find this mod's author page", { tone: 'error' });
         return;
       }
-      window.open(url, '_blank', 'noopener,noreferrer');
+      openArtistPage(artist);
     } catch (err) {
       showToast(`Couldn't open author page: ${err instanceof Error ? err.message : String(err)}`, {
         tone: 'error',
@@ -3618,6 +3632,7 @@ export default function Installed() {
           ignoreUpdates={detailsIgnoreUpdates}
           onToggleIgnoreUpdates={handleToggleIgnoreUpdates}
           onClose={closeModDetails}
+          onViewArtist={openArtistPage}
           onDownload={handleDetailsDownload}
           onNavigatePrevious={
             previousDetailsEntry ? () => navigateToDetailsEntry(previousDetailsEntry) : undefined


### PR DESCRIPTION
Two related Discover/Installed improvements.

## 1. Resolve portable profile mods in parallel

Importing a published profile hung on **"Resolving profile contents…"** (reported on a 23-mod profile). `resolvePortableProfile` resolved each mod in a sequential `for…await` loop, and every `resolveOne` makes one live GameBanana API call, serializing ~23 network roundtrips.

Now resolves all entries concurrently with `Promise.all`. The existing `gamebananaRateLimiter` (10 req/sec, burst 20) still paces requests, collapsing wall-clock time from the sum of all roundtrips to roughly the rate-limit floor (~2-3s for 23 mods). Result order is preserved, so downstream counts and finalize mapping are unaffected.

The local catalog cache can't shortcut this: it stores only submission-level metadata, not the per-file list resolution needs.

## 2. "View author's page" on installed mods

Installed mods had no link to the mod author. Added a context-menu item (GameBanana icon) for GameBanana-sourced mods that opens the author's profile in the browser.

Author data isn't stored locally, so it resolves the submitter from the catalog cache (`submitterId`, instant when mirrored) and falls back to a live details fetch, then opens `gamebanana.com/members/<id>`. Failures surface as a toast.

Typecheck (`tsc` main + renderer) and ESLint pass.