### PR TITLE
feat(settings): add Ko-fi support button to the header

### DIFF
--- a/src/components/KofiSupportButton.tsx
+++ b/src/components/KofiSupportButton.tsx
@@ -1,0 +1,42 @@
+import Tx from './translation/Tx';
+import { getAssetPath } from '../lib/assetPath';
+import { getHeroRenderPath } from '../lib/lockerUtils';
+
+const KOFI_URL = 'https://ko-fi.com/esocidae';
+
+/**
+ * Ko-fi tip-jar link for the Settings header. Mina (red umbrella and all) sits
+ * muted in the background of the pill, fading behind the label, with her hero
+ * icon as the leading mark. Visual treatment is in index.css under the `.kofi-*`
+ * classes; image paths are resolved with getAssetPath so they work under both
+ * the dev server and the packaged file:// build.
+ */
+export default function KofiSupportButton() {
+  const minaRender = getHeroRenderPath('Mina');
+  const minaIcon = getAssetPath('/heroes/icons/mina.png');
+  return (
+    <a
+      href={KOFI_URL}
+      target="_blank"
+      rel="noreferrer noopener"
+      title="Support Grimoire on Ko-fi"
+      className="kofi-button inline-flex shrink-0 items-center gap-2 rounded-sm border px-3.5 py-2 text-sm font-medium text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-kofi/40 whitespace-nowrap"
+    >
+      <span
+        aria-hidden="true"
+        className="kofi-mina"
+        style={{ backgroundImage: `url("${minaRender}")` }}
+      />
+      <span aria-hidden="true" className="kofi-fade" />
+      <img
+        src={minaIcon}
+        alt=""
+        aria-hidden="true"
+        className="kofi-icon relative z-10 h-5 w-5 object-contain"
+      />
+      <span className="relative z-10">
+        <Tx k="settings.support.kofi" fallback="Buy me a coffee" />
+      </span>
+    </a>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,7 @@
 
   /* Third-party brand colors (buttons/links that represent the brand itself). */
   --color-brand-discord: #5865F2;
+  --color-brand-kofi: #FF5E5B;
 
   --font-radiance: 'Radiance', system-ui, sans-serif;
   --font-reaver: 'Reaver', serif;
@@ -817,6 +818,65 @@ body {
 
 .animate-scale-in {
   animation: scaleIn 0.25s ease-out forwards;
+}
+
+/* ============================================================================
+   Ko-fi support button: Mina (with her red umbrella) sits muted in the back,
+   fading behind the label, her hero icon as the leading mark. Static, no
+   animation, no glow: neutral border with a faint kofi tint. Images are set
+   inline (getAssetPath) so they resolve in packaged builds.
+   ========================================================================== */
+.kofi-button {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background-color: color-mix(in srgb, var(--color-bg-tertiary) 60%, transparent);
+  border-color: var(--color-border);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.kofi-button:hover {
+  border-color: color-mix(in srgb, var(--color-brand-kofi) 40%, var(--color-border));
+  background-color: var(--color-bg-tertiary);
+}
+
+/* Mina render, pinned to the right and muted: her red umbrella and bats fan out
+   toward the label, the face sits behind "coffee". Dimmed + desaturated so she
+   reads as a quiet backdrop, not a vivid sticker. */
+.kofi-mina {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 78%;
+  z-index: -2;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: 55% 20%;
+  opacity: 0.4;
+  filter: saturate(0.7) brightness(0.85);
+  pointer-events: none;
+}
+
+.kofi-button:hover .kofi-mina {
+  opacity: 0.55;
+}
+
+/* Fade the card colour across her so the label stays readable. */
+.kofi-fade {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: linear-gradient(90deg,
+    var(--color-bg-tertiary) 40%,
+    color-mix(in srgb, var(--color-bg-tertiary) 65%, transparent) 65%,
+    color-mix(in srgb, var(--color-bg-tertiary) 25%, transparent) 100%);
+}
+
+/* Slightly soften the hero icon so it sits with the muted backdrop. */
+.kofi-icon {
+  opacity: 0.92;
 }
 
 .mod-details-body-content,

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -25,6 +25,7 @@ import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/a
 import { DEFAULT_SIDEBAR_HERO, HERO_NAMES_SORTED, getHeroChipIconPath } from '../lib/lockerUtils';
 import SocialAccountSection from '../components/social/SocialAccountSection';
 import PerformanceConfigCard from '../components/performance/PerformanceConfigCard';
+import KofiSupportButton from '../components/KofiSupportButton';
 import type { SaltIngestStatus } from '../types/electron';
 
 // GitHub Releases is the source of truth for changelogs. When we have local
@@ -634,6 +635,7 @@ export default function Settings() {
       <PageHeader
         title={<Tx k="nav.settings" fallback="Settings" />}
         description={<Tx k="settings.header.description" fallback="Game paths, preferences, and maintenance" />}
+        action={<KofiSupportButton />}
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## What

Adds a tip-jar link to the Settings page header (right side) that opens [ko-fi.com/esocidae](https://ko-fi.com/esocidae) in the browser.

## Design

- Mina (with her red umbrella) sits **muted** in the background of the pill, fading behind the label, with her hero icon as the leading mark.
- Static: no animation, no glow. A neutral border that picks up a faint Ko-fi coral tint on hover; her backdrop lifts slightly on hover so the red umbrella/bats peek out.
- New `--color-brand-kofi` token alongside the existing `--color-brand-discord`.
- Image paths resolved with `getAssetPath` so they work under both the dev server and the packaged `file://` build.

## i18n

Uses `settings.support.kofi` ("Buy me a coffee"), which already landed on `main` with the renderer i18n wiring (#196). No catalog or manifest change in this PR.

## Notes

- `KofiSupportButton` is `shrink-0` so the header CTA never clips its label.
- Verified visually in a throwaway instance (rest + hover states); lint clean.