### PR TITLE
i18n: live Translation Mode + simplify and migrate UI copy

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -74,6 +74,7 @@ import './ipc/stats';
 import './ipc/updater';
 import './ipc/launch';
 import './ipc/social';
+import './ipc/translation';
 import './ipc/diagnostics';
 import './ipc/portraits';
 import './ipc/abilitySounds';

--- a/electron/main/ipc/translation.ts
+++ b/electron/main/ipc/translation.ts
@@ -1,0 +1,24 @@
+import { ipcMain } from 'electron';
+import type { TranslationSuggestionRequest } from '../../../src/types/translation';
+import {
+    getTranslationCatalog,
+    getTranslationProgress,
+    registerTranslationContributor,
+    saveTranslationSuggestion,
+} from '../services/translation';
+
+ipcMain.handle('translation:getCatalog', async (_event, languageCode: string) => {
+    return getTranslationCatalog(languageCode);
+});
+
+ipcMain.handle('translation:getProgress', async (_event, languageCode: string) => {
+    return getTranslationProgress(languageCode);
+});
+
+ipcMain.handle('translation:saveSuggestion', async (_event, body: TranslationSuggestionRequest) => {
+    return saveTranslationSuggestion(body);
+});
+
+ipcMain.handle('translation:registerContributor', async () => {
+    return registerTranslationContributor();
+});

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -23,6 +23,8 @@ const DEFAULT_SETTINGS: AppSettings = {
     experimentalStats: false,
     experimentalCrosshair: false,
     experimentalSocial: false,
+    experimentalTranslationMode: false,
+    translationModeLanguage: null,
     experimentalUnknownModMatching: false,
     hasCompletedSetup: false,
     ignoredConflicts: [],

--- a/electron/main/services/translation.ts
+++ b/electron/main/services/translation.ts
@@ -1,0 +1,181 @@
+import { z } from 'zod';
+import { getSessionToken } from './social';
+import type {
+    TranslationCatalogResponse,
+    TranslationContributorResponse,
+    TranslationProgressResponse,
+    TranslationSuggestionRequest,
+    TranslationSuggestionResponse,
+} from '../../../src/types/translation';
+
+const DEFAULT_BASE_URL = 'https://translate.grimoiremods.com';
+const TRANSLATE_BASE_URL =
+    process.env['GRIMOIRE_TRANSLATE_BASE_URL']?.replace(/\/+$/, '') || DEFAULT_BASE_URL;
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const TranslationCatalogResponseSchema = z.object({
+    languageCode: z.string(),
+    rows: z.array(
+        z.object({
+            key: z.string(),
+            source: z.string(),
+            value: z.string(),
+            status: z.enum(['missing', 'shipped', 'draft', 'translated', 'reviewed']),
+            placeholders: z.array(z.string()),
+            missingPlaceholders: z.array(z.string()),
+            extraPlaceholders: z.array(z.string()),
+        })
+    ),
+    stats: z.object({
+        total: z.number(),
+        completed: z.number(),
+        reviewed: z.number(),
+        drafts: z.number(),
+    }),
+});
+
+const TranslationProgressResponseSchema = z.object({
+    languageCode: z.string(),
+    total: z.number(),
+    completed: z.number(),
+    reviewed: z.number(),
+    pendingSuggestions: z.number(),
+});
+
+const TranslationSuggestionResponseSchema = z.object({
+    suggestion: z.object({
+        id: z.string(),
+        languageCode: z.string(),
+        key: z.string(),
+        value: z.string(),
+        status: z.enum(['pending', 'accepted', 'rejected']),
+        createdAt: z.string(),
+    }),
+});
+
+const TranslationContributorResponseSchema = z.object({
+    contributor: z.object({
+        id: z.string(),
+        displayName: z.string(),
+        avatarUrl: z.string().nullable(),
+        role: z.enum(['translator', 'reviewer', 'admin']),
+        trustLevel: z.number(),
+        lastSeenAt: z.string(),
+    }),
+});
+
+class TranslationApiError extends Error {
+    readonly status: number;
+    readonly issues?: unknown;
+
+    constructor(message: string, status: number, issues?: unknown) {
+        super(message);
+        this.name = 'TranslationApiError';
+        this.status = status;
+        this.issues = issues;
+    }
+}
+
+function buildUrl(path: string, query?: Record<string, string | undefined>): string {
+    const url = new URL(`${TRANSLATE_BASE_URL}${path}`);
+    for (const [key, value] of Object.entries(query ?? {})) {
+        if (value !== undefined) url.searchParams.set(key, value);
+    }
+    return url.toString();
+}
+
+async function request<T>(
+    path: string,
+    schema: z.ZodType<T>,
+    options: {
+        method?: 'GET' | 'POST';
+        body?: unknown;
+        query?: Record<string, string | undefined>;
+        timeoutMs?: number;
+    } = {}
+): Promise<T> {
+    const token = getSessionToken();
+    if (!token) throw new TranslationApiError('Sign in with Steam before using Translation Mode', 401);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+        response = await fetch(buildUrl(path, options.query), {
+            method: options.method ?? 'GET',
+            headers: {
+                Accept: 'application/json',
+                Authorization: `Bearer ${token}`,
+                ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+            },
+            body: options.body === undefined ? undefined : JSON.stringify(options.body),
+            signal: controller.signal,
+        });
+    } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+            throw new TranslationApiError('Translation request timed out', 0);
+        }
+        throw new TranslationApiError(
+            `Translation request failed: ${err instanceof Error ? err.message : String(err)}`,
+            0
+        );
+    } finally {
+        clearTimeout(timeoutId);
+    }
+
+    const text = await response.text();
+    const body = text ? safeJson(text) : null;
+
+    if (!response.ok) {
+        const message =
+            body && typeof body === 'object' && 'error' in body && typeof body.error === 'string'
+                ? body.error
+                : response.statusText;
+        throw new TranslationApiError(message || 'Translation service error', response.status, body);
+    }
+
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+        throw new TranslationApiError(
+            'Translation service returned an unexpected response shape',
+            response.status,
+            parsed.error.flatten()
+        );
+    }
+
+    return parsed.data;
+}
+
+function safeJson(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
+
+export async function getTranslationCatalog(languageCode: string): Promise<TranslationCatalogResponse> {
+    return request('/api/live/catalog', TranslationCatalogResponseSchema, {
+        query: { lang: languageCode },
+    });
+}
+
+export async function getTranslationProgress(languageCode: string): Promise<TranslationProgressResponse> {
+    return request('/api/live/progress', TranslationProgressResponseSchema, {
+        query: { lang: languageCode },
+    });
+}
+
+export async function saveTranslationSuggestion(
+    body: TranslationSuggestionRequest
+): Promise<TranslationSuggestionResponse> {
+    return request('/api/live/suggestions', TranslationSuggestionResponseSchema, {
+        method: 'POST',
+        body,
+    });
+}
+
+export async function registerTranslationContributor(): Promise<TranslationContributorResponse> {
+    return request('/api/live/contributors/me', TranslationContributorResponseSchema);
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -52,6 +52,7 @@ import type {
     UpdateStatus,
 } from '../../src/types/electron';
 import type { DeadworksConnectProgress } from '../../src/types/deadworks';
+import type { TranslationSuggestionRequest } from '../../src/types/translation';
 import type {
     ProfileSort,
     PublishRequest,
@@ -463,6 +464,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
             ipcRenderer.on('social:session-changed', handler);
             return () => ipcRenderer.removeListener('social:session-changed', handler);
         },
+    },
+
+    // Translation Mode
+    translation: {
+        registerContributor: () => ipcRenderer.invoke('translation:registerContributor'),
+        getCatalog: (languageCode: string) =>
+            ipcRenderer.invoke('translation:getCatalog', languageCode),
+        getProgress: (languageCode: string) =>
+            ipcRenderer.invoke('translation:getProgress', languageCode),
+        saveSuggestion: (body: TranslationSuggestionRequest) =>
+            ipcRenderer.invoke('translation:saveSuggestion', body),
     },
 
     // Stats

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   X,
   Loader2,
@@ -154,6 +155,7 @@ export default function ImportCollectionModal({
   activeDeadlockPath,
   onClose,
 }: ImportCollectionModalProps) {
+  const { t } = useTranslation();
   const [input, setInput] = useState('');
   const [collection, setCollection] = useState<GameBananaCollection | null>(null);
   const [rows, setRows] = useState<ItemRow[]>([]);
@@ -354,7 +356,7 @@ export default function ImportCollectionModal({
   const resolveCollection = useCallback(async () => {
     const collectionId = parseCollectionId(input);
     if (collectionId === null) {
-      setResolveError('Enter a collection URL like https://gamebanana.com/collections/164637 or its numeric id.');
+      setResolveError(t('importCollection.invalidId'));
       return;
     }
 
@@ -406,7 +408,7 @@ export default function ImportCollectionModal({
         setLoadingItems(false);
       }
     }
-  }, [input, installedIds, queuedIds]);
+  }, [input, installedIds, queuedIds, t]);
 
   // ───────── Variant picker (lazy resolve) ─────────
 
@@ -796,7 +798,7 @@ export default function ImportCollectionModal({
                 Import Collection
               </h2>
               <p className="text-sm text-text-secondary mt-1">
-                Paste a GameBanana collection URL or id. Items get queued through the same download pipeline as Browse.
+                {t('importCollection.pasteHint')}
               </p>
             </div>
           </div>
@@ -906,7 +908,7 @@ export default function ImportCollectionModal({
                   onClick={() => void handleToggleShowAllVariants()}
                   disabled={variantScanProgress !== null}
                   className="text-xs inline-flex items-center gap-1.5 px-2 py-1 rounded-sm border border-white/10 text-text-secondary hover:text-text-primary hover:border-white/20 disabled:opacity-60 disabled:cursor-default cursor-pointer"
-                  title="Fetch every selectable mod's file list and expand any with multiple variants"
+                  title={t('importCollection.scanTitle')}
                 >
                   {variantScanProgress ? (
                     <>
@@ -1105,8 +1107,7 @@ export default function ImportCollectionModal({
                         <div className="text-xs text-text-tertiary flex items-start gap-1.5">
                           <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
                           <span>
-                            GameBanana returned no downloadable files for this mod.
-                            It may have been removed or taken down. The mod page is still browsable.
+                            {t('importCollection.noFiles')}
                           </span>
                         </div>
                       )}
@@ -1114,7 +1115,7 @@ export default function ImportCollectionModal({
                         <>
                           {row.details.files.length > 1 && (
                             <p className="text-[11px] text-text-tertiary mb-1.5">
-                              Check one or more variants. Leaving everything unchecked falls back to the most popular file.
+                              {t('importCollection.variantHint')}
                             </p>
                           )}
                           <ul className="space-y-1">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import { useAppStore } from '../stores/appStore';
 import type { OneClickSuspiciousFilesData, MultiVpkPickData } from '../types/electron';
 import MultiVpkPickerModal from './MultiVpkPickerModal';
 import DiscordPresence from './DiscordPresence';
+import TranslationModeBridge from './translation/TranslationModeBridge';
 
 export default function Layout() {
   const navigate = useNavigate();
@@ -197,6 +198,7 @@ export default function Layout() {
       <div className="flex min-h-0 flex-1">
       {/* Headless: drives opt-in Discord Rich Presence from the active route. */}
       <DiscordPresence />
+      <TranslationModeBridge />
       <Sidebar />
       <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-bg-primary">
         {gameinfoAlert && (

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Layers, X, AlertTriangle, Info } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
@@ -27,6 +28,7 @@ interface Props {
  * from the mod details modal after the fact if they want to.
  */
 export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm }: Props) {
+  const { t } = useTranslation();
   const groups = useMemo(() => buildSourceGroups(sources), [sources]);
 
   // Picks: one chosen variant id per multi-variant group. Singles + single-
@@ -135,7 +137,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
               </div>
               {groups.some((g) => g.kind === 'variants') && (
                 <div className="text-xs text-text-secondary">
-                  Pick one variant per mod
+                  {t('mergeMods.oneVariant')}
                 </div>
               )}
             </div>
@@ -214,8 +216,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
                 <div className="text-text-primary font-medium">
                   {localSourceCount} local mod{localSourceCount === 1 ? '' : 's'} included
                 </div>
-                Local mods (no GameBanana ID) merge fine but aren&apos;t included in the share code.
-                If you delete the disabled originals, those won&apos;t be recoverable on unmerge.
+                {t('mergeMods.localNote')}
               </div>
             </div>
           )}
@@ -230,7 +231,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
             <span>
               Strict mode
               <span className="block text-xs text-text-secondary mt-0.5">
-                Abort if two mods touch the same file path. Off by default (higher-priority mod wins).
+                {t('mergeMods.strictDescription')}
               </span>
             </span>
           </label>

--- a/src/components/MergedContentsModal.tsx
+++ b/src/components/MergedContentsModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Layers, X, Share2, Scissors, Check, PackageOpen, Loader2, AlertTriangle } from 'lucide-react';
 import type { Mod, MergedModSource } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
@@ -23,6 +24,7 @@ interface Props {
  * (with a copy button) and an Unmerge shortcut.
  */
 export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge, onExtractSource }: Props) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   // The fileName of the source row currently being extracted, and the last
   // error surfaced by an extract.
@@ -160,7 +162,7 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
                       {!src.enabledAtMergeTime && (
                         <span
                           className="text-[10px] uppercase tracking-wide text-text-secondary/70 px-1.5 py-0.5 rounded border border-border"
-                          title="This source was disabled when the merge happened"
+                          title={t('mergedContents.disabledAtMerge')}
                         >
                           off
                         </span>

--- a/src/components/MultiVpkPickerModal.tsx
+++ b/src/components/MultiVpkPickerModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FileArchive, Check, X } from 'lucide-react';
 import type { MultiVpkPickData } from '../types/electron';
 import { formatBytes } from '../lib/formatBytes';
@@ -26,6 +27,7 @@ interface Props {
  * useEffect here.
  */
 export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props) {
+    const { t } = useTranslation();
     const [selected, setSelected] = useState<Set<string>>(() => new Set(data.vpkFileNames));
 
     const allSelected = selected.size === data.vpkFileNames.length;
@@ -66,7 +68,7 @@ export default function MultiVpkPickerModal({ data, onConfirm, onCancel }: Props
                     <p className="text-sm text-text-secondary">
                         <span className="font-medium text-text-primary">{data.modName}</span> contains{' '}
                         {data.vpkFileNames.length} <code className="font-mono text-text-primary/90 bg-black/30 px-1 py-0.5 rounded">.vpk</code> files.
-                        Pick which ones to install: leave any unwanted ones unchecked and they&apos;ll be skipped.
+                        {t('multiVpk.uncheckHint')}
                     </p>
 
                     <div className="flex items-center justify-between pb-2 border-b border-border/60">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,6 +46,7 @@ import { getAssetPath } from '../lib/assetPath';
 import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath } from '../lib/lockerUtils';
 import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
+import Tx from './translation/Tx';
 
 const COLLAPSED_KEY = 'grimoire:sidebar-collapsed';
 const LAUNCH_BG_HIDDEN_KEY = 'grimoire:launch-bg-hidden';
@@ -494,6 +495,7 @@ export default function Sidebar() {
     type NavItem = {
       to: string;
       icon: typeof Boxes;
+      labelKey: string;
       label: string;
       tooltip: string;
       experimental?: 'crosshair' | 'stats' | 'social' | 'servers';
@@ -502,11 +504,12 @@ export default function Sidebar() {
       badgeTone?: BadgeTone;
     };
     const items: NavItem[] = [
-      { to: '/', icon: Boxes, label: t('nav.installed'), tooltip: t('sidebar.tooltip.installed'), badge: installedCount, badgeTone: 'muted' },
-      { to: '/browse', icon: Compass, label: t('nav.browse'), tooltip: t('sidebar.tooltip.browse') },
+      { to: '/', icon: Boxes, labelKey: 'nav.installed', label: t('nav.installed'), tooltip: t('sidebar.tooltip.installed'), badge: installedCount, badgeTone: 'muted' },
+      { to: '/browse', icon: Compass, labelKey: 'nav.browse', label: t('nav.browse'), tooltip: t('sidebar.tooltip.browse') },
       {
         to: '/discover',
         icon: Globe2,
+        labelKey: 'nav.discover',
         label: t('nav.discover'),
         tooltip: discoverNotificationCount > 0
           ? t('sidebar.tooltip.discoverNew', { count: discoverNotificationCount })
@@ -515,13 +518,13 @@ export default function Sidebar() {
         badge: discoverNotificationCount,
         badgeTone: 'info',
       },
-      { to: '/servers', icon: Server, label: t('nav.servers'), tooltip: t('sidebar.tooltip.servers'), experimental: 'servers' },
-      { to: '/locker', icon: Vault, label: t('nav.locker'), tooltip: t('sidebar.tooltip.locker') },
-      { to: '/crosshair', icon: Target, label: t('nav.crosshair'), tooltip: t('sidebar.tooltip.crosshair'), experimental: 'crosshair' },
-      { to: '/autoexec', icon: ScrollText, label: t('nav.autoexec'), tooltip: t('sidebar.tooltip.autoexec') },
-      { to: '/stats', icon: Activity, label: t('nav.stats'), tooltip: t('sidebar.tooltip.stats'), experimental: 'stats' },
-      { to: '/conflicts', icon: Swords, label: t('nav.conflicts'), tooltip: t('sidebar.tooltip.conflicts'), badge: conflictCount, badgeTone: 'warning' },
-      { to: '/profiles', icon: BookMarked, label: t('nav.profiles'), tooltip: t('sidebar.tooltip.profiles') },
+      { to: '/servers', icon: Server, labelKey: 'nav.servers', label: t('nav.servers'), tooltip: t('sidebar.tooltip.servers'), experimental: 'servers' },
+      { to: '/locker', icon: Vault, labelKey: 'nav.locker', label: t('nav.locker'), tooltip: t('sidebar.tooltip.locker') },
+      { to: '/crosshair', icon: Target, labelKey: 'nav.crosshair', label: t('nav.crosshair'), tooltip: t('sidebar.tooltip.crosshair'), experimental: 'crosshair' },
+      { to: '/autoexec', icon: ScrollText, labelKey: 'nav.autoexec', label: t('nav.autoexec'), tooltip: t('sidebar.tooltip.autoexec') },
+      { to: '/stats', icon: Activity, labelKey: 'nav.stats', label: t('nav.stats'), tooltip: t('sidebar.tooltip.stats'), experimental: 'stats' },
+      { to: '/conflicts', icon: Swords, labelKey: 'nav.conflicts', label: t('nav.conflicts'), tooltip: t('sidebar.tooltip.conflicts'), badge: conflictCount, badgeTone: 'warning' },
+      { to: '/profiles', icon: BookMarked, labelKey: 'nav.profiles', label: t('nav.profiles'), tooltip: t('sidebar.tooltip.profiles') },
     ];
 
     return items.filter((item) => {
@@ -760,7 +763,7 @@ export default function Sidebar() {
             </div>
           )}
           <ul ref={navListRef} className="relative z-10 space-y-0.5">
-            {navItems.map(({ to, icon: Icon, label, tooltip, tone, badge, badgeTone }, index) => {
+            {navItems.map(({ to, icon: Icon, labelKey, label, tooltip, tone, badge, badgeTone }, index) => {
               // Style from the optimistic index, not the router's isActive:
               // isActive trails the click by the destination page's render
               // time (see pendingNavPath above).
@@ -802,7 +805,7 @@ export default function Sidebar() {
                       </span>
                       {labelMounted && (
                         <span className={`relative z-10 ${navLabelClass}`} aria-hidden={!labelsVisible}>
-                          {label}
+                          <Tx k={labelKey} fallback={label} />
                         </span>
                       )}
                       {badge !== undefined && badge > 0 && (

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -105,8 +105,8 @@ export default function UpdateModal({ onClose }: Props) {
                             <Package className="w-5 h-5 flex-shrink-0 mt-0.5 text-accent" />
                             <div className="text-sm text-text-secondary space-y-2">
                                 <p className="text-text-primary font-medium">Managed by your package manager.</p>
-                                <p>This install was provided through a system package. Update with your distro's tools: <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch, or <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code> on Debian/Ubuntu.</p>
-                                <p>If you installed the <code className="font-mono text-text-primary">.deb</code> manually, add the apt repository for automatic updates (instructions at <code className="font-mono text-text-primary">grimoiremods.com/download</code>).</p>
+                                <p>Update with your distro's tools: <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch, or <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code> on Debian/Ubuntu.</p>
+                                <p>Installed the <code className="font-mono text-text-primary">.deb</code> manually? Add the apt repository for auto-updates: <code className="font-mono text-text-primary">grimoiremods.com/download</code>.</p>
                             </div>
                         </div>
                     )}

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FolderOpen, Wrench, Check, X, ArrowRight, Loader2, Terminal } from 'lucide-react';
 import { Button, Badge } from './common/ui';
 import { Modal } from './common/Modal';
@@ -17,6 +18,7 @@ interface WelcomeModalProps {
 }
 
 export default function WelcomeModal({ onComplete }: WelcomeModalProps) {
+    const { t } = useTranslation();
     const { detectDeadlock } = useAppStore();
     const [localPath, setLocalPath] = useState<string | null>(null);
     const [isValidPath, setIsValidPath] = useState<boolean | null>(null);
@@ -189,7 +191,7 @@ export default function WelcomeModal({ onComplete }: WelcomeModalProps) {
                         {detectFailed && !isDetecting && (
                             <div className="ml-7 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
                                 <p className="text-xs text-yellow-200 mb-2">
-                                    Couldn't auto-detect. Browse to your Steam library:
+                                    {t('welcome.autoDetectFailed')}
                                 </p>
                                 <code className="block text-xs text-text-secondary font-mono mb-2">
                                     steamapps/common/Deadlock
@@ -266,7 +268,7 @@ export default function WelcomeModal({ onComplete }: WelcomeModalProps) {
                         <div className="ml-7">
                             {autoexecStatus?.exists ? (
                                 <p className="text-xs text-text-secondary">
-                                    Existing autoexec.cfg found. Your settings will be preserved.
+                                    {t('welcome.autoexecExists')}
                                 </p>
                             ) : autoexecStatus ? (
                                 <div className="flex items-center gap-3">

--- a/src/components/profiles/ExportProfileModal.tsx
+++ b/src/components/profiles/ExportProfileModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Download, ClipboardCopy, CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react';
 import { Button } from '../common/ui';
 import { Modal } from '../common/Modal';
@@ -18,6 +19,7 @@ function safeFileName(name: string): string {
 }
 
 export default function ExportProfileModal({ profileId, profileName, onClose }: ExportProfileModalProps) {
+  const { t } = useTranslation();
   const [result, setResult] = useState<PortableExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -109,7 +111,7 @@ export default function ExportProfileModal({ profileId, profileName, onClose }: 
                       {result.warnings.map((w, i) => <div key={i}>{w}</div>)}
                     </div>
                     <div className="text-xs text-text-secondary mt-2">
-                      Local mods (not from GameBanana) can't be shared portably.
+                      {t('exportProfile.localBlocked')}
                     </div>
                   </div>
                 </div>

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   X,
   Loader2,
@@ -148,6 +149,7 @@ export default function ImportProfileDialog({
   onSignInRequested,
   onLikeWithoutSignIn,
 }: ImportProfileDialogProps) {
+  const { t } = useTranslation();
   // In social mode the share code arrives via SocialProfileHeader's detail
   // fetch; the input is empty until then. In paste mode it's seeded from
   // initialInput as before.
@@ -1072,7 +1074,7 @@ export default function ImportProfileDialog({
                           {r.status === 'already-installed' && (
                             <span
                               className="text-text-secondary inline-flex items-center gap-1.5 justify-end text-xs"
-                              title="Already installed locally — will be wired into the new profile without re-downloading"
+                              title={t('importProfile.alreadyInstalled')}
                             >
                               <CheckCircle2 className="w-3.5 h-3.5 flex-shrink-0" />
                               <span className="hidden sm:inline">On disk</span>
@@ -1131,7 +1133,7 @@ export default function ImportProfileDialog({
                             <div className="text-xs text-text-tertiary flex items-start gap-1.5">
                               <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
                               <span>
-                                GameBanana returned no downloadable files for this mod.
+                                {t('importProfile.noFiles')}
                               </span>
                             </div>
                           )}
@@ -1139,7 +1141,7 @@ export default function ImportProfileDialog({
                             <>
                               {r.details.files.length > 1 && (
                                 <p className="text-[11px] text-text-tertiary mb-1.5">
-                                  Check one or more variants. Leaving everything unchecked uses the file pinned by the profile.
+                                  {t('importProfile.variantHint')}
                                 </p>
                               )}
                               <ul className="space-y-1">

--- a/src/components/social/PublishDialog.tsx
+++ b/src/components/social/PublishDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, AlertTriangle, Loader2, CheckCircle2, Globe } from 'lucide-react';
 import { Button } from '../common/ui';
 import { Modal } from '../common/Modal';
@@ -40,6 +41,7 @@ export default function PublishDialog({
   onClose,
   onPublished,
 }: PublishDialogProps) {
+  const { t } = useTranslation();
   const [title, setTitle] = useState(profileName);
   const [description, setDescription] = useState('');
   const [exportResult, setExportResult] = useState<PortableExportResult | null>(null);
@@ -164,7 +166,7 @@ export default function PublishDialog({
                       {exportResult.warnings.map((w, i) => <div key={i}>{w}</div>)}
                     </div>
                     <div className="text-xs text-text-secondary mt-2">
-                      Locally-imported mods (not from GameBanana) can't be published.
+                      {t('social.publish.localBlocked')}
                     </div>
                   </div>
                 </div>

--- a/src/components/social/SocialAccountSection.tsx
+++ b/src/components/social/SocialAccountSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Globe, LogOut, AlertTriangle, ShieldAlert, Trash2, X, ExternalLink, ShieldCheck } from 'lucide-react';
 import { Button, Badge } from '../common/ui';
 import { ConfirmModal } from '../common/PageComponents';
@@ -21,6 +22,7 @@ function KeyringNotice() {
 }
 
 export default function SocialAccountSection() {
+  const { t } = useTranslation();
   const { status, loading, error, hydrated, hydrate, login, cancelLogin, logout, deleteAccount, clearError } =
     useSocialStore();
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -155,7 +157,7 @@ export default function SocialAccountSection() {
         onCancel={() => setDeleteConfirmOpen(false)}
         onConfirm={handleDelete}
         title="Delete Grimoire Social account"
-        message="This permanently deletes your account, removes your likes, and hides your published profiles from Discover. People who already imported your profiles keep them. This can't be undone."
+        message={t('social.account.deleteMessage')}
         confirmLabel="Delete account"
         variant="danger"
       />

--- a/src/components/translation/TranslationModeBridge.tsx
+++ b/src/components/translation/TranslationModeBridge.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../../stores/appStore';
+import { useSocialStore } from '../../stores/socialStore';
+import { useTranslationStore } from '../../stores/translationStore';
+
+export default function TranslationModeBridge() {
+  const enabled = useAppStore((s) => s.settings?.experimentalTranslationMode ?? false);
+  const languageCode = useAppStore((s) => s.settings?.translationModeLanguage?.trim() || null);
+  const signedIn = useSocialStore((s) => s.status.signedIn);
+  const configure = useTranslationStore((s) => s.configure);
+  const loadCatalog = useTranslationStore((s) => s.loadCatalog);
+  const registerContributor = useTranslationStore((s) => s.registerContributor);
+
+  useEffect(() => {
+    configure({ enabled, signedIn, languageCode });
+  }, [configure, enabled, languageCode, signedIn]);
+
+  useEffect(() => {
+    if (enabled && signedIn && languageCode) {
+      void loadCatalog(languageCode);
+    }
+  }, [enabled, languageCode, loadCatalog, signedIn]);
+
+  useEffect(() => {
+    if (enabled && signedIn) {
+      void registerContributor();
+    }
+  }, [enabled, registerContributor, signedIn]);
+
+  return null;
+}

--- a/src/components/translation/Tx.tsx
+++ b/src/components/translation/Tx.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+import { AlertTriangle, Check, Loader2, X } from 'lucide-react';
+import { useTranslationStore } from '../../stores/translationStore';
+
+interface TxProps {
+  k: string;
+  values?: Record<string, unknown>;
+  fallback?: string;
+  className?: string;
+}
+
+const PLACEHOLDER_RE = /{{\s*([\w.-]+)\s*}}/g;
+
+export default function Tx({ k, values, fallback, className = '' }: TxProps) {
+  const { t, i18n } = useTranslation();
+  const location = useLocation();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const enabled = useTranslationStore((s) => s.enabled);
+  const signedIn = useTranslationStore((s) => s.signedIn);
+  const languageCode = useTranslationStore((s) => s.languageCode);
+  const row = useTranslationStore((s) => s.rowsByKey[k]);
+  const override = useTranslationStore((s) => s.localOverrides[k]);
+  const saving = useTranslationStore((s) => !!s.savingKeys[k]);
+  const saved = useTranslationStore((s) => !!s.savedKeys[k]);
+  const remoteError = useTranslationStore((s) => s.errors[k]);
+  const saveSuggestion = useTranslationStore((s) => s.saveSuggestion);
+
+  const active = enabled && signedIn && !!languageCode;
+  const source = useMemo(() => {
+    const en = i18n.getFixedT('en');
+    return String(en(k, values));
+  }, [i18n, k, values]);
+  const defaultText = fallback ?? String(t(k, values));
+  const candidate = override ?? row?.value ?? '';
+  const displayText = active && candidate.trim() ? formatTemplate(candidate, values) : defaultText;
+
+  const openEditor = () => {
+    if (!active) return;
+    setDraft(override ?? row?.value ?? '');
+    setLocalError(null);
+    setEditing(true);
+  };
+
+  const save = async () => {
+    const check = checkPlaceholders(source, draft);
+    if (check.missing.length || check.extra.length) {
+      setLocalError(
+        `Keep the {{tags}}: missing ${check.missing.join(', ') || 'none'}, extra ${
+          check.extra.join(', ') || 'none'
+        }`
+      );
+      return;
+    }
+    const ok = await saveSuggestion({
+      key: k,
+      source,
+      value: draft,
+      contextRoute: location.pathname,
+    });
+    if (ok) setEditing(false);
+  };
+
+  return (
+    <>
+      <span
+        className={`${className} ${
+          active
+            ? 'rounded-[3px] outline outline-1 outline-teal-300/40 bg-teal-300/10 hover:bg-teal-300/20 cursor-text'
+            : ''
+        }`}
+        title={active ? `Double-click to translate ${k}` : undefined}
+        data-i18n-key={active ? k : undefined}
+        onDoubleClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          openEditor();
+        }}
+      >
+        {displayText}
+      </span>
+      {editing &&
+        createPortal(
+          <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 px-4">
+            <div className="w-full max-w-lg rounded-lg border border-border bg-bg-secondary p-4 shadow-2xl">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-xs text-text-tertiary">{k}</div>
+                  <div className="mt-1 text-sm font-medium text-text-primary">{source}</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setEditing(false)}
+                  className="rounded-sm p-1 text-text-secondary hover:bg-white/10 hover:text-text-primary"
+                  aria-label="Close translation editor"
+                  title="Close"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <textarea
+                value={draft}
+                onChange={(event) => {
+                  setDraft(event.target.value);
+                  setLocalError(null);
+                }}
+                autoFocus
+                rows={4}
+                className="w-full resize-y rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary"
+                dir="auto"
+              />
+              {(localError || remoteError) && (
+                <div className="mt-2 flex items-start gap-2 text-xs text-state-danger">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                  <span>{localError || remoteError}</span>
+                </div>
+              )}
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <div className="text-xs text-text-secondary">
+                  {saved ? 'Saved' : languageCode ? `Submitting to ${languageCode}` : ''}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setEditing(false)}
+                    className="rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-secondary hover:text-text-primary"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void save()}
+                    disabled={saving}
+                    className="inline-flex items-center gap-2 rounded-md border border-accent bg-accent px-3 py-2 text-sm font-medium text-bg-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
+function formatTemplate(template: string, values?: Record<string, unknown>): string {
+  if (!values) return template;
+  return template.replace(PLACEHOLDER_RE, (match, name: string) => {
+    const value = values[name];
+    return value === undefined || value === null ? match : String(value);
+  });
+}
+
+function placeholders(value: string): string[] {
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  PLACEHOLDER_RE.lastIndex = 0;
+  while ((match = PLACEHOLDER_RE.exec(value))) found.add(match[1]);
+  return [...found].sort();
+}
+
+function checkPlaceholders(source: string, target: string): { missing: string[]; extra: string[] } {
+  const sourceVars = new Set(placeholders(source));
+  const targetVars = new Set(placeholders(target));
+  return {
+    missing: [...sourceVars].filter((name) => !targetVars.has(name)).sort(),
+    extra: [...targetVars].filter((name) => !sourceVars.has(name)).sort(),
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,14 @@ import type {
   GameBananaCollectionItemsResponse,
   GameBananaArtistLink,
 } from '../types/gamebanana';
+import type {
+  TranslationCatalogResponse,
+  TranslationCatalogRow,
+  TranslationContributorResponse,
+  TranslationProgressResponse,
+  TranslationSuggestionRequest,
+  TranslationSuggestionResponse,
+} from '../types/translation';
 
 // Re-export types for convenience
 export type {
@@ -839,6 +847,41 @@ export function socialOnSessionChanged(
   callback: (status: SocialSessionStatus) => void
 ): () => void {
   return window.electronAPI.social.onSessionChanged(callback);
+}
+
+// =====================
+// Translation Mode API
+// =====================
+
+export type {
+  TranslationCatalogResponse,
+  TranslationCatalogRow,
+  TranslationContributorResponse,
+  TranslationProgressResponse,
+  TranslationSuggestionRequest,
+  TranslationSuggestionResponse,
+};
+
+export async function registerTranslationContributor(): Promise<TranslationContributorResponse> {
+  return window.electronAPI.translation.registerContributor();
+}
+
+export async function getTranslationCatalog(
+  languageCode: string
+): Promise<TranslationCatalogResponse> {
+  return window.electronAPI.translation.getCatalog(languageCode);
+}
+
+export async function getTranslationProgress(
+  languageCode: string
+): Promise<TranslationProgressResponse> {
+  return window.electronAPI.translation.getProgress(languageCode);
+}
+
+export async function saveTranslationSuggestion(
+  body: TranslationSuggestionRequest
+): Promise<TranslationSuggestionResponse> {
+  return window.electronAPI.translation.saveSuggestion(body);
 }
 
 // ── Deadworks custom-server browser ──

--- a/src/lib/translationLanguages.ts
+++ b/src/lib/translationLanguages.ts
@@ -1,0 +1,51 @@
+export interface TranslationLanguageOption {
+  code: string;
+  name: string;
+}
+
+export const TRANSLATION_LANGUAGE_OPTIONS: TranslationLanguageOption[] = [
+  { code: 'es', name: 'Spanish' },
+  { code: 'pt-BR', name: 'Portuguese (Brazil)' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'uk', name: 'Ukrainian' },
+  { code: 'tr', name: 'Turkish' },
+  { code: 'cs', name: 'Czech' },
+  { code: 'sk', name: 'Slovak' },
+  { code: 'hu', name: 'Hungarian' },
+  { code: 'ro', name: 'Romanian' },
+  { code: 'el', name: 'Greek' },
+  { code: 'bg', name: 'Bulgarian' },
+  { code: 'hr', name: 'Croatian' },
+  { code: 'sr', name: 'Serbian' },
+  { code: 'sv', name: 'Swedish' },
+  { code: 'da', name: 'Danish' },
+  { code: 'fi', name: 'Finnish' },
+  { code: 'no', name: 'Norwegian' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'zh-CN', name: 'Chinese (Simplified)' },
+  { code: 'zh-TW', name: 'Chinese (Traditional)' },
+  { code: 'th', name: 'Thai' },
+  { code: 'vi', name: 'Vietnamese' },
+  { code: 'id', name: 'Indonesian' },
+  { code: 'ms', name: 'Malay' },
+  { code: 'fil', name: 'Filipino' },
+  { code: 'hi', name: 'Hindi' },
+  { code: 'bn', name: 'Bengali' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'he', name: 'Hebrew' },
+  { code: 'fa', name: 'Persian' },
+];
+
+export function translationLanguageLabel(code: string): string {
+  const match = TRANSLATION_LANGUAGE_OPTIONS.find(
+    (language) => language.code.toLowerCase() === code.toLowerCase()
+  );
+  return match ? `${match.name} (${match.code})` : code;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -20,7 +20,88 @@
       "label": "Language",
       "description": "Choose the app language, or follow your system preference.",
       "systemDefault": "System default"
+    },
+    "header": {
+      "description": "Game paths, preferences, and maintenance"
+    },
+    "toggles": {
+      "hideOutdated": "Hide Browse mods older than the current game version.",
+      "expandLocker": "Start Locker list view with hero cards expanded.",
+      "switchVariants": "Installing a new variant disables the old one. Off keeps both active. Updates always replace the old file.",
+      "enableAfterDownload": "Enable mods as soon as they finish downloading. Stays disabled if no slot is free.",
+      "confirmProfileUpdate": "Confirm before overwriting a profile's saved mods. Off overwrites immediately.",
+      "ignoreConflicts": "Hide all conflicts from the Conflicts page. Off shows them.",
+      "discordRpc": "Show your current Grimoire activity on your Discord profile. Talks only to your local Discord app and sends nothing to Grimoire.",
+      "contributeSalts": "Share the replay keys Steam already caches for matches you view in-game. Sends only the match id, server cluster, and two download keys: no account id, no username, nothing about you or your mods.",
+      "translationMode": "Double-click translated labels to suggest edits. Requires Steam sign-in.",
+      "fixUnknown": "Match unknown local VPKs against GameBanana to recover names and thumbnails. May hit rate limits on large libraries.",
+      "deadworks": "Add a Servers tab to browse and join Deadworks community servers. Required content downloads before connecting.",
+      "performanceConfig": "One-click fps boost using Sqooky's community preset. Mods keep working. Remove any time."
+    },
+    "cache": {
+      "wipeMessage": "Removes cached mod metadata and sync state. Browse re-syncs from GameBanana next time. Installed mods are not affected.",
+      "clearPreviewMessage": "Deletes cached preview images to reclaim disk. They regenerate when you next view them. Installed mods are not affected."
     }
+  },
+  "crosshair": {
+    "toggles": {
+      "staticGap": "Keep the gap fixed. Off lets it expand with weapon spread (not shown in preview).",
+      "disableHeroCrosshairs": "Force your custom crosshair on heroes that override it."
+    }
+  },
+  "installed": {
+    "empty": {
+      "noGamePath": "Set your Deadlock path or enable dev mode.",
+      "noMods": "Download mods from Browse or import a custom VPK to get started."
+    }
+  },
+  "locker": {
+    "empty": {
+      "noGamePath": "Set your Deadlock path or enable dev mode."
+    }
+  },
+  "profiles": {
+    "empty": {
+      "noProfiles": "Create a profile to save your current mod setup."
+    }
+  },
+  "social": {
+    "account": {
+      "deleteMessage": "Permanently deletes your account, your likes, and your published profiles from Discover. People who already imported them keep their copy."
+    },
+    "publish": {
+      "localBlocked": "Local mods can't be published."
+    }
+  },
+  "exportProfile": {
+    "localBlocked": "Local mods can't be shared."
+  },
+  "importCollection": {
+    "invalidId": "Paste a collection URL or numeric id.",
+    "pasteHint": "Paste a GameBanana collection URL or id. Items queue like any Browse download.",
+    "scanTitle": "Fetch file lists and expand mods with variants",
+    "noFiles": "No downloadable files. This mod may have been removed.",
+    "variantHint": "Check a variant, or leave unchecked to use the most popular file."
+  },
+  "importProfile": {
+    "alreadyInstalled": "Already installed: reused without re-downloading",
+    "noFiles": "No downloadable files. This mod may have been removed.",
+    "variantHint": "Check a variant, or leave unchecked to use the profile's pinned file."
+  },
+  "mergeMods": {
+    "oneVariant": "One variant per mod",
+    "strictDescription": "Stop if two mods touch the same file. Off lets the higher-priority mod win.",
+    "localNote": "Local mods merge fine but aren't in the share code. Delete the disabled originals and they can't be recovered on unmerge."
+  },
+  "mergedContents": {
+    "disabledAtMerge": "Disabled at merge time"
+  },
+  "multiVpk": {
+    "uncheckHint": "Uncheck any you don't want to install."
+  },
+  "welcome": {
+    "autoexecExists": "Existing autoexec.cfg found. Your settings stay intact.",
+    "autoDetectFailed": "Auto-detect failed. Browse to your Steam library:"
   },
   "sidebar": {
     "expandSidebar": "Expand sidebar",

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Copy, Check, RotateCcw, Save, Trash2, Play, Pin, XCircle, Download } from 'lucide-react';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
@@ -22,6 +23,7 @@ function detectResolutionHeight(): number {
 }
 
 export default function Crosshair() {
+    const { t } = useTranslation();
     const [copied, setCopied] = useState(false);
     const [imported, setImported] = useState(false);
     const [resolution, setResolution] = useState(detectResolutionHeight);
@@ -254,13 +256,13 @@ export default function Crosshair() {
                         <div className="space-y-4">
                             <Toggle
                                 label="Static Gap"
-                                description="Keep the gap fixed. When off, the in-game gap expands with weapon spread (not simulated in the preview)."
+                                description={t('crosshair.toggles.staticGap')}
                                 checked={pipGapStatic}
                                 onChange={setPipGapStatic}
                             />
                             <Toggle
                                 label="Disable Hero Crosshairs"
-                                description="Some heroes override the crosshair with their own. Turn this on so your custom crosshair always wins."
+                                description={t('crosshair.toggles.disableHeroCrosshairs')}
                                 checked={disableHeroSpecificCrosshairs}
                                 onChange={setDisableHeroSpecificCrosshairs}
                             />

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,4 +1,5 @@
 import { memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import {
   DndContext,
@@ -601,6 +602,7 @@ function getCardSizeGridStyle(multiplier: number): CSSProperties {
 }
 
 export default function Installed() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const {
     settings,
@@ -2462,7 +2464,7 @@ export default function Installed() {
       <EmptyState
         icon={Package}
         title="No Game Path Set"
-        description="Configure your Deadlock installation path or enable dev mode to start managing mods."
+        description={t('installed.empty.noGamePath')}
         action={
           <Button onClick={() => navigate('/settings')} icon={Settings}>
             Open Settings
@@ -2875,7 +2877,7 @@ export default function Installed() {
         <EmptyState
           icon={Package}
           title="No Mods Found"
-          description="No mods installed yet. Download mods from the Browse tab, import a custom VPK, or manually place VPK files in your addons folder."
+          description={t('installed.empty.noMods')}
           action={
             <div className="flex items-center gap-3">
               <Button onClick={() => navigate('/browse')} icon={Search}>

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
@@ -122,6 +123,7 @@ function RainbowPaletteIcon({ className = '', title }: { className?: string; tit
 }
 
 export default function Locker() {
+  const { t } = useTranslation();
   const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, setBrowseUi, setLockerHeroName } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
@@ -498,7 +500,7 @@ export default function Locker() {
       <EmptyState
         icon={Shield}
         title="No Game Path Set"
-        description="Configure your Deadlock installation path or enable dev mode to manage hero skins."
+        description={t('locker.empty.noGamePath')}
       />
     );
   }

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X, Upload, Share2, Globe, History, RotateCcw, Camera } from 'lucide-react';
 import {
   getProfiles,
@@ -95,6 +96,7 @@ function getProfileModGroups(
 }
 
 export default function Profiles() {
+  const { t } = useTranslation();
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
   const [crosshairEnabled, setCrosshairEnabled] = useState(false);
@@ -594,7 +596,7 @@ export default function Profiles() {
               <EmptyState
                 icon={User}
                 title="No Profiles Yet"
-                description="Create your first profile above to save your current mod configuration."
+                description={t('profiles.empty.noProfiles')}
               />
             </div>
           ) : (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { AVAILABLE_LANGUAGES, languageDisplayName } from '../i18n';
+import { TRANSLATION_LANGUAGE_OPTIONS, translationLanguageLabel } from '../lib/translationLanguages';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
 import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
@@ -375,6 +376,24 @@ export default function Settings() {
     }
   };
 
+  const handleTranslationModeChange = async (checked: boolean) => {
+    if (!settings) return;
+    const existingLanguage = settings.translationModeLanguage ?? null;
+    const preferredLanguage =
+      settings.language && settings.language !== 'en' ? settings.language : null;
+    await saveSettings({
+      ...settings,
+      experimentalTranslationMode: checked,
+      translationModeLanguage: checked ? existingLanguage ?? preferredLanguage : existingLanguage,
+    });
+  };
+
+  const handleTranslationModeLanguageChange = async (language: string) => {
+    if (!settings) return;
+    const normalized = language.trim() || null;
+    await saveSettings({ ...settings, translationModeLanguage: normalized });
+  };
+
   const handleDevModeChange = async (checked: boolean) => {
     if (!settings) return;
     if (checked) {
@@ -631,7 +650,7 @@ export default function Settings() {
     <div className="p-8 max-w-5xl mx-auto space-y-8 animate-fade-in">
       <PageHeader
         title="Settings"
-        description="Configure game paths, preferences, and maintenance tasks"
+        description={t('settings.header.description')}
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -1109,7 +1128,7 @@ export default function Settings() {
               checked={settings?.hideOutdatedMods ?? false}
               onChange={handleHideOutdatedChange}
               label="Hide Outdated Mods"
-              description="Hide mods in Browse that haven't been updated since the current game version cutoff."
+              description={t('settings.toggles.hideOutdated')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1118,7 +1137,7 @@ export default function Settings() {
               checked={settings?.lockerCardsExpandedByDefault ?? false}
               onChange={handleLockerCardsExpandedByDefaultChange}
               label="Expand Locker cards by default"
-              description="Open hero cards expanded when you enter Locker list view. You can still collapse or expand them manually."
+              description={t('settings.toggles.expandLocker')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1127,7 +1146,7 @@ export default function Settings() {
               checked={settings?.autoDisableSiblingVariants ?? true}
               onChange={handleAutoDisableSiblingsChange}
               label="Switch variants instead of stacking them"
-              description="When you install a different file of a mod you already have enabled, disable the previous variant so only the new one is active. Turn off to keep multiple variants of the same mod enabled at once. (Updates always replace the old file regardless of this setting.)"
+              description={t('settings.toggles.switchVariants')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1136,7 +1155,7 @@ export default function Settings() {
               checked={settings?.autoEnableDownloads ?? false}
               onChange={handleAutoEnableDownloadsChange}
               label="Enable mods after download"
-              description="Move newly downloaded mods into the active load order as soon as installation finishes. If no enabled slot is available, the mod stays installed and disabled."
+              description={t('settings.toggles.enableAfterDownload')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1145,7 +1164,7 @@ export default function Settings() {
               checked={settings?.confirmProfileUpdate ?? true}
               onChange={handleConfirmProfileUpdateChange}
               label="Confirm before updating a profile"
-              description="Ask first when you click Update on a profile, since it overwrites that profile's saved mods with your current set and can't be undone. Turn off to overwrite immediately."
+              description={t('settings.toggles.confirmProfileUpdate')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1154,7 +1173,7 @@ export default function Settings() {
               checked={settings?.ignoreConflictsByDefault ?? false}
               onChange={handleIgnoreConflictsByDefaultChange}
               label="Ignore conflicts by default"
-              description="Hide every detected mod conflict instead of surfacing it in the Conflicts page. Turn off to bring them back."
+              description={t('settings.toggles.ignoreConflicts')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1163,7 +1182,7 @@ export default function Settings() {
               checked={settings?.discordRpcEnabled ?? false}
               onChange={handleDiscordRpcChange}
               label="Discord Rich Presence"
-              description="Show what you are doing in Grimoire on your Discord profile (browsing mods, in the Locker, and so on). Talks only to your local Discord app and sends nothing to Grimoire. Off by default."
+              description={t('settings.toggles.discordRpc')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1173,7 +1192,7 @@ export default function Settings() {
                 checked={settings?.contributeMatchSalts ?? false}
                 onChange={handleContributeMatchSaltsChange}
                 label="Contribute match data to deadlock-api.com"
-                description="Help the community stats project by submitting the replay keys (salts) Steam already caches for matches whose details you view in-game. Sends only the match id, server cluster, and two download keys: no account id, no username, nothing about you or your mods. Off by default."
+                description={t('settings.toggles.contributeSalts')}
               />
               {settings?.contributeMatchSalts && saltIngestStatus && (
                 <div className="mt-2 text-xs text-text-secondary">
@@ -1295,11 +1314,52 @@ export default function Settings() {
 
             <div className="h-px bg-white/5" />
 
+            <div className="space-y-3">
+              <Toggle
+                checked={settings?.experimentalTranslationMode ?? false}
+                onChange={handleTranslationModeChange}
+                label="Translation Mode"
+                description={t('settings.toggles.translationMode')}
+              />
+              {settings?.experimentalTranslationMode && (
+                <div className="max-w-xs">
+                  <label className="text-xs font-medium uppercase tracking-wider text-text-secondary">
+                    Target language
+                  </label>
+                  <select
+                    value={settings.translationModeLanguage ?? ''}
+                    onChange={(event) => handleTranslationModeLanguageChange(event.target.value)}
+                    className="mt-1 w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary"
+                  >
+                    <option value="">Choose a language</option>
+                    {settings.translationModeLanguage &&
+                      !TRANSLATION_LANGUAGE_OPTIONS.some(
+                        (language) => language.code === settings.translationModeLanguage
+                      ) && (
+                        <option value={settings.translationModeLanguage}>
+                          {translationLanguageLabel(settings.translationModeLanguage)}
+                        </option>
+                      )}
+                    {TRANSLATION_LANGUAGE_OPTIONS.map((language) => (
+                      <option key={language.code} value={language.code}>
+                        {language.name} ({language.code})
+                      </option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-text-secondary">
+                    Pick the language that should receive your translation suggestions.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="h-px bg-white/5" />
+
             <Toggle
               checked={settings?.experimentalUnknownModMatching ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalUnknownModMatching: checked })}
               label="Fix Unknown Mods"
-              description="Auto-match unknown local VPKs against GameBanana to recover their names and thumbnails. Currently hits rate limits on larger libraries while we rework it. The manual Custom Mod path stays available either way."
+              description={t('settings.toggles.fixUnknown')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1308,7 +1368,7 @@ export default function Settings() {
               checked={settings?.experimentalDeadworksServers ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalDeadworksServers: checked })}
               label="Deadworks Servers"
-              description="Browse and join Deadworks community dedicated servers from a Servers tab. Required map/addon content is downloaded automatically before connecting."
+              description={t('settings.toggles.deadworks')}
             />
 
             <div className="h-px bg-white/5" />
@@ -1317,7 +1377,7 @@ export default function Settings() {
               checked={settings?.experimentalPerformanceConfig ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalPerformanceConfig: checked })}
               label="Performance Config"
-              description="One-click fps boost using Sqooky's community preset. Mods keep working; removable any time."
+              description={t('settings.toggles.performanceConfig')}
             />
           </div>
         </Card>
@@ -1677,7 +1737,7 @@ export default function Settings() {
         onCancel={() => setWipeConfirmOpen(false)}
         onConfirm={handleWipeCache}
         title="Wipe mod cache?"
-        message="This removes all cached mod metadata and sync state. The next Browse session will re-sync from GameBanana (a few minutes on first run). Your installed mods are not affected."
+        message={t('settings.cache.wipeMessage')}
         confirmLabel="Wipe Cache"
         variant="danger"
       />
@@ -1687,7 +1747,7 @@ export default function Settings() {
         onCancel={() => setPreviewConfirmOpen(false)}
         onConfirm={handleClearPreviewCache}
         title="Clear preview cache?"
-        message="This deletes the cached 3D model stills, hero portraits, and locker card thumbnails to reclaim disk. They regenerate on demand the next time you view them (a brief pause on first view). Your installed mods are not affected."
+        message={t('settings.cache.clearPreviewMessage')}
         confirmLabel="Clear"
         variant="danger"
       />

--- a/src/stores/translationStore.ts
+++ b/src/stores/translationStore.ts
@@ -1,0 +1,161 @@
+import { create } from 'zustand';
+import {
+  getTranslationCatalog,
+  registerTranslationContributor,
+  saveTranslationSuggestion,
+  type TranslationCatalogRow,
+} from '../lib/api';
+
+interface TranslationStore {
+  enabled: boolean;
+  signedIn: boolean;
+  languageCode: string | null;
+  rowsByKey: Record<string, TranslationCatalogRow>;
+  localOverrides: Record<string, string>;
+  savingKeys: Record<string, boolean>;
+  savedKeys: Record<string, boolean>;
+  errors: Record<string, string>;
+  catalogLoading: boolean;
+  catalogLoadedLanguage: string | null;
+  catalogError: string | null;
+  registered: boolean;
+  registrationError: string | null;
+
+  configure: (next: { enabled: boolean; signedIn: boolean; languageCode: string | null }) => void;
+  registerContributor: () => Promise<void>;
+  loadCatalog: (languageCode?: string) => Promise<void>;
+  saveSuggestion: (args: {
+    key: string;
+    source: string;
+    value: string;
+    contextRoute?: string;
+    appVersion?: string;
+  }) => Promise<boolean>;
+}
+
+export const useTranslationStore = create<TranslationStore>((set, get) => ({
+  enabled: false,
+  signedIn: false,
+  languageCode: null,
+  rowsByKey: {},
+  localOverrides: {},
+  savingKeys: {},
+  savedKeys: {},
+  errors: {},
+  catalogLoading: false,
+  catalogLoadedLanguage: null,
+  catalogError: null,
+  registered: false,
+  registrationError: null,
+
+  configure: (next) => {
+    const prev = get();
+    const resetCatalog = prev.languageCode !== next.languageCode || !next.enabled || !next.signedIn;
+    set({
+      enabled: next.enabled,
+      signedIn: next.signedIn,
+      languageCode: next.languageCode,
+      ...(resetCatalog
+        ? {
+            rowsByKey: {},
+            localOverrides: {},
+            savingKeys: {},
+            savedKeys: {},
+            errors: {},
+            catalogLoading: false,
+            catalogLoadedLanguage: null,
+            catalogError: null,
+            registered: false,
+            registrationError: null,
+          }
+        : {}),
+    });
+  },
+
+  registerContributor: async () => {
+    const state = get();
+    if (!state.enabled || !state.signedIn || state.registered) return;
+    try {
+      await registerTranslationContributor();
+      set({ registered: true, registrationError: null });
+    } catch (err) {
+      set({ registrationError: err instanceof Error ? err.message : String(err) });
+    }
+  },
+
+  loadCatalog: async (languageCode = get().languageCode ?? undefined) => {
+    if (!languageCode) return;
+    const state = get();
+    if (!state.enabled || !state.signedIn) return;
+    if (state.catalogLoading || state.catalogLoadedLanguage === languageCode) return;
+
+    set({ catalogLoading: true, catalogError: null });
+    try {
+      const catalog = await getTranslationCatalog(languageCode);
+      set({
+        rowsByKey: Object.fromEntries(catalog.rows.map((row) => [row.key, row])),
+        catalogLoadedLanguage: catalog.languageCode,
+      });
+    } catch (err) {
+      set({ catalogError: err instanceof Error ? err.message : String(err) });
+    } finally {
+      set({ catalogLoading: false });
+    }
+  },
+
+  saveSuggestion: async ({ key, source, value, contextRoute, appVersion }) => {
+    const state = get();
+    const languageCode = state.languageCode;
+    if (!state.enabled || !state.signedIn || !languageCode) return false;
+
+    set((prev) => ({
+      localOverrides: { ...prev.localOverrides, [key]: value },
+      savingKeys: { ...prev.savingKeys, [key]: true },
+      savedKeys: { ...prev.savedKeys, [key]: false },
+      errors: clearKey(prev.errors, key),
+    }));
+
+    try {
+      await saveTranslationSuggestion({
+        languageCode,
+        key,
+        value,
+        source,
+        contextRoute,
+        appVersion,
+      });
+      set((prev) => ({
+        rowsByKey: {
+          ...prev.rowsByKey,
+          ...(prev.rowsByKey[key]
+            ? { [key]: { ...prev.rowsByKey[key], value, status: 'draft' } }
+            : {}),
+        },
+        savingKeys: { ...prev.savingKeys, [key]: false },
+        savedKeys: { ...prev.savedKeys, [key]: true },
+      }));
+      window.setTimeout(() => {
+        useTranslationStore.setState((prev) => ({
+          savedKeys: { ...prev.savedKeys, [key]: false },
+        }));
+      }, 1400);
+      return true;
+    } catch (err) {
+      set((prev) => ({
+        savingKeys: { ...prev.savingKeys, [key]: false },
+        errors: {
+          ...prev.errors,
+          [key]: err instanceof Error ? err.message : String(err),
+        },
+      }));
+      return false;
+    }
+  },
+}));
+
+function clearKey(map: Record<string, string>, key: string): Record<string, string> {
+  if (!(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -707,6 +707,20 @@ export interface ElectronAPI {
         ) => () => void;
     };
 
+    // Translation Mode
+    translation: {
+        registerContributor: () => Promise<import('./translation').TranslationContributorResponse>;
+        getCatalog: (
+            languageCode: string
+        ) => Promise<import('./translation').TranslationCatalogResponse>;
+        getProgress: (
+            languageCode: string
+        ) => Promise<import('./translation').TranslationProgressResponse>;
+        saveSuggestion: (
+            body: import('./translation').TranslationSuggestionRequest
+        ) => Promise<import('./translation').TranslationSuggestionResponse>;
+    };
+
     // Stats API
     stats: {
         // Steam Detection

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -735,6 +735,10 @@ export interface AppSettings {
   experimentalCrosshair: boolean;
   /** Grimoire Social: Discover page + publish/account UI. */
   experimentalSocial: boolean;
+  /** In-app translation contribution mode. Requires Grimoire Social sign-in. */
+  experimentalTranslationMode: boolean;
+  /** Target language code for in-app translation suggestions. */
+  translationModeLanguage?: string | null;
   /** Auto-match unknown local VPKs against GameBanana (CRC-32 + filter
    *  search). Off by default while the matching path is reworked: the
    *  current implementation hits GameBanana rate limits hard on libraries

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -1,0 +1,61 @@
+export type TranslationRowStatus = 'missing' | 'shipped' | 'draft' | 'translated' | 'reviewed';
+
+export interface TranslationCatalogRow {
+  key: string;
+  source: string;
+  value: string;
+  status: TranslationRowStatus;
+  placeholders: string[];
+  missingPlaceholders: string[];
+  extraPlaceholders: string[];
+}
+
+export interface TranslationCatalogResponse {
+  languageCode: string;
+  rows: TranslationCatalogRow[];
+  stats: {
+    total: number;
+    completed: number;
+    reviewed: number;
+    drafts: number;
+  };
+}
+
+export interface TranslationProgressResponse {
+  languageCode: string;
+  total: number;
+  completed: number;
+  reviewed: number;
+  pendingSuggestions: number;
+}
+
+export interface TranslationSuggestionRequest {
+  languageCode: string;
+  key: string;
+  value: string;
+  source: string;
+  contextRoute?: string;
+  appVersion?: string;
+}
+
+export interface TranslationSuggestionResponse {
+  suggestion: {
+    id: string;
+    languageCode: string;
+    key: string;
+    value: string;
+    status: 'pending' | 'accepted' | 'rejected';
+    createdAt: string;
+  };
+}
+
+export interface TranslationContributorResponse {
+  contributor: {
+    id: string;
+    displayName: string;
+    avatarUrl: string | null;
+    role: 'translator' | 'reviewer' | 'admin';
+    trustLevel: number;
+    lastSeenAt: string;
+  };
+}


### PR DESCRIPTION
Two related strands of the i18n effort, bundled because they share the i18n machinery, `Settings.tsx`, and the catalog (they were all sitting uncommitted in the tree together). Happy to split into two PRs if you'd rather review them separately.

## 1. Copy sweep (simplify for translation)
Tightened ~40 verbose, hard-to-translate UI strings to terse imperative copy. The recurring fixes:
- Collapsed run-on, multi-clause toggle descriptions (e.g. the "switch variants" toggle went 44 words -> 18).
- Dropped redundant reassurance ("can't be undone" after "permanently").
- Removed leaked implementation detail ("the same download pipeline as Browse") and parenthetical caveats.
- Replaced procedural explanations ("leave any unwanted ones unchecked and they'll be skipped" -> "Uncheck any you don't want to install").

Privacy promises on the **Discord RPC** and **match-salts** toggles were deliberately kept (trimmed, not gutted) since they earn their length against the no-telemetry trust pillar.

## 2. English catalog migration
Moved every simplified string into the source-of-truth catalog (`src/locales/en/translation.json`, +81 lines of keys) and wired the call sites through `react-i18next` `t()`, adding `useTranslation` to the 13 components that had none. Uniform `t()` (no mixed `<Tx>`) for predictability.

Note: `UpdateModal`'s distro-update block stays inline for now (embedded `<code>` elements need the `<Trans>` component) — flagged as a small follow-up.

## 3. Live Translation Mode infrastructure (pre-existing WIP)
Also includes the in-progress double-click-to-suggest feature against `translate.grimoiremods.com`: the translation IPC/service in the main process, `translationStore`, the `Tx` component, and the Translation Mode settings toggle.

## Verification
`pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.