### PR TITLE
feat(locker, browse): hide empty heroes + multi-file install picker (#207, #209)

### DIFF
--- a/docs/community-feedback-backlog.md
+++ b/docs/community-feedback-backlog.md
@@ -1,0 +1,86 @@
+# Community feedback backlog
+
+Scoping notes for feature requests filed by the community (mostly via GitHub
+issues). Each entry records what exists today, what's missing, and a rough
+difficulty so the work can be picked up without re-investigating.
+
+Status legend: **Shipped** / **Planned** / **Deferred**.
+
+## Locker + Browse batch (issues #207-#210, June 2026)
+
+All four were filed by one user (Minenash) in a single burst of feedback.
+
+### #207 - Hide heroes with no content in the Locker - Shipped
+
+Branch `feat/locker-hide-empty-and-quick-install`. In-Locker toolbar toggle
+(persisted to `localStorage` `lockerHideEmpty`, alongside `lockerViewMode`)
+that hides hero cards with no assigned skins/sounds. Favorited heroes stay
+visible. Reuses the exact "has content" expression the hero sort already uses
+in `Locker.tsx`, so what's hidden matches what sorts to the bottom. The
+hero-count stat reflects the filtered list. i18n keys under `locker.page.*`.
+
+### #209 (part 1) - Archived files shouldn't force the details modal - Shipped
+
+Same branch. `handleQuickDownload` in `Browse.tsx` filtered to live
+(non-archived) files before the "more than one file?" decision, falling back to
+the full list only when every file is archived. A mod with one live file plus
+archived legacy uploads now installs directly instead of opening the page.
+
+### #209 (part 2) - Quick-install file dropdown - Deferred
+
+Request: when a mod genuinely has multiple live files, the Install button
+should open a lightweight dropdown listing file names + descriptions for a
+one-click pick, instead of opening `ModDetailsModal`.
+
+- Today: multiple live files -> `setSelectedMod(details)` opens the modal
+  (`Browse.tsx` `handleQuickDownload`, ~line 2254).
+- Data is already loaded (`getModDetails` returns `files[]` with name,
+  description, size, `isArchived`); no extra fetch needed.
+- Reuse: file-row rendering exists in `ModDetailsModal.tsx`; picker interaction
+  in `MultiVpkPickerModal.tsx`.
+- Missing: a new anchored-popover component (positioning, outside-click/Escape
+  via the `useOverlayExit` pattern, responsive fallback to the modal), plus a
+  "View all files" escape hatch. Should land as its own component per the
+  Browse god-page policy.
+- Difficulty: **M**. Deferred because part 1 removes most of the actual pain;
+  reassess whether the dropdown is still wanted.
+
+### #208 - Show the installed skin on the Locker card - Deferred
+
+Request: the hero's Locker card should show the skin actually applied, not the
+generic render. User also wants a manual image override because some poses clip
+with some skins.
+
+Two paths, ship in order:
+
+1. **User-provided image (do first, ~M).** Reuse the existing
+   `HeroCardPicker.tsx` + `CardCropper.tsx` upload/crop flow. Store a per-hero
+   override image; render-path falls back to it before the vanilla render. This
+   alone satisfies the stated need (manual control over clipping poses).
+2. **Auto pose-to-PNG (follow-up, L).** Reuse `exportHeroPose()` (already proven
+   by `HeroPoseViewer`) to render the posed GLB with the active skin stack to a
+   cached PNG. Cache must be content-addressed by skin-stack hash (same lesson
+   as the soul-export cache) and invalidated on enable/disable/reorder. Watch
+   the packaged-build CSP/blob gotcha (see the packaged-3D-CSP note).
+
+Hero cards render art via CSS `background-image` + `object-position`, so the
+display swap touches layout, not just an `<img src>`.
+
+### #210 - Unify background art settings - Deferred
+
+Request: fold all three background-art controls into one Appearance section,
+each selectable from any hero, with the current launch art also selectable, plus
+a custom image upload.
+
+- Today, split across:
+  - Settings -> Appearance: `sidebarHeroHighlight` (dynamic, any hero) via the
+    hero-picker grid in `Settings.tsx` (~lines 1087-1142).
+  - Sidebar `Launch Modded`/`Launch Vanilla` right-click: hardcoded
+    `LAUNCH_MODDED_BG` / `LAUNCH_VANILLA_BG` in `Sidebar.tsx`; visibility lives
+    in `localStorage`, not `AppSettings`.
+- Plan: add ~3 `AppSettings` keys (modded/vanilla bg hero + optional custom
+  image path), extend the Appearance section reusing the hero-picker grid and
+  the `showOpenDialog` + `readImageDataUrl` upload flow, make the Sidebar
+  backgrounds dynamic. Custom upload is simpler here than hero cards (no VPK
+  build/crop, just render the file). Mind Sidebar memoization (perf-sensitive).
+- Difficulty: **M**. Self-contained, heavy reuse, no backend.

--- a/src/components/BrowseFileQuickPicker.tsx
+++ b/src/components/BrowseFileQuickPicker.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Clock, ListTree, X } from 'lucide-react';
+import type { GameBananaFile } from '../types/gamebanana';
+import { formatDate } from '../types/gamebanana';
+
+const POPOVER_WIDTH = 340;
+const VIEWPORT_MARGIN = 8;
+const ANCHOR_GAP = 6;
+
+// Adaptive size so tiny files don't render as "0.00 MB". KB below 1 MB.
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+export interface BrowseFileQuickPickerProps {
+  /** The mod whose files are being chosen. */
+  modName: string;
+  /** Installable (non-archived) files, in the order the picker should show. */
+  files: GameBananaFile[];
+  /** The Install button the popover anchors to. */
+  anchor: HTMLElement;
+  onPick: (file: GameBananaFile) => void;
+  onViewAll: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Compact popover anchored to a Browse card's Install button. Lets the user pick
+ * which file to install when a mod ships more than one, without opening the full
+ * details modal (issue #209). Files arrive pre-filtered to non-archived; the
+ * "View all files" link drops to the modal for archived/legacy uploads.
+ *
+ * Behaves as a keyboard-navigable menu: first item is focused on open, arrow
+ * keys move a roving focus across the file rows and the footer, Enter/Space
+ * activates, and Escape closes (returning focus to the anchor). The full menu
+ * lives at z-[80], the workspace popover layer (see index.css).
+ */
+export default function BrowseFileQuickPicker({
+  modName,
+  files,
+  anchor,
+  onPick,
+  onViewAll,
+  onClose,
+}: BrowseFileQuickPickerProps) {
+  const { t } = useTranslation();
+  const popoverRef = useRef<HTMLDivElement>(null);
+  // One ref per focusable menu item: every file row followed by the footer.
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Most-downloaded first, so the popular pick lands at the top of the list.
+  // Copy first so we never mutate the caller's array.
+  const sorted = useMemo(
+    () => [...files].sort((a, b) => b.downloadCount - a.downloadCount),
+    [files]
+  );
+  // Footer ("View all files") is the last item in the roving sequence.
+  const itemCount = sorted.length + 1;
+
+  // Position below the button by default, flipping above when there isn't room.
+  // Measured after render so the flip uses the popover's real height.
+  useLayoutEffect(() => {
+    const place = () => {
+      const r = anchor.getBoundingClientRect();
+      const width = Math.min(POPOVER_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2);
+      let left = r.right - width;
+      left = Math.max(VIEWPORT_MARGIN, Math.min(left, window.innerWidth - VIEWPORT_MARGIN - width));
+
+      const height = popoverRef.current?.offsetHeight ?? 0;
+      const below = r.bottom + ANCHOR_GAP;
+      const fitsBelow = below + height <= window.innerHeight - VIEWPORT_MARGIN;
+      const top = fitsBelow ? below : Math.max(VIEWPORT_MARGIN, r.top - ANCHOR_GAP - height);
+      setCoords({ top, left, width });
+    };
+    place();
+    // Re-measure once the content has laid out (height known) for the flip.
+    const raf = requestAnimationFrame(place);
+    return () => cancelAnimationFrame(raf);
+  }, [anchor, files.length]);
+
+  // Focus the first item on open, and return focus to the anchor on close so
+  // keyboard users land back on the Install button they came from.
+  useEffect(() => {
+    itemRefs.current[0]?.focus();
+    return () => anchor.focus();
+  }, [anchor]);
+
+  // Dismiss on any scroll/resize so the popover never drifts from its anchor.
+  // Outside clicks are caught by the backdrop; Escape/arrow keys live on the
+  // menu element itself (roving focus).
+  useEffect(() => {
+    window.addEventListener('scroll', onClose, true);
+    window.addEventListener('resize', onClose);
+    return () => {
+      window.removeEventListener('scroll', onClose, true);
+      window.removeEventListener('resize', onClose);
+    };
+  }, [onClose]);
+
+  // Roving focus: move the active item, then move DOM focus to match.
+  const focusItem = useCallback((index: number) => {
+    const clamped = (index + itemCount) % itemCount;
+    setActiveIndex(clamped);
+    itemRefs.current[clamped]?.focus();
+  }, [itemCount]);
+
+  const onMenuKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          focusItem(activeIndex + 1);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          focusItem(activeIndex - 1);
+          break;
+        case 'Home':
+          e.preventDefault();
+          focusItem(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          focusItem(itemCount - 1);
+          break;
+        // Enter/Space activate the focused item natively (real <button>s), so
+        // they need no special handling here.
+        default:
+          break;
+      }
+    },
+    [activeIndex, focusItem, itemCount, onClose]
+  );
+
+  return createPortal(
+    <>
+      {/* Transparent catcher so a click anywhere outside dismisses the picker
+          without also activating whatever card sits underneath. */}
+      <div className="fixed inset-0 z-[80]" onClick={onClose} aria-hidden="true" />
+      <div
+      ref={popoverRef}
+      role="menu"
+      aria-label={t('browse.filePicker.title', { name: modName })}
+      onKeyDown={onMenuKeyDown}
+      className="fixed z-[80] overflow-hidden rounded-lg border border-border bg-bg-primary shadow-2xl animate-fade-in"
+      style={{
+        top: coords?.top ?? -9999,
+        left: coords?.left ?? -9999,
+        width: coords?.width ?? POPOVER_WIDTH,
+        visibility: coords ? 'visible' : 'hidden',
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border/70 px-3 py-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-text-secondary">
+          {t('browse.filePicker.heading')}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('common.actions.close')}
+          className="-mr-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-text-tertiary transition-colors hover:bg-bg-secondary hover:text-text-primary focus:bg-bg-secondary focus:text-text-primary focus:outline-none"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="max-h-[min(60vh,360px)] overflow-y-auto py-1">
+        {sorted.map((file, index) => (
+          <button
+            key={file.id}
+            ref={(el) => { itemRefs.current[index] = el; }}
+            type="button"
+            role="menuitem"
+            tabIndex={activeIndex === index ? 0 : -1}
+            onClick={() => onPick(file)}
+            className="group flex w-full px-3 py-2 text-left transition-colors hover:bg-accent/10 focus:bg-accent/10 focus:outline-none"
+          >
+            <span className="min-w-0 flex-1">
+              <span className="block min-w-0 truncate text-sm font-medium text-text-primary" title={file.description?.trim() || file.fileName}>
+                {file.description?.trim() || file.fileName}
+              </span>
+              {file.description?.trim() && (
+                <span className="mt-0.5 block truncate text-xs text-text-secondary/90" title={file.fileName}>
+                  {file.fileName}
+                </span>
+              )}
+              <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-secondary">
+                <span className="whitespace-nowrap">{formatFileSize(file.fileSize)}</span>
+                <span className="opacity-50">-</span>
+                <span className="whitespace-nowrap">
+                  {t('browse.filePicker.downloads', { count: file.downloadCount })}
+                </span>
+                {file.dateAdded && file.dateAdded > 0 && (
+                  <>
+                    <span className="opacity-50">-</span>
+                    <span className="flex items-center gap-1 whitespace-nowrap">
+                      <Clock className="h-3 w-3" />
+                      {formatDate(file.dateAdded)}
+                    </span>
+                  </>
+                )}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+      <button
+        ref={(el) => { itemRefs.current[sorted.length] = el; }}
+        type="button"
+        role="menuitem"
+        tabIndex={activeIndex === sorted.length ? 0 : -1}
+        onClick={onViewAll}
+        className="flex w-full items-center gap-2 border-t border-border/70 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-secondary hover:text-text-primary focus:bg-bg-secondary focus:text-text-primary focus:outline-none"
+      >
+        <ListTree className="h-4 w-4" />
+        {t('browse.filePicker.viewAll')}
+      </button>
+      </div>
+    </>,
+    document.body
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1251,6 +1251,10 @@
       "expandAll": "Expand all",
       "collapseAllHeroes": "Collapse all heroes",
       "expandAllHeroes": "Expand all heroes",
+      "hideEmpty": "Hide empty",
+      "showEmpty": "Show all",
+      "hideEmptyHeroes": "Hide heroes with no skins or sounds",
+      "showEmptyHeroes": "Show all heroes",
       "gallery": "Gallery",
       "list": "List",
       "noHeroCategoriesFound": "No hero categories found.",
@@ -1766,6 +1770,13 @@
   "browse": {
     "actions": {
       "enableDisabledTitle": "Enable this mod (currently in your disabled folder)"
+    },
+    "filePicker": {
+      "title": "Choose a file to install for {{name}}",
+      "heading": "Choose a file to install",
+      "downloads_one": "{{count}} download",
+      "downloads_other": "{{count}} downloads",
+      "viewAll": "View all files"
     },
     "empty": {
       "configureGamePathTitle": "Configure Game Path",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1621,
+  "totalKeys": 1630,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1621,
+      "translatedKeys": 1630,
       "pct": 100
     }
   ]

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -70,6 +70,7 @@ import { useStableCallback } from '../lib/useStableCallback';
 import type {
   GameBananaMod,
   GameBananaModDetails,
+  GameBananaFile,
   GameBananaSection,
   GameBananaCategoryNode,
   GameBananaArtistLink,
@@ -80,6 +81,7 @@ import {
 } from '../stores/appStore';
 import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout, BrowseArtistRef } from '../stores/appStore';
 import ModThumbnail from '../components/ModThumbnail';
+import BrowseFileQuickPicker from '../components/BrowseFileQuickPicker';
 import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
@@ -791,7 +793,7 @@ function BrowseReadableAction({
   queuePosition?: number;
   density: BrowseReadableDensity;
   iconOnlyOverride?: boolean;
-  onQuickDownload: () => void;
+  onQuickDownload: (anchor?: HTMLElement) => void;
   onEnable?: () => void;
 }) {
   const { t } = useTranslation();
@@ -910,7 +912,7 @@ function BrowseReadableAction({
     return (
       <button
         type="button"
-        onClick={(event) => { event.stopPropagation(); onQuickDownload(); }}
+        onClick={(event) => { event.stopPropagation(); onQuickDownload(event.currentTarget); }}
         className={`${motionClassName} cursor-pointer`}
         title={`Install ${modName}`}
         aria-label={`Install ${modName}`}
@@ -1101,6 +1103,13 @@ export default function Browse() {
   const [syncing, setSyncing] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [downloadQueue, setDownloadQueue] = useState<Array<{ modId: number; fileId: number; fileName: string }>>([]);
+  // Multi-file quick-install picker anchored to a card's Install button (#209).
+  const [filePicker, setFilePicker] = useState<{
+    details: GameBananaModDetails;
+    files: GameBananaFile[];
+    anchor: HTMLElement;
+    dates: { dateAdded: number; dateModified: number };
+  } | null>(null);
   const [playingModId, setPlayingModId] = useState<number | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -2230,7 +2239,27 @@ export default function Browse() {
     }
   });
 
-  const handleQuickDownload = async (mod: GameBananaMod) => {
+  // Kick off the actual download of one specific file. Shared by the single-file
+  // quick install and the multi-file picker so both behave identically.
+  const runDownload = async (modId: number, file: GameBananaFile) => {
+    if (!downloading) {
+      setDownloading({ modId, fileId: file.id });
+      setDownloadProgress({ downloaded: 0, total: 0 });
+      setExtracting(false);
+    }
+    try {
+      await downloadMod(modId, file.id, file.fileName, section, effectiveCategoryId);
+    } catch (err) {
+      setError(String(err));
+      if (downloading?.modId === modId) {
+        setDownloading(null);
+        setDownloadProgress(null);
+        setExtracting(false);
+      }
+    }
+  };
+
+  const handleQuickDownload = async (mod: GameBananaMod, anchor?: HTMLElement) => {
     if (!activeDeadlockPath) return;
 
     // Check if already downloading or in queue
@@ -2239,34 +2268,36 @@ export default function Browse() {
 
     try {
       // Fetch mod details to get the first file. Include the submitter up front
-      // so the multi-file branch below can open the details panel (which shows
-      // the artist card) without a second round-trip against the rate limiter.
+      // so the picker's "View all files" link can open the details panel (which
+      // shows the artist card) without a second round-trip against the limiter.
       const details = await getModDetails(mod.id, section, { includeSubmitter: true });
       if (!details.files || details.files.length === 0) {
         setError(t('browse.errors.noDownloadableFiles'));
         return;
       }
 
-      // When a mod has more than one downloadable file (different versions,
+      // Archived files are legacy uploads that aren't meant to be installed
+      // anymore, so they shouldn't count toward the "is this a multi-file mod?"
+      // decision. Only fall back to the full list when every file is archived.
+      const liveFiles = details.files.filter((f) => !f.isArchived);
+      const installable = liveFiles.length > 0 ? liveFiles : details.files;
+
+      // When a mod has more than one installable file (different versions,
       // variant builds, etc.) we used to silently pick whichever had the
-      // highest download count. Forum feedback flagged that, so surface the
-      // details modal and let the user choose which file to install.
-      if (details.files.length > 1) {
-        setSelectedMod(details);
-        setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
+      // highest download count. Forum feedback flagged that, so surface a
+      // compact picker anchored to the Install button (issue #209) and let the
+      // user choose. Fall back to the details modal if we have no anchor.
+      if (installable.length > 1) {
+        if (anchor) {
+          setFilePicker({ details, files: installable, anchor, dates: { dateAdded: mod.dateAdded, dateModified: mod.dateModified } });
+        } else {
+          setSelectedMod(details);
+          setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
+        }
         return;
       }
 
-      const file = getPrimaryFile(details.files);
-
-      // If nothing is currently downloading, set this as the active download
-      if (!downloading) {
-        setDownloading({ modId: mod.id, fileId: file.id });
-        setDownloadProgress({ downloaded: 0, total: 0 });
-        setExtracting(false);
-      }
-
-      await downloadMod(mod.id, file.id, file.fileName, section, effectiveCategoryId);
+      await runDownload(mod.id, getPrimaryFile(installable));
     } catch (err) {
       setError(String(err));
       // Only clear downloading state if this was the active download
@@ -3372,7 +3403,7 @@ export default function Browse() {
                               });
                             }}
                             onClick={() => handleModClick(mod)}
-                            onQuickDownload={() => handleQuickDownload(mod)}
+                            onQuickDownload={(anchor) => handleQuickDownload(mod, anchor)}
                             onEnable={installedLocal && !installedLocal.enabled
                               ? () => toggleMod(installedLocal.id)
                               : undefined}
@@ -3412,6 +3443,26 @@ export default function Browse() {
       {/* Mod details: centered modal (portals to body). The sidebar variant is
           mounted in the <aside> outside this scroll container instead. */}
       {!detailsSidebarActive && renderModDetails('modal')}
+
+      {/* Multi-file quick-install picker, anchored to the Install button. */}
+      {filePicker && (
+        <BrowseFileQuickPicker
+          modName={filePicker.details.name}
+          files={filePicker.files}
+          anchor={filePicker.anchor}
+          onPick={(file) => {
+            const modId = filePicker.details.id;
+            setFilePicker(null);
+            void runDownload(modId, file);
+          }}
+          onViewAll={() => {
+            setSelectedMod(filePicker.details);
+            setSelectedModDates(filePicker.dates);
+            setFilePicker(null);
+          }}
+          onClose={() => setFilePicker(null)}
+        />
+      )}
 
       {collectionModalOpen && (
         <ImportCollectionModal
@@ -3772,7 +3823,7 @@ interface ModCardProps {
   actionContextKey?: string;
   onPlayingChange: (playing: boolean) => void;
   onClick: () => void;
-  onQuickDownload: () => void;
+  onQuickDownload: (anchor?: HTMLElement) => void;
   /** Toggle the local mod's enabled state. Provided only when there's an
    *  installed-but-disabled mod to enable. */
   onEnable?: () => void;
@@ -3903,7 +3954,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
               </span>
             ) : (
               <button
-                onClick={(e) => { e.stopPropagation(); onQuickDownload(); }}
+                onClick={(e) => { e.stopPropagation(); onQuickDownload(e.currentTarget); }}
                 className="flex-shrink-0 flex items-center justify-center w-7 h-7 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-full shadow-lg transition-colors cursor-pointer"
                 title={t('browse.card.install')}
               >
@@ -4289,7 +4340,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
           </div>
         ) : (
           <button
-            onClick={(e) => { e.stopPropagation(); onQuickDownload(); }}
+            onClick={(e) => { e.stopPropagation(); onQuickDownload(e.currentTarget); }}
             className={`flex items-center justify-center rounded-full bg-bg-primary/85 backdrop-blur-sm ring-1 ring-border shadow-md text-accent hover:bg-accent/20 hover:text-text-primary hover:ring-accent/60 transition-all cursor-pointer ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`}
             title={t('browse.card.install')}
           >

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
+import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
@@ -142,6 +142,12 @@ export default function Locker() {
     const stored = localStorage.getItem('lockerViewMode');
     return stored === 'list' ? 'list' : 'gallery';
   });
+  // When on, heroes without any assigned skins/sounds are hidden so the grid
+  // only shows the heroes you've actually customized. Favorited heroes stay
+  // visible regardless. Persisted alongside viewMode.
+  const [hideEmptyHeroes, setHideEmptyHeroes] = useState(
+    () => localStorage.getItem('lockerHideEmpty') === 'true'
+  );
   const [abilityRecolorSupport, setAbilityRecolorSupport] = useState<Record<string, boolean>>({});
   // Soul-container GLB import (lazy three.js modal), openable from the global
   // Locker tab. Mirrors the Installed-page trigger.
@@ -234,6 +240,10 @@ export default function Locker() {
   useEffect(() => {
     localStorage.setItem('lockerViewMode', viewMode);
   }, [viewMode]);
+
+  useEffect(() => {
+    localStorage.setItem('lockerHideEmpty', String(hideEmptyHeroes));
+  }, [hideEmptyHeroes]);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -367,6 +377,21 @@ export default function Locker() {
       return a.name.localeCompare(b.name);
     });
   }, [baseHeroList, favoriteHeroes, heroMods, heroSounds]);
+
+  // When "hide empty" is on, drop heroes with no assigned skins/sounds. Favorites
+  // are kept so an intentional pin never disappears. Uses the same content test
+  // as the sort above so what's hidden matches what sorts to the bottom.
+  const displayedHeroList = useMemo(() => {
+    if (!hideEmptyHeroes) return heroList;
+    return heroList.filter((hero) => {
+      if (favoriteHeroes.includes(hero.id)) return true;
+      return (
+        countLockerSkins(heroMods.map.get(hero.id) ?? []) > 0 ||
+        countLockerSkins(heroSounds.map.get(hero.id) ?? []) > 0
+      );
+    });
+  }, [heroList, hideEmptyHeroes, favoriteHeroes, heroMods, heroSounds]);
+
   const lockerCardsExpandedByDefault = settings?.lockerCardsExpandedByDefault ?? false;
 
   useEffect(() => {
@@ -625,7 +650,7 @@ export default function Locker() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm text-text-secondary">
           {[
-            t('locker.page.heroCount', { count: heroList.length }),
+            t('locker.page.heroCount', { count: displayedHeroList.length }),
             t('locker.page.skinCount', { count: installedSkinCount }),
             installedSoundCount > 0
               ? t('locker.page.soundCount', { count: installedSoundCount })
@@ -662,6 +687,19 @@ export default function Locker() {
               {allExpanded ? t('locker.page.collapseAll') : t('locker.page.expandAll')}
             </button>
           )}
+          <button
+            onClick={() => setHideEmptyHeroes((v) => !v)}
+            aria-pressed={hideEmptyHeroes}
+            className={`flex items-center gap-1.5 self-stretch rounded-sm border px-3 text-sm transition-colors cursor-pointer ${
+              hideEmptyHeroes
+                ? 'border-accent/50 bg-accent/15 text-accent hover:bg-accent/25'
+                : 'border-border bg-bg-secondary text-text-secondary hover:text-text-primary hover:bg-bg-tertiary'
+            }`}
+            title={hideEmptyHeroes ? t('locker.page.showEmptyHeroes') : t('locker.page.hideEmptyHeroes')}
+          >
+            <Filter className="w-4 h-4" />
+            {hideEmptyHeroes ? t('locker.page.showEmpty') : t('locker.page.hideEmpty')}
+          </button>
           <ViewModeToggle
             value={viewMode}
             options={[
@@ -687,7 +725,7 @@ export default function Locker() {
               onNavigate={() => navigate('/locker/global')}
             />
           )}
-          {heroList.map((hero) => (
+          {displayedHeroList.map((hero) => (
             <HeroGalleryCard
               key={hero.id}
               hero={hero}
@@ -740,7 +778,7 @@ export default function Locker() {
               <ChevronDown className="relative z-10 h-4 w-4 -rotate-90 text-text-secondary" />
             </button>
           )}
-          {heroList.map((hero) => (
+          {displayedHeroList.map((hero) => (
             <HeroCard
               key={hero.id}
               hero={hero}


### PR DESCRIPTION
## Summary

Two pieces of community feedback from the Locker + Browse batch.

### Locker: hide heroes with no content (#207)
- New toolbar toggle ("Hide empty" / "Show all") that hides hero cards with no assigned skins or sounds, so the grid shows only heroes you've actually customized.
- Favorited heroes stay visible even when empty.
- Persisted to `localStorage` alongside the view mode; the hero count reflects the filtered list. Reuses the same "has content" test the hero sort already uses.

### Browse: smarter quick install for multi-file mods (#209)
- **Archived-file fix:** the Install button now ignores archived (legacy) files when deciding single vs multi-file. A mod with one live file plus archived uploads installs directly instead of opening the page.
- **Quick-install picker:** new `BrowseFileQuickPicker`, a popover anchored to the Install button that lets you pick which file to install when a mod ships several, without opening the full details modal.
  - Uniform text rows: author caption as the title, filename underneath, then size / downloads / date (size is adaptive KB/MB so tiny files don't read as "0.00 MB").
  - Keyboard-navigable menu (arrows / Home / End, Enter / Space, Escape), dismiss via the X button or click-out.
  - "View all files" drops to the details modal for archived/legacy uploads.

### Docs
- `docs/community-feedback-backlog.md` records #207 and #209 as shipped, and #208 (skin-on-card) + #210 (unify background art) as deferred with scoping and difficulty estimates.

## Test plan
- `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check` all pass locally.
- Manual: verified the picker positions/flips, keyboard nav, and dismissal in the running app; confirmed the Locker toggle hides/shows correctly and persists.

Closes #207
Closes #209
