### PR TITLE
fix(browse): guard null downloading state in ModDetails fileId prop

### DIFF
--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -2623,7 +2623,7 @@ export default function Browse() {
         installedFileIds={installedFileIds}
         installedFileStates={installedFileStates}
         onEnableFile={toggleMod}
-        downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
+        downloadingFileId={downloading && downloading.modId === selectedMod.id ? downloading.fileId : null}
         queuedFileIds={selectedQueuedFileIds}
         extracting={extracting}
         progress={downloadProgress}


### PR DESCRIPTION
## Problem

Opening a mod's details panel in Browse could crash the panel with:

> Cannot read properties of null (reading 'fileId')

caught by the error boundary as "Something went wrong."

## Root cause

In `src/pages/Browse.tsx`, the `downloadingFileId` prop was computed as:

```tsx
downloadingFileId={downloading?.modId === selectedMod.id ? downloading.fileId : null}
```

When nothing is downloading, `downloading` is `null`, so `downloading?.modId`
evaluates to `undefined`. If the open mod's `id` was also `undefined`, then
`undefined === undefined` is `true`, the ternary took its true branch, and it
read `downloading.fileId` → `null.fileId` → crash.

It only triggers on the coincidence of *no active download* plus a mod whose
`id` came through undefined, which is why it's flaky to reproduce.

## Fix

Null-check `downloading` directly instead of relying on optional chaining in the
comparison, so it short-circuits to `null` regardless of `selectedMod.id`:

```tsx
downloadingFileId={downloading && downloading.modId === selectedMod.id ? downloading.fileId : null}
```

Type stays `number | null`; no downstream changes. One-line change.