### PR TITLE
Soul container import: move conflict toast into the footer

### DIFF
--- a/src/components/locker/SoulContainerImportModal.tsx
+++ b/src/components/locker/SoulContainerImportModal.tsx
@@ -9,8 +9,10 @@ import {
   ArrowLeft,
   ArrowRight,
   ArrowUp,
-  Boxes,
+  Ghost,
   Loader2,
+  Pause,
+  Play,
   RefreshCw,
   RotateCcw,
   RotateCw,
@@ -91,6 +93,7 @@ export default function SoulContainerImportModal({
   const [resolvedOrient, setResolvedOrient] = useState<string | null>(null);
   const [glow, setGlow] = useState<GlowMode>('recolor');
   const [showVanilla, setShowVanilla] = useState(true);
+  const [spinning, setSpinning] = useState(true);
   const [nsfw, setNsfw] = useState(false);
   const [notes, setNotes] = useState('');
   // When another soul container is already enabled, default to disabling it
@@ -278,7 +281,7 @@ export default function SoulContainerImportModal({
       <div className="bg-bg-secondary border border-border rounded-xl w-full max-w-3xl max-h-[92vh] flex flex-col">
         <div className="flex items-center justify-between p-5 border-b border-border">
           <h3 className="text-lg font-semibold text-text-primary flex items-center gap-2">
-            <Boxes className="w-5 h-5" />
+            <Ghost className="w-5 h-5" />
             {t('locker.soulImport.title')}
           </h3>
           <button
@@ -291,45 +294,50 @@ export default function SoulContainerImportModal({
         </div>
 
         <div className="p-5 overflow-y-auto grid grid-cols-1 md:grid-cols-2 gap-5">
-          {/* Left: drop zone + live preview */}
-          <div className="space-y-3">
-            <div
-              role="button"
-              tabIndex={0}
-              aria-label={glbPath ? t('locker.soulImport.dropzone.ariaSelected', { path: glbPath }) : t('locker.soulImport.dropzone.ariaBrowse')}
-              onClick={pickGlb}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  void pickGlb();
-                }
-              }}
-              onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
-              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setDragActive(true); }}
-              onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
-              onDrop={handleDrop}
-              className={`flex flex-col items-center justify-center gap-1 px-4 py-3 rounded-lg border border-dashed text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                dragActive
-                  ? 'border-accent bg-accent/10'
-                  : glbPath
-                    ? 'border-accent/40 bg-bg-tertiary/60 cursor-pointer hover:bg-bg-tertiary'
-                    : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
-              }`}
-            >
-              <UploadCloud className="w-5 h-5 text-text-secondary" aria-hidden />
-              {glbPath ? (
-                <span className="text-sm text-text-primary font-medium truncate max-w-full">
-                  {glbPath.split(/[\\/]/).pop()}
-                </span>
-              ) : (
-                <span className="text-sm text-text-primary font-medium">
-                  {t('locker.soulImport.dropzone.prompt')}
-                </span>
-              )}
+          {/* Left: source picker + live preview */}
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1.5">
+                {t('locker.soulImport.fields.source')}
+              </label>
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label={glbPath ? t('locker.soulImport.dropzone.ariaSelected', { path: glbPath }) : t('locker.soulImport.dropzone.ariaBrowse')}
+                onClick={pickGlb}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void pickGlb();
+                  }
+                }}
+                onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
+                onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setDragActive(true); }}
+                onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
+                onDrop={handleDrop}
+                className={`flex flex-col items-center justify-center gap-1 px-4 py-3 rounded-lg border border-dashed text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                  dragActive
+                    ? 'border-accent bg-accent/10'
+                    : glbPath
+                      ? 'border-accent/40 bg-bg-tertiary/60 cursor-pointer hover:bg-bg-tertiary'
+                      : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
+                }`}
+              >
+                <UploadCloud className="w-5 h-5 text-text-secondary" aria-hidden />
+                {glbPath ? (
+                  <span className="text-sm text-text-primary font-medium truncate max-w-full">
+                    {glbPath.split(/[\\/]/).pop()}
+                  </span>
+                ) : (
+                  <span className="text-sm text-text-primary font-medium">
+                    {t('locker.soulImport.dropzone.prompt')}
+                  </span>
+                )}
+              </div>
             </div>
 
             {/* Preview surface */}
-            <div className="relative aspect-square w-full rounded-lg border border-border bg-bg-tertiary/40 overflow-hidden">
+            <div className="relative w-full flex-1 min-h-[16rem] rounded-lg border border-border bg-bg-tertiary/40 overflow-hidden">
               {scene ? (
                 <Suspense fallback={null}>
                   <SoulImportPreview
@@ -337,13 +345,19 @@ export default function SoulContainerImportModal({
                     orientMode="y-up"
                     rotate={[0, 0, 0]}
                     showVanilla={showVanilla}
+                    spinning={spinning}
                     backdropIndex={backdropIndex}
                     captureRef={captureRef}
                   />
                 </Suspense>
               ) : (
-                <div className="absolute inset-0 flex items-center justify-center text-xs text-text-secondary px-6 text-center">
-                  {glbPath ? '' : t('locker.soulImport.dropzone.previewEmpty')}
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-xs text-text-secondary">
+                  {!glbPath && (
+                    <>
+                      <Ghost className="w-8 h-8 text-text-secondary/40" aria-hidden />
+                      <span>{t('locker.soulImport.dropzone.previewEmpty')}</span>
+                    </>
+                  )}
                 </div>
               )}
               {building && (
@@ -373,6 +387,15 @@ export default function SoulContainerImportModal({
                       />
                       {t('locker.soulImport.preview.vanillaShell')}
                     </label>
+                    <button
+                      type="button"
+                      onClick={() => setSpinning((s) => !s)}
+                      className="p-1 rounded bg-black/50 text-text-secondary hover:text-text-primary cursor-pointer"
+                      title={spinning ? t('locker.soulImport.preview.pause') : t('locker.soulImport.preview.play')}
+                      aria-label={spinning ? t('locker.soulImport.preview.pause') : t('locker.soulImport.preview.play')}
+                    >
+                      {spinning ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+                    </button>
                     <button
                       type="button"
                       onClick={rerollBackdrop}
@@ -531,9 +554,6 @@ export default function SoulContainerImportModal({
                   </button>
                 ))}
               </div>
-              <p className="mt-1 text-[11px] text-text-secondary">
-                {t('locker.soulImport.glow.notShownHint')}
-              </p>
             </div>
 
             <div>
@@ -564,31 +584,29 @@ export default function SoulContainerImportModal({
         {/* Conflict notice + error, full width above the footer */}
         <div className="px-5 space-y-3">
           {existingSoulImports.length > 0 && (
-            <div className="text-sm text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3 space-y-2">
-              <div className="flex items-center gap-2 font-medium">
-                <AlertTriangle className="w-4 h-4" />
-                {t('locker.soulImport.conflict.heading')}
-              </div>
-              <p className="text-xs text-amber-200/90">
-                {t('locker.soulImport.conflict.body', { name: existingSoulImports[0].name })}
-              </p>
-              <div className="flex gap-1.5">
+            <div
+              className="flex items-center gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2"
+              title={t('locker.soulImport.conflict.body', { name: existingSoulImports[0].name })}
+            >
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate text-amber-200/90">{t('locker.soulImport.conflict.heading')}</span>
+              <div className="ml-auto flex shrink-0 overflow-hidden rounded-md border border-amber-500/40">
                 <button
                   onClick={() => setDisableExisting(true)}
-                  className={`flex-1 px-2 py-1 rounded border text-xs cursor-pointer ${
+                  className={`px-2.5 py-1 text-[11px] cursor-pointer transition-colors ${
                     disableExisting
-                      ? 'border-accent/60 bg-accent/15 text-text-primary'
-                      : 'border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary'
+                      ? 'bg-accent/25 text-text-primary'
+                      : 'text-amber-200/70 hover:bg-amber-500/10'
                   }`}
                 >
                   {t('locker.soulImport.conflict.disableCurrent')}
                 </button>
                 <button
                   onClick={() => setDisableExisting(false)}
-                  className={`flex-1 px-2 py-1 rounded border text-xs cursor-pointer ${
+                  className={`px-2.5 py-1 text-[11px] cursor-pointer border-l border-amber-500/40 transition-colors ${
                     !disableExisting
-                      ? 'border-accent/60 bg-accent/15 text-text-primary'
-                      : 'border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary'
+                      ? 'bg-accent/25 text-text-primary'
+                      : 'text-amber-200/70 hover:bg-amber-500/10'
                   }`}
                 >
                   {t('locker.soulImport.conflict.keepBoth')}

--- a/src/components/locker/SoulContainerImportModal.tsx
+++ b/src/components/locker/SoulContainerImportModal.tsx
@@ -581,16 +581,39 @@ export default function SoulContainerImportModal({
           </div>
         </div>
 
-        {/* Conflict notice + error, full width above the footer */}
+        {/* High-poly + error notices, full width above the footer. The
+            "already enabled" conflict toast lives in the footer row itself. */}
         <div className="px-5 space-y-3">
+          {highPoly && (
+            <div className="flex items-start gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3">
+              <AlertTriangle className="w-4 h-4 shrink-0 mt-px" />
+              <span>
+                {t('locker.soulImport.preview.highPolyWarning', {
+                  count: triangleCount.toLocaleString(),
+                  threshold: TRIANGLE_WARN_THRESHOLD.toLocaleString(),
+                })}
+              </span>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg p-2">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 p-5 border-t border-border mt-3">
+          {/* "Already enabled" conflict toast, inline on the left of the bottom
+              bar; the action buttons stay pinned right via ml-auto. */}
           {existingSoulImports.length > 0 && (
             <div
-              className="flex items-center gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2"
+              className="flex min-w-0 items-center gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2"
               title={t('locker.soulImport.conflict.body', { name: existingSoulImports[0].name })}
             >
               <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
               <span className="truncate text-amber-200/90">{t('locker.soulImport.conflict.heading')}</span>
-              <div className="ml-auto flex shrink-0 overflow-hidden rounded-md border border-amber-500/40">
+              <div className="flex shrink-0 overflow-hidden rounded-md border border-amber-500/40">
                 <button
                   onClick={() => setDisableExisting(true)}
                   className={`px-2.5 py-1 text-[11px] cursor-pointer transition-colors ${
@@ -614,42 +637,23 @@ export default function SoulContainerImportModal({
               </div>
             </div>
           )}
-
-          {highPoly && (
-            <div className="flex items-start gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3">
-              <AlertTriangle className="w-4 h-4 shrink-0 mt-px" />
-              <span>
-                {t('locker.soulImport.preview.highPolyWarning', {
-                  count: triangleCount.toLocaleString(),
-                  threshold: TRIANGLE_WARN_THRESHOLD.toLocaleString(),
-                })}
-              </span>
-            </div>
-          )}
-
-          {error && (
-            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg p-2">
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="flex justify-end gap-3 p-5 border-t border-border mt-3">
-          <button
-            onClick={onClose}
-            disabled={submitting}
-            className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer disabled:opacity-50"
-          >
-            {t('common.actions.cancel')}
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            className="px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-          >
-            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-            {t('locker.soulImport.submit')}
-          </button>
+          <div className="flex justify-end gap-3 ml-auto shrink-0">
+            <button
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {t('common.actions.cancel')}
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+              {t('locker.soulImport.submit')}
+            </button>
+          </div>
         </div>
       </div>
     </div>,

--- a/src/components/locker/SoulImportPreview.tsx
+++ b/src/components/locker/SoulImportPreview.tsx
@@ -190,11 +190,13 @@ function PreviewScene({
   sourceScene,
   fit,
   showVanilla,
+  spinning,
   captureRef,
 }: {
   sourceScene: THREE.Object3D;
   fit: PreviewFit;
   showVanilla: boolean;
+  spinning: boolean;
   captureRef?: MutableRefObject<(() => string | null) | null>;
 }) {
   const spinGroup = useRef<THREE.Group>(null);
@@ -234,6 +236,7 @@ function PreviewScene({
   }, [captureRef, gl, scene, camera]);
 
   useFrame((_, delta) => {
+    if (!spinning) return;
     const group = spinGroup.current;
     if (group) group.rotation.y += delta * SPIN_RATE;
   });
@@ -261,6 +264,7 @@ export default function SoulImportPreview({
   orientMode,
   rotate,
   showVanilla,
+  spinning = true,
   backdropIndex = -1,
   captureRef,
 }: {
@@ -269,6 +273,8 @@ export default function SoulImportPreview({
   orientMode: SoulOrientMode;
   rotate: [number, number, number];
   showVanilla: boolean;
+  /** Whether the model auto-rotates. Paused models hold their current angle. */
+  spinning?: boolean;
   /** Index into SOUL_BACKDROPS for the baked background; < 0 for none. */
   backdropIndex?: number;
   captureRef?: MutableRefObject<(() => string | null) | null>;
@@ -295,7 +301,7 @@ export default function SoulImportPreview({
       <directionalLight position={[-3, 2, -2]} intensity={0.5} />
       {/* Faint accent rim from below/behind for a subtle soul glow. */}
       <pointLight position={[0, -SOUL_TARGET_SPAN, -SOUL_TARGET_SPAN]} intensity={0.6} color="#f97316" />
-      <PreviewScene sourceScene={scene} fit={fit} showVanilla={showVanilla} captureRef={captureRef} />
+      <PreviewScene sourceScene={scene} fit={fit} showVanilla={showVanilla} spinning={spinning} captureRef={captureRef} />
     </Canvas>
   );
 }

--- a/src/components/locker/soulBackdrops.ts
+++ b/src/components/locker/soulBackdrops.ts
@@ -6,33 +6,69 @@ import * as THREE from 'three';
  * transparency. Each entry paints a 2D gradient that becomes a CanvasTexture
  * for `scene.background`. The modal picks one at random per import (and can
  * reroll); a negative index means no backdrop.
+ *
+ * Each backdrop is a multi-stop glow (core -> mid -> deep) finished with a
+ * soft vignette, so the model reads as lit from a colored source against a
+ * darkened frame rather than a flat fill.
  */
 type BackdropDraw = (ctx: CanvasRenderingContext2D, w: number, h: number) => void;
+type Stop = [offset: number, color: string];
 
-const radialFill = (cx: number, cy: number, inner: string, outer: string): BackdropDraw =>
+/** Radial glow from (cx, cy). `spread` scales the gradient radius vs the diagonal. */
+const radial = (cx: number, cy: number, stops: Stop[], spread = 0.78): BackdropDraw =>
   (ctx, w, h) => {
-    const g = ctx.createRadialGradient(w * cx, h * cy, 0, w * cx, h * cy, Math.hypot(w, h) * 0.72);
-    g.addColorStop(0, inner);
-    g.addColorStop(1, outer);
+    const g = ctx.createRadialGradient(w * cx, h * cy, 0, w * cx, h * cy, Math.hypot(w, h) * spread);
+    for (const [offset, color] of stops) g.addColorStop(offset, color);
     ctx.fillStyle = g;
     ctx.fillRect(0, 0, w, h);
   };
 
-const linearFill = (top: string, bottom: string): BackdropDraw => (ctx, w, h) => {
+/** Top-to-bottom linear gradient. */
+const linear = (stops: Stop[]): BackdropDraw => (ctx, w, h) => {
   const g = ctx.createLinearGradient(0, 0, 0, h);
-  g.addColorStop(0, top);
-  g.addColorStop(1, bottom);
+  for (const [offset, color] of stops) g.addColorStop(offset, color);
   ctx.fillStyle = g;
   ctx.fillRect(0, 0, w, h);
 };
 
+/** Darken the corners so the lit center pops; applied over every backdrop. */
+const vignette = (ctx: CanvasRenderingContext2D, w: number, h: number, strength = 0.5): void => {
+  const g = ctx.createRadialGradient(
+    w / 2, h * 0.45, Math.min(w, h) * 0.18,
+    w / 2, h * 0.5, Math.hypot(w, h) * 0.62
+  );
+  g.addColorStop(0, 'rgba(0,0,0,0)');
+  g.addColorStop(1, `rgba(0,0,0,${strength})`);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, w, h);
+};
+
+const withVignette = (draw: BackdropDraw, strength?: number): BackdropDraw => (ctx, w, h) => {
+  draw(ctx, w, h);
+  vignette(ctx, w, h, strength);
+};
+
 const SOUL_BACKDROPS: BackdropDraw[] = [
-  radialFill(0.5, 0.42, '#272727', '#0b0b0b'), // charcoal spotlight
-  radialFill(0.5, 0.82, '#3a2410', '#090909'), // warm ember glow from below
-  linearFill('#1a2533', '#07090d'), // cool abyss blue
-  radialFill(0.5, 0.4, '#241836', '#0a0710'), // violet soul
-  radialFill(0.5, 0.46, '#10221a', '#070b08'), // deep forest
-  radialFill(0.5, 0.46, '#2a1115', '#0c0708'), // crimson dusk
+  // Charcoal spotlight (neutral, lets any model color sit cleanly)
+  withVignette(radial(0.5, 0.42, [[0, '#34343a'], [0.5, '#18181b'], [1, '#0a0a0b']])),
+  // Warm ember rising from below
+  withVignette(radial(0.5, 0.88, [[0, '#5e3717'], [0.4, '#2a160a'], [1, '#080605']], 0.85)),
+  // Cool abyss blue
+  withVignette(radial(0.5, 0.4, [[0, '#1f3a58'], [0.5, '#0d1a2a'], [1, '#05080d']])),
+  // Violet soul
+  withVignette(radial(0.5, 0.42, [[0, '#3d2160'], [0.5, '#1c0f30'], [1, '#080510']])),
+  // Deep forest
+  withVignette(radial(0.5, 0.46, [[0, '#17402e'], [0.5, '#0b1f17'], [1, '#050b08']])),
+  // Crimson dusk
+  withVignette(radial(0.5, 0.46, [[0, '#5e1a22'], [0.45, '#2a0d12'], [1, '#0c0608']])),
+  // Teal nebula (off-center light)
+  withVignette(radial(0.42, 0.38, [[0, '#0f5050'], [0.45, '#0a2626'], [1, '#04090a']])),
+  // Amber halo (echoes the app accent)
+  withVignette(radial(0.5, 0.5, [[0, '#7a4410'], [0.42, '#3a2208'], [1, '#0b0805']])),
+  // Indigo-to-rose dawn (vertical)
+  withVignette(linear([[0, '#241a3a'], [0.55, '#1a0f1e'], [1, '#08060a']]), 0.4),
+  // Ice steel (cold neutral wash)
+  withVignette(radial(0.5, 0.36, [[0, '#2c3a44'], [0.5, '#141a1f'], [1, '#070a0c']])),
 ];
 
 export const SOUL_BACKDROP_COUNT = SOUL_BACKDROPS.length;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -588,9 +588,12 @@
         "orientationLabel": "Orientation:",
         "vanillaShell": "Vanilla shell",
         "shuffleBackdrop": "Shuffle background",
+        "pause": "Pause rotation",
+        "play": "Resume rotation",
         "highPolyWarning": "This model has {{count}} triangles, well above the {{threshold}} a soul container usually needs. It will still build, but a very heavy model can hurt in-game performance."
       },
       "fields": {
+        "source": "Source model",
         "name": "Name",
         "namePlaceholder": "My soul container",
         "notes": "Notes",
@@ -623,8 +626,7 @@
         "base": "Keep gold",
         "baseHint": "Ship the stock gold glow unchanged",
         "off": "None",
-        "offHint": "Don't ship particles; base game glow plays",
-        "notShownHint": "The glow color isn't shown in this preview (particles render in-game only)."
+        "offHint": "Don't ship particles; base game glow plays"
       },
       "conflict": {
         "heading": "A soul container is already enabled",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1901,
+  "totalKeys": 1903,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1901,
+      "translatedKeys": 1903,
       "pct": 100
     }
   ]

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, startTransition, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import {
@@ -61,7 +61,6 @@ import {
   FileText,
   Banana,
   HelpCircle,
-  Boxes,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/common/menu';
@@ -169,11 +168,6 @@ function modEntryKey(mod: Mod): string {
   return `single:local:${mod.name}:${mod.size}`;
 }
 
-// Heavy (three.js): only pulled in when the user opens the soul-container GLB
-// import, so three stays out of the Installed page's main chunk.
-const SoulContainerImportModal = lazy(
-  () => import('../components/locker/SoulContainerImportModal')
-);
 
 function buildModEntries(mods: Mod[]): ModEntry[] {
   const byGb = new Map<number, Mod[]>();
@@ -634,13 +628,6 @@ export default function Installed() {
   } = useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
 
-  // Enabled soul-container imports (override the same model), so the import modal
-  // can warn + offer to replace rather than silently stack two.
-  const existingSoulImports = useMemo(
-    () => mods.filter((m) => m.enabled && m.globalType === 'soul-container'),
-    [mods]
-  );
-
   // Source mods absorbed into a merged VPK still live on disk (disabled) so
   // unmerge can restore them, but the user shouldn't see them as separate
   // cards: the merged mod is now the source of truth. Build the absorbed
@@ -836,7 +823,6 @@ export default function Installed() {
   // picker reflect immediately without juggling a separate snapshot.
   const [pickerGroupId, setPickerGroupId] = useState<number | null>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [soulImportOpen, setSoulImportOpen] = useState(false);
   const [unknownFilterGuess, setUnknownFilterGuess] = useState<{
     mod: Mod;
     loading: boolean;
@@ -2901,9 +2887,6 @@ export default function Installed() {
               <Button variant="secondary" onClick={() => setImportOpen(true)} icon={FilePlus}>
                 Import Custom Mod
               </Button>
-              <Button variant="secondary" onClick={() => setSoulImportOpen(true)} icon={Boxes}>
-                {t('locker.soulImport.trigger.label')}
-              </Button>
             </div>
           }
         />
@@ -2914,17 +2897,6 @@ export default function Installed() {
               await importCustomMod(args);
             }}
           />
-        )}
-        {soulImportOpen && (
-          <Suspense fallback={null}>
-            <SoulContainerImportModal
-              onClose={() => setSoulImportOpen(false)}
-              existingSoulImports={existingSoulImports}
-              onImported={() => {
-                void loadMods();
-              }}
-            />
-          </Suspense>
         )}
       </>
     );
@@ -3242,14 +3214,6 @@ export default function Installed() {
             />
             <Button
               variant="secondary"
-              onClick={() => setSoulImportOpen(true)}
-              icon={Boxes}
-              className="!px-2.5"
-              aria-label={t('locker.soulImport.trigger.ariaLabel')}
-              title={t('locker.soulImport.trigger.title')}
-            />
-            <Button
-              variant="secondary"
               onClick={() => openModsFolder().catch(() => {})}
               icon={FolderOpen}
               className="!px-2.5"
@@ -3541,17 +3505,6 @@ export default function Installed() {
         />
       )}
 
-      {soulImportOpen && (
-        <Suspense fallback={null}>
-          <SoulContainerImportModal
-            onClose={() => setSoulImportOpen(false)}
-            existingSoulImports={existingSoulImports}
-            onImported={() => {
-              void loadMods();
-            }}
-          />
-        </Suspense>
-      )}
 
       {localEditMod && (
         <EditLocalModModal

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Boxes, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
@@ -1116,7 +1116,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                     className="ml-auto inline-flex items-center gap-1.5 self-center rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:border-accent/60 hover:bg-accent/20"
                     title={t('locker.soulImport.trigger.title')}
                   >
-                    <Boxes className="h-3.5 w-3.5" />
+                    <Ghost className="h-3.5 w-3.5" />
                     {t('locker.soulImport.trigger.label')}
                   </button>
                 )}


### PR DESCRIPTION
## What

Moves the **"a soul container is already enabled"** conflict toast (with its *Disable the current one* / *Keep both enabled* toggle) from a full-width strip above the footer into the bottom action bar itself, sitting to the left of **Cancel** / **Build & Import**.

- Toast is left-aligned in the footer; the action buttons stay pinned right via `ml-auto shrink-0`.
- Heading is `truncate` + `min-w-0` so it shrinks gracefully on a narrow modal instead of pushing the buttons off-screen; the toggle and buttons never shrink.
- When there is no conflict, the buttons stay right-aligned exactly as before.
- High-poly and error notices are unchanged (still in the strip above the footer).

## Note on commits

This branch also carries `Clean up soul container import modal` (`f1be2de`), which was on local `main` but not yet on `origin/main`, so it shows up in this PR's diff. Merging this PR lands both the popup cleanup and the toast move. (Happy to split them if preferred.)

## Test

- `pnpm typecheck` and `eslint` on the modal: clean.
- No new i18n keys (reuses existing `conflict.*` strings); pre-push catalog/manifest gate passes.