### PR TITLE
i18n: wire app UI strings

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -34,6 +34,7 @@ function walk(dir) {
 }
 
 const keyRe = /\bt\(\s*['"]([\w.-]+)['"]/g;
+const txKeyRe = /<Tx\b[^>]*\bk\s*=\s*['"]([\w.-]+)['"]/g;
 const referenced = new Set();
 const missing = [];
 for (const file of walk(join(root, 'src'))) {
@@ -43,6 +44,11 @@ for (const file of walk(join(root, 'src'))) {
     const key = m[1];
     referenced.add(key);
     // A missing key resolves to itself; count:2 lets plural keys resolve.
+    if (i18next.t(key, { count: 2 }) === key) missing.push(`${file.replace(root, '')}: ${key}`);
+  }
+  while ((m = txKeyRe.exec(src))) {
+    const key = m[1];
+    referenced.add(key);
     if (i18next.t(key, { count: 2 }) === key) missing.push(`${file.replace(root, '')}: ${key}`);
   }
 }

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Download, Loader2, X, ChevronUp, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import type { DownloadQueueItem, DownloadProgressData } from '../types/electron';
 import { formatBytes } from '../lib/formatBytes';
+import Tx from './translation/Tx';
 
 interface DownloadQueueIndicatorProps {
     className?: string;
@@ -23,17 +26,18 @@ function formatSpeed(bytesPerSec: number): string {
     return `${formatBytes(bytesPerSec)}/s`;
 }
 
-function formatEta(seconds: number): string {
+function formatEta(seconds: number, t: TFunction): string {
     if (!isFinite(seconds) || seconds <= 0) return '';
-    if (seconds < 60) return `${Math.round(seconds)}s`;
+    if (seconds < 60) return t('downloadQueue.eta.seconds', { count: Math.round(seconds) });
     const m = Math.floor(seconds / 60);
     const s = Math.round(seconds % 60);
-    if (m < 60) return `${m}m ${s}s`;
+    if (m < 60) return t('downloadQueue.eta.minutesSeconds', { minutes: m, seconds: s });
     const h = Math.floor(m / 60);
-    return `${h}h ${m % 60}m`;
+    return t('downloadQueue.eta.hoursMinutes', { hours: h, minutes: m % 60 });
 }
 
 export default function DownloadQueueIndicator({ className = '' }: DownloadQueueIndicatorProps) {
+    const { t } = useTranslation();
     const [queueState, setQueueState] = useState<QueueState>({
         queue: [],
         currentDownload: null,
@@ -130,7 +134,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
 
     if (totalItems === 0) return null;
 
-    const currentFileName = queueState.currentDownload?.fileName ?? 'Preparing…';
+    const currentFileName = queueState.currentDownload?.fileName ?? t('downloadQueue.preparing');
     const currentTooltip = queueState.currentDownload?.modName ?? currentFileName;
 
     return (
@@ -147,7 +151,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                         type="button"
                         onClick={() => setIsExpanded(true)}
                         className="flex min-w-0 flex-1 items-center gap-2.5 px-3 py-2 cursor-pointer text-left"
-                        title="Show download details"
+                        title={t('downloadQueue.showDetails')}
                     >
                         <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-accent/15">
                             {queueState.currentDownload ? (
@@ -171,7 +175,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                 {totalItems > 1 && (
                                     <>
                                         <span className="opacity-50">·</span>
-                                        <span>{totalItems - 1} queued</span>
+                                        <span>{t('downloadQueue.remainingQueued', { count: totalItems - 1 })}</span>
                                     </>
                                 )}
                             </div>
@@ -186,8 +190,8 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                 void handleCancelActive();
                             }}
                             className="flex flex-shrink-0 items-center justify-center border-l border-white/5 px-3 text-text-secondary transition-colors hover:bg-red-500/10 hover:text-red-300 cursor-pointer"
-                            aria-label="Cancel download"
-                            title="Cancel download"
+                            aria-label={t('downloadQueue.cancelDownload')}
+                            title={t('downloadQueue.cancelDownload')}
                         >
                             <X className="h-4 w-4" />
                         </button>
@@ -212,15 +216,17 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                     <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
                         <div className="flex items-center gap-2">
                             <Download className="h-4 w-4 text-accent" />
-                            <span className="text-sm font-semibold text-text-primary">Downloads</span>
+                            <span className="text-sm font-semibold text-text-primary">
+                                <Tx k="downloadQueue.downloads" fallback="Downloads" />
+                            </span>
                             <span className="text-xs text-text-secondary">({totalItems})</span>
                         </div>
                         <button
                             type="button"
                             onClick={() => setIsExpanded(false)}
                             className="rounded-md p-1 text-text-secondary hover:bg-white/5 hover:text-text-primary transition-colors cursor-pointer"
-                            aria-label="Collapse"
-                            title="Collapse"
+                            aria-label={t('downloadQueue.collapse')}
+                            title={t('downloadQueue.collapse')}
                         >
                             <ChevronDown className="h-4 w-4" />
                         </button>
@@ -243,8 +249,8 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                     type="button"
                                     onClick={() => void handleCancelActive()}
                                     className="rounded-md p-1 text-text-secondary transition-colors hover:bg-red-500/10 hover:text-red-300 cursor-pointer"
-                                    aria-label="Cancel download"
-                                    title="Cancel download"
+                                    aria-label={t('downloadQueue.cancelDownload')}
+                                    title={t('downloadQueue.cancelDownload')}
                                 >
                                     <X className="h-3.5 w-3.5" />
                                 </button>
@@ -266,7 +272,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                     {etaSeconds > 0 && (
                                         <>
                                             <span className="opacity-50">·</span>
-                                            <span>{formatEta(etaSeconds)} left</span>
+                                            <span>{t('downloadQueue.eta.left', { eta: formatEta(etaSeconds, t) })}</span>
                                         </>
                                     )}
                                 </span>
@@ -277,7 +283,11 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                     {queueState.queue.length > 0 && (
                         <div className="px-4 py-2 max-h-56 overflow-y-auto">
                             <p className="text-[11px] uppercase tracking-wider text-text-secondary mb-1">
-                                Queued ({queueState.queue.length})
+                                <Tx
+                                    k="downloadQueue.queuedHeader"
+                                    values={{ count: queueState.queue.length }}
+                                    fallback={`Queued (${queueState.queue.length})`}
+                                />
                             </p>
                             <ul className="space-y-0.5">
                                 {queueState.queue.map((item, index) => (
@@ -301,7 +311,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                                 void handleCancelQueued(item.modId);
                                             }}
                                             className="rounded-md p-1 text-text-secondary opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100 cursor-pointer"
-                                            title="Remove from queue"
+                                            title={t('downloadQueue.removeFromQueue')}
                                         >
                                             <X className="h-3 w-3" />
                                         </button>
@@ -312,7 +322,9 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                     )}
 
                     {!queueState.currentDownload && queueState.queue.length === 0 && (
-                        <p className="px-4 py-3 text-xs text-text-secondary text-center">No downloads</p>
+                        <p className="px-4 py-3 text-xs text-text-secondary text-center">
+                            <Tx k="downloadQueue.noDownloads" fallback="No downloads" />
+                        </p>
                     )}
                 </div>
             )}

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import Tx from '../translation/Tx';
 
 interface ErrorBoundaryProps {
     children: ReactNode;
@@ -54,9 +55,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                     <div className="p-4 bg-red-500/10 rounded-full mb-4">
                         <AlertTriangle className="w-12 h-12 text-red-400" />
                     </div>
-                    <h2 className="text-xl font-bold text-text-primary mb-2">Something went wrong</h2>
+                    <h2 className="text-xl font-bold text-text-primary mb-2">
+                        <Tx k="common.errorBoundary.title" fallback="Something went wrong" />
+                    </h2>
                     <p className="text-text-secondary max-w-md mb-4">
-                        An error occurred while rendering this component. This won't affect other parts of the app.
+                        <Tx
+                            k="common.errorBoundary.description"
+                            fallback="An error occurred while rendering this component. This won't affect other parts of the app."
+                        />
                     </p>
                     {this.state.error && (
                         <pre className="text-xs text-red-400 bg-red-500/5 border border-red-500/20 rounded-lg p-3 mb-4 max-w-lg overflow-auto">
@@ -68,7 +74,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                         className="flex items-center gap-2 px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer"
                     >
                         <RefreshCw className="w-4 h-4" />
-                        Try Again
+                        <Tx k="common.errorBoundary.tryAgain" fallback="Try Again" />
                     </button>
                 </div>
             );

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
 import { type LucideIcon } from 'lucide-react';
 import { Modal } from './Modal';
+import Tx from '../translation/Tx';
 
 // ============================================================================
 // SectionHeader - Consistent section header styling
@@ -72,7 +73,7 @@ export function ViewModeToggle({ value, options, onChange, className = '' }: Vie
 // ============================================================================
 
 interface PageHeaderProps {
-    title: string;
+    title: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     stats?: ReactNode;
@@ -102,7 +103,7 @@ export function PageHeader({ title, description, action, stats, className = '' }
 
 interface EmptyStateProps {
     icon: LucideIcon;
-    title: string;
+    title: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     variant?: 'default' | 'error';
@@ -133,10 +134,10 @@ export function EmptyState({ icon: Icon, title, description, action, variant = '
 
 interface ConfirmModalProps {
     isOpen: boolean;
-    title: string;
+    title: ReactNode;
     message: ReactNode;
-    confirmLabel?: string;
-    cancelLabel?: string;
+    confirmLabel?: ReactNode;
+    cancelLabel?: ReactNode;
     variant?: 'danger' | 'primary';
     onConfirm: () => void;
     onCancel: () => void;
@@ -146,8 +147,8 @@ export function ConfirmModal({
     isOpen,
     title,
     message,
-    confirmLabel = 'Confirm',
-    cancelLabel = 'Cancel',
+    confirmLabel,
+    cancelLabel,
     variant = 'primary',
     onConfirm,
     onCancel,
@@ -172,13 +173,13 @@ export function ConfirmModal({
                     onClick={onCancel}
                     className="px-4 py-2 bg-bg-tertiary border border-border rounded-sm hover:bg-white/10 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                 >
-                    {cancelLabel}
+                    {cancelLabel ?? <Tx k="common.actions.cancel" fallback="Cancel" />}
                 </button>
                 <button
                     onClick={onConfirm}
                     className={`px-4 py-2 rounded-sm font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary ${confirmClass}`}
                 >
-                    {confirmLabel}
+                    {confirmLabel ?? <Tx k="common.actions.confirm" fallback="Confirm" />}
                 </button>
             </div>
         </Modal>

--- a/src/components/common/ToastStack.tsx
+++ b/src/components/common/ToastStack.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { AlertTriangle, Check, Info } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useToastStore, type Toast } from '../../stores/toastStore';
+import Tx from '../translation/Tx';
 
 // Renders the toast queue bottom-center at z-60 (above modals; see the
 // z-index scale in index.css). Mounted once in Layout.
@@ -28,6 +30,7 @@ export function ToastStack() {
 }
 
 function ToastItem({ toast }: { toast: Toast }) {
+  const { t } = useTranslation();
   const dismissToast = useToastStore((s) => s.dismissToast);
   const [closing, setClosing] = useState(false);
 
@@ -61,9 +64,9 @@ function ToastItem({ toast }: { toast: Toast }) {
           type="button"
           onClick={() => dismissToast(toast.id)}
           className="flex-shrink-0 cursor-pointer opacity-70 transition-opacity hover:opacity-100"
-          aria-label="Dismiss"
+          aria-label={t('common.actions.dismiss')}
         >
-          Dismiss
+          <Tx k="common.actions.dismiss" fallback="Dismiss" />
         </button>
       )}
     </div>

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { Check, type LucideIcon } from 'lucide-react';
+import Tx from '../translation/Tx';
 
 interface CardProps {
     children?: ReactNode;
@@ -7,7 +8,7 @@ interface CardProps {
     contentClassName?: string;
     title?: ReactNode;
     icon?: LucideIcon;
-    description?: string;
+    description?: ReactNode;
     action?: ReactNode;
     // Controls the left accent bar. 'subtle' is the default HUD callout look;
     // 'active' makes the bar thicker and full-opacity so it can stand in for a
@@ -125,7 +126,7 @@ export function Tag({
 export function ArchivedTag({ className = '' }: { className?: string }) {
     return (
         <span className={`flex-shrink-0 text-[10px] uppercase tracking-wide bg-bg-primary text-text-secondary rounded px-1.5 py-0.5 border border-border ${className}`}>
-            Archived
+            <Tx k="common.status.archived" fallback="Archived" />
         </span>
     );
 }
@@ -164,7 +165,7 @@ interface SliderProps {
     max: number;
     step?: number;
     onChange: (value: number) => void;
-    label?: string;
+    label?: ReactNode;
     showValue?: boolean;
     className?: string;
     formatValue?: (val: number) => string;
@@ -270,8 +271,8 @@ export function Slider({
 interface ToggleProps {
     checked: boolean;
     onChange: (checked: boolean) => void;
-    label?: string;
-    description?: string;
+    label?: ReactNode;
+    description?: ReactNode;
     className?: string;
     disabled?: boolean;
 }

--- a/src/components/conflicts/ConflictReorderActions.tsx
+++ b/src/components/conflicts/ConflictReorderActions.tsx
@@ -1,5 +1,7 @@
 import { ArrowDownUp, Crown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ModConflict } from '../../lib/api';
+import Tx from '../translation/Tx';
 
 interface ConflictModRef {
   id: string;
@@ -34,6 +36,7 @@ export default function ConflictReorderActions({
   busy,
   onSetWinner,
 }: ConflictReorderActionsProps) {
+  const { t } = useTranslation();
   const aIdx = orderedEnabledIds.indexOf(modA.id);
   const bIdx = orderedEnabledIds.indexOf(modB.id);
   // Reordering only moves mods that hold a load-order slot. A disabled mod has
@@ -44,11 +47,9 @@ export default function ConflictReorderActions({
   const aWins = bothEnabled && aIdx < bIdx;
   const bWins = bothEnabled && bIdx < aIdx;
 
-  const label =
-    conflict.conflictType === 'file' ? 'Wins shared files' : 'Resolve by load order';
   const hint = bothEnabled
-    ? 'The mod that loads first overrides shared files. This sets the pair adjacent in load order.'
-    : 'Enable both mods to set their load order.';
+    ? t('conflicts.reorder.hint')
+    : t('conflicts.reorder.enableBothHint');
 
   const renderButton = (mod: ConflictModRef, other: ConflictModRef, isWinner: boolean) => (
     <button
@@ -57,10 +58,10 @@ export default function ConflictReorderActions({
       disabled={busy || !bothEnabled || isWinner}
       title={
         !bothEnabled
-          ? 'Enable both mods to set their load order.'
+          ? t('conflicts.reorder.enableBothHint')
           : isWinner
-            ? `${mod.name} already wins this conflict`
-            : `Make ${mod.name} win (load it before ${other.name})`
+            ? t('conflicts.reorder.alreadyWins', { name: mod.name })
+            : t('conflicts.reorder.makeWinner', { name: mod.name, other: other.name })
       }
       className={`flex min-w-0 items-center justify-center gap-1.5 rounded-lg border px-2 py-1.5 text-xs font-medium transition-colors ${
         isWinner
@@ -82,7 +83,11 @@ export default function ConflictReorderActions({
         title={hint}
       >
         <ArrowDownUp className="w-3 h-3 flex-shrink-0" />
-        {label}
+        {conflict.conflictType === 'file' ? (
+          <Tx k="conflicts.reorder.winsSharedFiles" fallback="Wins shared files" />
+        ) : (
+          <Tx k="conflicts.reorder.resolveByLoadOrder" fallback="Resolve by load order" />
+        )}
       </div>
       <div className="grid grid-cols-2 gap-2">
         {renderButton(modA, modB, aWins)}

--- a/src/components/servers/ConnectServerDialog.tsx
+++ b/src/components/servers/ConnectServerDialog.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2, X, Download, CheckCircle2, AlertTriangle, Play } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../common/ui';
 import { Modal } from '../common/Modal';
+import Tx from '../translation/Tx';
 import {
   deadworksConnect,
   deadworksOnDownloadProgress,
@@ -15,15 +17,7 @@ interface Props {
 }
 
 type Phase = 'working' | 'done' | 'error';
-
-const STATUS_LABEL: Record<DeadworksConnectProgress['status'], string> = {
-  fetching: 'Checking server content',
-  checking: 'Verifying files',
-  downloading: 'Downloading content',
-  decompressing: 'Unpacking content',
-  ready: 'Ready',
-  connecting: 'Handing off to Steam',
-};
+type MessageKey = 'preparing' | 'launching' | 'connectionFailed';
 
 function formatBytes(n: number): string {
   if (!n || n < 0) return '';
@@ -32,10 +26,29 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
+function renderStatusLabel(status: DeadworksConnectProgress['status']) {
+  switch (status) {
+    case 'checking':
+      return <Tx k="servers.connect.status.checking" fallback="Verifying files" />;
+    case 'downloading':
+      return <Tx k="servers.connect.status.downloading" fallback="Downloading content" />;
+    case 'decompressing':
+      return <Tx k="servers.connect.status.decompressing" fallback="Unpacking content" />;
+    case 'ready':
+      return <Tx k="servers.connect.status.ready" fallback="Ready" />;
+    case 'connecting':
+      return <Tx k="servers.connect.status.connecting" fallback="Handing off to Steam" />;
+    default:
+      return <Tx k="servers.connect.status.fetching" fallback="Checking server content" />;
+  }
+}
+
 export default function ConnectServerDialog({ server, onClose }: Props) {
+  const { t } = useTranslation();
   const [progress, setProgress] = useState<DeadworksConnectProgress | null>(null);
   const [phase, setPhase] = useState<Phase>('working');
-  const [message, setMessage] = useState('Preparing to connect...');
+  const [messageKey, setMessageKey] = useState<MessageKey>('preparing');
+  const [messageText, setMessageText] = useState('');
   const startedRef = useRef(false);
 
   useEffect(() => {
@@ -48,15 +61,21 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
         .then((result) => {
           if (result.success) {
             setPhase('done');
-            setMessage('Launching Deadlock through Steam. Accept any Steam prompt to join.');
+            setMessageKey('launching');
+            setMessageText('');
           } else {
             setPhase('error');
-            setMessage(result.message);
+            setMessageText(result.message);
           }
         })
         .catch((e: unknown) => {
           setPhase('error');
-          setMessage(e instanceof Error ? e.message : 'Connection failed.');
+          if (e instanceof Error) {
+            setMessageText(e.message);
+          } else {
+            setMessageKey('connectionFailed');
+            setMessageText('');
+          }
         });
     }
 
@@ -70,6 +89,13 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
       ? Math.min(100, Math.round((progress.bytesDownloaded / progress.totalBytes) * 100))
       : null;
   const indeterminate = progress?.status === 'decompressing';
+  const message = messageText || (
+    messageKey === 'launching'
+      ? t('servers.connect.launchingSteam')
+      : messageKey === 'connectionFailed'
+        ? t('servers.connect.connectionFailed')
+        : t('servers.connect.preparingToConnect')
+  );
 
   return (
     <Modal
@@ -85,7 +111,7 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
             onClick={onClose}
             disabled={phase === 'working'}
             className="rounded-sm p-1 text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed"
-            aria-label="Close"
+            aria-label={t('common.actions.close')}
           >
             <X size={18} />
           </button>
@@ -102,7 +128,11 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
                 )}
                 <div className="min-w-0">
                   <div className="text-sm font-medium">
-                    {progress ? STATUS_LABEL[progress.status] : 'Preparing...'}
+                    {progress ? (
+                      renderStatusLabel(progress.status)
+                    ) : (
+                      <Tx k="servers.connect.preparing" fallback="Preparing..." />
+                    )}
                   </div>
                   {progress?.name && (
                     <div className="truncate text-xs text-text-secondary">
@@ -144,7 +174,7 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
               <CheckCircle2 size={40} className="text-green-400" />
               <p className="text-sm text-text-secondary">{message}</p>
               <Button variant="primary" icon={Play} onClick={onClose} className="mt-2">
-                Done
+                <Tx k="common.actions.done" fallback="Done" />
               </Button>
             </div>
           )}
@@ -154,7 +184,7 @@ export default function ConnectServerDialog({ server, onClose }: Props) {
               <AlertTriangle size={40} className="text-red-500" />
               <p className="text-sm text-text-secondary">{message}</p>
               <Button variant="secondary" onClick={onClose} className="mt-2">
-                Close
+                <Tx k="common.actions.close" fallback="Close" />
               </Button>
             </div>
           )}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,6 +1,46 @@
 {
   "common": {
-    "view": "View"
+    "view": "View",
+    "actions": {
+      "cancel": "Cancel",
+      "clear": "Clear",
+      "close": "Close",
+      "confirm": "Confirm",
+      "copy": "Copy",
+      "delete": "Delete",
+      "dismiss": "Dismiss",
+      "done": "Done",
+      "apply": "Apply",
+      "browse": "Browse",
+      "remove": "Remove",
+      "refresh": "Refresh",
+      "reset": "Reset",
+      "retry": "Retry",
+      "save": "Save",
+      "collapseDetails": "Collapse details",
+      "expandDetails": "Expand details",
+      "tryAgain": "Try again"
+    },
+    "errorBoundary": {
+      "title": "Something went wrong",
+      "description": "An error occurred while rendering this component. This won't affect other parts of the app.",
+      "tryAgain": "Try Again"
+    },
+    "status": {
+      "active": "Active",
+      "archived": "Archived",
+      "checking": "Checking...",
+      "configured": "Configured",
+      "copied": "Copied",
+      "inactive": "Inactive",
+      "invalid": "Invalid",
+      "missing": "Missing",
+      "valid": "Valid"
+    },
+    "emptyValue": "(empty)",
+    "none": "None",
+    "versus": "VS",
+    "versusLower": "vs"
   },
   "nav": {
     "installed": "Installed",
@@ -15,14 +55,419 @@
     "stats": "Stats",
     "settings": "Settings"
   },
+  "autoexec": {
+    "commands": {
+      "emptyTitle": "No commands added",
+      "emptyDescription": "Select from presets on the left",
+      "title_one": "Your Commands ({{count}})",
+      "title_other": "Your Commands ({{count}})"
+    },
+    "confirm": {
+      "clearTitle": "Clear all commands?",
+      "clearMessage_one": "Remove {{count}} command from the list? Your saved autoexec.cfg won't change until you click Save.",
+      "clearMessage_other": "Remove all {{count}} commands from the list? Your saved autoexec.cfg won't change until you click Save."
+    },
+    "customCommand": {
+      "title": "Custom Command",
+      "placeholder": "e.g. fps_max 0"
+    },
+    "launchOptions": {
+      "description": "Args passed to Deadlock when launched via Steam. Written into Steam's config right before grimoire launches the game.",
+      "inSteamNow": "In Steam now",
+      "saved": "Saved. Applied next time you launch Deadlock via grimoire.",
+      "savedWillOverwrite": "Your saved value will overwrite this on next grimoire launch.",
+      "steamConfigMissing": "Steam config not found. Launch Deadlock via Steam once, then come back.",
+      "steamRunning": "Steam is running. Close it before launching Deadlock via grimoire so the write isn't clobbered.",
+      "title": "Launch Options"
+    },
+    "presets": {
+      "performance": {
+        "category": "Performance",
+        "uncapFps": { "name": "Uncap FPS", "description": "Remove framerate limit" },
+        "capFps144": { "name": "Cap FPS 144", "description": "Cap to 144 FPS" },
+        "capFps240": { "name": "Cap FPS 240", "description": "Cap to 240 FPS" },
+        "lowLatencyNvidia": { "name": "Low Latency (Nvidia)", "description": "Enable Nvidia Reflex low latency" },
+        "engineLowLatency": { "name": "Engine Low Latency", "description": "Reduce input lag" }
+      },
+      "network": {
+        "category": "Network",
+        "maxNetworkRate": { "name": "Max Network Rate", "description": "Maximum network update rate" }
+      },
+      "hud": {
+        "category": "HUD & UI",
+        "newHealthBars": { "name": "New Health Bars", "description": "Enable new-style health bars" },
+        "hideHud": { "name": "Hide HUD", "description": "Hide the entire HUD" },
+        "showHud": { "name": "Show HUD", "description": "Show the HUD" },
+        "disablePostMatchSurvey": { "name": "Disable Post-Match Survey", "description": "Skip the survey after matches" }
+      },
+      "minimap": {
+        "category": "Minimap",
+        "fasterMinimap": { "name": "Faster Minimap", "description": "Update minimap at 60Hz" },
+        "largerClickRadius": { "name": "Larger Click Radius", "description": "Easier to click units on minimap" },
+        "largerPlayerIcons": { "name": "Larger Player Icons", "description": "Bigger player icons on minimap" },
+        "thickerZiplines": { "name": "Thicker Ziplines", "description": "More visible ziplines" }
+      },
+      "matchmaking": {
+        "category": "Matchmaking",
+        "soloQueueOnly": { "name": "Solo Queue Only", "description": "Prefer matches with solo players" },
+        "naRegion": { "name": "NA Region", "description": "Force North America servers" },
+        "euRegion": { "name": "EU Region", "description": "Force Europe servers" },
+        "asiaRegion": { "name": "Asia Region", "description": "Force Asia servers" },
+        "autoRegion": { "name": "Auto Region", "description": "Automatic region selection" }
+      },
+      "mouse": {
+        "category": "Mouse & Sensitivity",
+        "adsSensitivity": { "name": "1:1 ADS Sensitivity", "description": "Match ADS to hip-fire sensitivity" }
+      }
+    },
+    "search": {
+      "placeholder": "Search commands..."
+    },
+    "status": {
+      "error": "Error: {{error}}",
+      "gamePathNotConfigured": "Game path not configured",
+      "gamePathWarning": "Game path not configured. Set it in Settings to save.",
+      "savedToAutoexec": "Saved to autoexec.cfg!",
+      "unsavedChanges": "You have unsaved changes"
+    }
+  },
+  "downloadQueue": {
+    "cancelDownload": "Cancel download",
+    "collapse": "Collapse",
+    "downloads": "Downloads",
+    "eta": {
+      "seconds_one": "{{count}}s",
+      "seconds_other": "{{count}}s",
+      "minutesSeconds": "{{minutes}}m {{seconds}}s",
+      "hoursMinutes": "{{hours}}h {{minutes}}m",
+      "left": "{{eta}} left"
+    },
+    "noDownloads": "No downloads",
+    "preparing": "Preparing…",
+    "queuedHeader_one": "Queued ({{count}})",
+    "queuedHeader_other": "Queued ({{count}})",
+    "remainingQueued_one": "{{count}} queued",
+    "remainingQueued_other": "{{count}} queued",
+    "removeFromQueue": "Remove from queue",
+    "showDetails": "Show download details"
+  },
+  "stats": {
+    "title": "Deadlock Stats",
+    "tabs": {
+      "overview": "Overview",
+      "matches": "Matches",
+      "social": "Social",
+      "leaderboard": "Leaderboard"
+    },
+    "empty": {
+      "noPlayerSelected": {
+        "title": "No player selected",
+        "description": "Add a player from the dropdown in the top right to see their stats."
+      }
+    },
+    "error": {
+      "playerDataTitle": "Failed to load player data"
+    }
+  },
+  "servers": {
+    "actions": {
+      "join": "Join"
+    },
+    "connect": {
+      "connectionFailed": "Connection failed.",
+      "launchingSteam": "Launching Deadlock through Steam. Accept any Steam prompt to join.",
+      "preparing": "Preparing...",
+      "preparingToConnect": "Preparing to connect...",
+      "status": {
+        "checking": "Verifying files",
+        "connecting": "Handing off to Steam",
+        "decompressing": "Unpacking content",
+        "downloading": "Downloading content",
+        "fetching": "Checking server content",
+        "ready": "Ready"
+      }
+    },
+    "contentCount_one": "{{count}} content",
+    "contentCount_other": "{{count}} content",
+    "empty": {
+      "filtersTitle": "No servers match your filters",
+      "filtersDescription": "Try clearing the search, region, or map filter.",
+      "noneTitle": "No servers online",
+      "noneDescription": "No Deadworks servers are currently registered. Check back later, or host one (server hosting requires Windows)."
+    },
+    "errors": {
+      "relayTitle": "Could not reach the relay",
+      "relayUnreachable": "Could not reach the relay."
+    },
+    "filters": {
+      "allMaps": "All maps",
+      "allRegions": "All regions",
+      "hasSpace": "Has space",
+      "searchPlaceholder": "Search by name or map"
+    },
+    "header": {
+      "description": "Browse and join Deadworks community dedicated servers.",
+      "playersOnline_one": "{{count}} playing",
+      "playersOnline_other": "{{count}} playing",
+      "serversOnline_one": "{{count}} online",
+      "serversOnline_other": "{{count}} online"
+    },
+    "join": {
+      "serverFull": "Server is full",
+      "setGamePathFirst": "Set your game path first"
+    },
+    "loading": "Loading servers...",
+    "ping": {
+      "ms": "{{ms}} ms",
+      "unavailable": "n/a"
+    },
+    "status": {
+      "online": "Online",
+      "passwordProtected": "Password protected",
+      "stale": "Stale"
+    },
+    "table": {
+      "server": "Server",
+      "map": "Map",
+      "players": "Players",
+      "ping": "Ping"
+    },
+    "warning": {
+      "gamePathRequired": "Set your Deadlock game path in Settings before joining a server."
+    }
+  },
+  "conflicts": {
+    "actions": {
+      "clearIgnored": "Clear ignored",
+      "clearing": "Clearing…",
+      "disable": "Disable",
+      "disableNamed": "Disable {{name}}",
+      "disabling": "Disabling…",
+      "ignore": "Ignore",
+      "ignoreAll": "Ignore all",
+      "ignoreAllTitle": "Move every active conflict pair to the Ignored section. Reversible per-pair via Unignore.",
+      "ignoreCount_one": "Ignore {{count}}",
+      "ignoreCount_other": "Ignore {{count}}",
+      "ignoreTitle": "Stop flagging this pair as a conflict",
+      "ignoring": "Ignoring…",
+      "unignore": "Unignore"
+    },
+    "confirm": {
+      "clearIgnoredHint": "Pairs that still conflict will reappear in the active list after refresh.",
+      "clearIgnoredMessage": "Every ignored pair will be restored to normal conflict detection.",
+      "clearIgnoredTitle_one": "Clear {{count}} ignored conflict?",
+      "clearIgnoredTitle_other": "Clear {{count}} ignored conflicts?",
+      "disableMessage": "{{name}} will be disabled and moved out of the addons folder. You can re-enable it from the Installed page.",
+      "disableTitle": "Disable this mod?",
+      "ignoreAllHint": "Reversible — you can restore any pair individually with Unignore.",
+      "ignoreAllMessage": "Every currently active conflict pair will move to the Ignored section below.",
+      "ignoreAllTitle_one": "Ignore all {{count}} conflict?",
+      "ignoreAllTitle_other": "Ignore all {{count}} conflicts?"
+    },
+    "empty": {
+      "activeWithIgnored_one": "No active conflicts. {{count}} pair currently ignored — see below.",
+      "activeWithIgnored_other": "No active conflicts. {{count}} pairs currently ignored — see below.",
+      "noActive": "No active conflicts.",
+      "noConflicts": {
+        "title": "No Conflicts Detected",
+        "description": "Your installed mods don't have any conflicts. Great!"
+      }
+    },
+    "errors": {
+      "bothModsEnabled": "Both mods must be enabled to set their load order.",
+      "clearIgnoredFailed_one": "Failed to clear {{count}} ignored pair. See console for details.",
+      "clearIgnoredFailed_other": "Failed to clear {{count}} ignored pairs. See console for details.",
+      "ignoreFailed_one": "Failed to ignore {{count}} pair. See console for details.",
+      "ignoreFailed_other": "Failed to ignore {{count}} pairs. See console for details."
+    },
+    "errorTitle": "Error Loading Conflicts",
+    "header": {
+      "description": "Resolve conflicts between installed mods",
+      "noActiveDescription": "No active conflicts — review or restore your ignored pairs below."
+    },
+    "ignored": {
+      "clearTitle": "Restore conflict detection for every ignored pair",
+      "title_one": "Ignored ({{count}})",
+      "title_other": "Ignored ({{count}})",
+      "unignoreTitle": "Restore conflict detection for this pair"
+    },
+    "noPreview": "No Preview",
+    "removedMod": "(removed mod)",
+    "reorder": {
+      "alreadyWins": "{{name}} already wins this conflict",
+      "enableBothHint": "Enable both mods to set their load order.",
+      "hint": "The mod that loads first overrides shared files. This sets the pair adjacent in load order.",
+      "makeWinner": "Make {{name}} win (load it before {{other}})",
+      "resolveByLoadOrder": "Resolve by load order",
+      "winsSharedFiles": "Wins shared files"
+    },
+    "title_one": "Conflicts ({{count}})",
+    "title_other": "Conflicts ({{count}})",
+    "view": {
+      "grid": "Grid view",
+      "list": "List view"
+    }
+  },
   "settings": {
+    "header": {
+      "description": "Game paths, preferences, and maintenance"
+    },
+    "sections": {
+      "gameConfiguration": "Game Configuration",
+      "updates": "Updates",
+      "appearance": "Appearance",
+      "grimoireSocial": "Grimoire Social",
+      "preferences": "Preferences",
+      "experimentalFeatures": "Experimental Features",
+      "support": "Support",
+      "maintenance": "Maintenance",
+      "modDatabaseCache": "Mod Database Cache",
+      "localPreviewCache": "Local preview cache"
+    },
     "language": {
       "label": "Language",
       "description": "Choose the app language, or follow your system preference.",
       "systemDefault": "System default"
     },
-    "header": {
-      "description": "Game paths, preferences, and maintenance"
+    "gamePath": {
+      "selectFolder": "Select Deadlock folder",
+      "label": "Deadlock Installation Path",
+      "autoDetect": "Auto-detect",
+      "devModeActive": "Dev mode is active. Deadlock path selection is disabled.",
+      "selectHint": "Select your Deadlock game folder (contains the 'game' directory)",
+      "openGameFolder": "Open Game Folder"
+    },
+    "gameinfo": {
+      "checkingStatus": "Checking gameinfo.gi status...",
+      "title": "gameinfo.gi Status",
+      "issuesFound": "Issues Found",
+      "verifySteam": "In Steam: right-click Deadlock > Properties > Installed Files > Verify integrity of game files.",
+      "foundNearby": "Found nearby: {{candidates}}. Rename one to gameinfo.gi to restore.",
+      "fixConfiguration": "Fix Configuration"
+    },
+    "updates": {
+      "releaseNotesTitle": "View release notes for {{version}}",
+      "currentVersion": "Current Version",
+      "available": "available!",
+      "readyToInstall": "ready to install",
+      "upToDate": "You're up to date!",
+      "whatsNew": "What's New",
+      "installRestart": "Install & Restart",
+      "downloadUpdate": "Download Update",
+      "checkForUpdates": "Check for Updates",
+      "managed": "Updates are managed by your package manager.",
+      "managedPrefix": "Grimoire was installed via a system package. Update with your distro's tools:",
+      "onArchOr": "on Arch, or",
+      "onDebianUbuntu": "on Debian/Ubuntu.",
+      "installedDebPrefix": "Installed the",
+      "installedDebSuffix": "manually? Add the apt repository for automatic updates (instructions at",
+      "downloading": "Downloading update...",
+      "whatsNewIn": "What's New in",
+      "released": "Released {{date}}",
+      "noReleaseNotes": "No release notes available."
+    },
+    "appearance": {
+      "accentNamed": "Use {{name}} accent color",
+      "pickCustomColor": "Pick custom color",
+      "accentCustom": "Custom accent",
+      "sidebarHighlightNamed": "Sidebar highlight: {{hero}}",
+      "sidebarHighlightNone": "No sidebar highlight",
+      "customAccentColor": "Custom accent color",
+      "selectedColorPreview": "Selected color preview",
+      "closeSidebarHighlightPicker": "Close sidebar highlight picker",
+      "customAccent": "Custom Accent",
+      "sidebarHighlight": "Sidebar Highlight"
+    },
+    "preferences": {
+      "hideNsfw": "Hide NSFW Content",
+      "hideNsfwDescription": "Blur thumbnail images for mods marked as NSFW.",
+      "hideOutdated": "Hide Outdated Mods",
+      "expandLocker": "Expand Locker cards by default",
+      "switchVariants": "Switch variants instead of stacking them",
+      "enableAfterDownload": "Enable mods after download",
+      "confirmProfileUpdate": "Confirm before updating a profile",
+      "ignoreConflicts": "Ignore conflicts by default",
+      "discordRpc": "Discord Rich Presence",
+      "contributeMatchData": "Contribute match data to deadlock-api.com",
+      "saltsContributed_one": "{{count}} match key contributed.",
+      "saltsContributed_other": "{{count}} match keys contributed.",
+      "noSaltsYet": "Nothing to contribute yet. Salts appear after you view matches in-game.",
+      "lastSaltAttemptFailed": "Last upload failed: {{error}}",
+      "developerMode": "Developer Mode",
+      "developerModeDescription": "Use a dummy Deadlock directory for local testing without game files.",
+      "dateFormat": "Date Format",
+      "dateFormatDescription": "How upload and update dates are shown on mods and files."
+    },
+    "translationMode": {
+      "chooseLanguage": "Choose a language",
+      "targetLanguage": "Target language",
+      "pickLanguageDescription": "Pick the language that should receive your translation suggestions."
+    },
+    "experimental": {
+      "description": "These features are still in development and may be incomplete or buggy.",
+      "statsDashboard": "Stats Dashboard",
+      "statsDashboardDescription": "Track your performance with data from the Deadlock Stats API.",
+      "crosshairDesigner": "Crosshair Designer",
+      "crosshairDesignerDescription": "Create custom crosshairs with a live preview.",
+      "socialDescription": "Sign in with Steam to publish profiles and browse uploads from other players in Discover.",
+      "translationMode": "Translation Mode",
+      "fixUnknownMods": "Fix Unknown Mods",
+      "deadworksServers": "Deadworks Servers",
+      "performanceConfig": "Performance Config"
+    },
+    "support": {
+      "reportBuildFailed": "Failed to build report: {{error}}",
+      "bugReportTitle": "Grimoire bug report",
+      "bugPlaceholder": "Describe what went wrong...",
+      "description": "Found a bug or have a feature request? File an issue on GitHub or drop into our Discord.",
+      "githubIssues": "GitHub Issues",
+      "joinDiscord": "Join Discord",
+      "shareBugReport": "Share a bug report",
+      "bugReportDescription": "Describe what went wrong, generate a sanitized report, then paste it into Discord or a GitHub issue. The report bundles app and OS info plus the tail of your log; home paths, Steam IDs, bearer tokens, and emails are stripped before it leaves the app.",
+      "regenerateReport": "Regenerate report",
+      "generateReport": "Generate report",
+      "includeFullLog": "Include full log (up to 5 MB; Discord auto-attaches as a file)",
+      "reviewBeforeSharing": "Review before sharing. Nothing is sent automatically.",
+      "copyFailed": "Copy failed: select and Ctrl+C",
+      "copyReport": "Copy report",
+      "openDiscord": "Open Discord",
+      "openGithubIssue": "Open GitHub issue"
+    },
+    "maintenance": {
+      "archivesRemoved_one": "Removed {{count}} archive.",
+      "archivesRemoved_other": "Removed {{count}} archives.",
+      "cleanupAddons": "Cleanup Addons Folder",
+      "cleanupDescription": "Remove leftover archive downloads (zip, 7z).",
+      "cleanup": "Cleanup"
+    },
+    "setupWizard": {
+      "resetResult": "Setup wizard will show on next launch.",
+      "title": "Reset Setup Wizard",
+      "description": "Show the first-run setup wizard again on next app launch.",
+      "confirmTitle": "Reset setup wizard?",
+      "confirmMessage": "The first-run setup wizard will appear the next time you launch the app. Your settings and installed mods are not affected."
+    },
+    "cache": {
+      "cleared": "Cache cleared.",
+      "previewCleared": "Cleared {{size}} from preview cache.",
+      "lastSynchronized": "Last synchronized {{date}}",
+      "neverSynchronized": "Never synchronized",
+      "syncingSection": "Syncing {{section}}",
+      "cachedMods": "Cached Mods",
+      "wipeCache": "Wipe Cache",
+      "syncDatabase": "Sync Database",
+      "onDisk": "On Disk",
+      "previewDescription": "3D model stills, hero portraits, and locker card thumbnails. These rebuild automatically from your installed mods when next viewed. Your installed mods are not affected.",
+      "wipeTitle": "Wipe mod cache?",
+      "wipeMessage": "Removes cached mod metadata and sync state. Browse re-syncs from GameBanana next time. Installed mods are not affected.",
+      "clearPreviewTitle": "Clear preview cache?",
+      "clearPreviewMessage": "Deletes cached preview images to reclaim disk. They regenerate when you next view them. Installed mods are not affected."
+    },
+    "autoexec": {
+      "created": "Created {{path}}",
+      "title": "Autoexec Configuration",
+      "description": "Ensure autoexec.cfg exists for crosshairs and commands.",
+      "createFile": "Create File"
     },
     "toggles": {
       "hideOutdated": "Hide Browse mods older than the current game version.",
@@ -37,16 +482,79 @@
       "fixUnknown": "Match unknown local VPKs against GameBanana to recover names and thumbnails. May hit rate limits on large libraries.",
       "deadworks": "Add a Servers tab to browse and join Deadworks community servers. Required content downloads before connecting.",
       "performanceConfig": "One-click fps boost using Sqooky's community preset. Mods keep working. Remove any time."
-    },
-    "cache": {
-      "wipeMessage": "Removes cached mod metadata and sync state. Browse re-syncs from GameBanana next time. Installed mods are not affected.",
-      "clearPreviewMessage": "Deletes cached preview images to reclaim disk. They regenerate when you next view them. Installed mods are not affected."
     }
   },
   "crosshair": {
+    "actions": {
+      "applyToGame": "Apply to Game",
+      "copyCode": "Copy Code",
+      "importFromGame": "Import from Game",
+      "importTitle": "Load your current in-game crosshair settings into the editor",
+      "saveAsNewPreset": "Save as New Preset"
+    },
+    "alert": {
+      "applyPresetFailed": "Failed to apply preset. Make sure the game path is correct.",
+      "clearFailed": "Failed to clear crosshair. Check the game path in Settings.",
+      "configureGamePath": "Please configure your Deadlock game path in Settings first.",
+      "noSettingsFound": "No crosshair settings found in the game config. Change any crosshair setting in-game once, then try again.",
+      "readConfigFailed": "Failed to read the game config. Check the game path in Settings."
+    },
+    "colors": {
+      "blue": "Blue",
+      "cyan": "Cyan",
+      "green": "Green",
+      "magenta": "Magenta",
+      "red": "Red",
+      "white": "White",
+      "yellow": "Yellow"
+    },
+    "confirm": {
+      "clearActive": "Remove the active crosshair from autoexec.cfg? Your saved presets will be kept.\n\nNote: an in-progress game session keeps its current crosshair until you restart the game.",
+      "deletePreset": "Delete this crosshair preset?"
+    },
+    "controls": {
+      "gap": "Gap",
+      "height": "Height",
+      "opacity": "Opacity",
+      "outlineColor": "Outline color",
+      "outlineGap": "Outline Gap",
+      "outlineOpacity": "Outline Opacity",
+      "outlineWidth": "Outline Width",
+      "size": "Size",
+      "width": "Width"
+    },
+    "hints": {
+      "pressF7": "Press F7 in-game"
+    },
+    "presetNamePlaceholder": "Name...",
+    "presets": {
+      "deselectActive": "Deselect Active",
+      "deselectTitle": "Remove the active crosshair from autoexec.cfg (presets are kept)",
+      "savedTitle_one": "Saved Presets ({{count}})",
+      "savedTitle_other": "Saved Presets ({{count}})"
+    },
+    "preview": {
+      "description": "Preview approximates the in-game crosshair at the selected resolution. Dynamic spread bloom is not simulated.",
+      "pinned": "Pinned",
+      "pinTitle": "Keep the mod manager window on top of the game for quick adjustments",
+      "pinWindow": "Pin Window",
+      "resolutionTitle": "Render the preview at this display resolution's in-game size",
+      "zoom": "Zoom:"
+    },
+    "sections": {
+      "centerDot": "Center Dot",
+      "color": "Color",
+      "inGameBehavior": "In-Game Behavior",
+      "shape": "Crosshair Shape"
+    },
+    "status": {
+      "imported": "Imported"
+    },
     "toggles": {
       "staticGap": "Keep the gap fixed. Off lets it expand with weapon spread (not shown in preview).",
-      "disableHeroCrosshairs": "Force your custom crosshair on heroes that override it."
+      "staticGapLabel": "Static Gap",
+      "disableHeroCrosshairs": "Force your custom crosshair on heroes that override it.",
+      "disableHeroCrosshairsLabel": "Disable Hero Crosshairs"
     }
   },
   "installed": {
@@ -61,8 +569,116 @@
     }
   },
   "profiles": {
+    "loading": "Loading profiles...",
+    "thisProfile": "this profile",
+    "updated": "Updated",
+    "errors": {
+      "loadSnapshotFailed": "Failed to load snapshot: {{error}}",
+      "captureSnapshotFailed": "Failed to capture snapshot: {{error}}",
+      "deleteSnapshotFailed": "Failed to delete snapshot: {{error}}",
+      "bulkDeleteSnapshotsFailed": "Failed to delete {{failed}} of {{total}} snapshots: {{error}}"
+    },
+    "create": {
+      "title": "Create New Profile",
+      "placeholder": "Enter profile name, e.g. Competitive, Casual",
+      "profileName": "Profile name",
+      "submit": "Create Profile"
+    },
+    "import": {
+      "title": "Import a portable profile from a share code or file"
+    },
     "empty": {
+      "title": "No Profiles Yet",
       "noProfiles": "Create a profile to save your current mod setup."
+    },
+    "actions": {
+      "import": "Import",
+      "renameProfile": "Rename profile",
+      "cancelRename": "Cancel rename",
+      "reapplyTitle": "Re-apply this profile",
+      "updateTitle": "Overwrite this profile with your current mods",
+      "exportTitle": "Export/share profile",
+      "exportProfile": "Export Profile",
+      "publishToDiscover": "Publish to Discover",
+      "deleteProfile": "Delete profile",
+      "deleteCount_one": "Delete {{count}}",
+      "deleteCount_other": "Delete {{count}}",
+      "restore": "Restore",
+      "reapply": "Re-apply",
+      "apply": "Apply",
+      "update": "Update",
+      "deleting": "Deleting..."
+    },
+    "snapshots": {
+      "title_zero": "Snapshots",
+      "title_one": "Snapshots ({{count}})",
+      "title_other": "Snapshots ({{count}})",
+      "snapshotNowTitle": "Capture your current installed mods now. Use this before experimenting.",
+      "snapshotNow": "Snapshot now",
+      "collapse": "Collapse snapshots",
+      "expand": "Expand snapshots",
+      "collapseList": "Collapse snapshot list",
+      "showAll": "Show all snapshots",
+      "tooltip": "Snapshots are automatic recovery points taken before updates or profile applies.",
+      "collapsedEmpty": "Automatic recovery points captured before updates or profile applies. None yet - one will appear here the next time you run either.",
+      "mostRecent_one": "Most recent: {{date}} - {{count}} mod.",
+      "mostRecent_other": "Most recent: {{date}} - {{count}} mods.",
+      "expandedEmpty": "Grimoire takes a snapshot of your installed mod set automatically before each mod update and before applying a profile. Restore re-downloads those mods from GameBanana, so a bad update or wrong profile can be rolled back. Snapshots store only mod IDs, not VPK files, so disk cost stays tiny. You can also capture one manually before experimenting.",
+      "selectToBulkDelete_one": "Select to bulk delete ({{count}})",
+      "selectToBulkDelete_other": "Select to bulk delete ({{count}})",
+      "selected_one": "{{count}} selected",
+      "selected_other": "{{count}} selected",
+      "clearSelection": "Clear selection",
+      "selectAll": "Select all snapshots",
+      "deleteSelectedTitle_one": "Delete {{count}} selected snapshot",
+      "deleteSelectedTitle_other": "Delete {{count}} selected snapshots",
+      "trigger": {
+        "preUpdate": "Before mod update",
+        "preApplyProfile": "Before applying profile",
+        "manual": "Manual snapshot"
+      },
+      "explanation": {
+        "preUpdate": "Captured before a mod update changed your installed set.",
+        "preApplyProfile": "Captured before applying a profile changed your installed set.",
+        "manual": "Captured manually from the Profiles page."
+      },
+      "unselect": "Unselect snapshot",
+      "select": "Select snapshot",
+      "restoreTitle": "Opens the import dialog with this snapshot preloaded",
+      "deleteTitle": "Delete snapshot",
+      "delete": "Delete snapshot"
+    },
+    "mods": {
+      "label": "Mods",
+      "count_one": "{{count}} mod",
+      "count_other": "{{count}} mods",
+      "groupsAndFiles": "Mods ({{mods}}, {{files}} files)",
+      "groups_one": "Mods ({{count}})",
+      "groups_other": "Mods ({{count}})",
+      "files_one": "{{count}} file",
+      "files_other": "{{count}} files",
+      "empty": "No mods in profile"
+    },
+    "autoexec": {
+      "includesTitle": "Includes autoexec commands",
+      "count_one": "Autoexec ({{count}})",
+      "count_other": "Autoexec ({{count}})",
+      "commandsCount_one": "Autoexec ({{count}} command)",
+      "commandsCount_other": "Autoexec ({{count}} commands)"
+    },
+    "crosshair": {
+      "summary": "Gap: {{gap}} | Height: {{height}} | Width: {{width}}"
+    },
+    "confirm": {
+      "updateTitle": "Update Profile",
+      "updateMessage": "Overwrite {{name}} with your currently enabled mods? The profile's saved mod list will be replaced and can't be undone. To load this profile onto your install instead, use Apply. You can turn this prompt off in Settings -> Preferences.",
+      "deleteTitle": "Delete Profile",
+      "deleteMessage": "Are you sure you want to delete this profile? This action cannot be undone.",
+      "deleteSnapshotTitle": "Delete Snapshot",
+      "deleteSnapshotMessage": "Delete this recovery snapshot? You won't be able to restore from it later.",
+      "deleteSelectedSnapshotsTitle": "Delete Selected Snapshots",
+      "deleteSelectedSnapshotsMessage_one": "Delete {{count}} snapshot? Your installed mods are unaffected. You won't be able to restore from the deleted snapshot later.",
+      "deleteSelectedSnapshotsMessage_other": "Delete {{count}} snapshots? Your installed mods are unaffected. You won't be able to restore from the deleted snapshots later."
     }
   },
   "social": {

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -1,67 +1,75 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket } from 'lucide-react';
 import { getSettings, setSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
 import { ConfirmModal } from '../components/common/PageComponents';
+import Tx from '../components/translation/Tx';
 import type { AppSettings } from '../types/mod';
 import type { SteamLaunchOptionsStatus } from '../types/electron';
 
 // Popular Deadlock autoexec command presets
 const COMMAND_PRESETS = [
     {
-        category: 'Performance',
+        categoryKey: 'autoexec.presets.performance.category',
+        categoryFallback: 'Performance',
         icon: Zap,
         commands: [
-            { name: 'Uncap FPS', command: 'fps_max 0', description: 'Remove framerate limit' },
-            { name: 'Cap FPS 144', command: 'fps_max 144', description: 'Cap to 144 FPS' },
-            { name: 'Cap FPS 240', command: 'fps_max 240', description: 'Cap to 240 FPS' },
-            { name: 'Low Latency (Nvidia)', command: 'r_low_latency 2', description: 'Enable Nvidia Reflex low latency' },
-            { name: 'Engine Low Latency', command: 'engine_low_latency_sleep_after_client_tick true', description: 'Reduce input lag' },
+            { nameKey: 'autoexec.presets.performance.uncapFps.name', nameFallback: 'Uncap FPS', command: 'fps_max 0', descriptionKey: 'autoexec.presets.performance.uncapFps.description', descriptionFallback: 'Remove framerate limit' },
+            { nameKey: 'autoexec.presets.performance.capFps144.name', nameFallback: 'Cap FPS 144', command: 'fps_max 144', descriptionKey: 'autoexec.presets.performance.capFps144.description', descriptionFallback: 'Cap to 144 FPS' },
+            { nameKey: 'autoexec.presets.performance.capFps240.name', nameFallback: 'Cap FPS 240', command: 'fps_max 240', descriptionKey: 'autoexec.presets.performance.capFps240.description', descriptionFallback: 'Cap to 240 FPS' },
+            { nameKey: 'autoexec.presets.performance.lowLatencyNvidia.name', nameFallback: 'Low Latency (Nvidia)', command: 'r_low_latency 2', descriptionKey: 'autoexec.presets.performance.lowLatencyNvidia.description', descriptionFallback: 'Enable Nvidia Reflex low latency' },
+            { nameKey: 'autoexec.presets.performance.engineLowLatency.name', nameFallback: 'Engine Low Latency', command: 'engine_low_latency_sleep_after_client_tick true', descriptionKey: 'autoexec.presets.performance.engineLowLatency.description', descriptionFallback: 'Reduce input lag' },
         ],
     },
     {
-        category: 'Network',
+        categoryKey: 'autoexec.presets.network.category',
+        categoryFallback: 'Network',
         icon: Globe,
         commands: [
-            { name: 'Max Network Rate', command: 'rate 1000000', description: 'Maximum network update rate' },
+            { nameKey: 'autoexec.presets.network.maxNetworkRate.name', nameFallback: 'Max Network Rate', command: 'rate 1000000', descriptionKey: 'autoexec.presets.network.maxNetworkRate.description', descriptionFallback: 'Maximum network update rate' },
         ],
     },
     {
-        category: 'HUD & UI',
+        categoryKey: 'autoexec.presets.hud.category',
+        categoryFallback: 'HUD & UI',
         icon: Layout,
         commands: [
-            { name: 'New Health Bars', command: 'citadel_unit_status_use_new true', description: 'Enable new-style health bars' },
-            { name: 'Hide HUD', command: 'citadel_hud_visible false', description: 'Hide the entire HUD' },
-            { name: 'Show HUD', command: 'citadel_hud_visible true', description: 'Show the HUD' },
-            { name: 'Disable Post-Match Survey', command: 'deadlock_post_match_survey_disabled true', description: 'Skip the survey after matches' },
+            { nameKey: 'autoexec.presets.hud.newHealthBars.name', nameFallback: 'New Health Bars', command: 'citadel_unit_status_use_new true', descriptionKey: 'autoexec.presets.hud.newHealthBars.description', descriptionFallback: 'Enable new-style health bars' },
+            { nameKey: 'autoexec.presets.hud.hideHud.name', nameFallback: 'Hide HUD', command: 'citadel_hud_visible false', descriptionKey: 'autoexec.presets.hud.hideHud.description', descriptionFallback: 'Hide the entire HUD' },
+            { nameKey: 'autoexec.presets.hud.showHud.name', nameFallback: 'Show HUD', command: 'citadel_hud_visible true', descriptionKey: 'autoexec.presets.hud.showHud.description', descriptionFallback: 'Show the HUD' },
+            { nameKey: 'autoexec.presets.hud.disablePostMatchSurvey.name', nameFallback: 'Disable Post-Match Survey', command: 'deadlock_post_match_survey_disabled true', descriptionKey: 'autoexec.presets.hud.disablePostMatchSurvey.description', descriptionFallback: 'Skip the survey after matches' },
         ],
     },
     {
-        category: 'Minimap',
+        categoryKey: 'autoexec.presets.minimap.category',
+        categoryFallback: 'Minimap',
         icon: Map,
         commands: [
-            { name: 'Faster Minimap', command: 'minimap_update_rate_hz 60', description: 'Update minimap at 60Hz' },
-            { name: 'Larger Click Radius', command: 'citadel_minimap_unit_click_radius 200', description: 'Easier to click units on minimap' },
-            { name: 'Larger Player Icons', command: 'citadel_minimap_player_width 6.5', description: 'Bigger player icons on minimap' },
-            { name: 'Thicker Ziplines', command: 'citadel_minimap_zip_line_thickness 2', description: 'More visible ziplines' },
+            { nameKey: 'autoexec.presets.minimap.fasterMinimap.name', nameFallback: 'Faster Minimap', command: 'minimap_update_rate_hz 60', descriptionKey: 'autoexec.presets.minimap.fasterMinimap.description', descriptionFallback: 'Update minimap at 60Hz' },
+            { nameKey: 'autoexec.presets.minimap.largerClickRadius.name', nameFallback: 'Larger Click Radius', command: 'citadel_minimap_unit_click_radius 200', descriptionKey: 'autoexec.presets.minimap.largerClickRadius.description', descriptionFallback: 'Easier to click units on minimap' },
+            { nameKey: 'autoexec.presets.minimap.largerPlayerIcons.name', nameFallback: 'Larger Player Icons', command: 'citadel_minimap_player_width 6.5', descriptionKey: 'autoexec.presets.minimap.largerPlayerIcons.description', descriptionFallback: 'Bigger player icons on minimap' },
+            { nameKey: 'autoexec.presets.minimap.thickerZiplines.name', nameFallback: 'Thicker Ziplines', command: 'citadel_minimap_zip_line_thickness 2', descriptionKey: 'autoexec.presets.minimap.thickerZiplines.description', descriptionFallback: 'More visible ziplines' },
         ],
     },
     {
-        category: 'Matchmaking',
+        categoryKey: 'autoexec.presets.matchmaking.category',
+        categoryFallback: 'Matchmaking',
         icon: Users,
         commands: [
-            { name: 'Solo Queue Only', command: 'mm_prefer_solo_only 1', description: 'Prefer matches with solo players' },
-            { name: 'NA Region', command: 'citadel_region_override 0', description: 'Force North America servers' },
-            { name: 'EU Region', command: 'citadel_region_override 1', description: 'Force Europe servers' },
-            { name: 'Asia Region', command: 'citadel_region_override 2', description: 'Force Asia servers' },
-            { name: 'Auto Region', command: 'citadel_region_override -1', description: 'Automatic region selection' },
+            { nameKey: 'autoexec.presets.matchmaking.soloQueueOnly.name', nameFallback: 'Solo Queue Only', command: 'mm_prefer_solo_only 1', descriptionKey: 'autoexec.presets.matchmaking.soloQueueOnly.description', descriptionFallback: 'Prefer matches with solo players' },
+            { nameKey: 'autoexec.presets.matchmaking.naRegion.name', nameFallback: 'NA Region', command: 'citadel_region_override 0', descriptionKey: 'autoexec.presets.matchmaking.naRegion.description', descriptionFallback: 'Force North America servers' },
+            { nameKey: 'autoexec.presets.matchmaking.euRegion.name', nameFallback: 'EU Region', command: 'citadel_region_override 1', descriptionKey: 'autoexec.presets.matchmaking.euRegion.description', descriptionFallback: 'Force Europe servers' },
+            { nameKey: 'autoexec.presets.matchmaking.asiaRegion.name', nameFallback: 'Asia Region', command: 'citadel_region_override 2', descriptionKey: 'autoexec.presets.matchmaking.asiaRegion.description', descriptionFallback: 'Force Asia servers' },
+            { nameKey: 'autoexec.presets.matchmaking.autoRegion.name', nameFallback: 'Auto Region', command: 'citadel_region_override -1', descriptionKey: 'autoexec.presets.matchmaking.autoRegion.description', descriptionFallback: 'Automatic region selection' },
         ],
     },
     {
-        category: 'Mouse & Sensitivity',
+        categoryKey: 'autoexec.presets.mouse.category',
+        categoryFallback: 'Mouse & Sensitivity',
         icon: MousePointer2,
         commands: [
-            { name: '1:1 ADS Sensitivity', command: 'zoom_sensitivity_ratio 0.818933027098955175', description: 'Match ADS to hip-fire sensitivity' },
+            { nameKey: 'autoexec.presets.mouse.adsSensitivity.name', nameFallback: '1:1 ADS Sensitivity', command: 'zoom_sensitivity_ratio 0.818933027098955175', descriptionKey: 'autoexec.presets.mouse.adsSensitivity.description', descriptionFallback: 'Match ADS to hip-fire sensitivity' },
         ],
     },
 ];
@@ -73,6 +81,7 @@ interface AutoexecStatus {
 }
 
 export default function Autoexec() {
+    const { t } = useTranslation();
     const [gamePath, setGamePath] = useState<string | null>(null);
     const [status, setStatus] = useState<AutoexecStatus | null>(null);
     const [commands, setCommands] = useState<string[]>([]);
@@ -81,6 +90,7 @@ export default function Autoexec() {
     const [copied, setCopied] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
+    const [saveMessageTone, setSaveMessageTone] = useState<'success' | 'error' | null>(null);
     const [hasUnsaved, setHasUnsaved] = useState(false);
     const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
@@ -92,6 +102,7 @@ export default function Autoexec() {
     const [launchStatus, setLaunchStatus] = useState<SteamLaunchOptionsStatus | null>(null);
     const [launchSaving, setLaunchSaving] = useState(false);
     const [launchMessage, setLaunchMessage] = useState<string | null>(null);
+    const [launchMessageTone, setLaunchMessageTone] = useState<'success' | 'error' | null>(null);
 
     // Load game path, autoexec status, and existing commands
     useEffect(() => {
@@ -125,11 +136,13 @@ export default function Autoexec() {
         if (!appSettings) return;
         setLaunchSaving(true);
         setLaunchMessage(null);
+        setLaunchMessageTone(null);
         try {
             const next: AppSettings = { ...appSettings, steamLaunchOptions: launchOptionsDraft };
             await setSettings(next);
             setAppSettings(next);
-            setLaunchMessage('Saved. Applied next time you launch Deadlock via grimoire.');
+            setLaunchMessage(t('autoexec.launchOptions.saved'));
+            setLaunchMessageTone('success');
             // Re-read current VDF value so the user sees the actual on-disk
             // state (it only changes when we write before a launch).
             try {
@@ -140,7 +153,8 @@ export default function Autoexec() {
             }
             setTimeout(() => setLaunchMessage(null), 4000);
         } catch (err) {
-            setLaunchMessage(`Error: ${err}`);
+            setLaunchMessage(t('autoexec.status.error', { error: String(err) }));
+            setLaunchMessageTone('error');
         } finally {
             setLaunchSaving(false);
         }
@@ -153,12 +167,12 @@ export default function Autoexec() {
         return COMMAND_PRESETS.map(cat => ({
             ...cat,
             commands: cat.commands.filter(cmd =>
-                cmd.name.toLowerCase().includes(lowerSearch) ||
+                t(cmd.nameKey).toLowerCase().includes(lowerSearch) ||
                 cmd.command.toLowerCase().includes(lowerSearch) ||
-                cmd.description.toLowerCase().includes(lowerSearch)
+                t(cmd.descriptionKey).toLowerCase().includes(lowerSearch)
             )
         })).filter(cat => cat.commands.length > 0);
-    }, [searchTerm]);
+    }, [searchTerm, t]);
 
     const handleAddCommand = (command: string) => {
         if (commands.includes(command)) return;
@@ -185,21 +199,25 @@ export default function Autoexec() {
 
     const handleSave = async () => {
         if (!gamePath) {
-            setSaveMessage('Game path not configured');
+            setSaveMessage(t('autoexec.status.gamePathNotConfigured'));
+            setSaveMessageTone('error');
             return;
         }
         setIsSaving(true);
         setSaveMessage(null);
+        setSaveMessageTone(null);
         try {
             await window.electronAPI.saveAutoexecCommands(gamePath, commands);
-            setSaveMessage('Saved to autoexec.cfg!');
+            setSaveMessage(t('autoexec.status.savedToAutoexec'));
+            setSaveMessageTone('success');
             setHasUnsaved(false);
             // Refresh status
             const s = await window.electronAPI.getAutoexecStatus(gamePath);
             setStatus(s);
             setTimeout(() => setSaveMessage(null), 3000);
         } catch (err) {
-            setSaveMessage(`Error: ${err}`);
+            setSaveMessage(t('autoexec.status.error', { error: String(err) }));
+            setSaveMessageTone('error');
         } finally {
             setIsSaving(false);
         }
@@ -222,20 +240,20 @@ export default function Autoexec() {
                             type="text"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            placeholder="Search commands..."
+                            placeholder={t('autoexec.search.placeholder')}
                             className="w-full pl-10 pr-4 py-2.5 bg-bg-secondary border border-white/5 rounded-xl text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-text-secondary/50"
                         />
                     </div>
 
                     <div className="flex-1 overflow-y-auto space-y-4 pr-2">
                         {/* Custom Command Input */}
-                        <Card title="Custom Command">
+                        <Card title={<Tx k="autoexec.customCommand.title" fallback="Custom Command" />}>
                             <div className="flex gap-2">
                                 <input
                                     type="text"
                                     value={customCommand}
                                     onChange={(e) => setCustomCommand(e.target.value)}
-                                    placeholder="e.g. fps_max 0"
+                                    placeholder={t('autoexec.customCommand.placeholder')}
                                     className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
                                     onKeyDown={(e) => e.key === 'Enter' && handleAddCustomCommand()}
                                 />
@@ -244,7 +262,11 @@ export default function Autoexec() {
                         </Card>
 
                         {filteredPresets.map((category) => (
-                            <Card key={category.category} title={category.category} icon={category.icon}>
+                            <Card
+                                key={category.categoryKey}
+                                title={<Tx k={category.categoryKey} fallback={category.categoryFallback} />}
+                                icon={category.icon}
+                            >
                                 <div className="space-y-1">
                                     {category.commands.map((cmd) => {
                                         const isAdded = commands.includes(cmd.command);
@@ -260,12 +282,12 @@ export default function Autoexec() {
                                             >
                                                 <div className="flex items-center justify-between mb-1">
                                                     <span className={`text-sm font-medium ${isAdded ? 'text-accent' : 'text-text-primary'}`}>
-                                                        {cmd.name}
+                                                        <Tx k={cmd.nameKey} fallback={cmd.nameFallback} />
                                                     </span>
                                                     {isAdded && <Check className="w-3 h-3 text-accent" />}
                                                 </div>
                                                 <div className="flex items-center justify-between text-xs text-text-secondary">
-                                                    <span>{cmd.description}</span>
+                                                    <span><Tx k={cmd.descriptionKey} fallback={cmd.descriptionFallback} /></span>
                                                     <code className="bg-black/30 px-1.5 py-0.5 rounded font-mono text-text-primary/80">
                                                         {cmd.command}
                                                     </code>
@@ -285,12 +307,22 @@ export default function Autoexec() {
                         className="flex flex-col"
                         title={
                             <span className="flex items-center gap-2 min-w-0">
-                                <span className="truncate">Your Commands ({commands.length})</span>
+                                <span className="truncate">
+                                    <Tx
+                                        k="autoexec.commands.title"
+                                        values={{ count: commands.length }}
+                                        fallback={`Your Commands (${commands.length})`}
+                                    />
+                                </span>
                                 {status ? (
                                     status.exists ? (
-                                        <Badge variant="success">Active</Badge>
+                                        <Badge variant="success">
+                                            <Tx k="common.status.active" fallback="Active" />
+                                        </Badge>
                                     ) : (
-                                        <Badge variant="warning">Missing</Badge>
+                                        <Badge variant="warning">
+                                            <Tx k="common.status.missing" fallback="Missing" />
+                                        </Badge>
                                     )
                                 ) : null}
                             </span>
@@ -299,10 +331,14 @@ export default function Autoexec() {
                         action={
                             <div className="flex gap-2">
                                 <Button size="sm" variant="secondary" onClick={() => setClearConfirmOpen(true)} disabled={commands.length === 0} icon={RefreshCw}>
-                                    Clear
+                                    <Tx k="common.actions.clear" fallback="Clear" />
                                 </Button>
                                 <Button size="sm" variant="secondary" onClick={handleCopy} disabled={commands.length === 0} icon={copied ? Check : Copy}>
-                                    {copied ? 'Copied' : 'Copy'}
+                                    {copied ? (
+                                        <Tx k="common.status.copied" fallback="Copied" />
+                                    ) : (
+                                        <Tx k="common.actions.copy" fallback="Copy" />
+                                    )}
                                 </Button>
                                 <Button
                                     size="sm"
@@ -311,7 +347,7 @@ export default function Autoexec() {
                                     isLoading={isSaving}
                                     icon={Save}
                                 >
-                                    Save
+                                    <Tx k="common.actions.save" fallback="Save" />
                                 </Button>
                             </div>
                         }
@@ -321,19 +357,22 @@ export default function Autoexec() {
                                 {!gamePath && (
                                     <div className="text-xs text-yellow-400 flex items-center gap-2 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
                                         <AlertTriangle className="w-3 h-3 flex-shrink-0" />
-                                        Game path not configured. Set it in Settings to save.
+                                        <Tx
+                                            k="autoexec.status.gamePathWarning"
+                                            fallback="Game path not configured. Set it in Settings to save."
+                                        />
                                     </div>
                                 )}
                                 {saveMessage && (
-                                    <div className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${saveMessage.includes('Error') ? 'bg-red-500/10 border-red-500/20 text-red-400' : 'bg-green-500/10 border-green-500/20 text-green-400'}`}>
-                                        {saveMessage.includes('Error') ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
+                                    <div className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${saveMessageTone === 'error' ? 'bg-red-500/10 border-red-500/20 text-red-400' : 'bg-green-500/10 border-green-500/20 text-green-400'}`}>
+                                        {saveMessageTone === 'error' ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
                                         {saveMessage}
                                     </div>
                                 )}
                                 {hasUnsaved && !saveMessage && (
                                     <div className="text-xs text-yellow-400 flex items-center gap-2 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
                                         <div className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
-                                        You have unsaved changes
+                                        <Tx k="autoexec.status.unsavedChanges" fallback="You have unsaved changes" />
                                     </div>
                                 )}
                             </div>
@@ -352,7 +391,7 @@ export default function Autoexec() {
                                         <button
                                             onClick={() => handleRemoveCommand(i)}
                                             className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-text-secondary hover:text-red-400 rounded transition-all cursor-pointer"
-                                            title="Remove"
+                                            title={t('common.actions.remove')}
                                         >
                                             <Trash2 className="w-4 h-4" />
                                         </button>
@@ -362,8 +401,12 @@ export default function Autoexec() {
                                 <div className="flex items-center gap-3 py-6 text-text-secondary opacity-50">
                                     <Terminal className="w-6 h-6" />
                                     <div>
-                                        <p className="text-sm font-medium">No commands added</p>
-                                        <p className="text-xs">Select from presets on the left</p>
+                                        <p className="text-sm font-medium">
+                                            <Tx k="autoexec.commands.emptyTitle" fallback="No commands added" />
+                                        </p>
+                                        <p className="text-xs">
+                                            <Tx k="autoexec.commands.emptyDescription" fallback="Select from presets on the left" />
+                                        </p>
                                     </div>
                                 </div>
                             )}
@@ -372,11 +415,13 @@ export default function Autoexec() {
 
                     {/* Launch options — lives below Your Commands so the
                         primary editor surface owns the top of the column. */}
-                    <Card title="Launch Options" icon={Rocket} className="shrink-0">
+                    <Card title={<Tx k="autoexec.launchOptions.title" fallback="Launch Options" />} icon={Rocket} className="shrink-0">
                         <div className="space-y-2.5">
                             <p className="text-xs text-text-secondary">
-                                Args passed to Deadlock when launched via Steam. Written into
-                                Steam&apos;s config right before grimoire launches the game.
+                                <Tx
+                                    k="autoexec.launchOptions.description"
+                                    fallback="Args passed to Deadlock when launched via Steam. Written into Steam's config right before grimoire launches the game."
+                                />
                             </p>
 
                             <div className="flex gap-2">
@@ -393,7 +438,7 @@ export default function Autoexec() {
                                     isLoading={launchSaving}
                                     icon={Save}
                                 >
-                                    Save
+                                    <Tx k="common.actions.save" fallback="Save" />
                                 </Button>
                             </div>
 
@@ -402,12 +447,12 @@ export default function Autoexec() {
                                     role="status"
                                     aria-live="polite"
                                     className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${
-                                        launchMessage.startsWith('Error')
+                                        launchMessageTone === 'error'
                                             ? 'bg-red-500/10 border-red-500/20 text-red-400'
                                             : 'bg-green-500/10 border-green-500/20 text-green-400'
                                     }`}
                                 >
-                                    {launchMessage.startsWith('Error') ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
+                                    {launchMessageTone === 'error' ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
                                     {launchMessage}
                                 </div>
                             )}
@@ -418,8 +463,10 @@ export default function Autoexec() {
                                         <div className="flex items-start gap-1.5 text-xs text-yellow-400">
                                             <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
                                             <span>
-                                                Steam config not found. Launch Deadlock via Steam once,
-                                                then come back.
+                                                <Tx
+                                                    k="autoexec.launchOptions.steamConfigMissing"
+                                                    fallback="Steam config not found. Launch Deadlock via Steam once, then come back."
+                                                />
                                             </span>
                                         </div>
                                     );
@@ -431,23 +478,30 @@ export default function Autoexec() {
                                     <div className="space-y-2 pt-1 border-t border-border/40">
                                         {!inSync && (
                                             <div className="flex items-baseline justify-between gap-2 text-xs">
-                                                <span className="text-text-secondary uppercase tracking-wide">In Steam now</span>
+                                                <span className="text-text-secondary uppercase tracking-wide">
+                                                    <Tx k="autoexec.launchOptions.inSteamNow" fallback="In Steam now" />
+                                                </span>
                                                 <code className="font-mono text-text-primary/80 bg-black/30 px-1.5 py-0.5 rounded truncate min-w-0">
-                                                    {onDisk || '(empty)'}
+                                                    {onDisk || t('common.emptyValue')}
                                                 </code>
                                             </div>
                                         )}
                                         {!inSync && !launchSaving && (
                                             <div className="text-[11px] text-text-secondary/70">
-                                                Your saved value will overwrite this on next grimoire launch.
+                                                <Tx
+                                                    k="autoexec.launchOptions.savedWillOverwrite"
+                                                    fallback="Your saved value will overwrite this on next grimoire launch."
+                                                />
                                             </div>
                                         )}
                                         {launchStatus.steamRunning && (
                                             <div className="flex items-start gap-1.5 text-xs text-yellow-400">
                                                 <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
                                                 <span>
-                                                    Steam is running. Close it before launching Deadlock
-                                                    via grimoire so the write isn&apos;t clobbered.
+                                                    <Tx
+                                                        k="autoexec.launchOptions.steamRunning"
+                                                        fallback="Steam is running. Close it before launching Deadlock via grimoire so the write isn't clobbered."
+                                                    />
                                                 </span>
                                             </div>
                                         )}
@@ -463,9 +517,15 @@ export default function Autoexec() {
                 isOpen={clearConfirmOpen}
                 onCancel={() => setClearConfirmOpen(false)}
                 onConfirm={confirmClear}
-                title="Clear all commands?"
-                message={`Remove all ${commands.length} command${commands.length === 1 ? '' : 's'} from the list? Your saved autoexec.cfg won't change until you click Save.`}
-                confirmLabel="Clear"
+                title={<Tx k="autoexec.confirm.clearTitle" fallback="Clear all commands?" />}
+                message={
+                    <Tx
+                        k="autoexec.confirm.clearMessage"
+                        values={{ count: commands.length }}
+                        fallback={`Remove all ${commands.length} command${commands.length === 1 ? '' : 's'} from the list? Your saved autoexec.cfg won't change until you click Save.`}
+                    />
+                }
+                confirmLabel={<Tx k="common.actions.clear" fallback="Clear" />}
                 variant="danger"
             />
         </div>

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye, List, LayoutGrid, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import {
   getConflicts,
   disableMod,
@@ -16,6 +17,7 @@ import { useAppStore } from '../stores/appStore';
 import { Button } from '../components/common/ui';
 import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, type ViewMode } from '../components/common/PageComponents';
 import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
+import Tx from '../components/translation/Tx';
 
 const CONFLICTS_VIEW_MODE_KEY = 'grimoire:conflicts-view-mode';
 
@@ -112,6 +114,7 @@ function ConflictsSkeleton() {
 }
 
 export default function Conflicts() {
+  const { t } = useTranslation();
   const [conflicts, setConflicts] = useState<ModConflict[]>([]);
   const [modsMap, setModsMap] = useState<Map<string, ModWithThumbnail>>(new Map());
   // Enabled mod ids in true load order (index 0 loads first). Drives the
@@ -237,7 +240,7 @@ export default function Conflicts() {
       const order = orderedEnabledIds.slice();
       const winnerIdx = order.indexOf(winnerId);
       if (winnerIdx === -1 || !order.includes(loserId)) {
-        throw new Error('Both mods must be enabled to set their load order.');
+        throw new Error(t('conflicts.errors.bothModsEnabled'));
       }
       order.splice(winnerIdx, 1);
       const loserIdx = order.indexOf(loserId);
@@ -282,7 +285,7 @@ export default function Conflicts() {
       } else {
         // Partial failure — backend is the source of truth, refetch.
         await loadConflicts();
-        setError(`Failed to ignore ${failures.length} pair${failures.length === 1 ? '' : 's'}. See console for details.`);
+        setError(t('conflicts.errors.ignoreFailed', { count: failures.length }));
         console.warn('[Conflicts] ignore-all failures:', failures);
       }
       // Single event after the whole batch — the Sidebar badge re-fetches
@@ -330,7 +333,7 @@ export default function Conflicts() {
       await loadConflicts();
       if (failures.length > 0) {
         console.warn('[Conflicts] clear ignored failures:', failures);
-        setError(`Failed to clear ${failures.length} ignored pair${failures.length === 1 ? '' : 's'}. See console for details.`);
+        setError(t('conflicts.errors.clearIgnoredFailed', { count: failures.length }));
       }
       window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
     } finally {
@@ -379,11 +382,13 @@ export default function Conflicts() {
       <div className="h-full flex items-center justify-center p-6">
         <EmptyState
           icon={AlertTriangle}
-          title="Error Loading Conflicts"
+          title={<Tx k="conflicts.errorTitle" fallback="Error Loading Conflicts" />}
           description={error ?? undefined}
           variant="error"
           action={
-            <Button onClick={loadConflicts}>Retry</Button>
+            <Button onClick={loadConflicts}>
+              <Tx k="common.actions.retry" fallback="Retry" />
+            </Button>
           }
         />
       </div>
@@ -395,10 +400,17 @@ export default function Conflicts() {
       <div className="h-full flex items-center justify-center p-6">
         <EmptyState
           icon={CheckCircle}
-          title="No Conflicts Detected"
-          description="Your installed mods don't have any conflicts. Great!"
+          title={<Tx k="conflicts.empty.noConflicts.title" fallback="No Conflicts Detected" />}
+          description={
+            <Tx
+              k="conflicts.empty.noConflicts.description"
+              fallback="Your installed mods don't have any conflicts. Great!"
+            />
+          }
           action={
-            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
+            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>
+              <Tx k="common.actions.refresh" fallback="Refresh" />
+            </Button>
           }
         />
       </div>
@@ -408,11 +420,25 @@ export default function Conflicts() {
   return (
     <div className="p-6 max-w-5xl mx-auto animate-fade-in">
       <PageHeader
-        title={`Conflicts (${conflicts.length})`}
+        title={
+          <Tx
+            k="conflicts.title"
+            values={{ count: conflicts.length }}
+            fallback={`Conflicts (${conflicts.length})`}
+          />
+        }
         description={
-          conflicts.length === 0
-            ? 'No active conflicts — review or restore your ignored pairs below.'
-            : 'Resolve conflicts between installed mods'
+          conflicts.length === 0 ? (
+            <Tx
+              k="conflicts.header.noActiveDescription"
+              fallback="No active conflicts - review or restore your ignored pairs below."
+            />
+          ) : (
+            <Tx
+              k="conflicts.header.description"
+              fallback="Resolve conflicts between installed mods"
+            />
+          )
         }
         action={
           <div className="flex items-center gap-2">
@@ -421,8 +447,8 @@ export default function Conflicts() {
                 value={viewMode}
                 onChange={(mode) => setViewMode(mode === 'list' ? 'list' : 'grid')}
                 options={[
-                  { value: 'grid', label: 'Grid view', icon: LayoutGrid },
-                  { value: 'list', label: 'List view', icon: List },
+                  { value: 'grid', label: t('conflicts.view.grid'), icon: LayoutGrid },
+                  { value: 'list', label: t('conflicts.view.list'), icon: List },
                 ]}
               />
             )}
@@ -431,12 +457,14 @@ export default function Conflicts() {
                 variant="secondary"
                 onClick={() => setIgnoreAllConfirmOpen(true)}
                 icon={EyeOff}
-                title="Move every active conflict pair to the Ignored section. Reversible per-pair via Unignore."
+                title={t('conflicts.actions.ignoreAllTitle')}
               >
-                Ignore all
+                <Tx k="conflicts.actions.ignoreAll" fallback="Ignore all" />
               </Button>
             )}
-            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>Refresh</Button>
+            <Button variant="secondary" onClick={loadConflicts} icon={RefreshCw}>
+              <Tx k="common.actions.refresh" fallback="Refresh" />
+            </Button>
           </div>
         }
         className="mb-6"
@@ -449,7 +477,15 @@ export default function Conflicts() {
       {conflicts.length === 0 && (
         <div className="mb-6 p-4 rounded-xl border border-border bg-bg-secondary text-sm text-text-secondary flex items-center gap-2">
           <CheckCircle className="w-4 h-4 text-green-400" />
-          No active conflicts. {ignored.size > 0 && `${ignored.size} pair(s) currently ignored — see below.`}
+          {ignored.size > 0 ? (
+            <Tx
+              k="conflicts.empty.activeWithIgnored"
+              values={{ count: ignored.size }}
+              fallback={`No active conflicts. ${ignored.size} pair(s) currently ignored - see below.`}
+            />
+          ) : (
+            <Tx k="conflicts.empty.noActive" fallback="No active conflicts." />
+          )}
         </div>
       )}
 
@@ -468,7 +504,7 @@ export default function Conflicts() {
                     <img src={mod.thumbnailUrl} alt={mod.name} className="h-full w-full object-cover" />
                   ) : (
                     <div className="flex h-full w-full items-center justify-center text-[11px] text-text-tertiary">
-                      No Preview
+                      <Tx k="conflicts.noPreview" fallback="No Preview" />
                     </div>
                   )}
                 </div>
@@ -490,8 +526,8 @@ export default function Conflicts() {
                 <button
                   type="button"
                   onClick={() => setDisableTarget(mod)}
-                  aria-label={`Disable ${mod.name}`}
-                  title={`Disable ${mod.name}`}
+                  aria-label={t('conflicts.actions.disableNamed', { name: mod.name })}
+                  title={t('conflicts.actions.disableNamed', { name: mod.name })}
                   className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md border border-red-500/30 bg-red-500/10 text-red-300 transition-colors hover:bg-red-500/20 hover:text-red-200 cursor-pointer"
                 >
                   <X className="h-4 w-4" />
@@ -513,16 +549,18 @@ export default function Conflicts() {
                     type="button"
                     onClick={() => handleIgnore(conflict)}
                     disabled={pendingPair === getConflictIgnoreKey(conflict)}
-                    title="Stop flagging this pair as a conflict"
+                    title={t('conflicts.actions.ignoreTitle')}
                     className="inline-flex flex-shrink-0 items-center gap-1 rounded px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
                   >
                     <EyeOff className="h-3.5 w-3.5" />
-                    Ignore
+                    <Tx k="conflicts.actions.ignore" fallback="Ignore" />
                   </button>
                 </div>
                 <div className="grid grid-cols-[minmax(0,1fr)_2rem_minmax(0,1fr)] items-center gap-3 p-4">
                   {renderListSide(modA, variantA)}
-                  <span className="text-center text-sm font-bold text-text-tertiary">VS</span>
+                  <span className="text-center text-sm font-bold text-text-tertiary">
+                    <Tx k="common.versus" fallback="VS" />
+                  </span>
                   {renderListSide(modB, variantB)}
                 </div>
                 <ConflictReorderActions
@@ -560,11 +598,11 @@ export default function Conflicts() {
                     type="button"
                     onClick={() => handleIgnore(conflict)}
                     disabled={pendingPair === getConflictIgnoreKey(conflict)}
-                    title="Stop flagging this pair as a conflict"
+                    title={t('conflicts.actions.ignoreTitle')}
                     className="flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-tertiary rounded transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <EyeOff className="w-3.5 h-3.5" />
-                    Ignore
+                    <Tx k="conflicts.actions.ignore" fallback="Ignore" />
                   </button>
                 </div>
 
@@ -581,16 +619,17 @@ export default function Conflicts() {
                         />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center text-text-tertiary">
-                          No Preview
+                          <Tx k="conflicts.noPreview" fallback="No Preview" />
                         </div>
                       )}
                       <button
                         onClick={() => setDisableTarget(modA)}
-                        aria-label={`Disable ${modA.name}`}
+                        aria-label={t('conflicts.actions.disableNamed', { name: modA.name })}
                         className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                       >
                         <span className="text-white text-sm font-medium flex items-center gap-1">
-                          <X className="w-4 h-4" /> Disable
+                          <X className="w-4 h-4" />
+                          <Tx k="conflicts.actions.disable" fallback="Disable" />
                         </span>
                       </button>
                     </div>
@@ -611,7 +650,9 @@ export default function Conflicts() {
 
                   {/* VS divider */}
                   <div className="h-full flex items-center justify-center">
-                    <span className="text-text-tertiary text-sm font-bold">VS</span>
+                    <span className="text-text-tertiary text-sm font-bold">
+                      <Tx k="common.versus" fallback="VS" />
+                    </span>
                   </div>
 
                   {/* Mod B Card */}
@@ -625,16 +666,17 @@ export default function Conflicts() {
                         />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center text-text-tertiary">
-                          No Preview
+                          <Tx k="conflicts.noPreview" fallback="No Preview" />
                         </div>
                       )}
                       <button
                         onClick={() => setDisableTarget(modB)}
-                        aria-label={`Disable ${modB.name}`}
+                        aria-label={t('conflicts.actions.disableNamed', { name: modB.name })}
                         className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
                       >
                         <span className="text-white text-sm font-medium flex items-center gap-1">
-                          <X className="w-4 h-4" /> Disable
+                          <X className="w-4 h-4" />
+                          <Tx k="conflicts.actions.disable" fallback="Disable" />
                         </span>
                       </button>
                     </div>
@@ -677,16 +719,20 @@ export default function Conflicts() {
           <div className="mb-3 flex items-center justify-between gap-3">
             <h3 className="text-sm font-semibold uppercase tracking-wide text-text-secondary flex items-center gap-2">
               <EyeOff className="w-4 h-4" />
-              Ignored ({ignored.size})
+              <Tx
+                k="conflicts.ignored.title"
+                values={{ count: ignored.size }}
+                fallback={`Ignored (${ignored.size})`}
+              />
             </h3>
             <Button
               variant="secondary"
               size="sm"
               icon={Trash2}
               onClick={() => setClearIgnoredConfirmOpen(true)}
-              title="Restore conflict detection for every ignored pair"
+              title={t('conflicts.ignored.clearTitle')}
             >
-              Clear ignored
+              <Tx k="conflicts.actions.clearIgnored" fallback="Clear ignored" />
             </Button>
           </div>
           <div className="rounded-xl border border-border bg-bg-secondary divide-y divide-border">
@@ -698,8 +744,8 @@ export default function Conflicts() {
               // entry (using a placeholder) so the user can clean it up. The
               // backend's filter is a no-op for missing ids — they just
               // never re-appear as active conflicts.
-              const aName = a?.name ?? '(removed mod)';
-              const bName = b?.name ?? '(removed mod)';
+              const aName = a?.name ?? t('conflicts.removedMod');
+              const bName = b?.name ?? t('conflicts.removedMod');
               const aVariant = a ? getVariantLabel(a) : null;
               const bVariant = b ? getVariantLabel(b) : null;
               return (
@@ -708,7 +754,9 @@ export default function Conflicts() {
                     <span className="truncate text-text-primary" title={aVariant ? `${aName} - ${aVariant}` : aName}>
                       {aName}{aVariant ? ` (${aVariant})` : ''}
                     </span>
-                    <span className="text-text-tertiary text-xs flex-shrink-0">vs</span>
+                    <span className="text-text-tertiary text-xs flex-shrink-0">
+                      <Tx k="common.versusLower" fallback="vs" />
+                    </span>
                     <span className="truncate text-text-primary" title={bVariant ? `${bName} - ${bVariant}` : bName}>
                       {bName}{bVariant ? ` (${bVariant})` : ''}
                     </span>
@@ -718,10 +766,10 @@ export default function Conflicts() {
                     onClick={() => handleUnignore(key)}
                     disabled={pendingPair === key}
                     className="flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-tertiary rounded transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                    title="Restore conflict detection for this pair"
+                    title={t('conflicts.ignored.unignoreTitle')}
                   >
                     <Eye className="w-3.5 h-3.5" />
-                    Unignore
+                    <Tx k="conflicts.actions.unignore" fallback="Unignore" />
                   </button>
                 </div>
               );
@@ -734,12 +782,16 @@ export default function Conflicts() {
         isOpen={disableTarget !== null}
         onCancel={() => !disabling && setDisableTarget(null)}
         onConfirm={confirmDisable}
-        title="Disable this mod?"
+        title={<Tx k="conflicts.confirm.disableTitle" fallback="Disable this mod?" />}
         message={
           disableTarget ? (
             <>
               <p className="mb-2">
-                <span className="text-text-primary font-medium">{disableTarget.name}</span> will be disabled and moved out of the addons folder. You can re-enable it from the Installed page.
+                <Tx
+                  k="conflicts.confirm.disableMessage"
+                  values={{ name: disableTarget.name }}
+                  fallback={`${disableTarget.name} will be disabled and moved out of the addons folder. You can re-enable it from the Installed page.`}
+                />
               </p>
               {getVariantLabel(disableTarget) && (
                 <p className="text-xs text-accent truncate" title={getVariantLabel(disableTarget) ?? undefined}>
@@ -752,7 +804,13 @@ export default function Conflicts() {
             </>
           ) : ''
         }
-        confirmLabel={disabling ? 'Disabling…' : 'Disable'}
+        confirmLabel={
+          disabling ? (
+            <Tx k="conflicts.actions.disabling" fallback="Disabling..." />
+          ) : (
+            <Tx k="conflicts.actions.disable" fallback="Disable" />
+          )
+        }
         variant="danger"
       />
 
@@ -760,36 +818,76 @@ export default function Conflicts() {
         isOpen={ignoreAllConfirmOpen}
         onCancel={() => !ignoringAll && setIgnoreAllConfirmOpen(false)}
         onConfirm={handleIgnoreAll}
-        title={`Ignore all ${conflicts.length} conflict${conflicts.length === 1 ? '' : 's'}?`}
+        title={
+          <Tx
+            k="conflicts.confirm.ignoreAllTitle"
+            values={{ count: conflicts.length }}
+            fallback={`Ignore all ${conflicts.length} conflict${conflicts.length === 1 ? '' : 's'}?`}
+          />
+        }
         message={
           <>
             <p className="mb-2">
-              Every currently active conflict pair will move to the <span className="text-text-primary font-medium">Ignored</span> section below.
+              <Tx
+                k="conflicts.confirm.ignoreAllMessage"
+                fallback="Every currently active conflict pair will move to the Ignored section below."
+              />
             </p>
             <p className="text-xs text-text-tertiary">
-              Reversible — you can restore any pair individually with <em>Unignore</em>.
+              <Tx
+                k="conflicts.confirm.ignoreAllHint"
+                fallback="Reversible - you can restore any pair individually with Unignore."
+              />
             </p>
           </>
         }
-        confirmLabel={ignoringAll ? 'Ignoring…' : `Ignore ${conflicts.length}`}
+        confirmLabel={
+          ignoringAll ? (
+            <Tx k="conflicts.actions.ignoring" fallback="Ignoring..." />
+          ) : (
+            <Tx
+              k="conflicts.actions.ignoreCount"
+              values={{ count: conflicts.length }}
+              fallback={`Ignore ${conflicts.length}`}
+            />
+          )
+        }
       />
 
       <ConfirmModal
         isOpen={clearIgnoredConfirmOpen}
         onCancel={() => !clearingIgnored && setClearIgnoredConfirmOpen(false)}
         onConfirm={handleClearIgnored}
-        title={`Clear ${ignored.size} ignored conflict${ignored.size === 1 ? '' : 's'}?`}
+        title={
+          <Tx
+            k="conflicts.confirm.clearIgnoredTitle"
+            values={{ count: ignored.size }}
+            fallback={`Clear ${ignored.size} ignored conflict${ignored.size === 1 ? '' : 's'}?`}
+          />
+        }
         message={
           <>
             <p className="mb-2">
-              Every ignored pair will be restored to normal conflict detection.
+              <Tx
+                k="conflicts.confirm.clearIgnoredMessage"
+                fallback="Every ignored pair will be restored to normal conflict detection."
+              />
             </p>
             <p className="text-xs text-text-tertiary">
-              Pairs that still conflict will reappear in the active list after refresh.
+              <Tx
+                k="conflicts.confirm.clearIgnoredHint"
+                fallback="Pairs that still conflict will reappear in the active list after refresh."
+              />
             </p>
           </>
         }
-        confirmLabel={clearingIgnored ? 'Clearing…' : 'Clear ignored'}
+        confirmLabel={
+          clearingIgnored ? (
+            <Tx k="conflicts.actions.clearing" fallback="Clearing..." />
+          ) : (
+            <Tx k="conflicts.actions.clearIgnored" fallback="Clear ignored" />
+          )
+        }
       />
     </div>
   );

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -6,6 +6,7 @@ import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import { renderCrosshairThumbnail } from '../components/crosshair/drawCrosshair';
 import { getSettings } from '../lib/api';
 import { Card, Slider, Toggle, Button } from '../components/common/ui';
+import Tx from '../components/translation/Tx';
 
 // The in-game crosshair is authored in 1080p-reference px and scaled by
 // screen height, so the preview multiplies by (resolution / 1080).
@@ -141,7 +142,7 @@ export default function Crosshair() {
 
     const handleImportFromGame = async () => {
         if (!gamePath) {
-            alert('Please configure your Deadlock game path in Settings first.');
+            alert(t('crosshair.alert.configureGamePath'));
             return;
         }
         try {
@@ -150,11 +151,11 @@ export default function Crosshair() {
                 setImported(true);
                 setTimeout(() => setImported(false), 2000);
             } else {
-                alert('No crosshair settings found in the game config. Change any crosshair setting in-game once, then try again.');
+                alert(t('crosshair.alert.noSettingsFound'));
             }
         } catch (error) {
             console.error('Failed to import crosshair from game:', error);
-            alert('Failed to read the game config. Check the game path in Settings.');
+            alert(t('crosshair.alert.readConfigFailed'));
         }
     };
 
@@ -175,19 +176,19 @@ export default function Crosshair() {
 
     const handleApplyPreset = async (presetId: string) => {
         if (!gamePath) {
-            alert('Please configure your Deadlock game path in Settings first.');
+            alert(t('crosshair.alert.configureGamePath'));
             return;
         }
         try {
             await applyPreset(presetId, gamePath);
         } catch (error) {
             console.error('Failed to apply preset:', error);
-            alert('Failed to apply preset. Make sure the game path is correct.');
+            alert(t('crosshair.alert.applyPresetFailed'));
         }
     };
 
     const handleDeletePreset = async (presetId: string) => {
-        if (!confirm('Delete this crosshair preset?')) return;
+        if (!confirm(t('crosshair.confirm.deletePreset'))) return;
         const wasActive = presetId === activePresetId;
         if (wasActive && gamePath) {
             try {
@@ -201,17 +202,17 @@ export default function Crosshair() {
 
     const handleClearActive = async () => {
         if (!gamePath) {
-            alert('Please configure your Deadlock game path in Settings first.');
+            alert(t('crosshair.alert.configureGamePath'));
             return;
         }
-        if (!confirm('Remove the active crosshair from autoexec.cfg? Your saved presets will be kept.\n\nNote: an in-progress game session keeps its current crosshair until you restart the game.')) {
+        if (!confirm(t('crosshair.confirm.clearActive'))) {
             return;
         }
         try {
             await clearAutoexec(gamePath);
         } catch (error) {
             console.error('Failed to clear crosshair:', error);
-            alert('Failed to clear crosshair. Check the game path in Settings.');
+            alert(t('crosshair.alert.clearFailed'));
         }
     };
 
@@ -230,46 +231,46 @@ export default function Crosshair() {
                     of overflowing, which clips the controls and leaves
                     nothing for overflow-y-auto to scroll. */}
                 <div className="w-full lg:w-1/3 space-y-6 lg:min-h-0 lg:overflow-y-auto lg:p-6">
-                    <Card title="Crosshair Shape">
+                    <Card title={<Tx k="crosshair.sections.shape" fallback="Crosshair Shape" />}>
                         <div className="space-y-6">
-                            <Slider editable label="Gap" value={pipGap} min={-10} max={50} onChange={setPipGap} />
-                            <Slider editable label="Height" value={pipHeight} min={0} max={50} onChange={setPipHeight} />
-                            <Slider editable label="Width" value={pipWidth} min={0} max={10} step={0.5} onChange={setPipWidth} />
-                            <Slider editable label="Opacity" value={pipOpacity} min={0} max={1} step={0.05} onChange={setPipOpacity} />
-                            <Slider editable label="Outline Width" value={pipOutlineBorder} min={0} max={5} onChange={setPipOutlineBorder} />
-                            <Slider editable label="Outline Gap" value={pipOutlineGap} min={0} max={10} step={0.5} onChange={setPipOutlineGap} />
-                            <Slider editable label="Outline Opacity" value={pipOutlineOpacity} min={0} max={1} step={0.05} onChange={setPipOutlineOpacity} />
+                            <Slider editable label={<Tx k="crosshair.controls.gap" fallback="Gap" />} value={pipGap} min={-10} max={50} onChange={setPipGap} />
+                            <Slider editable label={<Tx k="crosshair.controls.height" fallback="Height" />} value={pipHeight} min={0} max={50} onChange={setPipHeight} />
+                            <Slider editable label={<Tx k="crosshair.controls.width" fallback="Width" />} value={pipWidth} min={0} max={10} step={0.5} onChange={setPipWidth} />
+                            <Slider editable label={<Tx k="crosshair.controls.opacity" fallback="Opacity" />} value={pipOpacity} min={0} max={1} step={0.05} onChange={setPipOpacity} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineWidth" fallback="Outline Width" />} value={pipOutlineBorder} min={0} max={5} onChange={setPipOutlineBorder} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={pipOutlineGap} min={0} max={10} step={0.5} onChange={setPipOutlineGap} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineOpacity" fallback="Outline Opacity" />} value={pipOutlineOpacity} min={0} max={1} step={0.05} onChange={setPipOutlineOpacity} />
                         </div>
                     </Card>
 
-                    <Card title="Center Dot">
+                    <Card title={<Tx k="crosshair.sections.centerDot" fallback="Center Dot" />}>
                         <div className="space-y-6">
-                            <Slider editable label="Size" value={dotSize} min={0} max={20} step={0.5} onChange={setDotSize} />
-                            <Slider editable label="Opacity" value={dotOpacity} min={0} max={1} step={0.05} onChange={setDotOpacity} />
-                            <Slider editable label="Outline Width" value={dotOutlineBorder} min={0} max={5} onChange={setDotOutlineBorder} />
-                            <Slider editable label="Outline Gap" value={dotOutlineGap} min={0} max={10} step={0.5} onChange={setDotOutlineGap} />
-                            <Slider editable label="Outline Opacity" value={dotOutlineOpacity} min={0} max={1} step={0.05} onChange={setDotOutlineOpacity} />
+                            <Slider editable label={<Tx k="crosshair.controls.size" fallback="Size" />} value={dotSize} min={0} max={20} step={0.5} onChange={setDotSize} />
+                            <Slider editable label={<Tx k="crosshair.controls.opacity" fallback="Opacity" />} value={dotOpacity} min={0} max={1} step={0.05} onChange={setDotOpacity} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineWidth" fallback="Outline Width" />} value={dotOutlineBorder} min={0} max={5} onChange={setDotOutlineBorder} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={dotOutlineGap} min={0} max={10} step={0.5} onChange={setDotOutlineGap} />
+                            <Slider editable label={<Tx k="crosshair.controls.outlineOpacity" fallback="Outline Opacity" />} value={dotOutlineOpacity} min={0} max={1} step={0.05} onChange={setDotOutlineOpacity} />
                         </div>
                     </Card>
 
-                    <Card title="In-Game Behavior">
+                    <Card title={<Tx k="crosshair.sections.inGameBehavior" fallback="In-Game Behavior" />}>
                         <div className="space-y-4">
                             <Toggle
-                                label="Static Gap"
-                                description={t('crosshair.toggles.staticGap')}
+                                label={<Tx k="crosshair.toggles.staticGapLabel" fallback="Static Gap" />}
+                                description={<Tx k="crosshair.toggles.staticGap" fallback="Keep the gap fixed. Off lets it expand with weapon spread (not shown in preview)." />}
                                 checked={pipGapStatic}
                                 onChange={setPipGapStatic}
                             />
                             <Toggle
-                                label="Disable Hero Crosshairs"
-                                description={t('crosshair.toggles.disableHeroCrosshairs')}
+                                label={<Tx k="crosshair.toggles.disableHeroCrosshairsLabel" fallback="Disable Hero Crosshairs" />}
+                                description={<Tx k="crosshair.toggles.disableHeroCrosshairs" fallback="Force your custom crosshair on heroes that override it." />}
                                 checked={disableHeroSpecificCrosshairs}
                                 onChange={setDisableHeroSpecificCrosshairs}
                             />
                         </div>
                     </Card>
 
-                    <Card title="Color">
+                    <Card title={<Tx k="crosshair.sections.color" fallback="Color" />}>
                         <div className="space-y-6">
                             <div className="flex items-center gap-4 p-3 bg-black/20 rounded-lg">
                                 <input
@@ -285,15 +286,15 @@ export default function Crosshair() {
                             {/* Quick color presets */}
                             <div className="flex gap-2">
                                 {[
-                                    { label: 'White', r: 255, g: 255, b: 255 },
-                                    { label: 'Green', r: 0, g: 255, b: 0 },
-                                    { label: 'Cyan', r: 0, g: 255, b: 255 },
-                                    { label: 'Yellow', r: 255, g: 255, b: 0 },
-                                    { label: 'Red', r: 255, g: 0, b: 0 },
-                                    { label: 'Magenta', r: 255, g: 0, b: 255 },
+                                    { label: t('crosshair.colors.white'), key: 'white', r: 255, g: 255, b: 255 },
+                                    { label: t('crosshair.colors.green'), key: 'green', r: 0, g: 255, b: 0 },
+                                    { label: t('crosshair.colors.cyan'), key: 'cyan', r: 0, g: 255, b: 255 },
+                                    { label: t('crosshair.colors.yellow'), key: 'yellow', r: 255, g: 255, b: 0 },
+                                    { label: t('crosshair.colors.red'), key: 'red', r: 255, g: 0, b: 0 },
+                                    { label: t('crosshair.colors.magenta'), key: 'magenta', r: 255, g: 0, b: 255 },
                                 ].map((color) => (
                                     <button
-                                        key={color.label}
+                                        key={color.key}
                                         onClick={() => { setColorR(color.r); setColorG(color.g); setColorB(color.b); }}
                                         className="w-6 h-6 rounded-md border border-white/20 hover:border-white/50 transition-colors cursor-pointer"
                                         style={{ backgroundColor: `rgb(${color.r}, ${color.g}, ${color.b})` }}
@@ -301,9 +302,9 @@ export default function Crosshair() {
                                     />
                                 ))}
                             </div>
-                            <Slider editable label="Red" value={colorR} min={0} max={255} onChange={setColorR} className="accent-red-500" />
-                            <Slider editable label="Green" value={colorG} min={0} max={255} onChange={setColorG} className="accent-green-500" />
-                            <Slider editable label="Blue" value={colorB} min={0} max={255} onChange={setColorB} className="accent-blue-500" />
+                            <Slider editable label={<Tx k="crosshair.colors.red" fallback="Red" />} value={colorR} min={0} max={255} onChange={setColorR} className="accent-red-500" />
+                            <Slider editable label={<Tx k="crosshair.colors.green" fallback="Green" />} value={colorG} min={0} max={255} onChange={setColorG} className="accent-green-500" />
+                            <Slider editable label={<Tx k="crosshair.colors.blue" fallback="Blue" />} value={colorB} min={0} max={255} onChange={setColorB} className="accent-blue-500" />
                             <div className="flex items-center gap-4 p-3 bg-black/20 rounded-lg">
                                 <input
                                     type="color"
@@ -312,7 +313,7 @@ export default function Crosshair() {
                                     className="w-8 h-8 rounded cursor-pointer bg-transparent border-none"
                                 />
                                 <div className="text-xs text-text-secondary">
-                                    Outline color
+                                    <Tx k="crosshair.controls.outlineColor" fallback="Outline color" />
                                     <span className="ml-2 font-mono">RGB({outlineColorR}, {outlineColorG}, {outlineColorB})</span>
                                 </div>
                             </div>
@@ -329,15 +330,21 @@ export default function Crosshair() {
                         <Card className="flex-1" contentClassName="p-3">
                             <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div className="flex flex-wrap items-center gap-2">
-                                    <Button variant="secondary" onClick={reset} icon={RotateCcw} size="sm">Reset</Button>
+                                    <Button variant="secondary" onClick={reset} icon={RotateCcw} size="sm">
+                                        <Tx k="common.actions.reset" fallback="Reset" />
+                                    </Button>
                                     <Button
                                         variant={imported ? 'success' : 'secondary'}
                                         onClick={handleImportFromGame}
                                         icon={imported ? Check : Download}
                                         size="sm"
-                                        title="Load your current in-game crosshair settings into the editor"
+                                        title={t('crosshair.actions.importTitle')}
                                     >
-                                        {imported ? 'Imported' : 'Import from Game'}
+                                        {imported ? (
+                                            <Tx k="crosshair.status.imported" fallback="Imported" />
+                                        ) : (
+                                            <Tx k="crosshair.actions.importFromGame" fallback="Import from Game" />
+                                        )}
                                     </Button>
                                     <Button
                                         variant={copied ? 'success' : 'primary'}
@@ -345,11 +352,15 @@ export default function Crosshair() {
                                         icon={copied ? Check : Copy}
                                         size="sm"
                                     >
-                                        {copied ? 'Copied' : 'Copy Code'}
+                                        {copied ? (
+                                            <Tx k="common.status.copied" fallback="Copied" />
+                                        ) : (
+                                            <Tx k="crosshair.actions.copyCode" fallback="Copy Code" />
+                                        )}
                                     </Button>
                                 </div>
                                 <div className="hidden sm:block text-xs text-text-secondary whitespace-nowrap">
-                                    Press F7 in-game
+                                    <Tx k="crosshair.hints.pressF7" fallback="Press F7 in-game" />
                                 </div>
                             </div>
                         </Card>
@@ -362,7 +373,7 @@ export default function Crosshair() {
                                             type="text"
                                             value={presetName}
                                             onChange={(e) => setPresetName(e.target.value)}
-                                            placeholder="Name..."
+                                            placeholder={t('crosshair.presetNamePlaceholder')}
                                             className="flex-1 px-3 py-1.5 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm focus:outline-none focus:ring-1 focus:ring-accent min-w-0"
                                             onKeyDown={(e) => e.key === 'Enter' && handleSavePreset()}
                                             autoFocus
@@ -374,15 +385,20 @@ export default function Crosshair() {
                                             icon={Save}
                                             size="sm"
                                         >
-                                            Save
+                                            <Tx k="common.actions.save" fallback="Save" />
                                         </Button>
-                                        <button onClick={() => setShowSaveInput(false)} className="text-text-secondary hover:text-text-primary cursor-pointer">
+                                        <button
+                                            onClick={() => setShowSaveInput(false)}
+                                            className="text-text-secondary hover:text-text-primary cursor-pointer"
+                                            title={t('common.actions.cancel')}
+                                            aria-label={t('common.actions.cancel')}
+                                        >
                                             <RotateCcw className="w-4 h-4" />
                                         </button>
                                     </>
                                 ) : (
                                     <Button className="w-full" variant="secondary" onClick={() => setShowSaveInput(true)} icon={Save} size="sm">
-                                        Save as New Preset
+                                        <Tx k="crosshair.actions.saveAsNewPreset" fallback="Save as New Preset" />
                                     </Button>
                                 )}
                             </div>
@@ -395,14 +411,16 @@ export default function Crosshair() {
                             <select
                                 value={resolution}
                                 onChange={(e) => setResolution(parseInt(e.target.value, 10))}
-                                title="Render the preview at this display resolution's in-game size"
+                                title={t('crosshair.preview.resolutionTitle')}
                                 className="bg-transparent text-xs text-text-secondary focus:outline-none cursor-pointer [&>option]:bg-bg-tertiary"
                             >
                                 {RESOLUTIONS.map((r) => (
                                     <option key={r.height} value={r.height}>{r.label}</option>
                                 ))}
                             </select>
-                            <span className="text-xs text-text-secondary">Zoom:</span>
+                            <span className="text-xs text-text-secondary">
+                                <Tx k="crosshair.preview.zoom" fallback="Zoom:" />
+                            </span>
                             <div className="relative w-20 h-4 flex items-center">
                                 <div className="absolute w-full h-1 bg-bg-tertiary rounded-full overflow-hidden">
                                     <div
@@ -433,15 +451,24 @@ export default function Crosshair() {
 
                         {/* Pin Window Control */}
                         <div className="p-4 border-t border-border flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-                            <p className="text-[10px] text-text-secondary italic">Preview approximates the in-game crosshair at the selected resolution. Dynamic spread bloom is not simulated.</p>
+                            <p className="text-[10px] text-text-secondary italic">
+                                <Tx
+                                    k="crosshair.preview.description"
+                                    fallback="Preview approximates the in-game crosshair at the selected resolution. Dynamic spread bloom is not simulated."
+                                />
+                            </p>
                             <Button
                                 variant={alwaysOnTop ? 'primary' : 'secondary'}
                                 size="sm"
                                 onClick={() => handleAlwaysOnTop(!alwaysOnTop)}
                                 icon={Pin}
-                                title="Keep the mod manager window on top of the game for quick adjustments"
+                                title={t('crosshair.preview.pinTitle')}
                             >
-                                {alwaysOnTop ? 'Pinned' : 'Pin Window'}
+                                {alwaysOnTop ? (
+                                    <Tx k="crosshair.preview.pinned" fallback="Pinned" />
+                                ) : (
+                                    <Tx k="crosshair.preview.pinWindow" fallback="Pin Window" />
+                                )}
                             </Button>
                         </div>
                     </Card>
@@ -449,16 +476,22 @@ export default function Crosshair() {
                     {/* Presets Gallery */}
                     {presets.length > 0 && (
                         <Card
-                            title={`Saved Presets (${presets.length})`}
+                            title={
+                                <Tx
+                                    k="crosshair.presets.savedTitle"
+                                    values={{ count: presets.length }}
+                                    fallback={`Saved Presets (${presets.length})`}
+                                />
+                            }
                             action={activePresetId ? (
                                 <Button
                                     variant="secondary"
                                     size="sm"
                                     onClick={handleClearActive}
                                     icon={XCircle}
-                                    title="Remove the active crosshair from autoexec.cfg (presets are kept)"
+                                    title={t('crosshair.presets.deselectTitle')}
                                 >
-                                    Deselect Active
+                                    <Tx k="crosshair.presets.deselectActive" fallback="Deselect Active" />
                                 </Button>
                             ) : undefined}
                         >
@@ -480,14 +513,14 @@ export default function Crosshair() {
                                                 <button
                                                     onClick={(e) => { e.stopPropagation(); handleApplyPreset(preset.id); }}
                                                     className="p-1.5 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 rounded-md text-text-primary cursor-pointer transition-colors"
-                                                    title="Apply to Game"
+                                                    title={t('crosshair.actions.applyToGame')}
                                                 >
                                                     <Play className="w-3 h-3" />
                                                 </button>
                                                 <button
                                                     onClick={(e) => { e.stopPropagation(); handleDeletePreset(preset.id); }}
                                                     className="p-1.5 bg-red-500/20 hover:bg-red-500/40 text-red-400 rounded-md cursor-pointer"
-                                                    title="Delete"
+                                                    title={t('common.actions.delete')}
                                                 >
                                                     <Trash2 className="w-3 h-3" />
                                                 </button>

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -28,6 +28,7 @@ import ExportProfileModal from '../components/profiles/ExportProfileModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import PublishDialog from '../components/social/PublishDialog';
 import { getActiveDeadlockPath } from '../lib/appSettings';
+import Tx from '../components/translation/Tx';
 import type { Mod } from '../types/mod';
 
 type ProfileModEntry = Profile['mods'][number];
@@ -179,11 +180,11 @@ export default function Profiles() {
       const json = await loadSnapshot(snapshotId);
       setRestoringSnapshotJson(json);
     } catch (err) {
-      setError(`Failed to load snapshot: ${String(err)}`);
+      setError(t('profiles.errors.loadSnapshotFailed', { error: String(err) }));
     } finally {
       setRestoringSnapshotId(null);
     }
-  }, []);
+  }, [t]);
 
   const handleCreateManualSnapshot = useCallback(async () => {
     setCreatingSnapshot(true);
@@ -192,11 +193,11 @@ export default function Profiles() {
       await loadSnapshotList();
       setSnapshotsExpanded(true);
     } catch (err) {
-      setError(`Failed to capture snapshot: ${String(err)}`);
+      setError(t('profiles.errors.captureSnapshotFailed', { error: String(err) }));
     } finally {
       setCreatingSnapshot(false);
     }
-  }, [loadSnapshotList]);
+  }, [loadSnapshotList, t]);
 
   const handleDeleteSnapshot = useCallback(async (snapshotId: string) => {
     try {
@@ -209,11 +210,11 @@ export default function Profiles() {
         return next;
       });
     } catch (err) {
-      setError(`Failed to delete snapshot: ${String(err)}`);
+      setError(t('profiles.errors.deleteSnapshotFailed', { error: String(err) }));
     } finally {
       setDeleteSnapshotConfirmId(null);
     }
-  }, [loadSnapshotList]);
+  }, [loadSnapshotList, t]);
 
   const toggleSnapshotSelected = useCallback((snapshotId: string) => {
     setSelectedSnapshotIds((prev) => {
@@ -247,9 +248,13 @@ export default function Profiles() {
     setBulkDeleteSnapshotsOpen(false);
     setBulkDeletingSnapshots(false);
     if (failures.length > 0) {
-      setError(`Failed to delete ${failures.length} of ${ids.length} snapshots: ${failures[0]}`);
+      setError(t('profiles.errors.bulkDeleteSnapshotsFailed', {
+        failed: failures.length,
+        total: ids.length,
+        error: failures[0],
+      }));
     }
-  }, [selectedSnapshotIds, loadSnapshotList]);
+  }, [selectedSnapshotIds, loadSnapshotList, t]);
 
   // Drop selections that refer to snapshots no longer in the list (deleted
   // elsewhere, refresh dropped them). Keeps the bulk-delete count honest.
@@ -376,7 +381,9 @@ export default function Profiles() {
     return (
       <div className="flex flex-col items-center justify-center h-full text-text-secondary">
         <RefreshCw className="w-8 h-8 animate-spin mb-4 text-accent" />
-        <p>Loading profiles...</p>
+        <p>
+          <Tx k="profiles.loading" fallback="Loading profiles..." />
+        </p>
       </div>
     );
   }
@@ -393,15 +400,15 @@ export default function Profiles() {
           )}
 
           {/* Create New Profile */}
-          <Card title="Create New Profile" icon={Plus}>
+          <Card title={<Tx k="profiles.create.title" fallback="Create New Profile" />} icon={Plus}>
             <div className="flex flex-wrap gap-3">
               <input
                 type="text"
                 value={newProfileName}
                 onChange={(e) => setNewProfileName(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && handleCreateProfile()}
-                placeholder="Enter profile name (e.g. Competitive, Casual, Testing)..."
-                aria-label="Profile name"
+                placeholder={t('profiles.create.placeholder')}
+                aria-label={t('profiles.create.profileName')}
                 className="flex-1 px-4 py-2.5 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent transition-all"
               />
               <Button
@@ -410,15 +417,15 @@ export default function Profiles() {
                 isLoading={isCreating}
                 icon={Save}
               >
-                Create Profile
+                <Tx k="profiles.create.submit" fallback="Create Profile" />
               </Button>
               <Button
                 variant="secondary"
                 onClick={() => setShowImport(true)}
                 icon={Upload}
-                title="Import a portable profile from a share code or file"
+                title={t('profiles.import.title')}
               >
-                Import
+                <Tx k="profiles.actions.import" fallback="Import" />
               </Button>
             </div>
           </Card>
@@ -428,7 +435,13 @@ export default function Profiles() {
               supports manual capture. Restore re-uses the portable-import
               dialog so the user sees exactly what will re-download. */}
           <Card
-            title={`Snapshots${snapshots.length > 0 ? ` (${snapshots.length})` : ''}`}
+            title={
+              <Tx
+                k="profiles.snapshots.title"
+                values={{ count: snapshots.length }}
+                fallback={`Snapshots${snapshots.length > 0 ? ` (${snapshots.length})` : ''}`}
+              />
+            }
             icon={History}
             action={
               <div className="flex items-center gap-1">
@@ -439,18 +452,18 @@ export default function Profiles() {
                   onClick={handleCreateManualSnapshot}
                   isLoading={creatingSnapshot}
                   disabled={creatingSnapshot}
-                  title="Capture your current installed mods now. Use this before experimenting (mass-installing variants, testing a collection, etc.) so you can roll back to this exact state."
-                  aria-label="Snapshot now"
+                  title={t('profiles.snapshots.snapshotNowTitle')}
+                  aria-label={t('profiles.snapshots.snapshotNow')}
                 >
-                  Snapshot now
+                  <Tx k="profiles.snapshots.snapshotNow" fallback="Snapshot now" />
                 </Button>
                 <Button
                   size="sm"
                   variant="ghost"
                   onClick={() => setSnapshotsExpanded((v) => !v)}
                   icon={snapshotsExpanded ? ChevronUp : ChevronDown}
-                  aria-label={snapshotsExpanded ? 'Collapse snapshots' : 'Expand snapshots'}
-                  title={snapshotsExpanded ? 'Collapse list' : 'Show all snapshots'}
+                  aria-label={snapshotsExpanded ? t('profiles.snapshots.collapse') : t('profiles.snapshots.expand')}
+                  title={snapshotsExpanded ? t('profiles.snapshots.collapseList') : t('profiles.snapshots.showAll')}
                   className="px-1.5"
                 />
               </div>
@@ -459,15 +472,32 @@ export default function Profiles() {
             {!snapshotsExpanded ? (
               <p
                 className="text-xs text-text-secondary"
-                title="Snapshots are automatic recovery points taken before mod updates and profile applies. They store the list of installed mods (not the VPK files), and restore by re-downloading from GameBanana. Snapshots accumulate until you delete them."
+                title={t('profiles.snapshots.tooltip')}
               >
                 {snapshots.length === 0
-                  ? 'Automatic recovery points captured before updates or profile applies. None yet — one will appear here the next time you run either.'
-                  : `Most recent: ${formatRelativeDate(snapshots[0].createdAt)} · ${snapshots[0].modCount} mods.`}
+                  ? (
+                    <Tx
+                      k="profiles.snapshots.collapsedEmpty"
+                      fallback="Automatic recovery points captured before updates or profile applies. None yet - one will appear here the next time you run either."
+                    />
+                  )
+                  : (
+                    <Tx
+                      k="profiles.snapshots.mostRecent"
+                      values={{
+                        date: formatRelativeDate(snapshots[0].createdAt),
+                        count: snapshots[0].modCount,
+                      }}
+                      fallback={`Most recent: ${formatRelativeDate(snapshots[0].createdAt)} - ${snapshots[0].modCount} mods.`}
+                    />
+                  )}
               </p>
             ) : snapshots.length === 0 ? (
               <p className="text-xs text-text-secondary">
-                Grimoire takes a snapshot of your installed mod set automatically before each mod update and before applying a profile. Restore re-downloads those mods from GameBanana, so a bad update or wrong-profile-applied can be rolled back. Snapshots store only the list of mods (their GameBanana IDs), never the VPK files, so disk cost stays tiny — they accumulate until you delete them. You can also capture one manually with the button above before experimenting.
+                <Tx
+                  k="profiles.snapshots.expandedEmpty"
+                  fallback="Grimoire takes a snapshot of your installed mod set automatically before each mod update and before applying a profile. Restore re-downloads those mods from GameBanana, so a bad update or wrong-profile-applied can be rolled back. Snapshots store only the list of mods (their GameBanana IDs), never the VPK files, so disk cost stays tiny - they accumulate until you delete them. You can also capture one manually with the button above before experimenting."
+                />
               </p>
             ) : (
               <>
@@ -489,14 +519,24 @@ export default function Profiles() {
                           checked={allSelected}
                           ref={(el) => { if (el) el.indeterminate = someSelected; }}
                           onChange={toggleAll}
-                          aria-label={allSelected ? 'Clear selection' : 'Select all snapshots'}
+                          aria-label={allSelected ? t('profiles.snapshots.clearSelection') : t('profiles.snapshots.selectAll')}
                           className="peer sr-only"
                         />
                         <CheckboxMark checked={allSelected} indeterminate={someSelected} />
                         <span>
-                          {selectedSnapshotIds.size === 0
-                            ? `Select to bulk delete (${snapshots.length})`
-                            : `${selectedSnapshotIds.size} selected`}
+                          {selectedSnapshotIds.size === 0 ? (
+                            <Tx
+                              k="profiles.snapshots.selectToBulkDelete"
+                              values={{ count: snapshots.length }}
+                              fallback={`Select to bulk delete (${snapshots.length})`}
+                            />
+                          ) : (
+                            <Tx
+                              k="profiles.snapshots.selected"
+                              values={{ count: selectedSnapshotIds.size }}
+                              fallback={`${selectedSnapshotIds.size} selected`}
+                            />
+                          )}
                         </span>
                       </label>
                       {selectedSnapshotIds.size > 0 && (
@@ -506,9 +546,13 @@ export default function Profiles() {
                           icon={Trash2}
                           onClick={() => setBulkDeleteSnapshotsOpen(true)}
                           className="ml-auto text-red-400 hover:text-red-300"
-                          title={`Delete the ${selectedSnapshotIds.size} selected snapshot${selectedSnapshotIds.size === 1 ? '' : 's'}.`}
+                          title={t('profiles.snapshots.deleteSelectedTitle', { count: selectedSnapshotIds.size })}
                         >
-                          Delete {selectedSnapshotIds.size}
+                          <Tx
+                            k="profiles.actions.deleteCount"
+                            values={{ count: selectedSnapshotIds.size }}
+                            fallback={`Delete ${selectedSnapshotIds.size}`}
+                          />
                         </Button>
                       )}
                     </div>
@@ -520,16 +564,16 @@ export default function Profiles() {
                   const isSelected = selectedSnapshotIds.has(snap.snapshotId);
                   const triggerLabel =
                     snap.trigger === 'pre-update'
-                      ? 'Before update'
+                      ? t('profiles.snapshots.trigger.preUpdate')
                       : snap.trigger === 'pre-apply-profile'
-                      ? 'Before applying profile'
-                      : 'Manual';
+                      ? t('profiles.snapshots.trigger.preApplyProfile')
+                      : t('profiles.snapshots.trigger.manual');
                   const triggerExplanation =
                     snap.trigger === 'pre-update'
-                      ? 'Captured automatically right before mod files were replaced by an update.'
+                      ? t('profiles.snapshots.explanation.preUpdate')
                       : snap.trigger === 'pre-apply-profile'
-                      ? 'Captured automatically right before a saved profile was applied (enable/disable layout rewritten).'
-                      : 'You captured this manually from the Snapshot now button.';
+                      ? t('profiles.snapshots.explanation.preApplyProfile')
+                      : t('profiles.snapshots.explanation.manual');
                   return (
                     <li
                       key={snap.snapshotId}
@@ -540,7 +584,7 @@ export default function Profiles() {
                           type="checkbox"
                           checked={isSelected}
                           onChange={() => toggleSnapshotSelected(snap.snapshotId)}
-                          aria-label={isSelected ? 'Unselect snapshot' : 'Select snapshot'}
+                          aria-label={isSelected ? t('profiles.snapshots.unselect') : t('profiles.snapshots.select')}
                           className="peer sr-only"
                         />
                         <CheckboxMark checked={isSelected} />
@@ -551,7 +595,14 @@ export default function Profiles() {
                           title={triggerExplanation}
                         >
                           {triggerLabel}
-                          <span className="text-text-secondary"> · {snap.modCount} mods</span>
+                          <span className="text-text-secondary">
+                            {' · '}
+                            <Tx
+                              k="profiles.mods.count"
+                              values={{ count: snap.modCount }}
+                              fallback={`${snap.modCount} mods`}
+                            />
+                          </span>
                         </div>
                         <div
                           className="text-xs text-text-secondary"
@@ -568,17 +619,17 @@ export default function Profiles() {
                           onClick={() => handleRestoreSnapshot(snap.snapshotId)}
                           isLoading={isRestoring}
                           disabled={isRestoring}
-                          title="Opens the import dialog with this snapshot's mod list pre-resolved. Mods already on disk stay as-is; anything missing or different re-downloads from GameBanana. Confirming creates a new profile you can apply to swap your install set back to this state."
+                          title={t('profiles.snapshots.restoreTitle')}
                         >
-                          Restore
+                          <Tx k="profiles.actions.restore" fallback="Restore" />
                         </Button>
                         <Button
                           size="sm"
                           variant="ghost"
                           icon={Trash2}
                           onClick={() => setDeleteSnapshotConfirmId(snap.snapshotId)}
-                          title="Delete this snapshot file. Other snapshots are unaffected; your installed mods are unaffected."
-                          aria-label="Delete snapshot"
+                          title={t('profiles.snapshots.deleteTitle')}
+                          aria-label={t('profiles.snapshots.delete')}
                           className="px-1.5"
                         />
                       </div>
@@ -595,8 +646,8 @@ export default function Profiles() {
             <div className="py-16">
               <EmptyState
                 icon={User}
-                title="No Profiles Yet"
-                description={t('profiles.empty.noProfiles')}
+                title={<Tx k="profiles.empty.title" fallback="No Profiles Yet" />}
+                description={<Tx k="profiles.empty.noProfiles" fallback="Create a profile to save your current mod setup." />}
               />
             </div>
           ) : (
@@ -627,7 +678,7 @@ export default function Profiles() {
                           }}
                           onBlur={submitRename}
                           disabled={isRenaming}
-                          aria-label="Rename profile"
+                          aria-label={t('profiles.actions.renameProfile')}
                           className="w-full px-2 py-1 bg-bg-tertiary border border-white/10 rounded text-text-primary text-lg font-semibold font-reaver focus:outline-none focus:ring-2 focus:ring-accent"
                         />
                       ) : (
@@ -644,8 +695,8 @@ export default function Profiles() {
                             type="button"
                             onClick={() => startRename(profile)}
                             disabled={isApplying || isUpdating}
-                            aria-label="Rename profile"
-                            title="Rename profile"
+                            aria-label={t('profiles.actions.renameProfile')}
+                            title={t('profiles.actions.renameProfile')}
                             className="p-1 text-text-secondary hover:text-text-primary hover:bg-white/5 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                           >
                             <Pencil className="w-3.5 h-3.5" />
@@ -657,29 +708,37 @@ export default function Profiles() {
                             onMouseDown={(e) => e.preventDefault()}
                             onClick={cancelRename}
                             disabled={isRenaming}
-                            aria-label="Cancel rename"
-                            title="Cancel"
+                            aria-label={t('profiles.actions.cancelRename')}
+                            title={t('common.actions.cancel')}
                             className="p-1 text-text-secondary hover:text-text-primary hover:bg-white/5 rounded transition-colors disabled:opacity-50"
                           >
                             <X className="w-3.5 h-3.5" />
                           </button>
                         )}
                         {isActive ? (
-                          <Badge variant="success" className="animate-pulse">Active</Badge>
+                          <Badge variant="success" className="animate-pulse">
+                            <Tx k="common.status.active" fallback="Active" />
+                          </Badge>
                         ) : (
-                          <Badge variant="neutral">Inactive</Badge>
+                          <Badge variant="neutral">
+                            <Tx k="common.status.inactive" fallback="Inactive" />
+                          </Badge>
                         )}
                       </div>
                     }
                   >
                     <div className="flex flex-col gap-4">
-                      <div className="flex items-center justify-between text-sm text-text-secondary bg-black/20 p-4 rounded-lg border border-white/5">
-                        <div className="flex flex-col items-center">
-                          <span className="text-2xl font-bold text-text-primary">{profileModGroups.length}</span>
-                          <span className="text-xs uppercase tracking-wider opacity-70">Mods</span>
-                        </div>
-                        <div className="text-right text-xs">
-                          <div className="mb-1 opacity-70">Updated</div>
+                        <div className="flex items-center justify-between text-sm text-text-secondary bg-black/20 p-4 rounded-lg border border-white/5">
+                          <div className="flex flex-col items-center">
+                            <span className="text-2xl font-bold text-text-primary">{profileModGroups.length}</span>
+                            <span className="text-xs uppercase tracking-wider opacity-70">
+                              <Tx k="profiles.mods.label" fallback="Mods" />
+                            </span>
+                          </div>
+                          <div className="text-right text-xs">
+                          <div className="mb-1 opacity-70">
+                            <Tx k="profiles.updated" fallback="Updated" />
+                          </div>
                           <div className="text-text-primary font-mono">{new Date(profile.updatedAt).toLocaleDateString()}</div>
                         </div>
                       </div>
@@ -687,9 +746,15 @@ export default function Profiles() {
                       {/* Capabilities Indicators */}
                       {profile.autoexecCommands && profile.autoexecCommands.length > 0 && (
                         <div className="flex gap-2">
-                          <div className="flex items-center gap-1.5 px-2 py-1 bg-white/5 rounded-md text-xs text-text-secondary" title="Includes Autoexec Commands">
+                          <div className="flex items-center gap-1.5 px-2 py-1 bg-white/5 rounded-md text-xs text-text-secondary" title={t('profiles.autoexec.includesTitle')}>
                             <Terminal className="w-3 h-3 text-blue-400" />
-                            <span>Autoexec ({profile.autoexecCommands.length})</span>
+                            <span>
+                              <Tx
+                                k="profiles.autoexec.count"
+                                values={{ count: profile.autoexecCommands.length }}
+                                fallback={`Autoexec (${profile.autoexecCommands.length})`}
+                              />
+                            </span>
                           </div>
                         </div>
                       )}
@@ -706,11 +771,15 @@ export default function Profiles() {
                             variant={isActive ? 'secondary' : 'primary'}
                             title={
                               isActive
-                                ? 'Re-apply: snap mods back to this profile if they have drifted'
+                                ? t('profiles.actions.reapplyTitle')
                                 : undefined
                             }
                           >
-                            {isActive ? 'Re-apply' : 'Apply'}
+                            {isActive ? (
+                              <Tx k="profiles.actions.reapply" fallback="Re-apply" />
+                            ) : (
+                              <Tx k="profiles.actions.apply" fallback="Apply" />
+                            )}
                           </Button>
                           <Button
                             size="sm"
@@ -724,9 +793,9 @@ export default function Profiles() {
                             disabled={isUpdating || isApplying}
                             isLoading={isUpdating}
                             icon={Save}
-                            title="Overwrite this profile with your current mods"
+                            title={t('profiles.actions.updateTitle')}
                           >
-                            Update
+                            <Tx k="profiles.actions.update" fallback="Update" />
                           </Button>
                         </div>
                         <div className="flex items-center gap-1 ml-auto">
@@ -736,8 +805,8 @@ export default function Profiles() {
                             onClick={() => setExportingProfileId(profile.id)}
                             disabled={isApplying || isUpdating}
                             icon={Share2}
-                            title="Export / share profile"
-                            aria-label="Export profile"
+                            title={t('profiles.actions.exportTitle')}
+                            aria-label={t('profiles.actions.exportProfile')}
                             className="px-1.5"
                           />
                           {socialSignedIn && (
@@ -747,8 +816,8 @@ export default function Profiles() {
                               onClick={() => setPublishingProfileId(profile.id)}
                               disabled={isApplying || isUpdating}
                               icon={Globe}
-                              title="Publish to Discover"
-                              aria-label="Publish to Discover"
+                              title={t('profiles.actions.publishToDiscover')}
+                              aria-label={t('profiles.actions.publishToDiscover')}
                               className="px-1.5"
                             />
                           )}
@@ -757,8 +826,8 @@ export default function Profiles() {
                             variant="ghost"
                             onClick={() => toggleExpand(profile.id)}
                             icon={isExpanded ? ChevronUp : ChevronDown}
-                            title={isExpanded ? 'Collapse details' : 'Expand details'}
-                            aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
+                            title={isExpanded ? t('common.actions.collapseDetails') : t('common.actions.expandDetails')}
+                            aria-label={isExpanded ? t('common.actions.collapseDetails') : t('common.actions.expandDetails')}
                             className="px-1.5"
                           />
                           <Button
@@ -767,8 +836,8 @@ export default function Profiles() {
                             onClick={() => setDeleteConfirmId(profile.id)}
                             disabled={isApplying || isUpdating}
                             icon={Trash2}
-                            title="Delete Profile"
-                            aria-label="Delete profile"
+                            title={t('profiles.actions.deleteProfile')}
+                            aria-label={t('profiles.actions.deleteProfile')}
                             className="px-1.5"
                           />
                         </div>
@@ -780,7 +849,19 @@ export default function Profiles() {
                           {/* Mods List */}
                           <div>
                             <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
-                              {`Mods (${profileModGroups.length}${profileFileCount !== profileModGroups.length ? `, ${profileFileCount} files` : ''})`}
+                              {profileFileCount !== profileModGroups.length ? (
+                                <Tx
+                                  k="profiles.mods.groupsAndFiles"
+                                  values={{ mods: profileModGroups.length, files: profileFileCount }}
+                                  fallback={`Mods (${profileModGroups.length}, ${profileFileCount} files)`}
+                                />
+                              ) : (
+                                <Tx
+                                  k="profiles.mods.groups"
+                                  values={{ count: profileModGroups.length }}
+                                  fallback={`Mods (${profileModGroups.length})`}
+                                />
+                              )}
                             </div>
                             <div className="max-h-32 overflow-y-auto pr-2 space-y-1">
                               {profileModGroups.map((group) => {
@@ -799,7 +880,11 @@ export default function Profiles() {
                                     <div className="flex items-center gap-2 shrink-0">
                                       {group.variants.length > 1 && (
                                         <span className="text-[10px] text-text-secondary bg-white/5 rounded px-1.5 py-0.5">
-                                          {group.variants.length} files
+                                          <Tx
+                                            k="profiles.mods.files"
+                                            values={{ count: group.variants.length }}
+                                            fallback={`${group.variants.length} files`}
+                                          />
                                         </span>
                                       )}
                                       {group.enabled && <Check className="w-3 h-3 text-green-400" />}
@@ -808,7 +893,9 @@ export default function Profiles() {
                                 );
                               })}
                               {profileModGroups.length === 0 && (
-                                <div className="text-xs text-text-secondary italic">No mods in profile</div>
+                                <div className="text-xs text-text-secondary italic">
+                                  <Tx k="profiles.mods.empty" fallback="No mods in profile" />
+                                </div>
                               )}
                             </div>
                           </div>
@@ -816,11 +903,23 @@ export default function Profiles() {
                           {/* Crosshair Preview */}
                           {profile.crosshair && (
                             <div className="pt-3 border-t border-white/5">
-                              <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">Crosshair</div>
+                              <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
+                                <Tx k="nav.crosshair" fallback="Crosshair" />
+                              </div>
                               <div className="flex items-center gap-4">
                                 <CrosshairPreview size={56} scale={1.3} settings={profile.crosshair} />
                                 <div className="text-xs text-text-secondary space-y-1">
-                                  <div>Gap: {profile.crosshair.pipGap} | Height: {profile.crosshair.pipHeight} | Width: {profile.crosshair.pipWidth}</div>
+                                  <div>
+                                    <Tx
+                                      k="profiles.crosshair.summary"
+                                      values={{
+                                        gap: profile.crosshair.pipGap,
+                                        height: profile.crosshair.pipHeight,
+                                        width: profile.crosshair.pipWidth,
+                                      }}
+                                      fallback={`Gap: ${profile.crosshair.pipGap} | Height: ${profile.crosshair.pipHeight} | Width: ${profile.crosshair.pipWidth}`}
+                                    />
+                                  </div>
                                   <div className="flex items-center gap-2">
                                     <div
                                       className="w-3 h-3 rounded-sm border border-white/20"
@@ -837,7 +936,11 @@ export default function Profiles() {
                           {profile.autoexecCommands && profile.autoexecCommands.length > 0 && (
                             <div className="pt-3 border-t border-white/5">
                               <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
-                                Autoexec ({profile.autoexecCommands.length} commands)
+                                <Tx
+                                  k="profiles.autoexec.commandsCount"
+                                  values={{ count: profile.autoexecCommands.length }}
+                                  fallback={`Autoexec (${profile.autoexecCommands.length} commands)`}
+                                />
                               </div>
                               <div className="space-y-1 max-h-24 overflow-y-auto">
                                 {profile.autoexecCommands.map((cmd, idx) => (
@@ -869,19 +972,17 @@ export default function Profiles() {
           setUpdateConfirmId(null);
           if (id) handleUpdateProfile(id);
         }}
-        title="Update Profile"
+        title={<Tx k="profiles.confirm.updateTitle" fallback="Update Profile" />}
         message={
           <>
-            Overwrite{' '}
-            <span className="text-text-primary font-medium">
-              {profiles.find((p) => p.id === updateConfirmId)?.name ?? 'this profile'}
-            </span>{' '}
-            with your currently enabled mods? The profile's saved mod list will be
-            replaced and can't be undone. (To load this profile onto your install
-            instead, use Apply.) You can turn this prompt off in Settings &rarr; Preferences.
+            <Tx
+              k="profiles.confirm.updateMessage"
+              values={{ name: profiles.find((p) => p.id === updateConfirmId)?.name ?? t('profiles.thisProfile') }}
+              fallback={`Overwrite ${profiles.find((p) => p.id === updateConfirmId)?.name ?? 'this profile'} with your currently enabled mods? The profile's saved mod list will be replaced and can't be undone. (To load this profile onto your install instead, use Apply.) You can turn this prompt off in Settings -> Preferences.`}
+            />
           </>
         }
-        confirmLabel="Update"
+        confirmLabel={<Tx k="profiles.actions.update" fallback="Update" />}
       />
 
       {/* Delete Confirmation Modal */}
@@ -889,9 +990,9 @@ export default function Profiles() {
         isOpen={deleteConfirmId !== null}
         onCancel={() => setDeleteConfirmId(null)}
         onConfirm={() => deleteConfirmId && handleDeleteProfile(deleteConfirmId)}
-        title="Delete Profile"
-        message="Are you sure you want to delete this profile? This action cannot be undone."
-        confirmLabel="Delete"
+        title={<Tx k="profiles.confirm.deleteTitle" fallback="Delete Profile" />}
+        message={<Tx k="profiles.confirm.deleteMessage" fallback="Are you sure you want to delete this profile? This action cannot be undone." />}
+        confirmLabel={<Tx k="common.actions.delete" fallback="Delete" />}
         variant="danger"
       />
 
@@ -936,9 +1037,9 @@ export default function Profiles() {
         isOpen={deleteSnapshotConfirmId !== null}
         onCancel={() => setDeleteSnapshotConfirmId(null)}
         onConfirm={() => deleteSnapshotConfirmId && handleDeleteSnapshot(deleteSnapshotConfirmId)}
-        title="Delete Snapshot"
-        message="Delete this recovery snapshot? You won't be able to restore from it later."
-        confirmLabel="Delete"
+        title={<Tx k="profiles.confirm.deleteSnapshotTitle" fallback="Delete Snapshot" />}
+        message={<Tx k="profiles.confirm.deleteSnapshotMessage" fallback="Delete this recovery snapshot? You won't be able to restore from it later." />}
+        confirmLabel={<Tx k="common.actions.delete" fallback="Delete" />}
         variant="danger"
       />
 
@@ -946,9 +1047,25 @@ export default function Profiles() {
         isOpen={bulkDeleteSnapshotsOpen}
         onCancel={() => !bulkDeletingSnapshots && setBulkDeleteSnapshotsOpen(false)}
         onConfirm={handleBulkDeleteSnapshots}
-        title="Delete Selected Snapshots"
-        message={`Delete ${selectedSnapshotIds.size} snapshot${selectedSnapshotIds.size === 1 ? '' : 's'}? Your installed mods are unaffected. You won't be able to restore from the deleted snapshots later.`}
-        confirmLabel={bulkDeletingSnapshots ? 'Deleting…' : `Delete ${selectedSnapshotIds.size}`}
+        title={<Tx k="profiles.confirm.deleteSelectedSnapshotsTitle" fallback="Delete Selected Snapshots" />}
+        message={
+          <Tx
+            k="profiles.confirm.deleteSelectedSnapshotsMessage"
+            values={{ count: selectedSnapshotIds.size }}
+            fallback={`Delete ${selectedSnapshotIds.size} snapshot${selectedSnapshotIds.size === 1 ? '' : 's'}? Your installed mods are unaffected. You won't be able to restore from the deleted snapshots later.`}
+          />
+        }
+        confirmLabel={
+          bulkDeletingSnapshots ? (
+            <Tx k="profiles.actions.deleting" fallback="Deleting..." />
+          ) : (
+            <Tx
+              k="profiles.actions.deleteCount"
+              values={{ count: selectedSnapshotIds.size }}
+              fallback={`Delete ${selectedSnapshotIds.size}`}
+            />
+          )
+        }
         variant="danger"
       />
     </div>

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Button, Badge } from '../components/common/ui';
 import { EmptyState, PageHeader } from '../components/common/PageComponents';
+import Tx from '../components/translation/Tx';
 import { useAppStore } from '../stores/appStore';
 import {
   deadworksListServers,
@@ -28,11 +29,11 @@ import ConnectServerDialog from '../components/servers/ConnectServerDialog';
 
 // Ping buckets drive the colour of the signal readout. Tuned for a competitive
 // shooter: under 60ms is comfortable, under 120ms is playable, beyond that hurts.
-function pingTone(ms: number): { color: string; label: string } {
-  if (ms < 0) return { color: 'text-text-secondary/50', label: 'n/a' };
-  if (ms < 60) return { color: 'text-green-400', label: `${ms} ms` };
-  if (ms < 120) return { color: 'text-yellow-400', label: `${ms} ms` };
-  return { color: 'text-red-400', label: `${ms} ms` };
+function pingTone(ms: number): { color: string } {
+  if (ms < 0) return { color: 'text-text-secondary/50' };
+  if (ms < 60) return { color: 'text-green-400' };
+  if (ms < 120) return { color: 'text-yellow-400' };
+  return { color: 'text-red-400' };
 }
 
 export default function Servers() {
@@ -74,11 +75,11 @@ export default function Servers() {
       setStats(relayStats);
       pingAll(list);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not reach the relay.');
+      setError(e instanceof Error ? e.message : t('servers.errors.relayUnreachable'));
     } finally {
       setLoading(false);
     }
-  }, [pingAll]);
+  }, [pingAll, t]);
 
   useEffect(() => {
     void refresh();
@@ -109,23 +110,38 @@ export default function Servers() {
   return (
     <div className="space-y-5 p-6">
       <PageHeader
-        title={t('nav.servers')}
-        description="Browse and join Deadworks community dedicated servers."
+        title={<Tx k="nav.servers" fallback="Servers" />}
+        description={
+          <Tx
+            k="servers.header.description"
+            fallback="Browse and join Deadworks community dedicated servers."
+          />
+        }
         stats={
           stats ? (
             <span className="flex items-center gap-3">
               <span className="flex items-center gap-1.5">
-                <ServerIcon size={14} /> {stats.servers_online} online
+                <ServerIcon size={14} />
+                <Tx
+                  k="servers.header.serversOnline"
+                  values={{ count: stats.servers_online }}
+                  fallback={`${stats.servers_online} online`}
+                />
               </span>
               <span className="flex items-center gap-1.5">
-                <Users size={14} /> {stats.players_online} playing
+                <Users size={14} />
+                <Tx
+                  k="servers.header.playersOnline"
+                  values={{ count: stats.players_online }}
+                  fallback={`${stats.players_online} playing`}
+                />
               </span>
             </span>
           ) : undefined
         }
         action={
           <Button variant="secondary" icon={RefreshCw} onClick={() => void refresh()} isLoading={loading}>
-            Refresh
+            <Tx k="common.actions.refresh" fallback="Refresh" />
           </Button>
         }
       />
@@ -133,7 +149,10 @@ export default function Servers() {
       {!hasGamePath && (
         <div className="flex items-center gap-2 rounded-sm border border-yellow-500/20 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-300">
           <AlertTriangle size={16} className="shrink-0" />
-          Set your Deadlock game path in Settings before joining a server.
+          <Tx
+            k="servers.warning.gamePathRequired"
+            fallback="Set your Deadlock game path in Settings before joining a server."
+          />
         </div>
       )}
 
@@ -144,7 +163,7 @@ export default function Servers() {
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search by name or map"
+            placeholder={t('servers.filters.searchPlaceholder')}
             className="w-full rounded-sm border border-border bg-bg-tertiary py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-secondary/60 focus:border-accent/50 focus:outline-none"
           />
         </div>
@@ -159,7 +178,7 @@ export default function Servers() {
             >
               {regions.map((r) => (
                 <option key={r} value={r} className="bg-bg-secondary">
-                  {r === 'all' ? 'All regions' : r}
+                  {r === 'all' ? t('servers.filters.allRegions') : r}
                 </option>
               ))}
             </select>
@@ -176,7 +195,7 @@ export default function Servers() {
             >
               {maps.map((m) => (
                 <option key={m} value={m} className="bg-bg-secondary">
-                  {m === 'all' ? 'All maps' : m}
+                  {m === 'all' ? t('servers.filters.allMaps') : m}
                 </option>
               ))}
             </select>
@@ -184,46 +203,70 @@ export default function Servers() {
         )}
 
         <Button variant={hideFull ? 'primary' : 'secondary'} size="sm" onClick={() => setHideFull((v) => !v)}>
-          Has space
+          <Tx k="servers.filters.hasSpace" fallback="Has space" />
         </Button>
       </div>
 
       {/* Content */}
       {loading && servers.length === 0 ? (
         <div className="flex items-center justify-center gap-2 py-20 text-text-secondary">
-          <Loader2 size={18} className="animate-spin" /> Loading servers...
+          <Loader2 size={18} className="animate-spin" />
+          <Tx k="servers.loading" fallback="Loading servers..." />
         </div>
       ) : error ? (
         <EmptyState
           icon={CloudOff}
-          title="Could not reach the relay"
+          title={<Tx k="servers.errors.relayTitle" fallback="Could not reach the relay" />}
           description={error}
-          action={<Button variant="secondary" icon={RefreshCw} onClick={() => void refresh()}>Try again</Button>}
+          action={
+            <Button variant="secondary" icon={RefreshCw} onClick={() => void refresh()}>
+              <Tx k="common.actions.tryAgain" fallback="Try again" />
+            </Button>
+          }
         />
       ) : visible.length === 0 ? (
         <EmptyState
           icon={ServerIcon}
-          title={servers.length === 0 ? 'No servers online' : 'No servers match your filters'}
+          title={
+            servers.length === 0 ? (
+              <Tx k="servers.empty.noneTitle" fallback="No servers online" />
+            ) : (
+              <Tx k="servers.empty.filtersTitle" fallback="No servers match your filters" />
+            )
+          }
           description={
-            servers.length === 0
-              ? 'No Deadworks servers are currently registered. Check back later, or host one (server hosting requires Windows).'
-              : 'Try clearing the search, region, or map filter.'
+            servers.length === 0 ? (
+              <Tx
+                k="servers.empty.noneDescription"
+                fallback="No Deadworks servers are currently registered. Check back later, or host one (server hosting requires Windows)."
+              />
+            ) : (
+              <Tx
+                k="servers.empty.filtersDescription"
+                fallback="Try clearing the search, region, or map filter."
+              />
+            )
           }
         />
       ) : (
         <div className="overflow-hidden rounded-md border border-border">
           {/* header row */}
           <div className="hidden grid-cols-[1fr_140px_90px_90px_110px] gap-3 border-b border-border bg-bg-secondary px-4 py-2 text-xs font-medium uppercase tracking-wide text-text-secondary md:grid">
-            <span>Server</span>
-            <span>Map</span>
-            <span className="text-center">Players</span>
-            <span className="text-center">Ping</span>
-            <span className="text-right">Join</span>
+            <span><Tx k="servers.table.server" fallback="Server" /></span>
+            <span><Tx k="servers.table.map" fallback="Map" /></span>
+            <span className="text-center"><Tx k="servers.table.players" fallback="Players" /></span>
+            <span className="text-center"><Tx k="servers.table.ping" fallback="Ping" /></span>
+            <span className="text-right"><Tx k="servers.actions.join" fallback="Join" /></span>
           </div>
           <ul className="divide-y divide-border">
             {visible.map((s) => {
               const ping = pings[s.id];
               const tone = pingTone(ping ?? -1);
+              const pingLabel = ping === undefined
+                ? null
+                : ping < 0
+                  ? t('servers.ping.unavailable')
+                  : t('servers.ping.ms', { ms: ping });
               const full = s.player_count >= s.max_players && s.max_players > 0;
               return (
                 <li
@@ -234,13 +277,13 @@ export default function Servers() {
                   <div className="flex min-w-0 items-center gap-2.5">
                     <span
                       className={`h-2 w-2 shrink-0 rounded-full ${s.online ? 'bg-green-400' : 'bg-text-secondary/40'}`}
-                      title={s.online ? 'Online' : 'Stale'}
+                      title={s.online ? t('servers.status.online') : t('servers.status.stale')}
                     />
                     <div className="min-w-0">
                       <div className="flex items-center gap-1.5">
                         <span className="truncate font-medium text-text-primary">{s.name}</span>
                         {s.password_protected && (
-                          <span title="Password protected" className="inline-flex shrink-0">
+                          <span title={t('servers.status.passwordProtected')} className="inline-flex shrink-0">
                             <Lock size={13} className="text-text-secondary" />
                           </span>
                         )}
@@ -248,7 +291,13 @@ export default function Servers() {
                       <div className="flex items-center gap-2 text-xs text-text-secondary">
                         {s.region && <span className="flex items-center gap-1"><MapPin size={11} />{s.region}</span>}
                         {s.content && s.content.length > 0 && (
-                          <Badge variant="info" className="!px-1.5 !py-0">{s.content.length} content</Badge>
+                          <Badge variant="info" className="!px-1.5 !py-0">
+                            <Tx
+                              k="servers.contentCount"
+                              values={{ count: s.content.length }}
+                              fallback={`${s.content.length} content`}
+                            />
+                          </Badge>
                         )}
                       </div>
                     </div>
@@ -268,7 +317,7 @@ export default function Servers() {
                   {/* ping */}
                   <div className={`flex items-center gap-1 text-sm md:justify-center ${tone.color}`}>
                     <Signal size={13} />
-                    {ping === undefined ? <Loader2 size={12} className="animate-spin" /> : tone.label}
+                    {ping === undefined ? <Loader2 size={12} className="animate-spin" /> : pingLabel}
                   </div>
 
                   {/* join */}
@@ -279,9 +328,15 @@ export default function Servers() {
                       icon={Play}
                       disabled={!hasGamePath || full}
                       onClick={() => setConnectTarget(s)}
-                      title={full ? 'Server is full' : !hasGamePath ? 'Set your game path first' : 'Join'}
+                      title={
+                        full
+                          ? t('servers.join.serverFull')
+                          : !hasGamePath
+                            ? t('servers.join.setGamePathFirst')
+                            : t('servers.actions.join')
+                      }
                     >
-                      Join
+                      <Tx k="servers.actions.join" fallback="Join" />
                     </Button>
                   </div>
                 </li>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -21,6 +21,7 @@ import { AVAILABLE_LANGUAGES, languageDisplayName } from '../i18n';
 import { TRANSLATION_LANGUAGE_OPTIONS, translationLanguageLabel } from '../lib/translationLanguages';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
+import Tx from '../components/translation/Tx';
 import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
 import { DEFAULT_SIDEBAR_HERO, HERO_NAMES_SORTED, getHeroChipIconPath } from '../lib/lockerUtils';
 import SocialAccountSection from '../components/social/SocialAccountSection';
@@ -37,13 +38,14 @@ const releaseTagUrl = (version?: string | null) =>
 // A version number that links to its GitHub release notes. Renders nothing when
 // there's no version to point at.
 function ReleaseVersionLink({ version, className = '' }: { version?: string | null; className?: string }) {
+  const { t } = useTranslation();
   if (!version) return null;
   return (
     <a
       href={releaseTagUrl(version)}
       target="_blank"
       rel="noopener noreferrer"
-      title={`View v${version} release notes on GitHub`}
+      title={t('settings.updates.releaseNotesTitle', { version })}
       className={`underline decoration-dotted underline-offset-2 transition-colors hover:text-accent ${className}`}
     >
       v{version}
@@ -180,7 +182,7 @@ export default function Settings() {
     if (isDevMode) return;
     const selected = await showOpenDialog({
       directory: true,
-      title: 'Select Deadlock Installation Folder',
+      title: t('settings.gamePath.selectFolder'),
     });
 
     if (selected) {
@@ -420,7 +422,7 @@ export default function Settings() {
     setCleanupResult(null);
     try {
       const result = await cleanupAddons();
-      setCleanupResult(`${result.removedArchives} archive file(s) removed.`);
+      setCleanupResult(t('settings.maintenance.archivesRemoved', { count: result.removedArchives }));
     } catch (err) {
       setCleanupResult(String(err));
     } finally {
@@ -451,7 +453,7 @@ export default function Settings() {
       const text = await buildDiagnosticReport(bugDescription, { includeFullLog });
       setBugReportText(text);
     } catch (err) {
-      setBugReportError(`Couldn't build report: ${String(err)}`);
+      setBugReportError(t('settings.support.reportBuildFailed', { error: String(err) }));
     } finally {
       setIsBuildingReport(false);
     }
@@ -475,7 +477,7 @@ export default function Settings() {
   // "copy the report, then click the button, then paste."
   const githubIssueUrl = useMemo(() => {
     const firstLine = bugDescription.split('\n').find((l) => l.trim().length > 0) ?? '';
-    const title = firstLine.trim().slice(0, 100) || 'Bug report';
+    const title = firstLine.trim().slice(0, 100) || t('settings.support.bugReportTitle');
     const body = [
       bugDescription.trim() || '<!-- describe what happened -->',
       '',
@@ -489,7 +491,7 @@ export default function Settings() {
     ].join('\n');
     const q = `?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
     return `https://github.com/Slush97/grimoire/issues/new${q}`;
-  }, [bugDescription]);
+  }, [bugDescription, t]);
 
   // Load sync status
   useEffect(() => {
@@ -595,7 +597,7 @@ export default function Settings() {
       await window.electronAPI.wipeModCache();
       const status = await window.electronAPI.getSyncStatus();
       setSyncStatus(status);
-      setWipeResult('Cache cleared.');
+      setWipeResult(t('settings.cache.cleared'));
     } catch (err) {
       setWipeResult(String(err));
     } finally {
@@ -610,7 +612,7 @@ export default function Settings() {
     try {
       const { bytesFreed } = await window.electronAPI.clearPreviewCache();
       setPreviewCacheBytes(0);
-      setPreviewResult(`Cleared ${formatBytes(bytesFreed)}.`);
+      setPreviewResult(t('settings.cache.previewCleared', { size: formatBytes(bytesFreed) }));
     } catch (err) {
       setPreviewResult(String(err));
     } finally {
@@ -623,7 +625,7 @@ export default function Settings() {
     if (!settings) return;
     try {
       await saveSettings({ ...settings, hasCompletedSetup: false });
-      setResetResult('The setup wizard will appear on the next app launch.');
+      setResetResult(t('settings.setupWizard.resetResult'));
       setTimeout(() => setResetResult(null), 5000);
     } catch (err) {
       setResetResult(`Error: ${String(err)}`);
@@ -649,21 +651,33 @@ export default function Settings() {
   return (
     <div className="p-8 max-w-5xl mx-auto space-y-8 animate-fade-in">
       <PageHeader
-        title="Settings"
-        description={t('settings.header.description')}
+        title={<Tx k="nav.settings" fallback="Settings" />}
+        description={<Tx k="settings.header.description" fallback="Game paths, preferences, and maintenance" />}
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Game Configuration Section - Full Width */}
-        <Card title="Game Configuration" icon={HardDrive} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.gameConfiguration" fallback="Game Configuration" />} icon={HardDrive} className="lg:col-span-2">
           <div className="space-y-6">
             <div>
               <div className="flex justify-between items-center mb-2">
-                <label className="text-sm font-medium text-text-primary">Deadlock Installation Path</label>
+                <label className="text-sm font-medium text-text-primary">
+                  <Tx k="settings.gamePath.label" fallback="Deadlock Installation Path" />
+                </label>
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-text-secondary">
-                    {isValidPath === true && <span className="text-green-400 flex items-center gap-1"><Check className="w-3 h-3" /> Valid</span>}
-                    {isValidPath === false && <span className="text-red-400 flex items-center gap-1"><X className="w-3 h-3" /> Invalid</span>}
+                    {isValidPath === true && (
+                      <span className="text-green-400 flex items-center gap-1">
+                        <Check className="w-3 h-3" />
+                        <Tx k="common.status.valid" fallback="Valid" />
+                      </span>
+                    )}
+                    {isValidPath === false && (
+                      <span className="text-red-400 flex items-center gap-1">
+                        <X className="w-3 h-3" />
+                        <Tx k="common.status.invalid" fallback="Invalid" />
+                      </span>
+                    )}
                   </span>
                   {!isDevMode && (
                     <Button
@@ -674,7 +688,7 @@ export default function Settings() {
                       size="sm"
                       icon={RefreshCw}
                     >
-                      Auto-detect
+                      <Tx k="settings.gamePath.autoDetect" fallback="Auto-detect" />
                     </Button>
                   )}
                 </div>
@@ -697,14 +711,22 @@ export default function Settings() {
                   variant="secondary"
                   icon={FolderOpen}
                 >
-                  Browse
+                  <Tx k="common.actions.browse" fallback="Browse" />
                 </Button>
               </div>
 
               <p className="text-xs text-text-secondary mt-2 pl-1">
-                {isDevMode
-                  ? 'Dev mode is active. Deadlock path selection is disabled.'
-                  : "Select your Deadlock game folder (contains the 'game' directory)"}
+                {isDevMode ? (
+                  <Tx
+                    k="settings.gamePath.devModeActive"
+                    fallback="Dev mode is active. Deadlock path selection is disabled."
+                  />
+                ) : (
+                  <Tx
+                    k="settings.gamePath.selectHint"
+                    fallback="Select your Deadlock game folder (contains the 'game' directory)"
+                  />
+                )}
               </p>
             </div>
 
@@ -713,26 +735,39 @@ export default function Settings() {
             <div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center">
               <div>
                 <div className="font-medium flex items-center gap-2">
-                  gameinfo.gi Status
+                  <Tx k="settings.gameinfo.title" fallback="gameinfo.gi Status" />
                   {gameinfoConfigured ? (
-                    <Badge variant="success">Configured</Badge>
+                    <Badge variant="success">
+                      <Tx k="common.status.configured" fallback="Configured" />
+                    </Badge>
                   ) : gameinfoConfigured === false ? (
-                    <Badge variant="error" className="animate-pulse">Issues Found</Badge>
+                    <Badge variant="error" className="animate-pulse">
+                      <Tx k="settings.gameinfo.issuesFound" fallback="Issues Found" />
+                    </Badge>
                   ) : (
-                    <Badge variant="neutral">Checking...</Badge>
+                    <Badge variant="neutral">
+                      <Tx k="common.status.checking" fallback="Checking..." />
+                    </Badge>
                   )}
                 </div>
                 <p className="text-xs text-text-secondary mt-1 max-w-md">
-                  {gameinfoStatus ?? 'Checking gameinfo.gi status...'}
+                  {gameinfoStatus ?? t('settings.gameinfo.checkingStatus')}
                 </p>
                 {gameinfoMissing && (
                   <div className="mt-2 max-w-md space-y-1">
                     <p className="text-xs text-text-secondary">
-                      In Steam: right-click Deadlock {'>'} Properties {'>'} Installed Files {'>'} Verify integrity of game files.
+                      <Tx
+                        k="settings.gameinfo.verifySteam"
+                        fallback="In Steam: right-click Deadlock > Properties > Installed Files > Verify integrity of game files."
+                      />
                     </p>
                     {gameinfoCandidates.length > 0 && (
                       <p className="text-xs text-amber-300">
-                        Found nearby: {gameinfoCandidates.join(', ')}. Rename one to gameinfo.gi to restore.
+                        <Tx
+                          k="settings.gameinfo.foundNearby"
+                          values={{ candidates: gameinfoCandidates.join(', ') }}
+                          fallback={`Found nearby: ${gameinfoCandidates.join(', ')}. Rename one to gameinfo.gi to restore.`}
+                        />
                       </p>
                     )}
                   </div>
@@ -745,7 +780,7 @@ export default function Settings() {
                   variant="primary"
                   icon={FolderOpen}
                 >
-                  Open Game Folder
+                  <Tx k="settings.gamePath.openGameFolder" fallback="Open Game Folder" />
                 </Button>
               ) : (
                 <Button
@@ -755,7 +790,7 @@ export default function Settings() {
                   variant={gameinfoConfigured ? 'secondary' : 'primary'}
                   icon={Wrench}
                 >
-                  Fix Configuration
+                  <Tx k="settings.gameinfo.fixConfiguration" fallback="Fix Configuration" />
                 </Button>
               )}
             </div>
@@ -763,27 +798,33 @@ export default function Settings() {
         </Card>
 
         {/* Updates */}
-        <Card title="Updates" icon={Download} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.updates" fallback="Updates" />} icon={Download} className="lg:col-span-2">
           <div className="space-y-4">
             <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium">Current Version</span>
+                  <span className="text-sm font-medium">
+                    <Tx k="settings.updates.currentVersion" fallback="Current Version" />
+                  </span>
                   <Badge variant="info">v{appVersion || '...'}</Badge>
                 </div>
                 {updateStatus?.available && !updateStatus.downloaded && (
                   <span className="text-xs text-accent">
-                    <ReleaseVersionLink version={updateStatus.updateInfo?.version} /> available!
+                    <ReleaseVersionLink version={updateStatus.updateInfo?.version} />{' '}
+                    <Tx k="settings.updates.available" fallback="available!" />
                   </span>
                 )}
                 {updateStatus?.downloaded && (
                   <span className="text-xs text-green-400 inline-flex items-center gap-1">
                     <Sparkles className="w-3 h-3" />
-                    <ReleaseVersionLink version={updateStatus.updateInfo?.version} /> ready to install
+                    <ReleaseVersionLink version={updateStatus.updateInfo?.version} />{' '}
+                    <Tx k="settings.updates.readyToInstall" fallback="ready to install" />
                   </span>
                 )}
                 {upToDate && !updateStatus?.available && !updateStatus?.checking && (
-                  <span className="text-xs text-green-400">✓ You're up to date!</span>
+                  <span className="text-xs text-green-400">
+                    <Tx k="settings.updates.upToDate" fallback="✓ You're up to date!" />
+                  </span>
                 )}
                 {updateStatus?.error && (
                   <span className="text-xs text-red-400 basis-full">{updateStatus.error}</span>
@@ -797,21 +838,21 @@ export default function Settings() {
                   variant="secondary"
                   icon={Sparkles}
                 >
-                  What's New
+                  <Tx k="settings.updates.whatsNew" fallback="What's New" />
                 </Button>
                 {installSource === 'managed' ? null : updateStatus?.downloaded ? (
                   <Button
                     onClick={handleInstallUpdate}
                     icon={ArrowDownCircle}
                   >
-                    Install & Restart
+                    <Tx k="settings.updates.installRestart" fallback="Install & Restart" />
                   </Button>
                 ) : updateStatus?.available && !updateStatus.downloading ? (
                   <Button
                     onClick={handleDownloadUpdate}
                     icon={Download}
                   >
-                    Download Update
+                    <Tx k="settings.updates.downloadUpdate" fallback="Download Update" />
                   </Button>
                 ) : (
                   <Button
@@ -821,7 +862,11 @@ export default function Settings() {
                     variant="secondary"
                     icon={RefreshCw}
                   >
-                    {updateStatus?.checking ? 'Checking...' : 'Check for Updates'}
+                    {updateStatus?.checking ? (
+                      <Tx k="common.status.checking" fallback="Checking..." />
+                    ) : (
+                      <Tx k="settings.updates.checkForUpdates" fallback="Check for Updates" />
+                    )}
                   </Button>
                 )}
               </div>
@@ -829,15 +874,21 @@ export default function Settings() {
 
             {installSource === 'managed' && (
               <div className="rounded-lg bg-bg-tertiary border border-white/10 p-3 text-sm text-text-secondary space-y-2">
-                <p className="text-text-primary font-medium">Updates are managed by your package manager.</p>
-                <p>
-                  Grimoire was installed via a system package. Update with your distro's tools:{' '}
-                  <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code> on Arch, or{' '}
-                  <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code> on Debian/Ubuntu.
+                <p className="text-text-primary font-medium">
+                  <Tx k="settings.updates.managed" fallback="Updates are managed by your package manager." />
                 </p>
                 <p>
-                  Installed the <code className="font-mono text-text-primary">.deb</code> manually? Add the apt repository for
-                  automatic updates (instructions at <code className="font-mono text-text-primary">grimoiremods.com/download</code>).
+                  <Tx k="settings.updates.managedPrefix" fallback="Grimoire was installed via a system package. Update with your distro's tools:" />{' '}
+                  <code className="font-mono text-text-primary">yay -Syu grimoire-bin</code>{' '}
+                  <Tx k="settings.updates.onArchOr" fallback="on Arch, or" />{' '}
+                  <code className="font-mono text-text-primary">{'sudo apt update && sudo apt upgrade'}</code>{' '}
+                  <Tx k="settings.updates.onDebianUbuntu" fallback="on Debian/Ubuntu." />
+                </p>
+                <p>
+                  <Tx k="settings.updates.installedDebPrefix" fallback="Installed the" />{' '}
+                  <code className="font-mono text-text-primary">.deb</code>{' '}
+                  <Tx k="settings.updates.installedDebSuffix" fallback="manually? Add the apt repository for automatic updates (instructions at" />{' '}
+                  <code className="font-mono text-text-primary">grimoiremods.com/download</code>).
                 </p>
               </div>
             )}
@@ -845,7 +896,7 @@ export default function Settings() {
             {updateStatus?.downloading && (
               <div className="animate-fade-in">
                 <div className="flex justify-between text-xs text-text-secondary mb-1">
-                  <span>Downloading update...</span>
+                  <span><Tx k="settings.updates.downloading" fallback="Downloading update..." /></span>
                   <span>{Math.round(updateStatus.progress)}%</span>
                 </div>
                 <div className="w-full bg-bg-tertiary rounded-sm h-1.5 overflow-hidden">
@@ -861,7 +912,7 @@ export default function Settings() {
 
         {/* Appearance */}
         <Card
-          title="Appearance"
+          title={<Tx k="settings.sections.appearance" fallback="Appearance" />}
           icon={Palette}
           className="lg:col-span-2"
           action={
@@ -881,7 +932,7 @@ export default function Settings() {
                           type="button"
                           onClick={() => handleAccentChange(preset.color)}
                           title={preset.name}
-                          aria-label={`Accent: ${preset.name}`}
+                          aria-label={t('settings.appearance.accentNamed', { name: preset.name })}
                           aria-pressed={isActive}
                           className={`${swatchBase} ${
                             isActive
@@ -898,8 +949,8 @@ export default function Settings() {
                     <button
                       type="button"
                       onClick={openCustomPicker}
-                      title="Pick a custom color"
-                      aria-label="Accent: Custom"
+                      title={t('settings.appearance.pickCustomColor')}
+                      aria-label={t('settings.appearance.accentCustom')}
                       aria-pressed={isCustomActive}
                       aria-haspopup="dialog"
                       className={`${swatchBase} ${
@@ -924,8 +975,16 @@ export default function Settings() {
                         setCustomPickerOpen(false);
                         setHeroPickerOpen(true);
                       }}
-                      title={selectedSidebarHero ? `Sidebar highlight: ${selectedSidebarHero}` : 'Sidebar highlight: None'}
-                      aria-label={selectedSidebarHero ? `Sidebar highlight: ${selectedSidebarHero}` : 'Sidebar highlight: None'}
+                      title={
+                        selectedSidebarHero
+                          ? t('settings.appearance.sidebarHighlightNamed', { hero: selectedSidebarHero })
+                          : t('settings.appearance.sidebarHighlightNone')
+                      }
+                      aria-label={
+                        selectedSidebarHero
+                          ? t('settings.appearance.sidebarHighlightNamed', { hero: selectedSidebarHero })
+                          : t('settings.appearance.sidebarHighlightNone')
+                      }
                       aria-haspopup="dialog"
                       className={`${swatchBase} bg-bg-tertiary ${
                         selectedSidebarHero
@@ -957,12 +1016,12 @@ export default function Settings() {
                           onClick={(e) => e.stopPropagation()}
                           role="dialog"
                           aria-modal="true"
-                          aria-label="Custom accent color"
+                          aria-label={t('settings.appearance.customAccentColor')}
                         >
                           <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
                           <h3 className="text-lg font-semibold text-text-primary tracking-wide font-reaver mb-4 flex items-center gap-2">
                             <Pipette className="w-4 h-4 text-accent" />
-                            Custom Accent
+                            <Tx k="settings.appearance.customAccent" fallback="Custom Accent" />
                           </h3>
                           <div className="space-y-4">
                             <HexColorPicker
@@ -974,7 +1033,7 @@ export default function Settings() {
                               <span
                                 className="block w-9 h-9 rounded-sm border border-white/10 shrink-0"
                                 style={{ backgroundColor: customDraft ?? settings?.accentColor ?? DEFAULT_ACCENT_COLOR }}
-                                aria-label="Selected color preview"
+                                aria-label={t('settings.appearance.selectedColorPreview')}
                               />
                               <span className="text-xs text-text-secondary font-mono">#</span>
                               <HexColorInput
@@ -993,14 +1052,14 @@ export default function Settings() {
                                   setCustomPickerOpen(false);
                                 }}
                               >
-                                Cancel
+                                <Tx k="common.actions.cancel" fallback="Cancel" />
                               </Button>
                               <Button
                                 variant="primary"
                                 size="sm"
                                 onClick={() => void commitCustomDraft()}
                               >
-                                Apply
+                                <Tx k="common.actions.apply" fallback="Apply" />
                               </Button>
                             </div>
                           </div>
@@ -1026,17 +1085,17 @@ export default function Settings() {
                           <div className="mb-4 flex items-center justify-between gap-3">
                             <div className="min-w-0">
                               <h3 id="sidebar-hero-picker-title" className="text-lg font-semibold text-text-primary tracking-wide font-reaver">
-                                Sidebar Highlight
+                                <Tx k="settings.appearance.sidebarHighlight" fallback="Sidebar Highlight" />
                               </h3>
                               <p className="text-xs text-text-secondary">
-                                {selectedSidebarHero ?? 'None'}
+                                {selectedSidebarHero ?? t('common.none')}
                               </p>
                             </div>
                             <button
                               type="button"
                               onClick={() => setHeroPickerOpen(false)}
-                              title="Close"
-                              aria-label="Close sidebar highlight picker"
+                              title={t('common.actions.close')}
+                              aria-label={t('settings.appearance.closeSidebarHighlightPicker')}
                               className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/10 text-text-secondary transition-colors hover:border-white/25 hover:bg-white/5 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                             >
                               <X className="h-4 w-4" aria-hidden />
@@ -1046,8 +1105,8 @@ export default function Settings() {
                             <button
                               type="button"
                               onClick={() => void handleSidebarHeroHighlightChange(null)}
-                              title="None"
-                              aria-label="Sidebar highlight: None"
+                              title={t('common.none')}
+                              aria-label={t('settings.appearance.sidebarHighlightNone')}
                               aria-pressed={selectedSidebarHero === null}
                               className={`relative flex aspect-square items-center justify-center rounded-sm border transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                                 selectedSidebarHero === null
@@ -1070,7 +1129,7 @@ export default function Settings() {
                                   type="button"
                                   onClick={() => void handleSidebarHeroHighlightChange(heroName)}
                                   title={heroName}
-                                  aria-label={`Sidebar highlight: ${heroName}`}
+                                  aria-label={t('settings.appearance.sidebarHighlightNamed', { hero: heroName })}
                                   aria-pressed={active}
                                   className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                                     active
@@ -1107,19 +1166,19 @@ export default function Settings() {
 
         {/* Grimoire Social */}
         {settings?.experimentalSocial && (
-          <Card title="Grimoire Social" icon={Globe} className="lg:col-span-2">
+          <Card title={<Tx k="settings.sections.grimoireSocial" fallback="Grimoire Social" />} icon={Globe} className="lg:col-span-2">
             <SocialAccountSection />
           </Card>
         )}
 
         {/* Preferences */}
-        <Card title="Preferences" icon={Shield}>
+        <Card title={<Tx k="settings.sections.preferences" fallback="Preferences" />} icon={Shield}>
           <div className="space-y-6">
             <Toggle
               checked={settings?.hideNsfwPreviews ?? true}
               onChange={handleHideNsfwChange}
-              label="Hide NSFW Content"
-              description="Blur thumbnail images for mods marked as NSFW."
+              label={<Tx k="settings.preferences.hideNsfw" fallback="Hide NSFW Content" />}
+              description={<Tx k="settings.preferences.hideNsfwDescription" fallback="Blur thumbnail images for mods marked as NSFW." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1127,8 +1186,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.hideOutdatedMods ?? false}
               onChange={handleHideOutdatedChange}
-              label="Hide Outdated Mods"
-              description={t('settings.toggles.hideOutdated')}
+              label={<Tx k="settings.preferences.hideOutdated" fallback="Hide Outdated Mods" />}
+              description={<Tx k="settings.toggles.hideOutdated" fallback="Hide Browse mods older than the current game version." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1136,8 +1195,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.lockerCardsExpandedByDefault ?? false}
               onChange={handleLockerCardsExpandedByDefaultChange}
-              label="Expand Locker cards by default"
-              description={t('settings.toggles.expandLocker')}
+              label={<Tx k="settings.preferences.expandLocker" fallback="Expand Locker cards by default" />}
+              description={<Tx k="settings.toggles.expandLocker" fallback="Start Locker list view with hero cards expanded." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1145,8 +1204,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.autoDisableSiblingVariants ?? true}
               onChange={handleAutoDisableSiblingsChange}
-              label="Switch variants instead of stacking them"
-              description={t('settings.toggles.switchVariants')}
+              label={<Tx k="settings.preferences.switchVariants" fallback="Switch variants instead of stacking them" />}
+              description={<Tx k="settings.toggles.switchVariants" fallback="Installing a new variant disables the old one. Off keeps both active. Updates always replace the old file." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1154,8 +1213,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.autoEnableDownloads ?? false}
               onChange={handleAutoEnableDownloadsChange}
-              label="Enable mods after download"
-              description={t('settings.toggles.enableAfterDownload')}
+              label={<Tx k="settings.preferences.enableAfterDownload" fallback="Enable mods after download" />}
+              description={<Tx k="settings.toggles.enableAfterDownload" fallback="Enable mods as soon as they finish downloading. Stays disabled if no slot is free." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1163,8 +1222,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.confirmProfileUpdate ?? true}
               onChange={handleConfirmProfileUpdateChange}
-              label="Confirm before updating a profile"
-              description={t('settings.toggles.confirmProfileUpdate')}
+              label={<Tx k="settings.preferences.confirmProfileUpdate" fallback="Confirm before updating a profile" />}
+              description={<Tx k="settings.toggles.confirmProfileUpdate" fallback="Confirm before overwriting a profile's saved mods. Off overwrites immediately." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1172,8 +1231,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.ignoreConflictsByDefault ?? false}
               onChange={handleIgnoreConflictsByDefaultChange}
-              label="Ignore conflicts by default"
-              description={t('settings.toggles.ignoreConflicts')}
+              label={<Tx k="settings.preferences.ignoreConflicts" fallback="Ignore conflicts by default" />}
+              description={<Tx k="settings.toggles.ignoreConflicts" fallback="Hide all conflicts from the Conflicts page. Off shows them." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1181,8 +1240,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.discordRpcEnabled ?? false}
               onChange={handleDiscordRpcChange}
-              label="Discord Rich Presence"
-              description={t('settings.toggles.discordRpc')}
+              label={<Tx k="settings.preferences.discordRpc" fallback="Discord Rich Presence" />}
+              description={<Tx k="settings.toggles.discordRpc" fallback="Show your current Grimoire activity on your Discord profile. Talks only to your local Discord app and sends nothing to Grimoire." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1191,15 +1250,15 @@ export default function Settings() {
               <Toggle
                 checked={settings?.contributeMatchSalts ?? false}
                 onChange={handleContributeMatchSaltsChange}
-                label="Contribute match data to deadlock-api.com"
-                description={t('settings.toggles.contributeSalts')}
+                label={<Tx k="settings.preferences.contributeMatchData" fallback="Contribute match data to deadlock-api.com" />}
+                description={<Tx k="settings.toggles.contributeSalts" fallback="Share the replay keys Steam already caches for matches you view in-game. Sends only the match id, server cluster, and two download keys: no account id, no username, nothing about you or your mods." />}
               />
               {settings?.contributeMatchSalts && saltIngestStatus && (
                 <div className="mt-2 text-xs text-text-secondary">
                   {saltIngestStatus.totalSubmitted > 0
-                    ? `${saltIngestStatus.totalSubmitted} match salt${saltIngestStatus.totalSubmitted === 1 ? '' : 's'} contributed so far.`
-                    : 'Nothing to contribute yet. Salts appear after you view match details in-game.'}
-                  {saltIngestStatus.lastError ? ` Last attempt failed: ${saltIngestStatus.lastError}.` : ''}
+                    ? t('settings.preferences.saltsContributed', { count: saltIngestStatus.totalSubmitted })
+                    : t('settings.preferences.noSaltsYet')}
+                  {saltIngestStatus.lastError ? ` ${t('settings.preferences.lastSaltAttemptFailed', { error: saltIngestStatus.lastError })}` : ''}
                 </div>
               )}
             </div>
@@ -1211,8 +1270,8 @@ export default function Settings() {
                 checked={isDevMode}
                 onChange={handleDevModeChange}
                 disabled={isCreatingDevPath}
-                label="Developer Mode"
-                description="Use a dummy Deadlock directory for local testing without game files."
+                label={<Tx k="settings.preferences.developerMode" fallback="Developer Mode" />}
+                description={<Tx k="settings.preferences.developerModeDescription" fallback="Use a dummy Deadlock directory for local testing without game files." />}
               />
               {isDevMode && settings?.devDeadlockPath && (
                 <div className="mt-2 text-xs font-mono bg-black/30 p-2 rounded-sm text-text-secondary break-all">
@@ -1224,9 +1283,14 @@ export default function Settings() {
             <div className="h-px bg-white/5" />
 
             <div>
-              <label className="text-sm font-medium text-text-primary block">Date Format</label>
+              <label className="text-sm font-medium text-text-primary block">
+                <Tx k="settings.preferences.dateFormat" fallback="Date Format" />
+              </label>
               <p className="text-xs text-text-secondary mt-0.5 mb-2">
-                How upload and update dates are shown on mods and files.
+                <Tx
+                  k="settings.preferences.dateFormatDescription"
+                  fallback="How upload and update dates are shown on mods and files."
+                />
               </p>
               <div className="inline-flex rounded-md border border-white/10 overflow-hidden">
                 {(['MM/DD/YYYY', 'DD/MM/YYYY'] as const).map((fmt, i) => {
@@ -1257,10 +1321,10 @@ export default function Settings() {
 
                 <div>
                   <label className="text-sm font-medium text-text-primary block">
-                    {t('settings.language.label')}
+                    <Tx k="settings.language.label" fallback="Language" />
                   </label>
                   <p className="text-xs text-text-secondary mt-0.5 mb-2">
-                    {t('settings.language.description')}
+                    <Tx k="settings.language.description" fallback="Choose the app language, or follow your system preference." />
                   </p>
                   <select
                     value={settings?.language ?? ''}
@@ -1281,17 +1345,20 @@ export default function Settings() {
         </Card>
 
         {/* Experimental Features */}
-        <Card title="Experimental Features" icon={Beaker}>
+        <Card title={<Tx k="settings.sections.experimentalFeatures" fallback="Experimental Features" />} icon={Beaker}>
           <div className="space-y-6">
             <p className="text-xs text-text-secondary -mt-2">
-              These features are still in development and may be incomplete or buggy.
+              <Tx
+                k="settings.experimental.description"
+                fallback="These features are still in development and may be incomplete or buggy."
+              />
             </p>
 
             <Toggle
               checked={settings?.experimentalStats ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalStats: checked })}
-              label="Stats Dashboard"
-              description="Track your performance with data from the Deadlock Stats API."
+              label={<Tx k="settings.experimental.statsDashboard" fallback="Stats Dashboard" />}
+              description={<Tx k="settings.experimental.statsDashboardDescription" fallback="Track your performance with data from the Deadlock Stats API." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1299,8 +1366,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.experimentalCrosshair ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalCrosshair: checked })}
-              label="Crosshair Designer"
-              description="Create custom crosshairs with a live preview."
+              label={<Tx k="settings.experimental.crosshairDesigner" fallback="Crosshair Designer" />}
+              description={<Tx k="settings.experimental.crosshairDesignerDescription" fallback="Create custom crosshairs with a live preview." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1308,8 +1375,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.experimentalSocial ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalSocial: checked })}
-              label="Grimoire Social"
-              description="Sign in with Steam to publish profiles and browse uploads from other players in Discover."
+              label={<Tx k="settings.sections.grimoireSocial" fallback="Grimoire Social" />}
+              description={<Tx k="settings.experimental.socialDescription" fallback="Sign in with Steam to publish profiles and browse uploads from other players in Discover." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1318,20 +1385,20 @@ export default function Settings() {
               <Toggle
                 checked={settings?.experimentalTranslationMode ?? false}
                 onChange={handleTranslationModeChange}
-                label="Translation Mode"
-                description={t('settings.toggles.translationMode')}
+                label={<Tx k="settings.experimental.translationMode" fallback="Translation Mode" />}
+                description={<Tx k="settings.toggles.translationMode" fallback="Double-click translated labels to suggest edits. Requires Steam sign-in." />}
               />
               {settings?.experimentalTranslationMode && (
                 <div className="max-w-xs">
                   <label className="text-xs font-medium uppercase tracking-wider text-text-secondary">
-                    Target language
+                    <Tx k="settings.translationMode.targetLanguage" fallback="Target language" />
                   </label>
                   <select
                     value={settings.translationModeLanguage ?? ''}
                     onChange={(event) => handleTranslationModeLanguageChange(event.target.value)}
                     className="mt-1 w-full rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary"
                   >
-                    <option value="">Choose a language</option>
+                    <option value="">{t('settings.translationMode.chooseLanguage')}</option>
                     {settings.translationModeLanguage &&
                       !TRANSLATION_LANGUAGE_OPTIONS.some(
                         (language) => language.code === settings.translationModeLanguage
@@ -1347,7 +1414,10 @@ export default function Settings() {
                     ))}
                   </select>
                   <p className="mt-1 text-xs text-text-secondary">
-                    Pick the language that should receive your translation suggestions.
+                    <Tx
+                      k="settings.translationMode.pickLanguageDescription"
+                      fallback="Pick the language that should receive your translation suggestions."
+                    />
                   </p>
                 </div>
               )}
@@ -1358,8 +1428,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.experimentalUnknownModMatching ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalUnknownModMatching: checked })}
-              label="Fix Unknown Mods"
-              description={t('settings.toggles.fixUnknown')}
+              label={<Tx k="settings.experimental.fixUnknownMods" fallback="Fix Unknown Mods" />}
+              description={<Tx k="settings.toggles.fixUnknown" fallback="Match unknown local VPKs against GameBanana to recover names and thumbnails. May hit rate limits on large libraries." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1367,8 +1437,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.experimentalDeadworksServers ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalDeadworksServers: checked })}
-              label="Deadworks Servers"
-              description={t('settings.toggles.deadworks')}
+              label={<Tx k="settings.experimental.deadworksServers" fallback="Deadworks Servers" />}
+              description={<Tx k="settings.toggles.deadworks" fallback="Add a Servers tab to browse and join Deadworks community servers. Required content downloads before connecting." />}
             />
 
             <div className="h-px bg-white/5" />
@@ -1376,8 +1446,8 @@ export default function Settings() {
             <Toggle
               checked={settings?.experimentalPerformanceConfig ?? false}
               onChange={(checked) => settings && saveSettings({ ...settings, experimentalPerformanceConfig: checked })}
-              label="Performance Config"
-              description={t('settings.toggles.performanceConfig')}
+              label={<Tx k="settings.experimental.performanceConfig" fallback="Performance Config" />}
+              description={<Tx k="settings.toggles.performanceConfig" fallback="One-click fps boost using Sqooky's community preset. Mods keep working. Remove any time." />}
             />
           </div>
         </Card>
@@ -1385,11 +1455,14 @@ export default function Settings() {
         {settings?.experimentalPerformanceConfig && <PerformanceConfigCard />}
 
         {/* Support */}
-        <Card title="Support" icon={LifeBuoy} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.support" fallback="Support" />} icon={LifeBuoy} className="lg:col-span-2">
           <div className="space-y-6">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
               <p className="text-sm text-text-secondary">
-                Found a bug or have a feature request? File an issue on GitHub or drop into our Discord.
+                <Tx
+                  k="settings.support.description"
+                  fallback="Found a bug or have a feature request? File an issue on GitHub or drop into our Discord."
+                />
               </p>
               <div className="flex flex-col sm:flex-row gap-2">
                 <a
@@ -1399,7 +1472,7 @@ export default function Settings() {
                   className="inline-flex items-center justify-center gap-2 rounded-sm px-4 py-2 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60 whitespace-nowrap"
                 >
                   <Github className="w-4 h-4" aria-hidden="true" />
-                  GitHub Issues
+                  <Tx k="settings.support.githubIssues" fallback="GitHub Issues" />
                 </a>
                 <a
                   href="https://discord.gg/KgYGHEMq2P"
@@ -1414,7 +1487,7 @@ export default function Settings() {
                   >
                     <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
                   </svg>
-                  Join Discord
+                  <Tx k="settings.support.joinDiscord" fallback="Join Discord" />
                 </a>
               </div>
             </div>
@@ -1425,17 +1498,20 @@ export default function Settings() {
               <div>
                 <h4 className="font-medium text-sm flex items-center gap-2">
                   <Bug className="w-4 h-4 text-text-secondary" aria-hidden="true" />
-                  Share a bug report
+                  <Tx k="settings.support.shareBugReport" fallback="Share a bug report" />
                 </h4>
                 <p className="text-xs text-text-secondary mt-1">
-                  Describe what went wrong, generate a sanitized report, then paste it into Discord or a GitHub issue. The report bundles app and OS info plus the tail of your log; home paths, Steam IDs, bearer tokens, and emails are stripped before it leaves the app.
+                  <Tx
+                    k="settings.support.bugReportDescription"
+                    fallback="Describe what went wrong, generate a sanitized report, then paste it into Discord or a GitHub issue. The report bundles app and OS info plus the tail of your log; home paths, Steam IDs, bearer tokens, and emails are stripped before it leaves the app."
+                  />
                 </p>
               </div>
 
               <textarea
                 value={bugDescription}
                 onChange={(e) => setBugDescription(e.target.value)}
-                placeholder="What were you doing when it broke? (Optional but helpful.)"
+                placeholder={t('settings.support.bugPlaceholder')}
                 rows={3}
                 className="w-full px-3 py-2 text-sm bg-bg-tertiary border border-white/5 rounded-sm text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-y"
               />
@@ -1448,7 +1524,11 @@ export default function Settings() {
                   variant="secondary"
                   icon={FileText}
                 >
-                  {bugReportText ? 'Regenerate report' : 'Generate report'}
+                  {bugReportText ? (
+                    <Tx k="settings.support.regenerateReport" fallback="Regenerate report" />
+                  ) : (
+                    <Tx k="settings.support.generateReport" fallback="Generate report" />
+                  )}
                 </Button>
                 <label className="inline-flex items-center gap-2 text-xs text-text-secondary cursor-pointer select-none">
                   <input
@@ -1457,7 +1537,10 @@ export default function Settings() {
                     onChange={(e) => setIncludeFullLog(e.target.checked)}
                     className="h-3.5 w-3.5 rounded-sm border border-white/20 bg-bg-tertiary accent-accent focus:outline-none focus:ring-2 focus:ring-accent"
                   />
-                  Include full log (up to 5 MB; Discord auto-attaches as a file)
+                  <Tx
+                    k="settings.support.includeFullLog"
+                    fallback="Include full log (up to 5 MB; Discord auto-attaches as a file)"
+                  />
                 </label>
               </div>
 
@@ -1468,7 +1551,10 @@ export default function Settings() {
               {bugReportText && (
                 <div className="space-y-2 animate-fade-in">
                   <p className="text-[11px] text-text-secondary/70">
-                    Review before sharing. Nothing is sent automatically.
+                    <Tx
+                      k="settings.support.reviewBeforeSharing"
+                      fallback="Review before sharing. Nothing is sent automatically."
+                    />
                   </p>
                   <textarea
                     value={bugReportText}
@@ -1484,10 +1570,10 @@ export default function Settings() {
                       icon={bugCopyState === 'copied' ? Check : Copy}
                     >
                       {bugCopyState === 'copied'
-                        ? 'Copied'
+                        ? <Tx k="common.status.copied" fallback="Copied" />
                         : bugCopyState === 'failed'
-                          ? 'Copy failed: select and Ctrl+C'
-                          : 'Copy report'}
+                          ? <Tx k="settings.support.copyFailed" fallback="Copy failed: select and Ctrl+C" />
+                          : <Tx k="settings.support.copyReport" fallback="Copy report" />}
                     </Button>
                     <a
                       href="https://discord.gg/KgYGHEMq2P"
@@ -1498,7 +1584,7 @@ export default function Settings() {
                       <svg aria-hidden="true" viewBox="0 0 24 24" className="w-4 h-4 fill-current">
                         <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
                       </svg>
-                      Open Discord
+                      <Tx k="settings.support.openDiscord" fallback="Open Discord" />
                     </a>
                     <a
                       href={githubIssueUrl}
@@ -1507,7 +1593,7 @@ export default function Settings() {
                       className="inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium border border-border bg-bg-tertiary/40 text-text-primary hover:bg-bg-tertiary/70 hover:border-text-secondary/60 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-text-secondary/60"
                     >
                       <Github className="w-4 h-4" aria-hidden="true" />
-                      Open GitHub issue
+                      <Tx k="settings.support.openGithubIssue" fallback="Open GitHub issue" />
                     </a>
                   </div>
                 </div>
@@ -1517,13 +1603,18 @@ export default function Settings() {
         </Card>
 
         {/* Maintenance */}
-        <Card title="Maintenance" icon={Wrench} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.maintenance" fallback="Maintenance" />} icon={Wrench} className="lg:col-span-2">
           <div className="space-y-6">
             <div className="flex justify-between items-start gap-4">
               <div>
-                <h4 className="font-medium text-sm">Cleanup Addons Folder</h4>
+                <h4 className="font-medium text-sm">
+                  <Tx k="settings.maintenance.cleanupAddons" fallback="Cleanup Addons Folder" />
+                </h4>
                 <p className="text-xs text-text-secondary mt-1">
-                  Remove leftover archive downloads (zip, 7z).
+                  <Tx
+                    k="settings.maintenance.cleanupDescription"
+                    fallback="Remove leftover archive downloads (zip, 7z)."
+                  />
                 </p>
                 {cleanupResult && (
                   <p className="text-xs text-accent mt-2 animate-fade-in">{cleanupResult}</p>
@@ -1537,7 +1628,7 @@ export default function Settings() {
                 size="sm"
                 icon={Trash2}
               >
-                Cleanup
+                <Tx k="settings.maintenance.cleanup" fallback="Cleanup" />
               </Button>
             </div>
 
@@ -1545,9 +1636,14 @@ export default function Settings() {
 
             <div className="flex justify-between items-start gap-4">
               <div>
-                <h4 className="font-medium text-sm">Reset Setup Wizard</h4>
+                <h4 className="font-medium text-sm">
+                  <Tx k="settings.setupWizard.title" fallback="Reset Setup Wizard" />
+                </h4>
                 <p className="text-xs text-text-secondary mt-1">
-                  Show the first-run setup wizard again on next app launch.
+                  <Tx
+                    k="settings.setupWizard.description"
+                    fallback="Show the first-run setup wizard again on next app launch."
+                  />
                 </p>
                 {resetResult && (
                   <p className="text-xs text-accent mt-2 animate-fade-in">{resetResult}</p>
@@ -1559,7 +1655,7 @@ export default function Settings() {
                 size="sm"
                 icon={RefreshCw}
               >
-                Reset
+                <Tx k="common.actions.reset" fallback="Reset" />
               </Button>
             </div>
 
@@ -1570,25 +1666,27 @@ export default function Settings() {
         </Card>
 
         {/* Mod Database Cache - Full Width */}
-        <Card title="Mod Database Cache" icon={Database} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.modDatabaseCache" fallback="Mod Database Cache" />} icon={Database} className="lg:col-span-2">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-6">
             <div className="flex-1">
               <div className="flex items-center gap-4 mb-2">
                 <div className="text-2xl font-bold font-valvepulp text-text-primary">
                   {syncStatus ? totalCachedMods.toLocaleString() : '---'}
                 </div>
-                <Badge variant="info">Cached Mods</Badge>
+                <Badge variant="info">
+                  <Tx k="settings.cache.cachedMods" fallback="Cached Mods" />
+                </Badge>
               </div>
               <p className="text-xs text-text-secondary">
                 {lastSyncTime > 0
-                  ? `Last synchronized: ${new Date(lastSyncTime * 1000).toLocaleString()}`
-                  : 'Never synchronized'}
+                  ? t('settings.cache.lastSynchronized', { date: new Date(lastSyncTime * 1000).toLocaleString() })
+                  : t('settings.cache.neverSynchronized')}
               </p>
 
               {syncProgress && (
                 <div className="mt-4 animate-fade-in">
                   <div className="flex justify-between text-xs text-text-secondary mb-1">
-                    <span>Syncing {syncProgress.section}...</span>
+                    <span>{t('settings.cache.syncingSection', { section: syncProgress.section })}</span>
                     <span>{Math.round((syncProgress.modsProcessed / syncProgress.totalMods) * 100)}%</span>
                   </div>
                   <div className="w-full bg-bg-tertiary rounded-sm h-1.5 overflow-hidden">
@@ -1613,7 +1711,7 @@ export default function Settings() {
                 variant="danger"
                 icon={Trash2}
               >
-                Wipe Cache
+                <Tx k="settings.cache.wipeCache" fallback="Wipe Cache" />
               </Button>
               <Button
                 onClick={handleSyncDatabase}
@@ -1621,26 +1719,29 @@ export default function Settings() {
                 isLoading={isSyncing}
                 icon={RefreshCw}
               >
-                Sync Database
+                <Tx k="settings.cache.syncDatabase" fallback="Sync Database" />
               </Button>
             </div>
           </div>
         </Card>
 
         {/* Local preview cache - Full Width */}
-        <Card title="Local preview cache" icon={HardDrive} className="lg:col-span-2">
+        <Card title={<Tx k="settings.sections.localPreviewCache" fallback="Local preview cache" />} icon={HardDrive} className="lg:col-span-2">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-6">
             <div className="flex-1">
               <div className="flex items-center gap-4 mb-2">
                 <div className="text-2xl font-bold font-valvepulp text-text-primary">
                   {previewCacheBytes != null ? formatBytes(previewCacheBytes) : '---'}
                 </div>
-                <Badge variant="info">On Disk</Badge>
+                <Badge variant="info">
+                  <Tx k="settings.cache.onDisk" fallback="On Disk" />
+                </Badge>
               </div>
               <p className="text-xs text-text-secondary">
-                3D model stills, hero portraits, and locker card thumbnails. These
-                rebuild automatically from your installed mods when next viewed.
-                Your installed mods are not affected.
+                <Tx
+                  k="settings.cache.previewDescription"
+                  fallback="3D model stills, hero portraits, and locker card thumbnails. These rebuild automatically from your installed mods when next viewed. Your installed mods are not affected."
+                />
               </p>
               {previewResult && (
                 <p className="text-xs text-text-secondary mt-2 animate-fade-in">{previewResult}</p>
@@ -1655,7 +1756,7 @@ export default function Settings() {
                 variant="danger"
                 icon={Trash2}
               >
-                Clear
+                <Tx k="common.actions.clear" fallback="Clear" />
               </Button>
             </div>
           </div>
@@ -1670,11 +1771,16 @@ export default function Settings() {
             <div className="flex items-center justify-between p-6 border-b border-white/10">
               <div>
                 <h2 className="text-xl font-bold">
-                  What's New in <ReleaseVersionLink version={updateStatus.updateInfo.version} />
+                  <Tx k="settings.updates.whatsNewIn" fallback="What's New in" />{' '}
+                  <ReleaseVersionLink version={updateStatus.updateInfo.version} />
                 </h2>
                 {updateStatus.updateInfo.releaseDate && (
                   <p className="text-sm text-text-secondary mt-1">
-                    Released {new Date(updateStatus.updateInfo.releaseDate).toLocaleDateString()}
+                    <Tx
+                      k="settings.updates.released"
+                      values={{ date: new Date(updateStatus.updateInfo.releaseDate).toLocaleDateString() }}
+                      fallback={`Released ${new Date(updateStatus.updateInfo.releaseDate).toLocaleDateString()}`}
+                    />
                   </p>
                 )}
               </div>
@@ -1708,7 +1814,9 @@ export default function Settings() {
                   ))}
                 </div>
               ) : (
-                <p className="text-text-secondary">No release notes available.</p>
+                <p className="text-text-secondary">
+                  <Tx k="settings.updates.noReleaseNotes" fallback="No release notes available." />
+                </p>
               )}
             </div>
             <div className="flex justify-end gap-3 p-6 border-t border-white/10">
@@ -1716,7 +1824,7 @@ export default function Settings() {
                 onClick={() => setShowChangelog(false)}
                 variant="secondary"
               >
-                Close
+                <Tx k="common.actions.close" fallback="Close" />
               </Button>
               <Button
                 onClick={() => {
@@ -1725,7 +1833,7 @@ export default function Settings() {
                 }}
                 icon={Download}
               >
-                Download Update
+                <Tx k="settings.updates.downloadUpdate" fallback="Download Update" />
               </Button>
             </div>
           </div>
@@ -1736,9 +1844,9 @@ export default function Settings() {
         isOpen={wipeConfirmOpen}
         onCancel={() => setWipeConfirmOpen(false)}
         onConfirm={handleWipeCache}
-        title="Wipe mod cache?"
-        message={t('settings.cache.wipeMessage')}
-        confirmLabel="Wipe Cache"
+        title={<Tx k="settings.cache.wipeTitle" fallback="Wipe mod cache?" />}
+        message={<Tx k="settings.cache.wipeMessage" fallback="Removes cached mod metadata and sync state. Browse re-syncs from GameBanana next time. Installed mods are not affected." />}
+        confirmLabel={<Tx k="settings.cache.wipeCache" fallback="Wipe Cache" />}
         variant="danger"
       />
 
@@ -1746,9 +1854,9 @@ export default function Settings() {
         isOpen={previewConfirmOpen}
         onCancel={() => setPreviewConfirmOpen(false)}
         onConfirm={handleClearPreviewCache}
-        title="Clear preview cache?"
-        message={t('settings.cache.clearPreviewMessage')}
-        confirmLabel="Clear"
+        title={<Tx k="settings.cache.clearPreviewTitle" fallback="Clear preview cache?" />}
+        message={<Tx k="settings.cache.clearPreviewMessage" fallback="Deletes cached preview images to reclaim disk. They regenerate when you next view them. Installed mods are not affected." />}
+        confirmLabel={<Tx k="common.actions.clear" fallback="Clear" />}
         variant="danger"
       />
 
@@ -1756,9 +1864,14 @@ export default function Settings() {
         isOpen={resetConfirmOpen}
         onCancel={() => setResetConfirmOpen(false)}
         onConfirm={handleResetWizard}
-        title="Reset setup wizard?"
-        message="The first-run setup wizard will appear the next time you launch the app. Your settings and installed mods are not affected."
-        confirmLabel="Reset"
+        title={<Tx k="settings.setupWizard.confirmTitle" fallback="Reset setup wizard?" />}
+        message={
+          <Tx
+            k="settings.setupWizard.confirmMessage"
+            fallback="The first-run setup wizard will appear the next time you launch the app. Your settings and installed mods are not affected."
+          />
+        }
+        confirmLabel={<Tx k="common.actions.reset" fallback="Reset" />}
         variant="primary"
       />
     </div>
@@ -1767,6 +1880,7 @@ export default function Settings() {
 
 // Autoexec.cfg helper section
 function AutoexecSection({ gamePath }: { gamePath: string | null }) {
+  const { t } = useTranslation();
   const [status, setStatus] = useState<{
     exists: boolean;
     path: string | null;
@@ -1789,7 +1903,7 @@ function AutoexecSection({ gamePath }: { gamePath: string | null }) {
     setResult(null);
     try {
       const res = await window.electronAPI.createAutoexec(gamePath);
-      setResult(`Created: ${res.path}`);
+      setResult(t('settings.autoexec.created', { path: res.path }));
       const newStatus = await window.electronAPI.getAutoexecStatus(gamePath);
       setStatus(newStatus);
     } catch (err) {
@@ -1806,17 +1920,26 @@ function AutoexecSection({ gamePath }: { gamePath: string | null }) {
       <div className="flex justify-between items-start gap-4">
         <div>
           <h4 className="font-medium text-sm flex items-center gap-2">
-            Autoexec Configuration
+            <Tx k="settings.autoexec.title" fallback="Autoexec Configuration" />
             {status === null ? (
-              <span className="text-xs text-text-secondary">Checking...</span>
+              <span className="text-xs text-text-secondary">
+                <Tx k="common.status.checking" fallback="Checking..." />
+              </span>
             ) : status.exists ? (
-              <Badge variant="success">Active</Badge>
+              <Badge variant="success">
+                <Tx k="common.status.active" fallback="Active" />
+              </Badge>
             ) : (
-              <Badge variant="warning">Missing</Badge>
+              <Badge variant="warning">
+                <Tx k="common.status.missing" fallback="Missing" />
+              </Badge>
             )}
           </h4>
           <p className="text-xs text-text-secondary mt-1">
-            Ensure autoexec.cfg exists for crosshairs and commands.
+            <Tx
+              k="settings.autoexec.description"
+              fallback="Ensure autoexec.cfg exists for crosshairs and commands."
+            />
           </p>
           {result && <p className="text-xs text-accent mt-2">{result}</p>}
         </div>
@@ -1829,7 +1952,7 @@ function AutoexecSection({ gamePath }: { gamePath: string | null }) {
             size="sm"
             icon={Loader2}
           >
-            Create File
+            <Tx k="settings.autoexec.createFile" fallback="Create File" />
           </Button>
         )}
       </div>

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -9,9 +9,11 @@ import {
     AlertCircle,
     type LucideIcon,
 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '../components/common/ui'
 import { Skeleton } from '../components/common/Skeleton'
 import { EmptyState } from '../components/common/PageComponents'
+import Tx from '../components/translation/Tx'
 import { usePlayerStore } from '../stores/stats/playerStore'
 import { useHeroStore } from '../stores/stats/heroStore'
 import { useLeaderboardStore } from '../stores/stats/leaderboardStore'
@@ -24,14 +26,15 @@ import { LeaderboardTab } from '../components/stats/tabs/LeaderboardTab'
 
 type Tab = 'overview' | 'matches' | 'social' | 'leaderboard'
 
-const TABS: { id: Tab; label: string; icon: LucideIcon; playerScoped: boolean }[] = [
-    { id: 'overview', label: 'Overview', icon: BarChart3, playerScoped: true },
-    { id: 'matches', label: 'Matches', icon: Gamepad2, playerScoped: true },
-    { id: 'social', label: 'Social', icon: Users2, playerScoped: true },
-    { id: 'leaderboard', label: 'Leaderboard', icon: Trophy, playerScoped: false },
+const TABS: { id: Tab; icon: LucideIcon; playerScoped: boolean }[] = [
+    { id: 'overview', icon: BarChart3, playerScoped: true },
+    { id: 'matches', icon: Gamepad2, playerScoped: true },
+    { id: 'social', icon: Users2, playerScoped: true },
+    { id: 'leaderboard', icon: Trophy, playerScoped: false },
 ]
 
 export default function Stats() {
+    const { t } = useTranslation()
     const [activeTab, setActiveTab] = useState<Tab>('overview')
 
     const detectSteamUsers = usePlayerStore((s) => s.detectSteamUsers)
@@ -72,13 +75,44 @@ export default function Stats() {
 
     const tab = TABS.find((t) => t.id === activeTab) ?? TABS[0]
 
+    const tabLabel = (id: Tab) => {
+        switch (id) {
+            case 'matches':
+                return t('stats.tabs.matches')
+            case 'social':
+                return t('stats.tabs.social')
+            case 'leaderboard':
+                return t('stats.tabs.leaderboard')
+            default:
+                return t('stats.tabs.overview')
+        }
+    }
+
+    const renderTabLabel = (id: Tab) => {
+        switch (id) {
+            case 'matches':
+                return <Tx k="stats.tabs.matches" fallback="Matches" />
+            case 'social':
+                return <Tx k="stats.tabs.social" fallback="Social" />
+            case 'leaderboard':
+                return <Tx k="stats.tabs.leaderboard" fallback="Leaderboard" />
+            default:
+                return <Tx k="stats.tabs.overview" fallback="Overview" />
+        }
+    }
+
     const renderPlayerScoped = (content: () => React.ReactNode) => {
         if (!selectedAccountId) {
             return (
                 <EmptyState
                     icon={Users}
-                    title="No player selected"
-                    description="Add a player from the dropdown in the top right to see their stats."
+                    title={<Tx k="stats.empty.noPlayerSelected.title" fallback="No player selected" />}
+                    description={
+                        <Tx
+                            k="stats.empty.noPlayerSelected.description"
+                            fallback="Add a player from the dropdown in the top right to see their stats."
+                        />
+                    }
                 />
             )
         }
@@ -86,12 +120,12 @@ export default function Stats() {
             return (
                 <EmptyState
                     icon={AlertCircle}
-                    title="Failed to load player data"
+                    title={<Tx k="stats.error.playerDataTitle" fallback="Failed to load player data" />}
                     description={playerData.error}
                     variant="error"
                     action={
                         <Button variant="secondary" icon={RefreshCw} onClick={() => syncPlayerData(selectedAccountId)}>
-                            Retry
+                            <Tx k="common.actions.retry" fallback="Retry" />
                         </Button>
                     }
                 />
@@ -121,29 +155,32 @@ export default function Stats() {
             <div className="px-6 py-3 border-b border-white/5 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-3 min-w-0">
                     <BarChart3 className="w-6 h-6 text-accent shrink-0" />
-                    <h1 className="text-xl font-bold font-reaver tracking-wide truncate">Deadlock Stats</h1>
+                    <h1 className="text-xl font-bold font-reaver tracking-wide truncate">
+                        <Tx k="stats.title" fallback="Deadlock Stats" />
+                    </h1>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                     <PlayerSelect />
                     <Button variant="secondary" onClick={handleRefresh} icon={RefreshCw}>
-                        Refresh
+                        <Tx k="common.actions.refresh" fallback="Refresh" />
                     </Button>
                 </div>
             </div>
 
             <div className="flex gap-1 px-4 py-2 border-b border-white/5 overflow-x-auto">
-                {TABS.map((t) => (
+                {TABS.map((tabOption) => (
                     <button
-                        key={t.id}
-                        onClick={() => setActiveTab(t.id)}
+                        key={tabOption.id}
+                        onClick={() => setActiveTab(tabOption.id)}
+                        aria-label={tabLabel(tabOption.id)}
                         className={`flex items-center gap-2 px-4 py-2 rounded-sm transition-colors text-sm whitespace-nowrap cursor-pointer ${
-                            activeTab === t.id
+                            activeTab === tabOption.id
                                 ? 'border border-accent/40 bg-accent/10 text-accent'
                                 : 'border border-transparent text-text-secondary hover:text-white hover:bg-white/5'
                         }`}
                     >
-                        <t.icon className="w-4 h-4" />
-                        {t.label}
+                        <tabOption.icon className="w-4 h-4" />
+                        {renderTabLabel(tabOption.id)}
                     </button>
                 ))}
             </div>


### PR DESCRIPTION
## Summary
- wire common UI components and high-value pages to semantic i18n keys with Tx/t()
- add English catalog entries and plural forms for common, stats, servers, conflicts, autoexec, crosshair, profiles, and settings surfaces
- extend i18n check coverage for literal Tx keys while leaving legacy unwired.* catalog entries for a later cleanup pass

## Verification
- pnpm i18n:extract-unwired
- pnpm i18n:check
- pnpm typecheck