### PR TITLE
Invalidate model preview GLB caches (vpkmerge index-offset fix)

### DIFF
--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -174,8 +174,12 @@ function riggedModelFile(key: string): string {
  *
  * v6: sheen now reads TextureSheenColor1 * tint and binds the g_tSheen texture
  * (was white sheen on most cloth), and glass honors the authored g_flIOR.
+ *
+ * v7: vpkmerge fixed draw-call index offsets for resourcecompiler/global-index
+ * meshes. Pre-v7 cached GLBs can contain out-of-range primitive indices, which
+ * renders shredded in three.js even after the bundled binary is fixed.
  */
-const POSE_CACHE_VERSION = '6';
+const POSE_CACHE_VERSION = '7';
 
 const POSE_VERSION_FILENAME = '.cache-version';
 
@@ -189,8 +193,10 @@ function versionFile(key: string): string {
  * invalidates the other's cache. v1: initial rigged-export spine: no `--pose`,
  * filtered to a single looping idle clip, emitting skin + per-bone nodes + one
  * glTF animation.
+ *
+ * v2: same vpkmerge index-offset fix as POSE_CACHE_VERSION v7.
  */
-const RIGGED_CACHE_VERSION = '1';
+const RIGGED_CACHE_VERSION = '2';
 
 const RIGGED_VERSION_FILENAME = '.rigged-cache-version';
 

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -29,7 +29,9 @@ export const SOUL_MODEL_SCHEME = 'grimoire-soul';
 // v1: the original pipeline (vpkmerge export + stripGlbSkins patch). Pre-sidecar
 // GLBs are treated as v1 in getSoulModelInfo, so introducing the sidecar did not
 // invalidate existing caches.
-const SOUL_CACHE_VERSION = '1';
+// v2: vpkmerge fixed draw-call index offsets for resourcecompiler/global-index
+// meshes, invalidating any model-export GLBs written by the broken binary.
+const SOUL_CACHE_VERSION = '2';
 
 /**
  * Canonical soul-container model entry. Present in the base pak01 and in the


### PR DESCRIPTION
Bumps the model-export cache versions so stale preview GLBs written by the pre-fix vpkmerge binary are regenerated.

vpkmerge fixed draw-call index offsets for resourcecompiler/global-index meshes. GLBs cached before that fix can carry out-of-range primitive indices, which render shredded in three.js even once the bundled binary is correct. Bumping the cache version forces a re-export.

## Changes
- `heroPoseModels.ts`: `POSE_CACHE_VERSION` 6 -> 7, `RIGGED_CACHE_VERSION` 1 -> 2
- `soulContainerModels.ts`: `SOUL_CACHE_VERSION` 1 -> 2

Cache-version-only change (no behavior change beyond forcing regeneration); next preview/pose/soul-model export rewrites the GLB.