### PR TITLE
fix(deadworks): spawn 7za from app.asar.unpacked, not inside the asar

### DIFF
--- a/electron/main/services/deadworksServers.ts
+++ b/electron/main/services/deadworksServers.ts
@@ -15,7 +15,7 @@ import https from 'https';
 import dgram from 'dgram';
 import { spawn } from 'child_process';
 import { shell } from 'electron';
-import { path7za } from '7zip-bin';
+import { find7zPath } from './extract';
 import {
     getDeadworksAddonsPath,
     getDeadworksMapsPath,
@@ -265,7 +265,11 @@ function decompressBz2(
     onProgress: (written: number) => void,
 ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-        const proc = spawn(path7za, ['e', '-so', bz2Path], { stdio: ['ignore', 'pipe', 'pipe'] });
+        // Use the same resolver as the archive extractor: it rewrites the bundled
+        // 7za path to its app.asar.unpacked location (binaries inside the asar
+        // can't be spawned) and falls back to a system 7-Zip / PATH lookup.
+        const sevenZip = find7zPath()[0];
+        const proc = spawn(sevenZip, ['e', '-so', bz2Path], { stdio: ['ignore', 'pipe', 'pipe'] });
         const out = createWriteStream(destPath);
         let written = 0;
         let settled = false;

--- a/electron/main/services/extract.ts
+++ b/electron/main/services/extract.ts
@@ -18,7 +18,7 @@ function resolveUnpackedPath(p: string): string {
 /**
  * Find 7z executable paths, preferring the bundled binary over system installs.
  */
-function find7zPath(): string[] {
+export function find7zPath(): string[] {
     const candidates: string[] = [];
 
     // 1. Bundled 7za (ships with the app, no user install required)


### PR DESCRIPTION
## Problem

A user reported this when joining a Deadworks server:

\`\`\`
Failed to prepare Map: bhop_dom: 7-Zip failed to start: spawn C:\Users\<USER>\AppData\Local\Programs\Grimoire\resources\app.asar\node_modules\7zip-bin\win\x64\7za.exe ENOENT
\`\`\`

When a Deadworks server's map/addon content ships as \`.bz2\`, Grimoire decompresses it with the bundled \`7za\` binary. The spawned path points **inside \`app.asar\`**, and Electron cannot execute a binary packed in the asar archive, hence the ENOENT.

## Root cause

\`electron-builder.yml\` already unpacks \`7zip-bin\` to \`app.asar.unpacked\`, and \`extract.ts\` (the GameBanana archive extractor) rewrites the path accordingly via \`resolveUnpackedPath()\`. But \`deadworksServers.ts\` imported \`path7za\` from \`7zip-bin\` and spawned it **raw**, so it pointed at the un-runnable in-asar location.

This only fails in packaged builds: in dev there is no asar, so it was invisible.

## Fix

- Export \`find7zPath()\` from \`extract.ts\` (it already prefers the unpacked bundled binary, then a system 7-Zip / PATH fallback).
- \`decompressBz2\` in \`deadworksServers.ts\` now spawns \`find7zPath()[0]\` instead of \`path7za\`.

This fixes the ENOENT and gives the Deadworks bz2 path the same system-7-Zip fallback the GameBanana extractor already has.

## Verification

- \`pnpm typecheck\` passes.
- No circular import (\`extract.ts\` does not import \`deadworksServers.ts\`).