### PR TITLE
Soul-container facing yaw slider + hero-scale preview

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -899,6 +899,8 @@ ipcMain.handle(
             name: 'preview',
             orient: args.orient,
             rotate: args.rotate,
+            yaw: args.yaw,
+            upright: args.upright,
             glow: args.glow,
         });
         return {
@@ -926,7 +928,7 @@ ipcMain.handle(
         if (!deadlockPath) {
             throw new Error('No Deadlock path configured');
         }
-        const { glbPath, name, orient, rotate, glow, status, notes, nsfw, thumbnailDataUrl, replaceMetaKey } = args;
+        const { glbPath, name, orient, rotate, yaw, upright, glow, status, notes, nsfw, thumbnailDataUrl, replaceMetaKey } = args;
         if (!name?.trim()) {
             throw new Error('A name is required');
         }
@@ -937,6 +939,8 @@ ipcMain.handle(
             name: name.trim(),
             orient,
             rotate,
+            yaw,
+            upright,
             glow,
         });
 
@@ -965,6 +969,8 @@ ipcMain.handle(
                 orient,
                 glow,
                 ...(rotate && (rotate[0] || rotate[1] || rotate[2]) ? { rotate } : {}),
+                ...(yaw ? { yaw } : {}),
+                ...(upright === false ? { upright } : {}),
                 vpkmergeVersion: built.report.version,
                 fitScale: built.report.fitScale,
                 sourceSpan: built.report.sourceSpan,

--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -178,8 +178,15 @@ function riggedModelFile(key: string): string {
  * v7: vpkmerge fixed draw-call index offsets for resourcecompiler/global-index
  * meshes. Pre-v7 cached GLBs can contain out-of-range primitive indices, which
  * renders shredded in three.js even after the bundled binary is fixed.
+ *
+ * v8: vpkmerge static pose baking keeps Source 2 secondary-motion cloth/fabric
+ * chains bind-relative instead of freezing their authored sim tracks mid-pose.
+ * Pre-v8 GLBs can show detached coat tails, skirts, and cloth panels.
+ *
+ * v9: same static-pose fabric fix, with old dev preview caches force-expired
+ * after confirming one-frame menu poses can carry unsolved cloth state.
  */
-const POSE_CACHE_VERSION = '7';
+const POSE_CACHE_VERSION = '9';
 
 const POSE_VERSION_FILENAME = '.cache-version';
 

--- a/electron/main/services/soulContainerImport.ts
+++ b/electron/main/services/soulContainerImport.ts
@@ -23,6 +23,12 @@ export interface BuildSoulContainerArgs {
     orient: SoulOrient;
     /** Extra Euler degrees [X, Y, Z] applied after orient. */
     rotate?: [number, number, number];
+    /** Facing yaw in degrees: turn the fitted orb in place about its vertical
+     *  axis. The slider knob; survives the upright orientation pass. */
+    yaw?: number;
+    /** Apply the psyduck upright-orientation recipe so the orb stands still and
+     *  upright instead of tumbling. Defaults to true when omitted. */
+    upright?: boolean;
     glow: SoulGlow;
 }
 
@@ -33,6 +39,8 @@ export interface SoulImportCliReport {
     fitScale?: number;
     sourceSpan?: number;
     targetSpan?: number;
+    yaw?: number;
+    upright?: boolean;
     glowHue?: number;
     entryCount?: number;
 }
@@ -101,6 +109,13 @@ export async function buildSoulContainerVpk(
     const rotate = nonZeroRotate(args.rotate);
     if (rotate) {
         cliArgs.push('--rotate', `${rotate[0]},${rotate[1]},${rotate[2]}`);
+    }
+    if (args.yaw) {
+        cliArgs.push('--yaw', `${args.yaw}`);
+    }
+    // Upright defaults on in the CLI; only pass the opt-out flag.
+    if (args.upright === false) {
+        cliArgs.push('--no-upright');
     }
 
     let stdout = '';

--- a/src/components/locker/SoulContainerImportModal.tsx
+++ b/src/components/locker/SoulContainerImportModal.tsx
@@ -20,8 +20,8 @@ import {
   UploadCloud,
   X,
 } from 'lucide-react';
-import { importSoulContainerGlb, previewSoulContainerGlb, showOpenDialog } from '../../lib/api';
-import { parseGltfPreview } from '../../lib/loadGltfPreview';
+import { exportHeroPose, getHeroPoseInfo, importSoulContainerGlb, previewSoulContainerGlb, showOpenDialog } from '../../lib/api';
+import { loadGltfPreview, parseGltfPreview } from '../../lib/loadGltfPreview';
 import { computeSceneStats, deriveNameFromPath, norm360, TRIANGLE_WARN_THRESHOLD } from '../../lib/soulImport';
 import { useAppStore } from '../../stores/appStore';
 import type { Mod } from '../../types/mod';
@@ -53,6 +53,18 @@ const GLOW_OPTIONS: { value: GlowMode; labelKey: string; hintKey: string }[] = [
   { value: 'base', labelKey: 'locker.soulImport.glow.base', hintKey: 'locker.soulImport.glow.baseHint' },
   { value: 'off', labelKey: 'locker.soulImport.glow.off', hintKey: 'locker.soulImport.glow.offHint' },
 ];
+
+// Fixed default hero used as the size/facing yardstick beside the orb. A
+// medium build that reliably exports a pose; the reference is approximate, so
+// the in-game read remains the source of truth.
+const SCALE_HERO_NAME = 'Abrams';
+const HERO_POSE_SCHEME = 'grimoire-hero';
+
+/** Build the privileged URL the `grimoire-hero:` protocol serves the posed GLB
+ *  from (mirrors HeroPoseViewer's helper). */
+function heroPoseUrl(key: string, mtimeMs: number | null): string {
+  return `${HERO_POSE_SCHEME}://m/${encodeURIComponent(key)}/model.glb?v=${mtimeMs ?? 0}`;
+}
 
 function describeScene(
   scene: THREE.Object3D,
@@ -90,10 +102,22 @@ export default function SoulContainerImportModal({
   const [scene, setScene] = useState<THREE.Object3D | null>(null);
   const [orientMode, setOrientMode] = useState<SoulOrientMode>('y-up');
   const [rotate, setRotate] = useState<[number, number, number]>([0, 0, 0]);
+  // Facing yaw (degrees), baked about the orb's vertical axis. The slider knob
+  // for dialing in which way the orb faces near a hero's hip.
+  const [yaw, setYaw] = useState<number>(0);
+  // Upright orientation (psyduck recipe): orb stands still instead of tumbling.
+  // On by default so the yaw facing is stable.
+  const [upright, setUpright] = useState<boolean>(true);
   const [resolvedOrient, setResolvedOrient] = useState<string | null>(null);
   const [glow, setGlow] = useState<GlowMode>('recolor');
   const [showVanilla, setShowVanilla] = useState(true);
   const [spinning, setSpinning] = useState(true);
+  // Hero-for-scale reference: a standing default hero rendered beside the orb.
+  // Loaded lazily the first time the toggle is switched on, then cached.
+  const [showHero, setShowHero] = useState(false);
+  const [heroScene, setHeroScene] = useState<THREE.Object3D | null>(null);
+  const [heroLoading, setHeroLoading] = useState(false);
+  const heroSceneRef = useRef<THREE.Object3D | null>(null);
   const [nsfw, setNsfw] = useState(false);
   const [notes, setNotes] = useState('');
   // When another soul container is already enabled, default to disabling it
@@ -118,8 +142,41 @@ export default function SoulContainerImportModal({
   useEffect(() => {
     return () => {
       if (sceneRef.current) disposeScene(sceneRef.current);
+      if (heroSceneRef.current) disposeScene(heroSceneRef.current);
     };
   }, []);
+
+  // Lazily load the fixed scale-reference hero the first time the toggle is
+  // switched on, then cache it for the rest of the modal's life. Exporting the
+  // pose can take a moment, hence the loading flag.
+  useEffect(() => {
+    if (!showHero || heroSceneRef.current) return;
+    let cancelled = false;
+    setHeroLoading(true);
+    (async () => {
+      try {
+        let info = await getHeroPoseInfo(SCALE_HERO_NAME, []);
+        if (!info.hasModel) info = await exportHeroPose(SCALE_HERO_NAME, []);
+        if (cancelled || !info.hasModel) return;
+        const gltf = await loadGltfPreview(heroPoseUrl(info.key, info.mtimeMs));
+        if (cancelled) {
+          disposeScene(gltf.scene);
+          return;
+        }
+        heroSceneRef.current = gltf.scene;
+        setHeroScene(gltf.scene);
+      } catch {
+        // Reference hero is a nicety; on failure just leave the toggle on with
+        // no hero rather than surfacing an error over the import flow.
+        if (!cancelled) setShowHero(false);
+      } finally {
+        if (!cancelled) setHeroLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [showHero]);
 
   const hasRotation = rotate[0] !== 0 || rotate[1] !== 0 || rotate[2] !== 0;
 
@@ -137,10 +194,15 @@ export default function SoulContainerImportModal({
     const handle = window.setTimeout(() => {
       (async () => {
         try {
+          // `upright` only edits the soul particle, which the model-export
+          // preview does not render, so it is intentionally omitted here (no
+          // pointless rebuild when it toggles). `yaw` is baked into geometry, so
+          // it does show up in the exported mesh.
           const preview = await previewSoulContainerGlb({
             glbPath,
             orient: orientMode,
             rotate: hasRotation ? rotate : undefined,
+            yaw: yaw || undefined,
             glow,
           });
           const gltf = await parseGltfPreview(preview.glb);
@@ -175,7 +237,7 @@ export default function SoulContainerImportModal({
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [glbPath, orientMode, rotate, glow, hasRotation, t]);
+  }, [glbPath, orientMode, rotate, yaw, glow, hasRotation, t]);
 
   const acceptGlbPath = (picked: string) => {
     setError(null);
@@ -225,6 +287,17 @@ export default function SoulContainerImportModal({
     });
   };
 
+  // Facing yaw, normalized to (-180, 180]. The left/right preview arrows nudge
+  // it; the slider covers the full range. Final-space, so it is unambiguous
+  // unlike the pre-swizzle rotate Euler.
+  const normYaw = (deg: number) => {
+    if (!Number.isFinite(deg)) return 0;
+    let d = ((deg + 180) % 360 + 360) % 360 - 180;
+    if (d === -180) d = 180;
+    return d;
+  };
+  const bumpYaw = (delta: number) => setYaw((y) => normYaw(y + delta));
+
   const rerollBackdrop = () => {
     setBackdropIndex((current) => {
       if (SOUL_BACKDROP_COUNT <= 1) return current;
@@ -254,6 +327,8 @@ export default function SoulContainerImportModal({
         name: name.trim(),
         orient: orientMode,
         rotate: hasRotation ? rotate : undefined,
+        yaw: yaw || undefined,
+        upright,
         glow,
         status: 'untested',
         notes: notes.trim() || undefined,
@@ -336,8 +411,9 @@ export default function SoulContainerImportModal({
               </div>
             </div>
 
-            {/* Preview surface */}
-            <div className="relative w-full flex-1 min-h-[16rem] rounded-lg border border-border bg-bg-tertiary/40 overflow-hidden">
+            {/* Preview surface: kept square so the orb and the hero-scale view
+                read consistently and the canvas never stretches. */}
+            <div className="relative w-full aspect-square rounded-lg border border-border bg-bg-tertiary/40 overflow-hidden">
               {scene ? (
                 <Suspense fallback={null}>
                   <SoulImportPreview
@@ -347,6 +423,7 @@ export default function SoulContainerImportModal({
                     showVanilla={showVanilla}
                     spinning={spinning}
                     backdropIndex={backdropIndex}
+                    heroScene={showHero ? heroScene : null}
                     captureRef={captureRef}
                   />
                 </Suspense>
@@ -376,17 +453,9 @@ export default function SoulContainerImportModal({
                     </span>
                   )}
 
-                  {/* Top-right: vanilla shell toggle + backdrop reroll. */}
+                  {/* Top-right: playback only (pause + backdrop reroll). The view
+                      toggles live in the bottom bar to keep the top uncluttered. */}
                   <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 text-[11px]">
-                    <label className="px-2 py-0.5 rounded bg-black/50 text-text-secondary flex items-center gap-1.5 cursor-pointer select-none">
-                      <input
-                        type="checkbox"
-                        checked={showVanilla}
-                        onChange={(e) => setShowVanilla(e.target.checked)}
-                        className="w-3 h-3 accent-accent cursor-pointer"
-                      />
-                      {t('locker.soulImport.preview.vanillaShell')}
-                    </label>
                     <button
                       type="button"
                       onClick={() => setSpinning((s) => !s)}
@@ -407,9 +476,10 @@ export default function SoulContainerImportModal({
                     </button>
                   </div>
 
-                  {/* Directional arrows over the preview for quick visual
-                      reorientation (quarter turns; pitch on X, yaw on Y). Each
-                      tweaks rotate and rebuilds, like the side-panel nudges. */}
+                  {/* Directional arrows over the preview. Up/down quarter-turn
+                      the pre-swizzle pitch (rotate X) to upright the mesh;
+                      left/right nudge the final-space facing yaw (the stable
+                      facing knob, distinct from the ambiguous Euler rotate). */}
                   <button
                     type="button"
                     onClick={() => bumpAxis(0, 90)}
@@ -428,7 +498,7 @@ export default function SoulContainerImportModal({
                   </button>
                   <button
                     type="button"
-                    onClick={() => bumpAxis(1, -90)}
+                    onClick={() => bumpYaw(-15)}
                     className="absolute left-1.5 top-1/2 -translate-y-1/2 z-10 p-1 rounded-full bg-black/45 text-white/80 hover:bg-black/70 hover:text-white cursor-pointer"
                     aria-label={t('locker.soulImport.orient.turnLeft')}
                   >
@@ -436,18 +506,44 @@ export default function SoulContainerImportModal({
                   </button>
                   <button
                     type="button"
-                    onClick={() => bumpAxis(1, 90)}
+                    onClick={() => bumpYaw(15)}
                     className="absolute right-1.5 top-1/2 -translate-y-1/2 z-10 p-1 rounded-full bg-black/45 text-white/80 hover:bg-black/70 hover:text-white cursor-pointer"
                     aria-label={t('locker.soulImport.orient.turnRight')}
                   >
                     <ArrowRight className="w-4 h-4" />
                   </button>
 
-                  {/* Bottom: resolved orientation label. */}
-                  <div className="absolute bottom-2 left-2 right-2 z-10 flex items-center text-[11px]">
-                    <span className="px-2 py-0.5 rounded bg-black/50 text-text-secondary">
+                  {/* Bottom: resolved orientation label (left) + view toggles
+                      (right). Vanilla shell is hidden in hero mode (no effect). */}
+                  <div className="absolute bottom-2 left-2 right-2 z-10 flex items-center justify-between gap-2 text-[11px]">
+                    <span className="px-2 py-0.5 rounded bg-black/50 text-text-secondary truncate">
                       {t('locker.soulImport.preview.orientationLabel')} <span className="text-text-primary">{modeLabel}</span>
                     </span>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <label
+                        className="px-2 py-0.5 rounded bg-black/50 text-text-secondary flex items-center gap-1.5 cursor-pointer select-none"
+                        title={t('locker.soulImport.preview.heroScaleHint')}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={showHero}
+                          onChange={(e) => setShowHero(e.target.checked)}
+                          className="w-3 h-3 accent-accent cursor-pointer"
+                        />
+                        {heroLoading ? t('locker.soulImport.preview.heroScaleLoading') : t('locker.soulImport.preview.heroScale')}
+                      </label>
+                      {!showHero && (
+                        <label className="px-2 py-0.5 rounded bg-black/50 text-text-secondary flex items-center gap-1.5 cursor-pointer select-none">
+                          <input
+                            type="checkbox"
+                            checked={showVanilla}
+                            onChange={(e) => setShowVanilla(e.target.checked)}
+                            className="w-3 h-3 accent-accent cursor-pointer"
+                          />
+                          {t('locker.soulImport.preview.vanillaShell')}
+                        </label>
+                      )}
+                    </div>
                   </div>
                 </>
               )}
@@ -533,6 +629,54 @@ export default function SoulContainerImportModal({
                   </button>
                 </div>
               </div>
+            </div>
+
+            {/* Facing: final-space yaw (the stable facing knob) + upright toggle */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1.5">
+                {t('locker.soulImport.facing.label')}
+              </label>
+              <div className="flex items-center gap-2 mb-2">
+                <input
+                  type="range"
+                  min={-180}
+                  max={180}
+                  step={5}
+                  value={yaw}
+                  onChange={(e) => setYaw(normYaw(parseFloat(e.target.value)))}
+                  disabled={!upright}
+                  className="flex-1 accent-accent cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  aria-label={t('locker.soulImport.facing.label')}
+                />
+                <input
+                  type="number"
+                  value={yaw}
+                  onChange={(e) => setYaw(normYaw(parseFloat(e.target.value)))}
+                  step={15}
+                  disabled={!upright}
+                  className="w-16 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs text-text-primary focus:outline-none focus:border-accent disabled:opacity-40"
+                  aria-label={t('locker.soulImport.facing.label')}
+                />
+                <span className="text-[11px] text-text-secondary">{t('locker.soulImport.orient.deg')}</span>
+                <button
+                  type="button"
+                  onClick={() => setYaw(0)}
+                  disabled={!upright || yaw === 0}
+                  className="p-1.5 rounded border border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  aria-label={t('common.actions.reset')}
+                >
+                  <RefreshCw className="w-3 h-3" />
+                </button>
+              </div>
+              <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={upright}
+                  onChange={(e) => setUpright(e.target.checked)}
+                  className="accent-accent cursor-pointer"
+                />
+                <span>{t('locker.soulImport.facing.upright')}</span>
+              </label>
             </div>
 
             {/* Glow */}

--- a/src/components/locker/SoulImportPreview.tsx
+++ b/src/components/locker/SoulImportPreview.tsx
@@ -20,10 +20,56 @@ export const SOUL_TARGET_SPAN = 12.65;
 
 const SPIN_RATE = 0.35; // rad/sec
 const CAMERA_DISTANCE = SOUL_TARGET_SPAN * 3.0;
+const CAMERA_HEIGHT = SOUL_TARGET_SPAN * 0.35;
 // Saved thumbnails freeze to this 3/4 yaw (instead of a random spin frame) so
 // every card reads from a consistent, flattering angle.
 const CAPTURE_YAW = -Math.PI * 0.18;
 type SoulOrientMode = 'y-up' | 'z-up' | 'flip-y' | 'auto';
+
+// --- Hero-for-scale reference --------------------------------------------
+// A standing hero rendered around the orb so the user can judge size + facing
+// without going in-game. The orb stays at the origin and the hero is placed so
+// the orb floats at their back hip (where a soul container sits in-game): the
+// hero faces away from the camera, the orb hovering just off their lower back.
+// Heights are in the same preview units as the orb's SOUL_TARGET_SPAN: an
+// in-game hero is roughly 5.7x the orb's span tall. Tunable; the in-game read
+// is the source of truth.
+const HERO_PREVIEW_HEIGHT = SOUL_TARGET_SPAN * 5.7;
+const HERO_HIP_FRACTION = 0.52; // hip is ~52% up the body
+const HERO_HIP_SIDE = 0.55; // orb sits at one hip, this fraction of the half-width off-center
+const ORB_BACK_PROUD = (SOUL_TARGET_SPAN / 2) * 0.4; // how far the orb pokes out past the hero's back
+// Slight up + right nudge of the orb relative to the hero (the orb stays at the
+// origin for capture, so we shift the hero the opposite way).
+const ORB_NUDGE_UP = SOUL_TARGET_SPAN * 0.35;
+const ORB_NUDGE_RIGHT = SOUL_TARGET_SPAN * 0.3;
+
+interface HeroFit {
+  scale: number;
+  /** Pre-scale offset that grounds the feet at y=0 and centers x/z. */
+  offset: THREE.Vector3;
+  /** Post-scale half-width, for placing the orb at one hip. */
+  halfWidth: number;
+  /** Post-scale half-depth (front-to-back), so the orb clears the back surface. */
+  halfDepth: number;
+}
+
+/** Fit a hero pose GLB to HERO_PREVIEW_HEIGHT, feet grounded, centered x/z. */
+function buildHeroFit(scene: THREE.Object3D): HeroFit {
+  scene.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(scene);
+  if (box.isEmpty()) {
+    return { scale: 1, offset: new THREE.Vector3(), halfWidth: SOUL_TARGET_SPAN, halfDepth: SOUL_TARGET_SPAN };
+  }
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  const scale = HERO_PREVIEW_HEIGHT / (size.y || 1);
+  return {
+    scale,
+    offset: new THREE.Vector3(-center.x, -box.min.y, -center.z),
+    halfWidth: (size.x * scale) / 2,
+    halfDepth: (size.z * scale) / 2,
+  };
+}
 
 /**
  * Attaches the chosen backdrop as the scene background (declaratively, so r3f
@@ -64,13 +110,21 @@ function makeSourceMeshesVisible(scene: THREE.Object3D): void {
   });
 }
 
-function PreviewCamera() {
+/** Position + aim the camera. Orb-only: tight on the origin. Hero mode: pull
+ *  back and up to frame the full standing hero (the orb stays at the origin,
+ *  which is the hero's back hip), still looking at the origin. */
+function PreviewCamera({ heroMode }: { heroMode: boolean }) {
   const camera = useThree((s) => s.camera);
 
   useLayoutEffect(() => {
+    if (heroMode) {
+      camera.position.set(0, HERO_PREVIEW_HEIGHT * 0.18, HERO_PREVIEW_HEIGHT * 1.7);
+    } else {
+      camera.position.set(0, CAMERA_HEIGHT, CAMERA_DISTANCE);
+    }
     camera.lookAt(0, 0, 0);
     camera.updateMatrixWorld();
-  }, [camera]);
+  }, [camera, heroMode]);
 
   return null;
 }
@@ -191,36 +245,56 @@ function PreviewScene({
   fit,
   showVanilla,
   spinning,
+  heroScene,
+  heroFit,
   captureRef,
 }: {
   sourceScene: THREE.Object3D;
   fit: PreviewFit;
   showVanilla: boolean;
   spinning: boolean;
+  /** Optional standing hero rendered around the orb for scale + facing. */
+  heroScene?: THREE.Object3D | null;
+  heroFit?: HeroFit | null;
   captureRef?: MutableRefObject<(() => string | null) | null>;
 }) {
   const spinGroup = useRef<THREE.Group>(null);
+  const heroGroup = useRef<THREE.Group>(null);
   const vanillaRef = useRef<THREE.Group>(null);
   const gl = useThree((s) => s.gl);
   const scene = useThree((s) => s.scene);
   const camera = useThree((s) => s.camera);
+  const heroMode = !!(heroScene && heroFit);
+
+  // In hero mode the orb holds its true (baked) facing toward the camera so it
+  // reads against the hero; outside hero mode it free-spins.
+  useLayoutEffect(() => {
+    if (heroMode && spinGroup.current) spinGroup.current.rotation.y = 0;
+  }, [heroMode]);
 
   useEffect(() => {
     if (!captureRef) return;
-    // The saved thumbnail freezes to a fixed angle and drops the orange vanilla
-    // reference (a sizing aid, not part of the model), then restores the live
-    // spin/visibility so the preview keeps animating.
+    // The saved card thumbnail is always the orb alone: freeze to a fixed yaw,
+    // hide the orange reference shell AND the hero, and reset the camera to the
+    // orb-only framing, then restore everything so the live view keeps going.
     captureRef.current = () => {
       const group = spinGroup.current;
       const vanilla = vanillaRef.current;
+      const hero = heroGroup.current;
       const prevYaw = group ? group.rotation.y : 0;
       const prevVanillaVisible = vanilla ? vanilla.visible : false;
+      const prevHeroVisible = hero ? hero.visible : false;
+      const prevCamPos = camera.position.clone();
       try {
         if (group) {
           group.rotation.y = CAPTURE_YAW;
           group.updateMatrixWorld(true);
         }
         if (vanilla) vanilla.visible = false;
+        if (hero) hero.visible = false;
+        camera.position.set(0, CAMERA_HEIGHT, CAMERA_DISTANCE);
+        camera.lookAt(0, 0, 0);
+        camera.updateMatrixWorld();
         gl.render(scene, camera);
         return gl.domElement.toDataURL('image/png');
       } catch {
@@ -228,6 +302,10 @@ function PreviewScene({
       } finally {
         if (group) group.rotation.y = prevYaw;
         if (vanilla) vanilla.visible = prevVanillaVisible;
+        if (hero) hero.visible = prevHeroVisible;
+        camera.position.copy(prevCamPos);
+        camera.lookAt(0, 0, 0);
+        camera.updateMatrixWorld();
       }
     };
     return () => {
@@ -236,26 +314,50 @@ function PreviewScene({
   }, [captureRef, gl, scene, camera]);
 
   useFrame((_, delta) => {
-    if (!spinning) return;
+    if (!spinning || heroMode) return;
     const group = spinGroup.current;
     if (group) group.rotation.y += delta * SPIN_RATE;
   });
 
   return (
-    <group ref={spinGroup}>
-      <group scale={fit.scale}>
-        <group position={fit.offset}>
-          <group matrix={fit.matrix} matrixAutoUpdate={false}>
-            <primitive object={sourceScene} dispose={null} />
+    <>
+      <group ref={spinGroup}>
+        <group scale={fit.scale}>
+          <group position={fit.offset}>
+            <group matrix={fit.matrix} matrixAutoUpdate={false}>
+              <primitive object={sourceScene} dispose={null} />
+            </group>
           </group>
         </group>
+        {showVanilla && !heroMode && (
+          <group ref={vanillaRef}>
+            <VanillaReference />
+          </group>
+        )}
       </group>
-      {showVanilla && (
-        <group ref={vanillaRef}>
-          <VanillaReference />
+      {heroMode && heroScene && heroFit && (
+        // Hero wraps the orb (which stays at the origin = the back hip): turned
+        // 180deg so the back faces the camera, dropped so the hip sits at y=0,
+        // pushed back by its own half-depth so the back surface sits just behind
+        // the orb (the orb pokes out toward the camera, not buried in the body),
+        // and nudged sideways so the orb rests at one hip rather than dead-center.
+        <group
+          ref={heroGroup}
+          position={[
+            heroFit.halfWidth * HERO_HIP_SIDE - ORB_NUDGE_RIGHT,
+            -HERO_PREVIEW_HEIGHT * HERO_HIP_FRACTION - ORB_NUDGE_UP,
+            -(heroFit.halfDepth + ORB_BACK_PROUD),
+          ]}
+          rotation={[0, Math.PI, 0]}
+        >
+          <group scale={heroFit.scale}>
+            <group position={heroFit.offset}>
+              <primitive object={heroScene} dispose={null} />
+            </group>
+          </group>
         </group>
       )}
-    </group>
+    </>
   );
 }
 
@@ -266,6 +368,7 @@ export default function SoulImportPreview({
   showVanilla,
   spinning = true,
   backdropIndex = -1,
+  heroScene = null,
   captureRef,
 }: {
   /** The selected source GLB scene. */
@@ -277,31 +380,44 @@ export default function SoulImportPreview({
   spinning?: boolean;
   /** Index into SOUL_BACKDROPS for the baked background; < 0 for none. */
   backdropIndex?: number;
+  /** Standing hero rendered beside the orb for a size + facing reference. */
+  heroScene?: THREE.Object3D | null;
   captureRef?: MutableRefObject<(() => string | null) | null>;
 }) {
   useLayoutEffect(() => {
     makeSourceMeshesVisible(scene);
-  }, [scene]);
+    if (heroScene) makeSourceMeshesVisible(heroScene);
+  }, [scene, heroScene]);
 
   const fit = useMemo(
     () => buildPreviewFit(scene, orientMode, rotate),
     [scene, orientMode, rotate]
   );
+  const heroFit = useMemo(() => (heroScene ? buildHeroFit(heroScene) : null), [heroScene]);
+  const heroMode = !!(heroScene && heroFit);
 
   return (
     <Canvas
-      camera={{ position: [0, SOUL_TARGET_SPAN * 0.35, CAMERA_DISTANCE], fov: 35 }}
+      camera={{ position: [0, CAMERA_HEIGHT, CAMERA_DISTANCE], fov: 35 }}
       gl={{ alpha: true, antialias: true, preserveDrawingBuffer: true }}
       dpr={[1, 2]}
     >
-      <PreviewCamera />
+      <PreviewCamera heroMode={heroMode} />
       <Backdrop index={backdropIndex} />
       <ambientLight intensity={0.7} />
       <directionalLight position={[3, 5, 2]} intensity={1.3} />
       <directionalLight position={[-3, 2, -2]} intensity={0.5} />
       {/* Faint accent rim from below/behind for a subtle soul glow. */}
       <pointLight position={[0, -SOUL_TARGET_SPAN, -SOUL_TARGET_SPAN]} intensity={0.6} color="#f97316" />
-      <PreviewScene sourceScene={scene} fit={fit} showVanilla={showVanilla} spinning={spinning} captureRef={captureRef} />
+      <PreviewScene
+        sourceScene={scene}
+        fit={fit}
+        showVanilla={showVanilla}
+        spinning={spinning}
+        heroScene={heroScene}
+        heroFit={heroFit}
+        captureRef={captureRef}
+      />
     </Canvas>
   );
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1012,9 +1012,7 @@
       },
       "facing": {
         "label": "Facing yaw",
-        "upright": "Keep upright (no tumble)",
-        "uprightHint": "Orb stands still and faces one way. Use the slider or arrows to aim it.",
-        "tumbleHint": "Orb spins freely like the default gold orb. Turn this on to aim a fixed facing."
+        "upright": "Lock in place"
       },
       "glow": {
         "label": "Soul glow",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1615,
+  "totalKeys": 1613,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1615,
+      "translatedKeys": 1613,
       "pct": 100
     }
   ]

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -158,6 +158,10 @@ export interface ImportSoulContainerGlbArgs {
     orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
     /** Extra Euler degrees [X, Y, Z] applied after orient. */
     rotate?: [number, number, number];
+    /** Facing yaw in degrees: turn the fitted orb about its vertical axis. */
+    yaw?: number;
+    /** Upright orientation (psyduck recipe); defaults true when omitted. */
+    upright?: boolean;
     glow: 'recolor' | 'base' | 'off';
     /** User-tracked test status; defaults to 'untested'. */
     status?: SoulImportStatus;
@@ -176,6 +180,10 @@ export interface PreviewSoulContainerGlbArgs {
     glbPath: string;
     orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
     rotate?: [number, number, number];
+    /** Facing yaw in degrees: turn the fitted orb about its vertical axis. */
+    yaw?: number;
+    /** Upright orientation (psyduck recipe); defaults true when omitted. */
+    upright?: boolean;
     glow: 'recolor' | 'base' | 'off';
 }
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -518,6 +518,10 @@ export interface SoulContainerImportInfo {
   orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
   /** Extra Euler rotation in degrees [X, Y, Z] applied after orient, if any. */
   rotate?: [number, number, number];
+  /** Facing yaw in degrees: turn about the orb's vertical axis, if any. */
+  yaw?: number;
+  /** False when the upright orientation pass was opted out (defaults true). */
+  upright?: boolean;
   /** Soul-glow particle handling. */
   glow: 'recolor' | 'base' | 'off';
   /** vpkmerge version that built the VPK. */


### PR DESCRIPTION
## What

Drives the new `vpkmerge soul-container import` orientation knobs (Slush97/vpkmerge#27) from the Locker's soul-container import modal.

- **Facing yaw** slider (-180..180) + numeric box; the on-preview left/right arrows nudge yaw 15 deg. The live preview reflects it (the build bakes yaw into the geometry).
- **"Lock in place"** toggle (default on) maps to the upright orientation pass; turning it off lets the orb tumble like the stock gold orb.
- **"Hero scale"** toggle renders a fixed default hero (Abrams) with the orb floating at their **back hip**, where a soul container sits in-game, so you can judge size + facing without launching the game. The orb stays at the origin (so the card-thumbnail capture is unaffected) and the hero is placed around it, turned back-to-camera and depth-offset so the orb pokes out past the spine.
- Preview surface kept **square**; the view toggles moved to the bottom bar to declutter the top.

Wired through IPC (`BuildSoulContainerArgs` / preview args) and persisted in `SoulContainerImportInfo`.

## Notes
- Depends on the bundled vpkmerge binary carrying `--yaw` / `--no-upright` (Slush97/vpkmerge#27); dev mode picks up the sibling `target/release` build.
- Renderer + electron typecheck clean for the touched files; in-game facing/scale tuning is the remaining step (tunable constants noted in `SoulImportPreview.tsx`).