### PR TITLE
chore(release): v1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.13.0';
+const VPKMERGE_VERSION = 'v0.15.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '49fa476ef49ed252bd418ee00c5aa4b13aa731eb4c10c406bd45fd63aa501097' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: 'aa2602b2040eef87e814a92c078a7987cd9bf8584cfb18fc6919c092ef8ea56f' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '2a5a6f4a36b8e940cc95536b2baaca19c9d6c37fc1056d046ba60caad9919006' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'a0cd8b505142a2970f3133df1d6b37f10404096bd1057932d65810500785a652' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '91018e0db3299caa9efb80ccc9eeedd09f80164bbc0a1d5034f2252e08929e63' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'd046399f5093714dc7fdd1976693ba2147b089254ba2119a7cd228f747ccc54a' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Release prep for **v1.20.0**.

- Bumps `version` 1.19.0 -> 1.20.0.
- Bumps the vpkmerge pin v0.14.0 -> **v0.15.0** in `scripts/fetch-vpkmerge.mjs` (with v0.15.0 SHAs). v0.15.0 adds `soul-container --yaw` / `--no-upright` for the facing slider (#197) and the default-mesh-group pose-export fix. Closes the release gate from #202 (already closed); v0.14.0 predated those flags.

Verified the packaged Linux build bundles vpkmerge 0.15.0 and the soul-container facing slider works end-to-end.

### Draft release notes (for the GitHub Release body after tagging)

Big Locker release. Bring your own soul containers, and hero previews look a lot closer to in-game.

**New Features**
- Custom soul containers: drag a `.glb` into the Locker and it becomes a soul orb. Spin it to face the right way and check it at hero scale first.
- Better 3D previews: hero models get real lighting and tonemapping, much closer to in-game.
- Rename local mods: double-click a local mod's name on Installed.
- Jump to the author from installed mod details, opened in-app.
- Ko-fi button in the header.

**Changed**
- Translation groundwork: whole UI wired for translation, language packs download on demand. English only so far.
- A little hidden personality in the UI.

**Bug Fixes**
- Deadworks downloads extract again (7-Zip spawns from the unpacked path).
- Stale/mangled 3D preview thumbnails after a fix (caches cleared).

### Thanks
@oldreceipt for the 3D preview work (#187) and the default-mesh-group fix in vpkmerge (Slush97/vpkmerge#28).
