### PR TITLE
Move browse downloads above artist

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -586,6 +586,49 @@ function ModDetailsModal({
     );
   };
 
+  const filesSection = files.length > 0 ? (
+    <section>
+      <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
+        {t('modDetails.sections.files')} {files.length > 1 && <span className="text-text-secondary/70 normal-case tracking-normal">({files.length})</span>}
+      </h3>
+      <div className="space-y-2">
+        {currentFiles.map((file) => renderFileRow(file))}
+        {archivedFiles.length > 0 && (
+          <div className={currentFiles.length > 0 ? 'pt-1' : undefined}>
+            <button
+              type="button"
+              onClick={() => setArchivedFilesOpen((open) => !open)}
+              aria-expanded={archivedFilesOpen}
+              className="w-full flex items-center justify-between gap-3 px-1 py-1.5 text-left text-sm text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+            >
+              <span className="flex items-center gap-2 min-w-0">
+                {archivedFilesOpen ? (
+                  <ChevronDown className="w-4 h-4 flex-shrink-0" />
+                ) : (
+                  <ChevronRight className="w-4 h-4 flex-shrink-0" />
+                )}
+                <span className="font-medium truncate">{t('modDetails.files.archived')}</span>
+                {installedFileIsArchived && (
+                  <span className="flex-shrink-0 rounded-full border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
+                    {t('modDetails.files.yourVersion')}
+                  </span>
+                )}
+              </span>
+              <span className="flex-shrink-0 text-[11px] leading-none text-text-tertiary">
+                ({archivedFiles.length})
+              </span>
+            </button>
+            {archivedFilesOpen && (
+              <div className="mt-2 space-y-2">
+                {archivedFiles.map((file) => renderFileRow(file, true))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  ) : null;
+
   const navigationSkeleton = (
     <div
       className="mod-details-navigation-skeleton absolute inset-0 bg-bg-secondary"
@@ -838,9 +881,9 @@ function ModDetailsModal({
               </span>
             )}
           </div>
-          {/* Sidebar moves the title down into the body (above the artist) to
-              keep this header from cramming, so here it's just a spacer that
-              pushes the action buttons to the right edge. */}
+          {/* Sidebar moves the title down into the body to keep this header from
+              cramming, so here it's just a spacer that pushes the action buttons
+              to the right edge. */}
           {isSidebar ? (
             <div className="min-w-0 flex-1" />
           ) : (
@@ -1208,8 +1251,8 @@ function ModDetailsModal({
                 installing a file doesn't move the image stack on the left. */}
             <div className={detailsColClass}>
               {/* Sidebar-only title block. The header drops the title to stay
-                  uncluttered, so the mod name lives here, right above the artist,
-                  with its dates/downloads underneath. */}
+                  uncluttered, so the mod name lives here with its
+                  dates/downloads underneath. */}
               {isSidebar && (
                 <div className="space-y-1.5">
                   {isNavigating ? (
@@ -1259,6 +1302,8 @@ function ModDetailsModal({
                   })()}
                 </div>
               )}
+
+              {filesSection}
 
               {submitter && (
                 <section>
@@ -1447,48 +1492,6 @@ function ModDetailsModal({
                 )}
               </section>
 
-              {files.length > 0 && (
-                <section>
-                  <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
-                    {t('modDetails.sections.files')} {files.length > 1 && <span className="text-text-secondary/70 normal-case tracking-normal">({files.length})</span>}
-                  </h3>
-                  <div className="space-y-2">
-                    {currentFiles.map((file) => renderFileRow(file))}
-                    {archivedFiles.length > 0 && (
-                      <div className={currentFiles.length > 0 ? 'pt-1' : undefined}>
-                        <button
-                          type="button"
-                          onClick={() => setArchivedFilesOpen((open) => !open)}
-                          aria-expanded={archivedFilesOpen}
-                          className="w-full flex items-center justify-between gap-3 px-1 py-1.5 text-left text-sm text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
-                        >
-                          <span className="flex items-center gap-2 min-w-0">
-                            {archivedFilesOpen ? (
-                              <ChevronDown className="w-4 h-4 flex-shrink-0" />
-                            ) : (
-                              <ChevronRight className="w-4 h-4 flex-shrink-0" />
-                            )}
-                            <span className="font-medium truncate">{t('modDetails.files.archived')}</span>
-                            {installedFileIsArchived && (
-                              <span className="flex-shrink-0 rounded-full border border-green-500/40 bg-green-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400">
-                                {t('modDetails.files.yourVersion')}
-                              </span>
-                            )}
-                          </span>
-                          <span className="flex-shrink-0 text-[11px] leading-none text-text-tertiary">
-                            ({archivedFiles.length})
-                          </span>
-                        </button>
-                        {archivedFilesOpen && (
-                          <div className="mt-2 space-y-2">
-                            {archivedFiles.map((file) => renderFileRow(file, true))}
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </section>
-              )}
               <section>
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h3 className="flex min-w-0 items-center gap-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3204,28 +3204,6 @@ export default function Browse() {
               );
             })()}
           </div>
-
-          {section === 'Sound' && (
-            <div className="mt-3 inline-flex max-w-full items-center gap-3 rounded-lg border border-border bg-bg-secondary/70 px-3 py-2">
-              <div className="inline-flex shrink-0 items-center gap-2 text-sm font-medium text-text-primary">
-                <Volume2 className="h-4 w-4 flex-shrink-0 text-text-secondary" />
-                <span>{t('browse.previewVolume')}</span>
-              </div>
-              <input
-                type="range"
-                min="0"
-                max="100"
-                value={Math.round(soundVolume * 100)}
-                onChange={(e) => setSoundVolume(parseInt(e.target.value, 10) / 100)}
-                className="h-1.5 w-40 cursor-pointer accent-accent sm:w-48"
-                title={`Volume: ${Math.round(soundVolume * 100)}%`}
-                aria-label={t('browse.previewVolume')}
-              />
-              <span className="w-9 text-right text-xs tabular-nums text-text-secondary">
-                {Math.round(soundVolume * 100)}%
-              </span>
-            </div>
-          )}
         </form>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Move the browse details file-download section above the artist card
- Keep sidebar and popup behavior shared through ModDetailsModal

## Verification
- pnpm typecheck
- pnpm lint
- pre-push i18n:check