### PR TITLE
feat: a little UI flair

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from './components/common/ErrorBoundary';
 import { useSocialStore } from './stores/socialStore';
 import { useAppStore } from './stores/appStore';
 import { getAssetPath } from './lib/assetPath';
+import { rollMemeAppTitle } from './lib/easterEggs';
 
 const GASSY_SOUND = getAssetPath('/sounds/gassy.mp3');
 
@@ -48,6 +49,12 @@ export default function App() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  // Easter egg: rarely boot under his "DeadGame" alias.
+  useEffect(() => {
+    const memeTitle = rollMemeAppTitle();
+    if (memeTitle) document.title = memeTitle;
   }, []);
 
   // Pull the persisted social-session state into the renderer once at boot.

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { DownloadQueueItem, DownloadProgressData } from '../types/electron';
 import { formatBytes } from '../lib/formatBytes';
+import { rollPreparingSuffix } from '../lib/easterEggs';
 import Tx from './translation/Tx';
 
 interface DownloadQueueIndicatorProps {
@@ -51,6 +52,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
     // bleeding speed from the previous one.
     const sampleRef = useRef<SpeedSample | null>(null);
     const [speed, setSpeed] = useState(0);
+    const [preparingSuffix] = useState(rollPreparingSuffix);
 
     useEffect(() => {
         Promise.all([
@@ -134,7 +136,8 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
 
     if (totalItems === 0) return null;
 
-    const currentFileName = queueState.currentDownload?.fileName ?? t('downloadQueue.preparing');
+    const currentFileName =
+        queueState.currentDownload?.fileName ?? t('downloadQueue.preparing') + preparingSuffix;
     const currentTooltip = queueState.currentDownload?.modName ?? currentFileName;
 
     return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -43,6 +43,7 @@ import {
 } from '../lib/api';
 
 import { getAssetPath } from '../lib/assetPath';
+import { rollMemeTooltip } from '../lib/easterEggs';
 import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath } from '../lib/lockerUtils';
 import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
@@ -214,6 +215,7 @@ export default function Sidebar() {
   // Persisted via localStorage so it survives reloads without round-tripping
   // through the main-process settings file. This is pure UI state.
   const [collapsed, setCollapsed] = useState<boolean>(readCollapsedPreference);
+  const [memeTooltip, setMemeTooltip] = useState<{ to: string; text: string } | null>(null);
   const [launchBgHidden, setLaunchBgHidden] = useState<boolean>(readLaunchBgHiddenPreference);
   const [labelsVisible, setLabelsVisible] = useState<boolean>(() => !readCollapsedPreference());
   const [labelMounted, setLabelMounted] = useState<boolean>(() => !readCollapsedPreference());
@@ -777,7 +779,18 @@ export default function Sidebar() {
               >
                 <NavLink
                   to={to}
-                  title={collapsed ? `${label}: ${tooltip}` : tooltip}
+                  title={
+                    memeTooltip?.to === to
+                      ? memeTooltip.text
+                      : collapsed
+                        ? `${label}: ${tooltip}`
+                        : tooltip
+                  }
+                  onMouseEnter={() => {
+                    const meme = rollMemeTooltip(to);
+                    setMemeTooltip(meme ? { to, text: meme } : null);
+                  }}
+                  onMouseLeave={() => setMemeTooltip((cur) => (cur?.to === to ? null : cur))}
                   onClick={() => setPendingNavPath(to)}
                   className={`group relative flex items-center h-10 overflow-hidden leading-5 rounded-sm text-sm transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 border ${
                       collapsed ? '' : 'pr-3'
@@ -1103,7 +1116,12 @@ export default function Sidebar() {
         <button
           type="button"
           onClick={() => navigate('/settings')}
-          title={t('sidebar.openSettings')}
+          title={memeTooltip?.to === '/settings' ? memeTooltip.text : t('sidebar.openSettings')}
+          onMouseEnter={() => {
+            const meme = rollMemeTooltip('/settings');
+            setMemeTooltip(meme ? { to: '/settings', text: meme } : null);
+          }}
+          onMouseLeave={() => setMemeTooltip((cur) => (cur?.to === '/settings' ? null : cur))}
           aria-current={settingsActive ? 'page' : undefined}
           className={`group relative flex w-full h-10 items-center overflow-hidden rounded-sm border text-sm transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 ${
             settingsActive

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import Tx from '../translation/Tx';
+import { MEME_ERROR_NOTE, MEME_ERROR_BUTTON, rollErrorBoundaryEgg } from '../../lib/easterEggs';
 
 interface ErrorBoundaryProps {
     children: ReactNode;
@@ -11,6 +12,7 @@ interface ErrorBoundaryState {
     hasError: boolean;
     error: Error | null;
     errorInfo: ErrorInfo | null;
+    egg: boolean;
 }
 
 /**
@@ -24,11 +26,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             hasError: false,
             error: null,
             errorInfo: null,
+            egg: false,
         };
     }
 
     static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
-        return { hasError: true, error };
+        return { hasError: true, error, egg: rollErrorBoundaryEgg() };
     }
 
     componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
@@ -39,7 +42,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     }
 
     handleReset = (): void => {
-        this.setState({ hasError: false, error: null, errorInfo: null });
+        this.setState({ hasError: false, error: null, errorInfo: null, egg: false });
     };
 
     render(): ReactNode {
@@ -69,12 +72,19 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                             {this.state.error.message}
                         </pre>
                     )}
+                    {this.state.egg && (
+                        <p className="text-sm text-text-secondary/70 mb-4">{MEME_ERROR_NOTE}</p>
+                    )}
                     <button
                         onClick={this.handleReset}
                         className="flex items-center gap-2 px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer"
                     >
                         <RefreshCw className="w-4 h-4" />
-                        <Tx k="common.errorBoundary.tryAgain" fallback="Try Again" />
+                        {this.state.egg ? (
+                            MEME_ERROR_BUTTON
+                        ) : (
+                            <Tx k="common.errorBoundary.tryAgain" fallback="Try Again" />
+                        )}
                     </button>
                 </div>
             );

--- a/src/lib/easterEggs.ts
+++ b/src/lib/easterEggs.ts
@@ -1,0 +1,53 @@
+// Rare meme tooltips that occasionally replace a nav item's real hover text.
+// Deliberately hardcoded here and never run through t(): these must never reach
+// the en translation catalog (and therefore Weblate), or they'd get "translated"
+// and tank the completeness numbers. Keyed by NavLink `to` path.
+const MEME_NAV_TOOLTIPS: Record<string, string> = {
+  '/': 'W Mods Only',
+  '/browse': 'Mod Shopping Spree',
+  '/discover': "Other People's Drip",
+  '/servers': 'Friend Simulator',
+  '/locker': 'Fortnite Locker',
+  '/crosshair': 'Aimbot (Legal)',
+  '/autoexec': "Hacker Voice: I'm In",
+  '/stats': 'Losing Streak',
+  '/conflicts': 'They Are Fighting',
+  '/profiles': 'Alt Accounts',
+  '/settings': 'Nerd Stuff',
+};
+
+const MEME_TOOLTIP_CHANCE = 0.07;
+
+// Rolls once per hover. Returns a meme tooltip on a hit, otherwise null so the
+// caller falls back to the real localized tooltip.
+export function rollMemeTooltip(to: string): string | null {
+  const meme = MEME_NAV_TOOLTIPS[to];
+  if (!meme) return null;
+  return Math.random() < MEME_TOOLTIP_CHANCE ? meme : null;
+}
+
+// One-in-twenty boot rolls the window title to his signature "DeadGame".
+export function rollMemeAppTitle(): string | null {
+  return Math.random() < 0.05 ? 'DeadGame' : null;
+}
+
+// Appended (never substituted) to a low-stakes toast on a rare hit. The real
+// localized message always shows; the meme is just a trailing flourish.
+export function memeToastSuffix(tone: 'success' | 'error'): string {
+  if (Math.random() >= 0.1) return '';
+  return tone === 'success' ? ' YAY' : ' Womp Womp';
+}
+
+export const MEME_ERROR_NOTE = 'Womp Womp';
+export const MEME_ERROR_BUTTON = 'Try Again now papi';
+
+// Rolled once when an error is caught, so the crash screen doesn't flicker.
+export function rollErrorBoundaryEgg(): boolean {
+  return Math.random() < 0.2;
+}
+
+// Rolled once per indicator mount so "Preparing…" doesn't flicker between
+// renders. Returns the suffix to append, or '' for the normal label.
+export function rollPreparingSuffix(): string {
+  return Math.random() < 0.12 ? ' brppapapa' : '';
+}

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -7,6 +7,7 @@ import { ConfirmModal } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import type { AppSettings } from '../types/mod';
 import type { SteamLaunchOptionsStatus } from '../types/electron';
+import { memeToastSuffix } from '../lib/easterEggs';
 
 // Popular Deadlock autoexec command presets
 const COMMAND_PRESETS = [
@@ -208,7 +209,7 @@ export default function Autoexec() {
         setSaveMessageTone(null);
         try {
             await window.electronAPI.saveAutoexecCommands(gamePath, commands);
-            setSaveMessage(t('autoexec.status.savedToAutoexec'));
+            setSaveMessage(t('autoexec.status.savedToAutoexec') + memeToastSuffix('success'));
             setSaveMessageTone('success');
             setHasUnsaved(false);
             // Refresh status
@@ -216,7 +217,7 @@ export default function Autoexec() {
             setStatus(s);
             setTimeout(() => setSaveMessage(null), 3000);
         } catch (err) {
-            setSaveMessage(t('autoexec.status.error', { error: String(err) }));
+            setSaveMessage(t('autoexec.status.error', { error: String(err) }) + memeToastSuffix('error'));
             setSaveMessageTone('error');
         } finally {
             setIsSaving(false);


### PR DESCRIPTION
Minor polish pass that gives a few surfaces some optional personality.

The visible defaults are unchanged: real labels, real tooltips, real toasts. There's just a small chance you catch something a little different here and there. No translation catalog changes, nothing for Weblate to see.

Not going to spoil where. Click around. You'll know it when you see it. ¯\_(ツ)_/¯