### PR TITLE
feat(locker): skin load ordering, per-skin/global delete, soul card fixes

### DIFF
--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -113,10 +113,10 @@ ipcMain.handle(
 
 ipcMain.handle(
     'export-soul-model',
-    async (_, metaKey: string): Promise<SoulModelInfo> => {
+    async (_, metaKey: string, cacheKey: string): Promise<SoulModelInfo> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return exportSoulModel(deadlockPath, metaKey);
+        return exportSoulModel(deadlockPath, metaKey, cacheKey);
     }
 );
 

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -181,11 +181,21 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
 /**
  * Export a soul-container mod's model to a `.glb` by running the bundled
  * `vpkmerge model export` against the mod's VPK (mesh + textures) with the base
- * pak as the fallback resolver. Keyed by the mod's metaKey.
+ * pak as the fallback resolver.
+ *
+ * The SOURCE VPK is resolved by `metaKey` (its on-disk location, which changes
+ * as a mod is enabled/disabled), but the CACHE is keyed by `cacheKey` (the mod's
+ * content-stable sha256). Keying the cache by metaKey was wrong: enabling a soul
+ * renames it to a `pakNN_dir.vpk` slot, and that slot name is reused by other
+ * soul containers over time, so a lookup by the slot name could serve a stale
+ * GLB exported for whatever soul last occupied it (the "wrong/white model on
+ * select" bug). Content addressing also means a toggle (same content, new
+ * metaKey) is a cache hit, so enabling/disabling no longer re-exports or flickers.
  */
 export async function exportSoulModel(
     deadlockPath: string,
-    metaKey: string
+    metaKey: string,
+    cacheKey: string
 ): Promise<SoulModelInfo> {
     const vpk = await resolveModVpk(deadlockPath, metaKey);
     if (!vpk) {
@@ -193,9 +203,9 @@ export async function exportSoulModel(
     }
     const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
 
-    const dir = modelDir(metaKey);
+    const dir = modelDir(cacheKey);
     await fs.mkdir(dir, { recursive: true });
-    const out = modelFile(metaKey);
+    const out = modelFile(cacheKey);
 
     await runVpkmerge([
         'model',
@@ -217,9 +227,9 @@ export async function exportSoulModel(
     const raw = await fs.readFile(out);
     const patched = stripGlbSkins(raw);
     if (patched !== raw) await fs.writeFile(out, patched);
-    await fs.writeFile(versionFile(metaKey), SOUL_CACHE_VERSION);
+    await fs.writeFile(versionFile(cacheKey), SOUL_CACHE_VERSION);
 
-    return getSoulModelInfo(metaKey);
+    return getSoulModelInfo(cacheKey);
 }
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -139,8 +139,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('get-applied-custom-card', heroName),
     getSoulModelInfo: (key: string) =>
         ipcRenderer.invoke('get-soul-model-info', key),
-    exportSoulModel: (metaKey: string) =>
-        ipcRenderer.invoke('export-soul-model', metaKey),
+    exportSoulModel: (metaKey: string, cacheKey: string) =>
+        ipcRenderer.invoke('export-soul-model', metaKey, cacheKey),
     getHeroPoseInfo: (heroName: string, skinSources?: unknown[]) =>
         ipcRenderer.invoke('get-hero-pose-info', heroName, skinSources),
     exportHeroPose: (heroName: string, skinSources?: unknown[], fallbackSkinMetaKey?: string) =>

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -1,8 +1,25 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ExternalLink } from 'lucide-react';
+import { ChevronDown, ExternalLink, GripVertical, Trash2 } from 'lucide-react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { Mod } from '../../types/mod';
-import { getLockerSkinKey } from '../../lib/lockerUtils';
+import { getLockerSkinKey, modLoadOrder } from '../../lib/lockerUtils';
 import { useAppStore } from '../../stores/appStore';
 import ModThumbnail from '../ModThumbnail';
 import AudioPreviewPlayer from '../AudioPreviewPlayer';
@@ -24,6 +41,13 @@ function variantPillLabel(mod: Mod): string {
     mod.sourceFileName ??
     mod.fileName
   );
+}
+
+/** A group's enabled variant VPKs in load order (lower pak## first). */
+function groupEnabledVariants(group: SkinGroup): Mod[] {
+  return group.variants
+    .filter((v) => v.enabled)
+    .sort((a, b) => modLoadOrder(a) - modLoadOrder(b));
 }
 
 function groupVariants(mods: Mod[]): SkinGroup[] {
@@ -63,6 +87,10 @@ interface HeroSkinsPanelProps {
    *  in the same group, so a model VPK + voice-lines VPK can both stay on.
    *  Falls back to onSelect when not provided. */
   onToggleVariant?: (modId: string) => void;
+  /** Request deletion of a whole skin group (all its variant VPKs). The page
+   *  owns the confirmation dialog + the delete; the panel only asks. When
+   *  omitted, no delete affordance is shown. */
+  onRequestDelete?: (modIds: string[], name: string) => void;
   hideNsfwPreviews?: boolean;
   categoryId?: number;
   /** Render thumbnails as the hero portrait instead of the mod's uploader
@@ -88,35 +116,214 @@ interface HeroSkinsPanelProps {
   layout?: 'list' | 'cards';
 }
 
-/** One skin group as a media card (hero detail view). The whole card is the
- *  select control for single-variant groups; multi-variant groups select via
- *  their footer pills instead, mirroring the list rows' behavior. */
+/** One row of the Load order strip: a drag handle, position badge, thumbnail
+ *  and name for an enabled skin group. */
+function LoadOrderRow({
+  group,
+  position,
+  hideNsfwPreviews,
+  useHeroPortraitThumbnails,
+  heroName,
+}: {
+  group: SkinGroup;
+  position: number;
+  hideNsfwPreviews: boolean;
+  useHeroPortraitThumbnails: boolean;
+  heroName?: string;
+}) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: group.key,
+  });
+  const primary = group.primary;
+  const enabledCount = groupEnabledVariants(group).length;
+  // The whole row is the drag handle (and keyboard-focusable via the sortable
+  // attributes), so you can grab a skin anywhere on its card, not just a tiny
+  // handle. touch-none keeps a drag from scrolling the sidebar mid-grab.
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      role="button"
+      aria-label={t('locker.skins.dragToReorder')}
+      title={t('locker.skins.dragToReorder')}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`flex touch-none items-center gap-2.5 rounded-md border px-2 py-1.5 transition-colors ${
+        isDragging
+          ? 'z-10 cursor-grabbing border-accent/40 bg-[#1c1c1c] opacity-95 shadow-lg shadow-black/40'
+          : 'cursor-grab border-white/[0.08] bg-[#141414]/70 hover:border-white/[0.18] hover:bg-[#1a1a1a]/80'
+      }`}
+    >
+      <GripVertical className="h-4 w-4 flex-shrink-0 text-white/40" aria-hidden />
+      <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-accent/20 text-[11px] font-semibold tabular-nums text-accent">
+        {position}
+      </span>
+      <div className="h-9 w-9 flex-shrink-0 overflow-hidden rounded bg-bg-tertiary">
+        <ModThumbnail
+          src={primary.thumbnailUrl}
+          alt={primary.name}
+          nsfw={primary.nsfw}
+          hideNsfw={hideNsfwPreviews}
+          heroPortrait={useHeroPortraitThumbnails ? heroName : undefined}
+          className="h-full w-full"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium text-white" title={primary.name}>
+          {primary.name}
+        </div>
+        {enabledCount > 1 && (
+          <div className="text-[10px] text-white/50">{`${enabledCount} files`}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Enabled skin groups for a hero in load order (top loads first / wins). */
+function activeSkinGroups(mods: Mod[]): SkinGroup[] {
+  return groupVariants(mods)
+    .filter((g) => g.variants.some((v) => v.enabled))
+    .sort(
+      (a, b) =>
+        modLoadOrder(groupEnabledVariants(a)[0]) - modLoadOrder(groupEnabledVariants(b)[0])
+    );
+}
+
+/** Draggable list of the hero's currently-enabled skins. Top = loads first
+ *  (pak01) = wins when two skins write the same file. Self-contained: pass the
+ *  hero's skin `mods` and it renders nothing unless 2+ are active. Lives in the
+ *  hero detail sidebar (see LockerHero), separate from the skin grid. */
+export function SkinLoadOrderStrip({
+  mods,
+  onReorder,
+  hideNsfwPreviews = false,
+  useHeroPortraitThumbnails = false,
+  heroName,
+}: {
+  mods: Mod[];
+  onReorder: (orderedModIds: string[]) => void | Promise<void>;
+  hideNsfwPreviews?: boolean;
+  useHeroPortraitThumbnails?: boolean;
+  heroName?: string;
+}) {
+  const { t } = useTranslation();
+  const groups = useMemo(() => activeSkinGroups(mods), [mods]);
+  // Local draft order so the list reflects a drop instantly instead of snapping
+  // back while the rename round-trips through the main process. Re-synced from
+  // props (the post-rescan order) only when the enabled SET changes (a skin was
+  // enabled/disabled) — a pure reorder keeps the same set, so we keep our draft.
+  // Adjusting state during render (vs an effect) is React's recommended pattern
+  // for deriving state from props and avoids a cascading re-render.
+  const propKeys = useMemo(() => groups.map((g) => g.key), [groups]);
+  const [orderedKeys, setOrderedKeys] = useState<string[]>(propKeys);
+  const [prevPropKeys, setPrevPropKeys] = useState<string[]>(propKeys);
+  if (propKeys !== prevPropKeys) {
+    setPrevPropKeys(propKeys);
+    const sameSet =
+      orderedKeys.length === propKeys.length && orderedKeys.every((k) => propKeys.includes(k));
+    if (!sameSet) setOrderedKeys(propKeys);
+  }
+
+  const byKey = useMemo(() => new Map(groups.map((g) => [g.key, g])), [groups]);
+  const orderedGroups = orderedKeys
+    .map((k) => byKey.get(k))
+    .filter((g): g is SkinGroup => Boolean(g));
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = orderedKeys.indexOf(String(active.id));
+    const newIndex = orderedKeys.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    const nextKeys = arrayMove(orderedKeys, oldIndex, newIndex);
+    setOrderedKeys(nextKeys);
+    const flatIds = nextKeys.flatMap((k) =>
+      groupEnabledVariants(byKey.get(k)!).map((v) => v.id)
+    );
+    void onReorder(flatIds);
+  };
+
+  // Load order is only meaningful when 2+ skins are stacked.
+  if (groups.length < 2) return null;
+
+  return (
+    <div className="animate-drop-in rounded-lg border border-white/[0.08] bg-black/20 p-2.5 backdrop-blur-sm">
+      <div className="mb-2 px-0.5">
+        <div className="text-xs font-semibold text-white">{t('locker.skins.loadOrder')}</div>
+        <div className="text-[11px] leading-snug text-white/60">
+          {t('locker.skins.loadOrderHint')}
+        </div>
+      </div>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={orderedKeys} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-1.5">
+            {orderedGroups.map((group, i) => (
+              <LoadOrderRow
+                key={group.key}
+                group={group}
+                position={i + 1}
+                hideNsfwPreviews={hideNsfwPreviews}
+                useHeroPortraitThumbnails={useHeroPortraitThumbnails}
+                heroName={heroName}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}
+
+/** One skin group as a media card (hero detail view). Every card holds the same
+ *  height (media + title + a fixed status row); the variant chooser opens as a
+ *  floating popover so expanding it never reflows the grid. */
 function SkinGroupCard({
   group,
   onSelect,
   onToggleVariant,
+  onRequestDelete,
   hideNsfwPreviews,
   useHeroPortraitThumbnails,
   heroName,
   soundVolume,
+  loadOrderPosition,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
   onToggleVariant?: (modId: string) => void;
+  onRequestDelete?: (modIds: string[], name: string) => void;
   hideNsfwPreviews: boolean;
   useHeroPortraitThumbnails: boolean;
   heroName?: string;
   soundVolume: number;
+  /** 1-based load-order position, shown as a corner chip. Only set when 2+
+   *  skins are active for the hero (otherwise order is meaningless). */
+  loadOrderPosition?: number;
 }) {
   const { t } = useTranslation();
   const isMulti = group.variants.length > 1;
   const groupActive = group.variants.some((v) => v.enabled);
   const enabledCount = group.variants.filter((v) => v.enabled).length;
   const primary = group.primary;
-  // Variant tray, collapsed by default so multi-variant cards match the
-  // single-variant card height. Starts open when nothing is enabled yet:
-  // that's the one moment the user must pick before anything works.
-  const [variantsOpen, setVariantsOpen] = useState(enabledCount === 0);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [variantsOpen, setVariantsOpen] = useState(false);
+  // Close the variant popover on any click outside the card.
+  useEffect(() => {
+    if (!variantsOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        setVariantsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [variantsOpen]);
   // Skipped when NSFW previews are hidden so we never bleed hidden imagery
   // into the glass tint, even blurred.
   const glassBackdropUrl =
@@ -124,11 +331,12 @@ function SkinGroupCard({
 
   return (
     <div
+      ref={cardRef}
       className={`group/card relative flex flex-col rounded-[10px] border p-2.5 transition-[border-color,background-color,box-shadow] duration-200 ${
         groupActive
           ? 'border-accent bg-white/[0.02] hover:bg-white/[0.04]'
           : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
-      }`}
+      } ${variantsOpen ? 'z-20' : ''}`}
     >
       {/* Glass backdrop: a blurred copy of the cover art bleeds behind the
           card so it's tinted by its own thumbnail, matching the Global view
@@ -176,6 +384,14 @@ function SkinGroupCard({
             {t('common.status.active')}
           </span>
         )}
+        {loadOrderPosition !== undefined && (
+          <span
+            className="pointer-events-none absolute bottom-2 right-2 z-10 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-black/65 px-1.5 text-[10px] font-semibold tabular-nums text-white backdrop-blur-sm"
+            title={t('locker.skins.loadOrderPosition', { position: loadOrderPosition })}
+          >
+            {`#${loadOrderPosition}`}
+          </span>
+        )}
       </div>
 
       {/* Title. */}
@@ -189,13 +405,11 @@ function SkinGroupCard({
       </div>
 
       {/* Whole card is the primary control: select for single-variant groups,
-          open/close the variant tray for multi. Sits under the tray/audio
-          (z-20) so those keep their own handlers. */}
+          open/close the variant popover for multi. Sits under the popover/audio
+          (z-30) so those keep their own handlers. */}
       <button
         type="button"
-        onClick={() =>
-          isMulti ? setVariantsOpen((open) => !open) : onSelect(primary.id)
-        }
+        onClick={() => (isMulti ? setVariantsOpen((open) => !open) : onSelect(primary.id))}
         aria-pressed={isMulti ? undefined : groupActive}
         aria-expanded={isMulti ? variantsOpen : undefined}
         aria-label={
@@ -217,12 +431,32 @@ function SkinGroupCard({
         className="absolute inset-0 z-10 cursor-pointer rounded-[10px]"
       />
 
+      {/* Delete: removes the whole group (every variant VPK). Hover-revealed so
+          it stays out of the way; z-30 keeps it above the full-card toggle. */}
+      {onRequestDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRequestDelete(
+              group.variants.map((v) => v.id),
+              primary.name
+            );
+          }}
+          aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
+          title={t('locker.skins.deleteSkin', { name: primary.name })}
+          className="absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-red-500/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
+
       {/* Sound preview. All variants of one GameBanana submission share the
           same preview clip, so the group's primary audioUrl is the
-          representative sample. z-20 keeps it above the full-card toggle. */}
+          representative sample. z-30 keeps it above the full-card toggle. */}
       {primary.sourceSection === 'Sound' && primary.audioUrl && (
         <div
-          className="relative z-20 mt-2"
+          className="relative z-30 mt-2"
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >
@@ -230,14 +464,14 @@ function SkinGroupCard({
         </div>
       )}
 
-      {/* Variant state line + collapsible tray (multi-variant groups only).
-          Collapsed it's a one-line summary, so the card holds the same height
-          as its single-variant neighbors; the whole-card button (z-10 under
-          this) toggles it. */}
+      {/* Fixed-height status row for multi-variant groups: a one-line summary
+          that toggles the variant popover. Keeping it a single line means every
+          card holds the same height; the popover floats (absolute) so opening
+          it never reflows the grid. */}
       {isMulti && (
         <>
           <div
-            className={`pointer-events-none mt-0.5 flex items-center gap-1 px-0.5 text-[11px] ${
+            className={`pointer-events-none mt-1 flex items-center gap-1 px-0.5 text-[11px] ${
               enabledCount === 0 ? 'text-accent' : 'text-text-secondary'
             }`}
           >
@@ -247,18 +481,15 @@ function SkinGroupCard({
                 : `${enabledCount}/${group.variants.length} active`}
             </span>
             <ChevronDown
-              className={`h-3 w-3 transition-transform duration-200 ${
-                variantsOpen ? 'rotate-180' : ''
-              }`}
+              className={`h-3 w-3 transition-transform duration-200 ${variantsOpen ? 'rotate-180' : ''}`}
             />
           </div>
           {variantsOpen && (
             <div
-              className={`relative z-20 mt-1.5 flex flex-wrap items-center gap-1.5 rounded-md border px-2 py-1.5 ${
-                enabledCount === 0 ? 'border-accent/30 bg-accent/[0.04]' : 'border-white/[0.08]'
-              }`}
+              className="absolute left-2 right-2 top-full z-30 mt-1 flex flex-wrap items-center gap-1.5 rounded-md border border-white/[0.12] bg-bg-secondary/95 px-2 py-2 shadow-xl shadow-black/50 backdrop-blur-md"
               role="group"
               aria-label={t('locker.skins.variantToggles')}
+              onMouseDown={(e) => e.stopPropagation()}
             >
               {group.variants.map((variant) => {
                 const label = variantPillLabel(variant);
@@ -294,6 +525,7 @@ function SkinGroupRow({
   group,
   onSelect,
   onToggleVariant,
+  onRequestDelete,
   hideNsfwPreviews,
   useHeroPortraitThumbnails,
   heroName,
@@ -302,6 +534,7 @@ function SkinGroupRow({
   group: SkinGroup;
   onSelect: (modId: string) => void;
   onToggleVariant?: (modId: string) => void;
+  onRequestDelete?: (modIds: string[], name: string) => void;
   hideNsfwPreviews: boolean;
   useHeroPortraitThumbnails: boolean;
   heroName?: string;
@@ -314,12 +547,29 @@ function SkinGroupRow({
   const primary = group.primary;
   return (
     <div
-      className={`rounded-md border transition-colors ${
+      className={`group/row relative rounded-md border transition-colors ${
         groupActive
           ? 'border-accent/60 bg-white/[0.04] backdrop-blur-sm'
           : 'border-border bg-bg-secondary/70 hover:border-accent/60 hover:bg-bg-secondary/85'
       }`}
     >
+      {onRequestDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRequestDelete(
+              group.variants.map((v) => v.id),
+              primary.name
+            );
+          }}
+          aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
+          title={t('locker.skins.deleteSkin', { name: primary.name })}
+          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-red-500/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
       <button
         type="button"
         onClick={() => {
@@ -432,6 +682,7 @@ export default function HeroSkinsPanel({
   mods,
   onSelect,
   onToggleVariant,
+  onRequestDelete,
   hideNsfwPreviews = false,
   categoryId,
   useHeroPortraitThumbnails = false,
@@ -444,6 +695,23 @@ export default function HeroSkinsPanel({
   const hasMods = mods.length > 0;
   const soundVolume = useAppStore((s) => s.soundVolume);
   const groups = useMemo(() => groupVariants(mods), [mods]);
+
+  // Per-card #N chip: the load-order position of each active skin. Mirrors the
+  // SkinLoadOrderStrip (now in the hero sidebar). The chip only shows when 2+
+  // skins are active — a single active skin has no meaningful order.
+  const loadOrderByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    const active = groups
+      .filter((g) => g.variants.some((v) => v.enabled))
+      .sort(
+        (a, b) =>
+          modLoadOrder(groupEnabledVariants(a)[0]) - modLoadOrder(groupEnabledVariants(b)[0])
+      );
+    if (active.length >= 2) {
+      active.forEach((g, i) => map.set(g.key, i + 1));
+    }
+    return map;
+  }, [groups]);
 
   const browseLink = browseAction ? (
     <button
@@ -459,6 +727,7 @@ export default function HeroSkinsPanel({
   const groupProps = {
     onSelect,
     onToggleVariant,
+    onRequestDelete,
     hideNsfwPreviews,
     useHeroPortraitThumbnails,
     heroName,
@@ -472,7 +741,12 @@ export default function HeroSkinsPanel({
           {layout === 'cards' ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {groups.map((group) => (
-                <SkinGroupCard key={group.key} group={group} {...groupProps} />
+                <SkinGroupCard
+                  key={group.key}
+                  group={group}
+                  loadOrderPosition={loadOrderByKey.get(group.key)}
+                  {...groupProps}
+                />
               ))}
             </div>
           ) : (

--- a/src/components/locker/SoulContainerCanvas.tsx
+++ b/src/components/locker/SoulContainerCanvas.tsx
@@ -132,9 +132,13 @@ export default function SoulContainerCanvas({
   paneRef: RefObject<HTMLElement | null>;
 }) {
   return (
-    // z-30 keeps models above the cards' frosted backdrop but below the retag
-    // menu (z-80) and any modal/toast, so an overlay never sits under a dialog.
-    <div className="pointer-events-none fixed inset-0 z-30">
+    // Mounted INSIDE the scroll pane (its stacking context), so z-[5] lands the
+    // models above each card's background/frosted panel (z-auto) but BELOW the
+    // card chrome (Active/Disabled tags z-10, retag + delete buttons z-20) so
+    // that chrome paints on top of the model instead of behind it. Still
+    // `fixed inset-0` (not absolute) so it overlays the viewport rather than
+    // scrolling away with the pane content; per-tile scissor clamps to the pane.
+    <div className="pointer-events-none fixed inset-0 z-[5]">
       {/* r3f sets pointerEvents:'auto' on its own container div, which would
           override the wrapper above and swallow every click on the page. We
           don't raycast, so force it back to none (merged after r3f's default). */}

--- a/src/components/locker/SoulContainerTile.tsx
+++ b/src/components/locker/SoulContainerTile.tsx
@@ -33,8 +33,9 @@ export default function SoulContainerTile({
   /** Content-stable id (sha256) used as the registry key, so the model survives
    *  the metaKey change that a toggle causes. */
   tileId: string;
-  /** The mod's metaKey: the source the main process resolves and exports from,
-   *  and the on-disk model cache key. Changes when the mod is enabled/disabled. */
+  /** The mod's metaKey: the SOURCE the main process resolves and exports from.
+   *  Changes when the mod is enabled/disabled (the VPK is renamed); the export
+   *  CACHE is keyed by the content-stable tileId instead, not this. */
   modKey: string;
 }) {
   const registry = useSoulRegistry();
@@ -53,13 +54,19 @@ export default function SoulContainerTile({
     let cancelled = false;
     (async () => {
       try {
-        let info = await getSoulModelInfo(modKey);
+        // The export cache is keyed by tileId (the mod's content-stable sha256),
+        // NOT modKey: a mod's metaKey changes when it's enabled/disabled (the VPK
+        // is renamed into a reused pakNN slot), and keying by it served a stale
+        // GLB from whatever soul last held that slot (wrong/white model on
+        // select). Content addressing also makes a toggle a cache hit, so it no
+        // longer re-exports. The SOURCE for an export is still resolved by modKey.
+        let info = await getSoulModelInfo(tileId);
         if (!info.hasModel) {
           if (cancelled) return;
           // Spinner only when there's nothing to show yet; on a reload (toggle)
           // the existing model keeps rendering instead.
           if (!rootRef.current) setGenerating(true);
-          info = await exportSoulModel(modKey);
+          info = await exportSoulModel(modKey, tileId);
           if (cancelled) return;
           setGenerating(false);
         }
@@ -67,7 +74,7 @@ export default function SoulContainerTile({
           if (!rootRef.current && !cancelled) setFailed(true);
           return;
         }
-        const url = meshUrlFor(modKey, info.mtimeMs);
+        const url = meshUrlFor(tileId, info.mtimeMs);
         const gltf = await loadGltfPreview(url);
         if (cancelled) {
           disposeScene(gltf.scene);

--- a/src/index.css
+++ b/src/index.css
@@ -752,6 +752,18 @@ body {
   }
 }
 
+@keyframes dropIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes modDetailsContentOutLeft {
   from {
     opacity: 1;
@@ -818,6 +830,10 @@ body {
 
 .animate-scale-in {
   animation: scaleIn 0.25s ease-out forwards;
+}
+
+.animate-drop-in {
+  animation: dropIn 0.3s ease-out forwards;
 }
 
 /* ============================================================================
@@ -1258,6 +1274,7 @@ body {
   .animate-fade-in,
   .animate-fade-out,
   .animate-scale-in,
+  .animate-drop-in,
   .mod-details-body--loading-next .mod-details-body-content,
   .mod-details-body--loading-previous .mod-details-body-content,
   .mod-details-body--loading-next .mod-details-navigation-skeleton,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -187,10 +187,12 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
   return window.electronAPI.getSoulModelInfo(key);
 }
 
-/** Export a soul-container mod's model via the bundled vpkmerge exporter.
- *  Keyed by the mod's metaKey (folder-qualified for overflow mods). */
-export async function exportSoulModel(metaKey: string): Promise<SoulModelInfo> {
-  return window.electronAPI.exportSoulModel(metaKey);
+/** Export a soul-container mod's model via the bundled vpkmerge exporter. The
+ *  SOURCE VPK is located by `metaKey` (folder-qualified for overflow mods); the
+ *  cache is keyed by `cacheKey` (the mod's content-stable sha256) so an
+ *  enable/disable rename can't serve a different soul's stale export. */
+export async function exportSoulModel(metaKey: string, cacheKey: string): Promise<SoulModelInfo> {
+  return window.electronAPI.exportSoulModel(metaKey, cacheKey);
 }
 
 /** Whether a hero's posed 3D still exists for the given active skin stack (+ mtime, key). */

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -355,6 +355,20 @@ export function getLockerSkinKey(mod: Mod): string {
     : `mod:${mod.id}`;
 }
 
+/**
+ * Global load-order rank of a mod: lower = higher priority (loads as pak01,
+ * wins file conflicts). With overflow folders the pakNN (mod.priority) repeats
+ * per folder, so we fold in the folder index from metaKey (addons{N}/...) to
+ * get a single monotonic order. Base citadel/addons (and disabled) is folder 0,
+ * addons1 is 1, etc. Mirrors the formula used by the Installed page so reorder
+ * math stays consistent across both surfaces.
+ */
+export function modLoadOrder(mod: Mod): number {
+  const match = mod.metaKey.match(/^addons(\d+)\//);
+  const folderIndex = match ? parseInt(match[1], 10) : 0;
+  return folderIndex * 100 + mod.priority;
+}
+
 export function groupLockerSkins(mods: Mod[]): LockerSkin[] {
   const bySkin = new Map<string, Mod[]>();
   for (const mod of mods) {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -953,7 +953,8 @@
     "global": {
       "activeBadgeTitle": "This soul container is active and loaded in-game",
       "disabledBadge": "Disabled",
-      "disabledBadgeTitle": "This mod is disabled and not loaded in-game"
+      "disabledBadgeTitle": "This mod is disabled and not loaded in-game",
+      "deleteMod": "Delete {{name}}"
     },
     "soulImport": {
       "trigger": {
@@ -1196,7 +1197,16 @@
     "skins": {
       "noPreview": "No preview",
       "pickAVariant": "Pick a variant",
-      "variantToggles": "Variant toggles"
+      "variantToggles": "Variant toggles",
+      "loadOrder": "Load order",
+      "loadOrderHint": "Drag to set which skin wins when two cover the same files. Top loads first.",
+      "dragToReorder": "Drag to reorder",
+      "loadOrderPosition": "Load order position {{position}}",
+      "deleteSkin": "Delete {{name}}"
+    },
+    "deleteConfirm": {
+      "title": "Delete mod?",
+      "body": "Permanently delete \"{{name}}\" and its files? This cannot be undone."
     },
     "crop": {
       "imageLoadFailed": "That image could not be loaded. Try a different PNG or JPG.",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1613,
+  "totalKeys": 1621,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1613,
+      "translatedKeys": 1621,
       "pct": 100
     }
   ]

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
@@ -25,7 +25,7 @@ const SoulContainerImportModal = lazy(() => import('../components/locker/SoulCon
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { GlobalModType, Mod } from '../types/mod';
-import { ViewModeToggle, EmptyState, SectionHeader } from '../components/common/PageComponents';
+import { ViewModeToggle, EmptyState, SectionHeader, ConfirmModal } from '../components/common/PageComponents';
 import { Tag } from '../components/common/ui';
 import { Skeleton } from '../components/common/Skeleton';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -46,6 +46,7 @@ import {
   groupModsByCategory,
   isLockerManagedMod,
   isLockerManagedSound,
+  modLoadOrder,
   readStoredFavorites,
   type GlobalModGroups,
   type HeroCategory,
@@ -129,7 +130,7 @@ function RainbowPaletteIcon({ className = '', title }: { className?: string; tit
 
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, setBrowseUi, setLockerHeroName } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(
@@ -480,6 +481,55 @@ export default function Locker() {
     await toggleMod(modId);
   };
 
+  // Reorder the load order of a hero's enabled skins. `orderedModIds` is the
+  // new desired order of THIS hero's enabled skin VPK ids (lower index = loads
+  // first = wins file conflicts). We splice that order into the full global
+  // enabled list in place (every other mod keeps its relative slot) and hand
+  // the whole list to reorderMods, which renames pak## prefixes to match. We
+  // must pass the FULL list, not just the subset: reorderMods packs the ids it
+  // receives into the lowest free slots, so a subset would yank these skins to
+  // the front of the global load order.
+  const reorderHeroSkins = async (heroId: number, orderedModIds: string[]) => {
+    const skins = heroMods.map.get(heroId) ?? [];
+    const heroSkinIds = new Set(skins.map((m) => m.id));
+    // Keep only ids that really belong to this hero and are enabled, in the
+    // requested order; ignore anything stale.
+    const desired = orderedModIds.filter(
+      (id) => heroSkinIds.has(id) && mods.find((m) => m.id === id)?.enabled
+    );
+    if (desired.length < 2) return;
+
+    const globalEnabled = mods
+      .filter((m) => m.enabled)
+      .sort((a, b) => modLoadOrder(a) - modLoadOrder(b));
+
+    const desiredSet = new Set(desired);
+    let cursor = 0;
+    const nextOrder = globalEnabled.map((m) =>
+      desiredSet.has(m.id) ? desired[cursor++] : m.id
+    );
+
+    const prevOrder = globalEnabled.map((m) => m.id);
+    if (nextOrder.every((id, i) => id === prevOrder[i])) return;
+
+    await reorderMods(nextOrder);
+  };
+
+  // Delete a skin (all its variant VPKs) straight from the Locker. We confirm
+  // first, then delete sequentially to keep priority bookkeeping coherent (the
+  // store removes each id locally as it goes).
+  // Shared delete confirmation for the Locker (hero skins + global cosmetics).
+  // Holds the mod ids to remove and a display name for the prompt copy.
+  const [deletePrompt, setDeletePrompt] = useState<{ ids: string[]; name: string } | null>(null);
+  const confirmDeleteMods = async () => {
+    if (!deletePrompt) return;
+    const { ids } = deletePrompt;
+    setDeletePrompt(null);
+    for (const id of ids) {
+      await deleteMod(id);
+    }
+  };
+
   // Soul containers are single-select: there's one soul-container slot, so
   // enabling one disables any other active soul container, and clicking the
   // already-active card turns it back off (vanilla). Other global types keep
@@ -702,6 +752,7 @@ export default function Locker() {
               onBrowseSkins={() => openHeroInBrowse(hero)}
               onSelect={(modId) => setActiveSkin(hero.id, modId)}
               onToggleVariant={(modId) => toggleHeroVariant(hero.id, modId)}
+              onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
               isFavorite={favoriteHeroes.includes(hero.id)}
               onToggleFavorite={() =>
                 setFavoriteHeroes((prev) =>
@@ -807,6 +858,8 @@ export default function Locker() {
             }
             onSelect={(modId) => setActiveSkin(overlayHero.id, modId)}
             onToggleVariant={(modId) => toggleHeroVariant(overlayHero.id, modId)}
+            onReorderSkins={(orderedModIds) => reorderHeroSkins(overlayHero.id, orderedModIds)}
+            onRequestDeleteSkin={(ids, name) => setDeletePrompt({ ids, name })}
             hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
           />
         </div>
@@ -845,6 +898,7 @@ export default function Locker() {
             onBack={() => navigate('/locker')}
             onToggle={selectGlobalMod}
             onSetGlobalType={tagModGlobalType}
+            onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
             onImportSoul={() => setSoulImportOpen(true)}
           />
         </div>
@@ -861,6 +915,16 @@ export default function Locker() {
           />
         </Suspense>
       )}
+
+      <ConfirmModal
+        isOpen={deletePrompt !== null}
+        variant="danger"
+        title={t('locker.deleteConfirm.title')}
+        message={t('locker.deleteConfirm.body', { name: deletePrompt?.name ?? '' })}
+        confirmLabel={t('common.actions.delete')}
+        onConfirm={confirmDeleteMods}
+        onCancel={() => setDeletePrompt(null)}
+      />
     </div>
   );
 }
@@ -876,6 +940,7 @@ interface HeroCardProps {
   onBrowseSkins: () => void;
   onSelect: (modId: string) => void;
   onToggleVariant: (modId: string) => void;
+  onRequestDelete: (modIds: string[], name: string) => void;
   isFavorite: boolean;
   onToggleFavorite: () => void;
   hideNsfwPreviews: boolean;
@@ -944,6 +1009,8 @@ interface LockerGlobalViewProps {
   onToggle: (modId: string) => void | Promise<unknown>;
   /** Reassign a mod to another global type, or null to drop it off the axis. */
   onSetGlobalType: (modId: string, globalType: GlobalModType | null) => void | Promise<unknown>;
+  /** Request deletion of a global mod (its VPK). The page owns the confirm. */
+  onRequestDelete: (modIds: string[], name: string) => void;
   /** Open the soul-container GLB import modal (shown on the soul-container tab). */
   onImportSoul: () => void;
 }
@@ -953,7 +1020,7 @@ interface LockerGlobalViewProps {
  * frosted-glass carousel of cosmetic types (echoing the LockerHeroView shell's
  * art + blur language). Selecting a tile reveals that type's toggleable mods.
  */
-function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onImportSoul }: LockerGlobalViewProps) {
+function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onRequestDelete, onImportSoul }: LockerGlobalViewProps) {
   const { t } = useTranslation();
   const soundVolume = useAppStore((s) => s.soundVolume);
   const available = GLOBAL_MOD_TYPE_ORDER.filter((type) => groups[type].length > 0);
@@ -1271,11 +1338,26 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                             }}
                             aria-label={t('locker.page.changeCategoryForNamed', { name: mod.name })}
                             title={t('locker.page.changeCategory')}
-                            className="absolute right-2 top-2 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-white/15 bg-black/45 text-white/85 opacity-0 backdrop-blur-sm transition-opacity hover:bg-black/65 focus:opacity-100 focus-visible:opacity-100 group-hover/card:opacity-100"
+                            className="absolute right-11 top-2 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-white/15 bg-black/45 text-white/85 opacity-0 backdrop-blur-sm transition-opacity hover:bg-black/65 focus:opacity-100 focus-visible:opacity-100 group-hover/card:opacity-100"
                           >
                             <MoreVertical className="h-4 w-4" />
                           </button>
                         )}
+                        {/* Delete: removes this global mod's VPK. Sits above the
+                            full-card toggle (z-20 > z-10), to the right of the
+                            retag kebab; red on hover. */}
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onRequestDelete([mod.id], mod.name);
+                          }}
+                          aria-label={t('locker.global.deleteMod', { name: mod.name })}
+                          title={t('locker.global.deleteMod', { name: mod.name })}
+                          className="absolute right-2 top-2 z-20 flex h-7 w-7 items-center justify-center rounded-md border border-white/15 bg-black/45 text-white/85 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] hover:bg-red-500/80 hover:text-white focus:opacity-100 focus-visible:opacity-100 group-hover/card:opacity-100"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
                       </div>
 
                       {/* Title only — the whole card is the enable/disable control. */}
@@ -1326,6 +1408,18 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             <p className="text-sm text-white/70">{t('locker.page.noGlobalNonHeroCosmeticsInstalledYet')}</p>
           )}
         </div>
+
+        {/* Shared 3D canvas for the Global soul-container grid: one WebGL context
+            renders every card (scissored into its on-screen rect), so the grid
+            can't exhaust the browser's live-context cap. Mounted INSIDE the pane
+            (not at the view root) so its z-[5] sits below each card's tags/kebab
+            but above the card background, keeping chrome on top of the model.
+            Only mounted while that type is selected. */}
+        {activeType === 'soul-container' && (
+          <Suspense fallback={null}>
+            <SoulContainerCanvas paneRef={paneRef} />
+          </Suspense>
+        )}
       </div>
 
       {/* Retag menu (fixed-positioned, anchored at the kebab's viewport coords so
@@ -1384,15 +1478,6 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
         </>
       )}
 
-      {/* Shared 3D canvas for the Global soul-container grid: one WebGL context
-          renders every card (scissored into its on-screen rect), so the grid
-          can't exhaust the browser's live-context cap. Only mounted while that
-          type is selected. */}
-      {activeType === 'soul-container' && (
-        <Suspense fallback={null}>
-          <SoulContainerCanvas paneRef={paneRef} />
-        </Suspense>
-      )}
     </div>
     </SoulRegistryProvider>
   );
@@ -1604,6 +1689,7 @@ function HeroCard({
   onBrowseSkins,
   onSelect,
   onToggleVariant,
+  onRequestDelete,
   isFavorite,
   onToggleFavorite,
   hideNsfwPreviews,
@@ -1765,6 +1851,7 @@ function HeroCard({
           mods={activeList}
           onSelect={onSelect}
           onToggleVariant={onToggleVariant}
+          onRequestDelete={onRequestDelete}
           hideNsfwPreviews={hideNsfwPreviews}
           showDownloadable={activeSection === 'skins'}
           browseAction={

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -11,7 +11,7 @@ import {
   Sparkles,
   type LucideIcon,
 } from 'lucide-react';
-import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
+import HeroSkinsPanel, { SkinLoadOrderStrip } from '../components/locker/HeroSkinsPanel';
 import HeroCardPicker from '../components/locker/HeroCardPicker';
 import HeroSoundPicker from '../components/locker/HeroSoundPicker';
 import HeroEffectsPanel from '../components/locker/HeroEffectsPanel';
@@ -42,6 +42,12 @@ interface LockerHeroViewProps {
   onToggleFavorite: () => void;
   onSelect: (modId: string) => void | Promise<void>;
   onToggleVariant: (modId: string) => void | Promise<void>;
+  /** Reorder the load order of this hero's enabled skins. `orderedModIds` is
+   *  the new desired order of enabled skin VPK ids (lower index = loads first). */
+  onReorderSkins?: (orderedModIds: string[]) => void | Promise<void>;
+  /** Request deletion of a skin group (all its variant VPKs). The page owns the
+   *  confirmation dialog and the actual delete. */
+  onRequestDeleteSkin?: (modIds: string[], name: string) => void;
   hideNsfwPreviews?: boolean;
 }
 
@@ -70,6 +76,8 @@ export function LockerHeroView({
   onToggleFavorite,
   onSelect,
   onToggleVariant,
+  onReorderSkins,
+  onRequestDeleteSkin,
   hideNsfwPreviews = false,
 }: LockerHeroViewProps) {
   const { t } = useTranslation();
@@ -210,6 +218,7 @@ export function LockerHeroView({
         mods={skinList}
         onSelect={handleSelect}
         onToggleVariant={handleToggleVariant}
+        onRequestDelete={onRequestDeleteSkin}
         hideNsfwPreviews={hideNsfwPreviews}
         categoryId={hero.id}
         showDownloadable
@@ -381,6 +390,17 @@ export function LockerHeroView({
             );
           })}
         </nav>
+
+        {/* Load order for stacked skins. Lives in the sidebar (not over the
+            grid) and self-hides unless 2+ skins are active. Only relevant to
+            the Skins section. */}
+        {activeSection === 'skins' && onReorderSkins && (
+          <SkinLoadOrderStrip
+            mods={skinList}
+            onReorder={onReorderSkins}
+            hideNsfwPreviews={hideNsfwPreviews}
+          />
+        )}
       </div>
 
       {/* Right pane: the active section's content. Width-capped on lg+ so the

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -488,7 +488,7 @@ export interface ElectronAPI {
         heroName: string
     ) => Promise<{ variant: string; dataUrl: string }[]>;
     getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
-    exportSoulModel: (metaKey: string) => Promise<SoulModelInfo>;
+    exportSoulModel: (metaKey: string, cacheKey: string) => Promise<SoulModelInfo>;
     getHeroPoseInfo: (
         heroName: string,
         skinSources?: HeroPoseSkinSource[]


### PR DESCRIPTION
## Summary
Locker improvements across the hero skins view and the Global (soul container) tab.

### Skins
- **Load ordering**: a drag-to-reorder strip in the hero **sidebar** (drops in animated; the whole row is the drag handle), shown only when 2+ skins are active. Top = `pak01` = wins file conflicts. Per-hero reorder splices the hero's skins into the **full global enabled list** before calling `reorderMods`, so other heroes' load-order slots are untouched (passing just the subset would yank them to the front of global load order).
- **Card cleanup**: uniform card heights — the multi-variant chooser now opens as a floating **popover** instead of an inline tray that reflowed the 2-col grid. Added a `#N` load-order chip on active cards.

### Delete
- Hover-revealed trash button on skin cards/rows **and** Global-tab cards, backed by one shared delete confirmation owned by `Locker`.

### Soul containers (Global tab)
- **Z-order fix**: the shared GLB canvas was a sibling of the pane at `z-30` and painted over the card chrome, so tags/kebab/delete rendered *behind* the model. It now mounts inside the pane at `z-[5]` — above the card background/frosted panel, below the chrome. Model stays crisp (paints after the backdrop-blur panel).
- **Wrong/white-model-on-select fix**: the soul export cache was keyed by `metaKey`, which is reused across `pakNN` slots, so enabling a soul could serve a different soul's stale GLB. The cache is now **content-addressed by sha256** (the source VPK is still resolved by `metaKey`). Bonus: toggling enable/disable is now a cache hit (no re-export, no flicker).

### i18n
- Added `locker.deleteConfirm.*`, `locker.global.deleteMod`, and `locker.skins` load-order keys; regenerated `manifest.json`.

## Testing
- `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check` all pass.
- Soul z-order and wrong-model-on-select fixes verified in the running app (user-confirmed).
- No tests exist for this area (TS strict + ESLint only).