### PR TITLE
feat(locker): per-skin Locker images, unified tabbed picker (#208)

### DIFF
--- a/docs/community-feedback-backlog.md
+++ b/docs/community-feedback-backlog.md
@@ -45,26 +45,33 @@ one-click pick, instead of opening `ModDetailsModal`.
 - Difficulty: **M**. Deferred because part 1 removes most of the actual pain;
   reassess whether the dropdown is still wanted.
 
-### #208 - Show the installed skin on the Locker card - Deferred
+### #208 - Show the installed skin on the Locker card - Shipped (per-mod)
 
 Request: the hero's Locker card should show the skin actually applied, not the
-generic render. User also wants a manual image override because some poses clip
-with some skins.
+generic render, with manual image control (some poses clip with some skins).
 
-Two paths, ship in order:
+Shipped as a **per-mod (per-skin) Locker image**, not a per-hero override (the
+maintainer's call): the user picks, per skin, which image represents it in the
+Locker, choosing from the mod's own GameBanana gallery (fetched on demand) or a
+custom upload. The picker opens from a small image button on each skin
+card/row in the Locker (`LockerModImagePicker.tsx`). The hero card / detail
+backdrop shows the **active** (highest-priority enabled) skin's chosen image,
+falling back to the hero render when none is set (`activeLockerSkin` in
+`lockerUtils.ts`).
 
-1. **User-provided image (do first, ~M).** Reuse the existing
-   `HeroCardPicker.tsx` + `CardCropper.tsx` upload/crop flow. Store a per-hero
-   override image; render-path falls back to it before the vanilla render. This
-   alone satisfies the stated need (manual control over clipping poses).
-2. **Auto pose-to-PNG (follow-up, L).** Reuse `exportHeroPose()` (already proven
-   by `HeroPoseViewer`) to render the posed GLB with the active skin stack to a
-   cached PNG. Cache must be content-addressed by skin-stack hash (same lesson
-   as the soul-export cache) and invalidated on enable/disable/reorder. Watch
-   the packaged-build CSP/blob gotcha (see the packaged-3D-CSP note).
+Storage: `userData/locker-mod-images/<encodeURIComponent(skinKey)>.<ext>`, keyed
+by `getLockerSkinKey(mod)` (stable across folder/priority moves, unlike
+metaKey). Gallery picks are downloaded and custom uploads copied in locally, so
+the Locker stays offline-capable; both are served back as `data:` URLs (already
+allowed by img-src, so no CSP change). Backend: `lockerModImages.ts` service +
+`ipc/lockerModImages.ts`; store map `lockerModImages` keyed by skin key. Skin
+thumbnails + the card glass backdrop honor the override; sound mods get no
+picker (they keep the hero-portrait thumbnail). i18n under `locker.modImage.*`.
 
-Hero cards render art via CSS `background-image` + `object-position`, so the
-display swap touches layout, not just an `<img src>`.
+Possible follow-up (not built): auto pose-to-PNG of the active skin stack via
+`exportHeroPose()` as a default when the user hasn't picked an image. Would need
+a content-addressed cache (skin-stack hash) and to mind the packaged-3D CSP/blob
+gotcha. Deferred: the manual per-skin picker already satisfies the stated need.
 
 ### #210 - Unify background art settings - Deferred
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -81,6 +81,7 @@ import './ipc/abilitySounds';
 import './ipc/abilityColors';
 import './ipc/trippyEffects';
 import './ipc/locker';
+import './ipc/lockerModImages';
 import './ipc/previewCache';
 import './ipc/discord';
 import './ipc/saltIngest';

--- a/electron/main/ipc/lockerModImages.ts
+++ b/electron/main/ipc/lockerModImages.ts
@@ -3,6 +3,19 @@ import {
     getLockerModImages,
     setLockerModImage,
     removeLockerModImage,
+    getLockerModImageFlags,
+    setLockerModImageHideName,
+    fetchLockerImageAsDataUrl,
+    getLockerModBackgrounds,
+    setLockerModBackground,
+    removeLockerModBackground,
+    getLockerModBackgroundFlags,
+    setLockerModBackgroundHideName,
+    getLockerModThumbnails,
+    setLockerModThumbnail,
+    removeLockerModThumbnail,
+    getLockerModThumbnailFlags,
+    setLockerModThumbnailHideName,
 } from '../services/lockerModImages';
 
 // Per-mod (per-skin) Locker view images (issue #208). Display-only override of
@@ -20,3 +33,70 @@ ipcMain.handle('set-locker-mod-image', (_, skinKey: string, source: string): Pro
 ipcMain.handle('remove-locker-mod-image', (_, skinKey: string): Promise<void> => {
     return removeLockerModImage(skinKey);
 });
+
+ipcMain.handle('get-locker-mod-image-flags', (): Promise<Record<string, boolean>> => {
+    return getLockerModImageFlags();
+});
+
+ipcMain.handle(
+    'set-locker-mod-image-hide-name',
+    (_, skinKey: string, hide: boolean): Promise<void> => {
+        return setLockerModImageHideName(skinKey, hide);
+    }
+);
+
+ipcMain.handle('fetch-locker-image-data-url', (_, url: string): Promise<string> => {
+    return fetchLockerImageAsDataUrl(url);
+});
+
+ipcMain.handle('get-locker-mod-backgrounds', (): Promise<Record<string, string>> => {
+    return getLockerModBackgrounds();
+});
+
+ipcMain.handle(
+    'set-locker-mod-background',
+    (_, skinKey: string, source: string): Promise<string> => {
+        return setLockerModBackground(skinKey, source);
+    }
+);
+
+ipcMain.handle('remove-locker-mod-background', (_, skinKey: string): Promise<void> => {
+    return removeLockerModBackground(skinKey);
+});
+
+ipcMain.handle('get-locker-mod-background-flags', (): Promise<Record<string, boolean>> => {
+    return getLockerModBackgroundFlags();
+});
+
+ipcMain.handle(
+    'set-locker-mod-background-hide-name',
+    (_, skinKey: string, hide: boolean): Promise<void> => {
+        return setLockerModBackgroundHideName(skinKey, hide);
+    }
+);
+
+ipcMain.handle('get-locker-mod-thumbnails', (): Promise<Record<string, string>> => {
+    return getLockerModThumbnails();
+});
+
+ipcMain.handle(
+    'set-locker-mod-thumbnail',
+    (_, skinKey: string, source: string): Promise<string> => {
+        return setLockerModThumbnail(skinKey, source);
+    }
+);
+
+ipcMain.handle('remove-locker-mod-thumbnail', (_, skinKey: string): Promise<void> => {
+    return removeLockerModThumbnail(skinKey);
+});
+
+ipcMain.handle('get-locker-mod-thumbnail-flags', (): Promise<Record<string, boolean>> => {
+    return getLockerModThumbnailFlags();
+});
+
+ipcMain.handle(
+    'set-locker-mod-thumbnail-hide-name',
+    (_, skinKey: string, hide: boolean): Promise<void> => {
+        return setLockerModThumbnailHideName(skinKey, hide);
+    }
+);

--- a/electron/main/ipc/lockerModImages.ts
+++ b/electron/main/ipc/lockerModImages.ts
@@ -16,6 +16,10 @@ import {
     removeLockerModThumbnail,
     getLockerModThumbnailFlags,
     setLockerModThumbnailHideName,
+    getLockerModImageEdit,
+    setLockerModImageEdit,
+    type LockerImageVariant,
+    type CropRect,
 } from '../services/lockerModImages';
 
 // Per-mod (per-skin) Locker view images (issue #208). Display-only override of
@@ -98,5 +102,33 @@ ipcMain.handle(
     'set-locker-mod-thumbnail-hide-name',
     (_, skinKey: string, hide: boolean): Promise<void> => {
         return setLockerModThumbnailHideName(skinKey, hide);
+    }
+);
+
+// Full-fidelity crop persistence (issue #208 follow-up): the ORIGINAL source +
+// a viewport-independent crop rect, so reopening the editor restores the exact
+// framing and lets the user zoom out / pan to recover area cropped outside the
+// last baked frame. Independent of the baked-override save above.
+ipcMain.handle(
+    'get-locker-mod-image-edit',
+    (
+        _,
+        variant: LockerImageVariant,
+        skinKey: string
+    ): Promise<{ source: string; crop: CropRect } | null> => {
+        return getLockerModImageEdit(variant, skinKey);
+    }
+);
+
+ipcMain.handle(
+    'set-locker-mod-image-edit',
+    (
+        _,
+        variant: LockerImageVariant,
+        skinKey: string,
+        source: string,
+        crop: CropRect
+    ): Promise<void> => {
+        return setLockerModImageEdit(variant, skinKey, source, crop);
     }
 );

--- a/electron/main/ipc/lockerModImages.ts
+++ b/electron/main/ipc/lockerModImages.ts
@@ -1,0 +1,22 @@
+import { ipcMain } from 'electron';
+import {
+    getLockerModImages,
+    setLockerModImage,
+    removeLockerModImage,
+} from '../services/lockerModImages';
+
+// Per-mod (per-skin) Locker view images (issue #208). Display-only override of
+// the skin's thumbnail / hero backdrop in the Locker; no game/VPK involvement.
+// See the service for storage layout.
+
+ipcMain.handle('get-locker-mod-images', (): Promise<Record<string, string>> => {
+    return getLockerModImages();
+});
+
+ipcMain.handle('set-locker-mod-image', (_, skinKey: string, source: string): Promise<string> => {
+    return setLockerModImage(skinKey, source);
+});
+
+ipcMain.handle('remove-locker-mod-image', (_, skinKey: string): Promise<void> => {
+    return removeLockerModImage(skinKey);
+});

--- a/electron/main/services/lockerModImages.ts
+++ b/electron/main/services/lockerModImages.ts
@@ -66,10 +66,40 @@ function metaPath(dir: string): string {
     return join(dir, 'meta.json');
 }
 
-/** Per-skin display flags. Currently just `hideHeroName`. Each image kind (card
- *  vs background) keeps its own flags in its own directory's meta.json. */
+/** Which surface the picker is editing. Maps 1:1 to the storage dirs above. */
+export type LockerImageVariant = 'card' | 'thumbnail' | 'background';
+
+/** The storage dir for a surface variant. */
+function dirForVariant(variant: LockerImageVariant): string {
+    return variant === 'card'
+        ? imagesDir()
+        : variant === 'thumbnail'
+          ? thumbnailsDir()
+          : backgroundsDir();
+}
+
+/** Subdirectory of a surface dir holding the ORIGINAL (pre-crop) source bytes,
+ *  one per skin, so the crop editor can be reopened with the full original. The
+ *  baked override lives at the dir root; the source lives one level down here so
+ *  readImageMap/clearKey (which list only the dir root, never recurse) never
+ *  mistake it for a baked override. */
+function sourcesDir(dir: string): string {
+    return join(dir, 'sources');
+}
+
+/** A viewport-independent crop rectangle in source-image fractions (each 0..1):
+ *  sx/sy = top-left, sw/sh = width/height. Stored alongside the ORIGINAL source
+ *  bytes so reopening the crop editor restores the exact framing AND lets the
+ *  user zoom out / pan to reveal area cropped outside the last baked frame. */
+export type CropRect = { sx: number; sy: number; sw: number; sh: number };
+
+/** Per-skin display flags. `hideHeroName` is the name-label toggle; `crop` is the
+ *  normalized crop rect for the stored original source (issue #208 follow-up).
+ *  Each image kind (card vs background) keeps its own flags in its own
+ *  directory's meta.json. */
 interface SkinImageFlags {
     hideHeroName?: boolean;
+    crop?: CropRect;
 }
 
 type FlagsFile = Record<string, SkinImageFlags>;
@@ -113,6 +143,20 @@ async function setHideName(dir: string, skinKey: string, hide: boolean): Promise
     await writeFlags(dir, flags);
 }
 
+/** Store the crop rect for `skinKey` under `dir`, merging with existing flags. */
+async function setCrop(dir: string, skinKey: string, crop: CropRect): Promise<void> {
+    if (!skinKey.trim()) return;
+    const flags = await readFlags(dir);
+    flags[skinKey] = { ...flags[skinKey], crop };
+    await writeFlags(dir, flags);
+}
+
+/** Read the stored crop rect for `skinKey` under `dir`, or null if none. */
+async function readCrop(dir: string, skinKey: string): Promise<CropRect | null> {
+    const flags = await readFlags(dir);
+    return flags[skinKey]?.crop ?? null;
+}
+
 /** Drop all flags for `skinKey` under `dir` (called when its image is removed). */
 async function clearFlags(dir: string, skinKey: string): Promise<void> {
     const flags = await readFlags(dir);
@@ -148,7 +192,15 @@ async function clearKey(dir: string, stem: string): Promise<void> {
     }
     await Promise.all(
         entries
-            .filter((name) => basename(name, extname(name)) === stem)
+            // Only baked image files at the dir root; never the `sources/` subdir
+            // (it has no image extension, but guard explicitly so it's never
+            // mistaken for a baked override even if a stem ever collides).
+            .filter(
+                (name) =>
+                    name !== 'sources' &&
+                    MIME_BY_EXT[extname(name).toLowerCase()] &&
+                    basename(name, extname(name)) === stem
+            )
             .map((name) => fs.rm(join(dir, name), { force: true }))
     );
 }
@@ -214,19 +266,21 @@ async function readImageMap(dir: string): Promise<Record<string, string>> {
     return out;
 }
 
+/** Resolve `source` (a `data:` URL or an `http(s)` URL to download) into bytes +
+ *  a file extension. Shared by the baked-override and original-source writers. */
+async function resolveImageBytes(source: string): Promise<{ buf: Buffer; ext: string }> {
+    if (!source) throw new Error('Missing image source');
+    if (source.startsWith('data:')) return decodeDataUrl(source);
+    if (/^https?:\/\//i.test(source)) return fetchImage(source);
+    throw new Error('Unsupported image source');
+}
+
 /** Store `source` (a `data:` URL or an `http(s)` URL to download) under `dir` for
  *  this skin, replacing any existing one. Returns the new data URL. */
 async function storeImage(dir: string, skinKey: string, source: string): Promise<string> {
     if (!skinKey.trim()) throw new Error('Missing skin key');
-    if (!source) throw new Error('Missing image source');
 
-    const { buf, ext } = source.startsWith('data:')
-        ? decodeDataUrl(source)
-        : /^https?:\/\//i.test(source)
-          ? await fetchImage(source)
-          : (() => {
-                throw new Error('Unsupported image source');
-            })();
+    const { buf, ext } = await resolveImageBytes(source);
 
     await ensureDir(dir);
     const stem = keyStem(skinKey);
@@ -234,6 +288,75 @@ async function storeImage(dir: string, skinKey: string, source: string): Promise
     const dest = join(dir, `${stem}${ext}`);
     await fs.writeFile(dest, buf);
     return readAsDataUrl(dest);
+}
+
+/** Write the ORIGINAL source bytes for `skinKey` into `<dir>/sources/`, replacing
+ *  any prior source (any extension). */
+async function storeSource(dir: string, skinKey: string, source: string): Promise<void> {
+    if (!skinKey.trim()) throw new Error('Missing skin key');
+    const { buf, ext } = await resolveImageBytes(source);
+    const sub = sourcesDir(dir);
+    await ensureDir(sub);
+    const stem = keyStem(skinKey);
+    await clearKey(sub, stem);
+    await fs.writeFile(join(sub, `${stem}${ext}`), buf);
+}
+
+/** Read the stored original source for `skinKey` from `<dir>/sources/` as a data
+ *  URL, or null if none is stored. */
+async function readSource(dir: string, skinKey: string): Promise<string | null> {
+    const sub = sourcesDir(dir);
+    const stem = keyStem(skinKey);
+    let entries: string[] = [];
+    try {
+        entries = await fs.readdir(sub);
+    } catch {
+        return null;
+    }
+    const match = entries.find(
+        (name) => MIME_BY_EXT[extname(name).toLowerCase()] && basename(name, extname(name)) === stem
+    );
+    if (!match) return null;
+    try {
+        return await readAsDataUrl(join(sub, match));
+    } catch {
+        return null;
+    }
+}
+
+/** Delete the stored original source for `skinKey` from `<dir>/sources/`. */
+async function clearSource(dir: string, skinKey: string): Promise<void> {
+    await clearKey(sourcesDir(dir), keyStem(skinKey));
+}
+
+/** Persist the editable state for a surface: the ORIGINAL source bytes (in the
+ *  dir's `sources/` subdir) plus a normalized crop rect (in the dir's meta).
+ *  Reopening the crop editor can then restore the exact framing and reveal area
+ *  cropped outside the last baked frame. Independent of the baked override write. */
+export async function setLockerModImageEdit(
+    variant: LockerImageVariant,
+    skinKey: string,
+    source: string,
+    crop: CropRect
+): Promise<void> {
+    if (!skinKey.trim()) return;
+    const dir = dirForVariant(variant);
+    await storeSource(dir, skinKey, source);
+    await setCrop(dir, skinKey, crop);
+}
+
+/** Read back the editable state for a surface (original source data URL + crop
+ *  rect), or null if either piece is missing (no migration: legacy overrides
+ *  predate this and just have no source/crop). */
+export async function getLockerModImageEdit(
+    variant: LockerImageVariant,
+    skinKey: string
+): Promise<{ source: string; crop: CropRect } | null> {
+    if (!skinKey.trim()) return null;
+    const dir = dirForVariant(variant);
+    const [source, crop] = await Promise.all([readSource(dir, skinKey), readCrop(dir, skinKey)]);
+    if (!source || !crop) return null;
+    return { source, crop };
 }
 
 /** All stored skin card images as { skinKey -> data URL }. */
@@ -257,17 +380,21 @@ export async function setLockerModBackground(skinKey: string, source: string): P
     return storeImage(backgroundsDir(), skinKey, source);
 }
 
-/** Remove this skin's stored Locker card image AND its display flags, if any. */
+/** Remove this skin's stored Locker card image, original source, AND its display
+ *  flags (hideHeroName + crop), if any. */
 export async function removeLockerModImage(skinKey: string): Promise<void> {
     if (!skinKey.trim()) return;
     await clearKey(imagesDir(), keyStem(skinKey));
+    await clearSource(imagesDir(), skinKey);
     await clearFlags(imagesDir(), skinKey);
 }
 
-/** Remove this skin's stored backdrop image AND its display flags, if any. */
+/** Remove this skin's stored backdrop image, original source, AND its display
+ *  flags (hideHeroName + crop), if any. */
 export async function removeLockerModBackground(skinKey: string): Promise<void> {
     if (!skinKey.trim()) return;
     await clearKey(backgroundsDir(), keyStem(skinKey));
+    await clearSource(backgroundsDir(), skinKey);
     await clearFlags(backgroundsDir(), skinKey);
 }
 
@@ -281,10 +408,12 @@ export async function setLockerModThumbnail(skinKey: string, source: string): Pr
     return storeImage(thumbnailsDir(), skinKey, source);
 }
 
-/** Remove this skin's stored grid-thumbnail image AND its display flags, if any. */
+/** Remove this skin's stored grid-thumbnail image, original source, AND its
+ *  display flags (hideHeroName + crop), if any. */
 export async function removeLockerModThumbnail(skinKey: string): Promise<void> {
     if (!skinKey.trim()) return;
     await clearKey(thumbnailsDir(), keyStem(skinKey));
+    await clearSource(thumbnailsDir(), skinKey);
     await clearFlags(thumbnailsDir(), skinKey);
 }
 

--- a/electron/main/services/lockerModImages.ts
+++ b/electron/main/services/lockerModImages.ts
@@ -1,0 +1,156 @@
+/**
+ * Per-mod (per-skin) Locker view images.
+ *
+ * Issue #208: a hero's Locker card should reflect the skin you actually run.
+ * The user picks, per skin, which image represents it in the Locker, choosing
+ * from the mod's own GameBanana gallery OR a custom upload. The Locker then
+ * shows that image on the skin's card and uses the active skin's image as the
+ * hero card / detail backdrop.
+ *
+ * This is a Grimoire-side display override only: it does NOT touch the game,
+ * build a VPK, or change the in-game card art.
+ *
+ * Layout: userData/locker-mod-images/<encodeURIComponent(skinKey)>.<ext>
+ *
+ * The skin key is `getLockerSkinKey(mod)` (stable across folder/priority moves,
+ * unlike metaKey), URL-encoded into the filename so it round-trips without a
+ * separate index. One image per skin; re-picking replaces it. Whether the user
+ * picked a gallery image (remote URL) or a custom file (data URL), the bytes
+ * are copied in locally so the Locker stays offline-capable. Images are handed
+ * back as base64 data URLs (CSP already allows `data:` in img-src).
+ */
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { join, extname, basename } from 'path';
+import { app } from 'electron';
+
+const MIME_BY_EXT: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+};
+
+const EXT_BY_MIME: Record<string, string> = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+};
+
+function imagesDir(): string {
+    return join(app.getPath('userData'), 'locker-mod-images');
+}
+
+async function ensureDir(): Promise<string> {
+    const dir = imagesDir();
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+}
+
+function keyStem(skinKey: string): string {
+    return encodeURIComponent(skinKey.trim());
+}
+
+async function readAsDataUrl(filePath: string): Promise<string> {
+    const mime = MIME_BY_EXT[extname(filePath).toLowerCase()];
+    if (!mime) throw new Error(`Unsupported image type: ${extname(filePath)}`);
+    const buf = await fs.readFile(filePath);
+    return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+/** Delete any stored image for this skin (any extension). */
+async function clearKey(dir: string, stem: string): Promise<void> {
+    let entries: string[] = [];
+    try {
+        entries = await fs.readdir(dir);
+    } catch {
+        return;
+    }
+    await Promise.all(
+        entries
+            .filter((name) => basename(name, extname(name)) === stem)
+            .map((name) => fs.rm(join(dir, name), { force: true }))
+    );
+}
+
+/** Decode a `data:<mime>;base64,...` URL into bytes + a file extension. */
+function decodeDataUrl(source: string): { buf: Buffer; ext: string } {
+    const match = /^data:([^;,]+)(;base64)?,(.*)$/s.exec(source);
+    if (!match) throw new Error('Malformed data URL');
+    const mime = match[1].toLowerCase();
+    const ext = EXT_BY_MIME[mime];
+    if (!ext) throw new Error(`Unsupported image type: ${mime}`);
+    const buf = match[2]
+        ? Buffer.from(match[3], 'base64')
+        : Buffer.from(decodeURIComponent(match[3]), 'utf8');
+    return { buf, ext };
+}
+
+/** Fetch a remote image URL into bytes + a file extension. */
+async function fetchImage(url: string): Promise<{ buf: Buffer; ext: string }> {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Image fetch failed: ${res.status}`);
+    const contentType = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+    // Prefer the URL's own extension (GameBanana serves .jpg/.png/.webp); fall
+    // back to the response content-type.
+    const urlExt = extname(new URL(url).pathname).toLowerCase();
+    const ext = MIME_BY_EXT[urlExt] ? urlExt : EXT_BY_MIME[contentType];
+    if (!ext) throw new Error(`Unsupported image type: ${contentType || urlExt || 'unknown'}`);
+    const buf = Buffer.from(await res.arrayBuffer());
+    return { buf, ext };
+}
+
+/** All stored skin images as { skinKey -> data URL }. */
+export async function getLockerModImages(): Promise<Record<string, string>> {
+    const dir = imagesDir();
+    if (!existsSync(dir)) return {};
+    const entries = await fs.readdir(dir);
+    const out: Record<string, string> = {};
+    for (const name of entries) {
+        const ext = extname(name).toLowerCase();
+        if (!MIME_BY_EXT[ext]) continue;
+        let skinKey: string;
+        try {
+            skinKey = decodeURIComponent(basename(name, ext));
+        } catch {
+            continue; // malformed filename; skip rather than fail the whole load
+        }
+        try {
+            out[skinKey] = await readAsDataUrl(join(dir, name));
+        } catch {
+            // unreadable file; leave the skin without an override
+        }
+    }
+    return out;
+}
+
+/** Store `source` (a `data:` URL from a custom upload, or an `http(s)` gallery
+ *  image URL to download) as this skin's Locker image, replacing any existing
+ *  one. Returns the new data URL for immediate display. */
+export async function setLockerModImage(skinKey: string, source: string): Promise<string> {
+    if (!skinKey.trim()) throw new Error('Missing skin key');
+    if (!source) throw new Error('Missing image source');
+
+    const { buf, ext } = source.startsWith('data:')
+        ? decodeDataUrl(source)
+        : /^https?:\/\//i.test(source)
+          ? await fetchImage(source)
+          : (() => {
+                throw new Error('Unsupported image source');
+            })();
+
+    const dir = await ensureDir();
+    const stem = keyStem(skinKey);
+    await clearKey(dir, stem);
+    const dest = join(dir, `${stem}${ext}`);
+    await fs.writeFile(dest, buf);
+    return readAsDataUrl(dest);
+}
+
+/** Remove this skin's stored Locker image, if any. */
+export async function removeLockerModImage(skinKey: string): Promise<void> {
+    if (!skinKey.trim()) return;
+    await clearKey(imagesDir(), keyStem(skinKey));
+}

--- a/electron/main/services/lockerModImages.ts
+++ b/electron/main/services/lockerModImages.ts
@@ -18,6 +18,11 @@
  * picked a gallery image (remote URL) or a custom file (data URL), the bytes
  * are copied in locally so the Locker stays offline-capable. Images are handed
  * back as base64 data URLs (CSP already allows `data:` in img-src).
+ *
+ * Per-skin display flags (e.g. "hide the hero name label because this art already
+ * has the name on it") live alongside the images in a single `meta.json`, keyed by
+ * the same skinKey. The flag is metadata about the override, so removing the image
+ * also clears the flag.
  */
 import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
@@ -43,8 +48,81 @@ function imagesDir(): string {
     return join(app.getPath('userData'), 'locker-mod-images');
 }
 
-async function ensureDir(): Promise<string> {
-    const dir = imagesDir();
+/** Issue #208: per-skin background images for the hero-detail backdrop. Same
+ *  storage scheme as the card images, just a sibling directory. The backdrop
+ *  is a wide full-bleed area, so these are framed to 16:9 instead of 3:4. */
+function backgroundsDir(): string {
+    return join(app.getPath('userData'), 'locker-mod-backgrounds');
+}
+
+/** Per-skin grid thumbnail images for the main Locker hero-grid card. Same
+ *  storage scheme and 3:4 framing as the card images, but rendered on the hero
+ *  grid card instead of the skin-panel card, so it's an independent override. */
+function thumbnailsDir(): string {
+    return join(app.getPath('userData'), 'locker-mod-thumbnails');
+}
+
+function metaPath(dir: string): string {
+    return join(dir, 'meta.json');
+}
+
+/** Per-skin display flags. Currently just `hideHeroName`. Each image kind (card
+ *  vs background) keeps its own flags in its own directory's meta.json. */
+interface SkinImageFlags {
+    hideHeroName?: boolean;
+}
+
+type FlagsFile = Record<string, SkinImageFlags>;
+
+/** Read the flags map for `dir`; missing/corrupt file reads as empty (non-fatal). */
+async function readFlags(dir: string): Promise<FlagsFile> {
+    try {
+        const raw = await fs.readFile(metaPath(dir), 'utf8');
+        const parsed: unknown = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? (parsed as FlagsFile) : {};
+    } catch {
+        return {};
+    }
+}
+
+async function writeFlags(dir: string, flags: FlagsFile): Promise<void> {
+    await ensureDir(dir);
+    await fs.writeFile(metaPath(dir), JSON.stringify(flags), 'utf8');
+}
+
+/** Only `hideHeroName: true` entries, as { skinKey -> true } (sparse). */
+async function readHideNameMap(dir: string): Promise<Record<string, boolean>> {
+    const flags = await readFlags(dir);
+    const out: Record<string, boolean> = {};
+    for (const [skinKey, value] of Object.entries(flags)) {
+        if (value?.hideHeroName) out[skinKey] = true;
+    }
+    return out;
+}
+
+/** Set (or clear) the hide-name flag for `skinKey` under `dir`. */
+async function setHideName(dir: string, skinKey: string, hide: boolean): Promise<void> {
+    if (!skinKey.trim()) return;
+    const flags = await readFlags(dir);
+    if (hide) {
+        flags[skinKey] = { ...flags[skinKey], hideHeroName: true };
+    } else if (flags[skinKey]) {
+        delete flags[skinKey].hideHeroName;
+        if (Object.keys(flags[skinKey]).length === 0) delete flags[skinKey];
+    }
+    await writeFlags(dir, flags);
+}
+
+/** Drop all flags for `skinKey` under `dir` (called when its image is removed). */
+async function clearFlags(dir: string, skinKey: string): Promise<void> {
+    const flags = await readFlags(dir);
+    if (flags[skinKey]) {
+        delete flags[skinKey];
+        await writeFlags(dir, flags);
+    }
+}
+
+async function ensureDir(dir: string): Promise<string> {
     await fs.mkdir(dir, { recursive: true });
     return dir;
 }
@@ -102,9 +180,19 @@ async function fetchImage(url: string): Promise<{ buf: Buffer; ext: string }> {
     return { buf, ext };
 }
 
-/** All stored skin images as { skinKey -> data URL }. */
-export async function getLockerModImages(): Promise<Record<string, string>> {
-    const dir = imagesDir();
+/** Fetch a remote gallery image and return it as a base64 data URL WITHOUT
+ *  storing it. Used to seed the crop editor: a renderer canvas can't read pixels
+ *  from a cross-origin <img> (it taints the canvas), but a data URL is safe. The
+ *  cropped result is what actually gets stored, via setLockerModImage. */
+export async function fetchLockerImageAsDataUrl(url: string): Promise<string> {
+    if (!/^https?:\/\//i.test(url)) throw new Error('Unsupported image source');
+    const { buf, ext } = await fetchImage(url);
+    const mime = MIME_BY_EXT[ext];
+    return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+/** All stored images in `dir` as { skinKey -> data URL }. */
+async function readImageMap(dir: string): Promise<Record<string, string>> {
     if (!existsSync(dir)) return {};
     const entries = await fs.readdir(dir);
     const out: Record<string, string> = {};
@@ -126,10 +214,9 @@ export async function getLockerModImages(): Promise<Record<string, string>> {
     return out;
 }
 
-/** Store `source` (a `data:` URL from a custom upload, or an `http(s)` gallery
- *  image URL to download) as this skin's Locker image, replacing any existing
- *  one. Returns the new data URL for immediate display. */
-export async function setLockerModImage(skinKey: string, source: string): Promise<string> {
+/** Store `source` (a `data:` URL or an `http(s)` URL to download) under `dir` for
+ *  this skin, replacing any existing one. Returns the new data URL. */
+async function storeImage(dir: string, skinKey: string, source: string): Promise<string> {
     if (!skinKey.trim()) throw new Error('Missing skin key');
     if (!source) throw new Error('Missing image source');
 
@@ -141,7 +228,7 @@ export async function setLockerModImage(skinKey: string, source: string): Promis
                 throw new Error('Unsupported image source');
             })();
 
-    const dir = await ensureDir();
+    await ensureDir(dir);
     const stem = keyStem(skinKey);
     await clearKey(dir, stem);
     const dest = join(dir, `${stem}${ext}`);
@@ -149,8 +236,84 @@ export async function setLockerModImage(skinKey: string, source: string): Promis
     return readAsDataUrl(dest);
 }
 
-/** Remove this skin's stored Locker image, if any. */
+/** All stored skin card images as { skinKey -> data URL }. */
+export async function getLockerModImages(): Promise<Record<string, string>> {
+    return readImageMap(imagesDir());
+}
+
+/** All stored skin backdrop images as { skinKey -> data URL }. */
+export async function getLockerModBackgrounds(): Promise<Record<string, string>> {
+    return readImageMap(backgroundsDir());
+}
+
+/** Store this skin's Locker card image, replacing any existing one. Returns the
+ *  new data URL for immediate display. */
+export async function setLockerModImage(skinKey: string, source: string): Promise<string> {
+    return storeImage(imagesDir(), skinKey, source);
+}
+
+/** Store this skin's hero-detail backdrop image, replacing any existing one. */
+export async function setLockerModBackground(skinKey: string, source: string): Promise<string> {
+    return storeImage(backgroundsDir(), skinKey, source);
+}
+
+/** Remove this skin's stored Locker card image AND its display flags, if any. */
 export async function removeLockerModImage(skinKey: string): Promise<void> {
     if (!skinKey.trim()) return;
     await clearKey(imagesDir(), keyStem(skinKey));
+    await clearFlags(imagesDir(), skinKey);
+}
+
+/** Remove this skin's stored backdrop image AND its display flags, if any. */
+export async function removeLockerModBackground(skinKey: string): Promise<void> {
+    if (!skinKey.trim()) return;
+    await clearKey(backgroundsDir(), keyStem(skinKey));
+    await clearFlags(backgroundsDir(), skinKey);
+}
+
+/** All stored skin grid-thumbnail images as { skinKey -> data URL }. */
+export async function getLockerModThumbnails(): Promise<Record<string, string>> {
+    return readImageMap(thumbnailsDir());
+}
+
+/** Store this skin's hero-grid thumbnail image, replacing any existing one. */
+export async function setLockerModThumbnail(skinKey: string, source: string): Promise<string> {
+    return storeImage(thumbnailsDir(), skinKey, source);
+}
+
+/** Remove this skin's stored grid-thumbnail image AND its display flags, if any. */
+export async function removeLockerModThumbnail(skinKey: string): Promise<void> {
+    if (!skinKey.trim()) return;
+    await clearKey(thumbnailsDir(), keyStem(skinKey));
+    await clearFlags(thumbnailsDir(), skinKey);
+}
+
+/** Per-skin thumbnail hide-name flags as { skinKey -> true } (sparse). */
+export async function getLockerModThumbnailFlags(): Promise<Record<string, boolean>> {
+    return readHideNameMap(thumbnailsDir());
+}
+
+/** Set (or clear) the grid-thumbnail's "hide the hero name label" flag. */
+export async function setLockerModThumbnailHideName(skinKey: string, hide: boolean): Promise<void> {
+    return setHideName(thumbnailsDir(), skinKey, hide);
+}
+
+/** Per-skin card-image hide-name flags as { skinKey -> true } (sparse). */
+export async function getLockerModImageFlags(): Promise<Record<string, boolean>> {
+    return readHideNameMap(imagesDir());
+}
+
+/** Per-skin backdrop-image hide-name flags as { skinKey -> true } (sparse). */
+export async function getLockerModBackgroundFlags(): Promise<Record<string, boolean>> {
+    return readHideNameMap(backgroundsDir());
+}
+
+/** Set (or clear) the card image's "hide the hero name label" flag for this skin. */
+export async function setLockerModImageHideName(skinKey: string, hide: boolean): Promise<void> {
+    return setHideName(imagesDir(), skinKey, hide);
+}
+
+/** Set (or clear) the backdrop image's "hide the hero name label" flag. */
+export async function setLockerModBackgroundHideName(skinKey: string, hide: boolean): Promise<void> {
+    return setHideName(backgroundsDir(), skinKey, hide);
 }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -231,6 +231,27 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-locker-mod-image', skinKey, source),
     removeLockerModImage: (skinKey: string) =>
         ipcRenderer.invoke('remove-locker-mod-image', skinKey),
+    getLockerModImageFlags: () => ipcRenderer.invoke('get-locker-mod-image-flags'),
+    setLockerModImageHideName: (skinKey: string, hide: boolean) =>
+        ipcRenderer.invoke('set-locker-mod-image-hide-name', skinKey, hide),
+    fetchLockerImageDataUrl: (url: string) =>
+        ipcRenderer.invoke('fetch-locker-image-data-url', url),
+    getLockerModBackgrounds: () => ipcRenderer.invoke('get-locker-mod-backgrounds'),
+    setLockerModBackground: (skinKey: string, source: string) =>
+        ipcRenderer.invoke('set-locker-mod-background', skinKey, source),
+    removeLockerModBackground: (skinKey: string) =>
+        ipcRenderer.invoke('remove-locker-mod-background', skinKey),
+    getLockerModBackgroundFlags: () => ipcRenderer.invoke('get-locker-mod-background-flags'),
+    setLockerModBackgroundHideName: (skinKey: string, hide: boolean) =>
+        ipcRenderer.invoke('set-locker-mod-background-hide-name', skinKey, hide),
+    getLockerModThumbnails: () => ipcRenderer.invoke('get-locker-mod-thumbnails'),
+    setLockerModThumbnail: (skinKey: string, source: string) =>
+        ipcRenderer.invoke('set-locker-mod-thumbnail', skinKey, source),
+    removeLockerModThumbnail: (skinKey: string) =>
+        ipcRenderer.invoke('remove-locker-mod-thumbnail', skinKey),
+    getLockerModThumbnailFlags: () => ipcRenderer.invoke('get-locker-mod-thumbnail-flags'),
+    setLockerModThumbnailHideName: (skinKey: string, hide: boolean) =>
+        ipcRenderer.invoke('set-locker-mod-thumbnail-hide-name', skinKey, hide),
     mergeMods: (args: MergeModsArgs) => ipcRenderer.invoke('merge-mods', args),
     unmergeMod: (mergedModId: string) => ipcRenderer.invoke('unmerge-mod', mergedModId),
     extractMergeSource: (mergedModId: string, sourceFileName: string) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -52,6 +52,8 @@ import type {
     MultiVpkPickData,
     SyncProgressData,
     UpdateStatus,
+    LockerImageVariant,
+    CropRect,
 } from '../../src/types/electron';
 import type { DeadworksConnectProgress } from '../../src/types/deadworks';
 import type {
@@ -252,6 +254,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getLockerModThumbnailFlags: () => ipcRenderer.invoke('get-locker-mod-thumbnail-flags'),
     setLockerModThumbnailHideName: (skinKey: string, hide: boolean) =>
         ipcRenderer.invoke('set-locker-mod-thumbnail-hide-name', skinKey, hide),
+    getLockerModImageEdit: (variant: LockerImageVariant, skinKey: string) =>
+        ipcRenderer.invoke('get-locker-mod-image-edit', variant, skinKey),
+    setLockerModImageEdit: (
+        variant: LockerImageVariant,
+        skinKey: string,
+        source: string,
+        crop: CropRect
+    ) => ipcRenderer.invoke('set-locker-mod-image-edit', variant, skinKey, source, crop),
     mergeMods: (args: MergeModsArgs) => ipcRenderer.invoke('merge-mods', args),
     unmergeMod: (mergedModId: string) => ipcRenderer.invoke('unmerge-mod', mergedModId),
     extractMergeSource: (mergedModId: string, sourceFileName: string) =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -226,6 +226,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('read-glb-file', glbPath),
     readImageDataUrl: (imagePath: string) =>
         ipcRenderer.invoke('read-image-data-url', imagePath),
+    getLockerModImages: () => ipcRenderer.invoke('get-locker-mod-images'),
+    setLockerModImage: (skinKey: string, source: string) =>
+        ipcRenderer.invoke('set-locker-mod-image', skinKey, source),
+    removeLockerModImage: (skinKey: string) =>
+        ipcRenderer.invoke('remove-locker-mod-image', skinKey),
     mergeMods: (args: MergeModsArgs) => ipcRenderer.invoke('merge-mods', args),
     unmergeMod: (mergedModId: string) => ipcRenderer.invoke('unmerge-mod', mergedModId),
     extractMergeSource: (mergedModId: string, sourceFileName: string) =>

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ExternalLink, GripVertical, Trash2 } from 'lucide-react';
+import { ChevronDown, ExternalLink, GripVertical, ImagePlus, Trash2 } from 'lucide-react';
 import {
   DndContext,
   KeyboardSensor,
@@ -24,6 +24,7 @@ import { useAppStore } from '../../stores/appStore';
 import ModThumbnail from '../ModThumbnail';
 import AudioPreviewPlayer from '../AudioPreviewPlayer';
 import DownloadableSkinsSection from './DownloadableSkinsSection';
+import { LockerModImagePicker } from './LockerModImagePicker';
 
 interface SkinGroup {
   key: string;
@@ -293,6 +294,8 @@ function SkinGroupCard({
   heroName,
   soundVolume,
   loadOrderPosition,
+  overrideSrc,
+  onPickImage,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -305,12 +308,18 @@ function SkinGroupCard({
   /** 1-based load-order position, shown as a corner chip. Only set when 2+
    *  skins are active for the hero (otherwise order is meaningless). */
   loadOrderPosition?: number;
+  /** Issue #208: user-chosen Locker image for this skin (data URL), if any. */
+  overrideSrc?: string;
+  /** Open the image picker for this skin. Omitted for sound mods. */
+  onPickImage?: () => void;
 }) {
   const { t } = useTranslation();
   const isMulti = group.variants.length > 1;
   const groupActive = group.variants.some((v) => v.enabled);
   const enabledCount = group.variants.filter((v) => v.enabled).length;
   const primary = group.primary;
+  // The user's chosen image wins over the uploader's thumbnail (issue #208).
+  const displaySrc = overrideSrc ?? primary.thumbnailUrl;
   const cardRef = useRef<HTMLDivElement>(null);
   const [variantsOpen, setVariantsOpen] = useState(false);
   // Close the variant popover on any click outside the card.
@@ -327,7 +336,7 @@ function SkinGroupCard({
   // Skipped when NSFW previews are hidden so we never bleed hidden imagery
   // into the glass tint, even blurred.
   const glassBackdropUrl =
-    primary.thumbnailUrl && !(primary.nsfw && hideNsfwPreviews) ? primary.thumbnailUrl : null;
+    displaySrc && !(primary.nsfw && hideNsfwPreviews) ? displaySrc : null;
 
   return (
     <div
@@ -364,11 +373,11 @@ function SkinGroupCard({
           }`}
         >
           <ModThumbnail
-            src={primary.thumbnailUrl}
+            src={displaySrc}
             alt={primary.name}
-            nsfw={primary.nsfw}
+            nsfw={overrideSrc ? false : primary.nsfw}
             hideNsfw={hideNsfwPreviews}
-            heroPortrait={useHeroPortraitThumbnails ? heroName : undefined}
+            heroPortrait={overrideSrc ? undefined : useHeroPortraitThumbnails ? heroName : undefined}
             className="h-full w-full"
             imageClassName="origin-center transform-gpu will-change-transform transition-transform duration-200 group-hover/card:scale-[1.03]"
             fallback={
@@ -430,6 +439,25 @@ function SkinGroupCard({
         }
         className="absolute inset-0 z-10 cursor-pointer rounded-[10px]"
       />
+
+      {/* Set Locker image (issue #208): pick this skin's view from its gallery
+          or a custom upload. Hover-revealed; z-30 keeps it above the toggle. */}
+      {onPickImage && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onPickImage();
+          }}
+          aria-label={t('locker.modImage.set', { name: primary.name })}
+          title={t('locker.modImage.set', { name: primary.name })}
+          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${
+            overrideSrc ? 'opacity-100' : 'opacity-0'
+          } ${onRequestDelete ? 'right-9' : 'right-1.5'}`}
+        >
+          <ImagePlus className="h-3.5 w-3.5" />
+        </button>
+      )}
 
       {/* Delete: removes the whole group (every variant VPK). Hover-revealed so
           it stays out of the way; z-30 keeps it above the full-card toggle. */}
@@ -530,6 +558,8 @@ function SkinGroupRow({
   useHeroPortraitThumbnails,
   heroName,
   soundVolume,
+  overrideSrc,
+  onPickImage,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -539,12 +569,18 @@ function SkinGroupRow({
   useHeroPortraitThumbnails: boolean;
   heroName?: string;
   soundVolume: number;
+  /** Issue #208: user-chosen Locker image for this skin (data URL), if any. */
+  overrideSrc?: string;
+  /** Open the image picker for this skin. Omitted for sound mods. */
+  onPickImage?: () => void;
 }) {
   const { t } = useTranslation();
   const isMulti = group.variants.length > 1;
   const groupActive = group.variants.some((v) => v.enabled);
   const enabledCount = group.variants.filter((v) => v.enabled).length;
   const primary = group.primary;
+  // The user's chosen image wins over the uploader's thumbnail (issue #208).
+  const displaySrc = overrideSrc ?? primary.thumbnailUrl;
   return (
     <div
       className={`group/row relative rounded-md border transition-colors ${
@@ -553,6 +589,22 @@ function SkinGroupRow({
           : 'border-border bg-bg-secondary/70 hover:border-accent/60 hover:bg-bg-secondary/85'
       }`}
     >
+      {onPickImage && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onPickImage();
+          }}
+          aria-label={t('locker.modImage.set', { name: primary.name })}
+          title={t('locker.modImage.set', { name: primary.name })}
+          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${
+            overrideSrc ? 'opacity-100' : 'opacity-0'
+          } ${onRequestDelete ? 'right-10' : 'right-2'}`}
+        >
+          <ImagePlus className="h-3.5 w-3.5" />
+        </button>
+      )}
       {onRequestDelete && (
         <button
           type="button"
@@ -589,11 +641,11 @@ function SkinGroupRow({
       >
         <div className="w-20 h-20 rounded-md overflow-hidden bg-bg-tertiary flex-shrink-0">
           <ModThumbnail
-            src={primary.thumbnailUrl}
+            src={displaySrc}
             alt={primary.name}
-            nsfw={primary.nsfw}
+            nsfw={overrideSrc ? false : primary.nsfw}
             hideNsfw={hideNsfwPreviews}
-            heroPortrait={useHeroPortraitThumbnails ? heroName : undefined}
+            heroPortrait={overrideSrc ? undefined : useHeroPortraitThumbnails ? heroName : undefined}
             className="w-full h-full"
             fallback={
               <div className="w-full h-full flex items-center justify-center text-text-secondary text-[10px]">
@@ -694,7 +746,13 @@ export default function HeroSkinsPanel({
 }: HeroSkinsPanelProps) {
   const hasMods = mods.length > 0;
   const soundVolume = useAppStore((s) => s.soundVolume);
+  const lockerModImages = useAppStore((s) => s.lockerModImages);
   const groups = useMemo(() => groupVariants(mods), [mods]);
+  // Issue #208: which skin's image picker is open (null = none). Skins only;
+  // sound mods keep the hero-portrait thumbnail and get no picker.
+  const [pickerGroup, setPickerGroup] = useState<SkinGroup | null>(null);
+  const pickImageFor = (group: SkinGroup) =>
+    group.primary.sourceSection === 'Sound' ? undefined : () => setPickerGroup(group);
 
   // Per-card #N chip: the load-order position of each active skin. Mirrors the
   // SkinLoadOrderStrip (now in the hero sidebar). The chip only shows when 2+
@@ -745,12 +803,22 @@ export default function HeroSkinsPanel({
                   key={group.key}
                   group={group}
                   loadOrderPosition={loadOrderByKey.get(group.key)}
+                  overrideSrc={lockerModImages[group.key]}
+                  onPickImage={pickImageFor(group)}
                   {...groupProps}
                 />
               ))}
             </div>
           ) : (
-            groups.map((group) => <SkinGroupRow key={group.key} group={group} {...groupProps} />)
+            groups.map((group) => (
+              <SkinGroupRow
+                key={group.key}
+                group={group}
+                overrideSrc={lockerModImages[group.key]}
+                onPickImage={pickImageFor(group)}
+                {...groupProps}
+              />
+            ))
           )}
           {browseLink && (
             <div className="flex justify-center px-1 pt-0.5">
@@ -766,6 +834,14 @@ export default function HeroSkinsPanel({
       )}
 
       {showDownloadable && categoryId && <DownloadableSkinsSection categoryId={categoryId} />}
+
+      {pickerGroup && (
+        <LockerModImagePicker
+          mod={pickerGroup.primary}
+          skinKey={pickerGroup.key}
+          onClose={() => setPickerGroup(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -451,9 +451,7 @@ function SkinGroupCard({
           }}
           aria-label={t('locker.modImage.set', { name: primary.name })}
           title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${
-            overrideSrc ? 'opacity-100' : 'opacity-0'
-          } ${onRequestDelete ? 'right-9' : 'right-1.5'}`}
+          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${onRequestDelete ? 'right-9' : 'right-1.5'}`}
         >
           <ImagePlus className="h-3.5 w-3.5" />
         </button>
@@ -598,9 +596,7 @@ function SkinGroupRow({
           }}
           aria-label={t('locker.modImage.set', { name: primary.name })}
           title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${
-            overrideSrc ? 'opacity-100' : 'opacity-0'
-          } ${onRequestDelete ? 'right-10' : 'right-2'}`}
+          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${onRequestDelete ? 'right-10' : 'right-2'}`}
         >
           <ImagePlus className="h-3.5 w-3.5" />
         </button>
@@ -747,6 +743,8 @@ export default function HeroSkinsPanel({
   const hasMods = mods.length > 0;
   const soundVolume = useAppStore((s) => s.soundVolume);
   const lockerModImages = useAppStore((s) => s.lockerModImages);
+  // The "Locker image" (grid-thumbnail surface) the picker mirrors from.
+  const lockerModThumbnails = useAppStore((s) => s.lockerModThumbnails);
   const groups = useMemo(() => groupVariants(mods), [mods]);
   // Issue #208: which skin's image picker is open (null = none). Skins only;
   // sound mods keep the hero-portrait thumbnail and get no picker.
@@ -840,7 +838,7 @@ export default function HeroSkinsPanel({
           mod={pickerGroup.primary}
           skinKey={pickerGroup.key}
           heroName={heroName ?? pickerGroup.primary.lockerHero ?? ''}
-          cardImageDataUrl={lockerModImages[pickerGroup.key]}
+          lockerImageDataUrl={lockerModThumbnails[pickerGroup.key]}
           onClose={() => setPickerGroup(null)}
         />
       )}

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -839,6 +839,8 @@ export default function HeroSkinsPanel({
         <LockerModImagePicker
           mod={pickerGroup.primary}
           skinKey={pickerGroup.key}
+          heroName={heroName ?? pickerGroup.primary.lockerHero ?? ''}
+          cardImageDataUrl={lockerModImages[pickerGroup.key]}
           onClose={() => setPickerGroup(null)}
         />
       )}

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -12,8 +12,14 @@ interface LockerImageCropperProps {
   aspect?: number;
   /** Hero whose name label is previewed (when nameControls is on). */
   heroName?: string;
-  /** Show the hero-name overlay preview + "hide name" toggle. */
+  /** Show the hero-name overlay preview (matching surfaces that bake the name
+   *  over the image). The "hide name" toggle is gated separately by
+   *  `allowHideName` so a surface can preview its name without offering to hide
+   *  it (e.g. the backdrop, whose name logo always shows). */
   nameControls?: boolean;
+  /** Show the "hide hero name label" toggle. Only meaningful with nameControls.
+   *  Defaults to nameControls so existing callers keep the combined behavior. */
+  allowHideName?: boolean;
   /** Where the name label sits, matching its real surface: the card overlays it
    *  bottom-right; the focus-view backdrop shows the name logo top-left. */
   namePosition?: 'card' | 'backdrop';
@@ -78,6 +84,7 @@ export default function LockerImageCropper({
   aspect = 3 / 4,
   heroName = '',
   nameControls = true,
+  allowHideName,
   namePosition = 'card',
   initialHideHeroName = false,
   emptyHint,
@@ -339,7 +346,7 @@ export default function LockerImageCropper({
         </button>
       </div>
 
-      {nameControls && (
+      {(allowHideName ?? nameControls) && (
         <Toggle
           checked={hideHeroName}
           onChange={setHideHeroName}

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -1,0 +1,362 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, AlertCircle, Crop, ZoomIn, RotateCcw, ImagePlus } from 'lucide-react';
+import { Toggle } from '../common/ui';
+import { getHeroNamePath } from '../../lib/lockerUtils';
+
+interface LockerImageCropperProps {
+  /** Source image to frame (any size), as a data URL. Null = nothing picked yet:
+   *  the viewport renders empty so the framing surface is previewed up front. */
+  imageDataUrl: string | null;
+  /** Output/preview aspect ratio (width / height). Card = 3/4, backdrop = 16/9. */
+  aspect?: number;
+  /** Hero whose name label is previewed (when nameControls is on). */
+  heroName?: string;
+  /** Show the hero-name overlay preview + "hide name" toggle. */
+  nameControls?: boolean;
+  /** Where the name label sits, matching its real surface: the card overlays it
+   *  bottom-right; the focus-view backdrop shows the name logo top-left. */
+  namePosition?: 'card' | 'backdrop';
+  /** Initial state of the "hide hero name label" toggle. */
+  initialHideHeroName?: boolean;
+  /** Hint shown over the empty viewport before a source is chosen. */
+  emptyHint?: string;
+  busy?: boolean;
+  /** Receives the framed image (PNG data URL at `aspect`) and the name choice. */
+  onApply: (result: { dataUrl: string; hideHeroName: boolean }) => void;
+}
+
+/** The editing viewport keeps the target aspect; the source is scaled to cover it
+ *  and pans/zooms within. */
+const MAX_ZOOM = 5;
+/** Cap the baked output so we never upscale a small source past this long edge. */
+const MAX_OUTPUT_LONG = 1280;
+
+/** A real Locker grid card is ~230px wide; its name label and padding are fixed
+ *  px tuned to that width. The crop viewport differs, so the overlay's fixed-px
+ *  chrome would render off-scale. Reproduce it as a proportion of the viewport
+ *  instead, so the preview is to scale with the card. */
+const REFERENCE_CARD_W = 230;
+
+/** Sizing for the side-by-side pane the editor lives in. */
+const PANE_MAX_W = 300;
+const PANE_MAX_H = 400;
+const PANE_MIN_H = 180;
+/** Vertical space the modal chrome around the preview needs (header, tabs, the
+ *  zoom/toggle/button stack below, paddings + gaps). Used so the preview shrinks
+ *  on short windows instead of overflowing them. */
+const CHROME_BUDGET = 360;
+
+/** Largest viewport at `aspect` that fits the pane width and the window height. */
+function fitView(aspect: number): { w: number; h: number } {
+  const winH = typeof window !== 'undefined' ? window.innerHeight : 800;
+  const maxH = Math.max(PANE_MIN_H, Math.min(PANE_MAX_H, winH - CHROME_BUDGET));
+  let w = PANE_MAX_W;
+  let h = w / aspect;
+  if (h > maxH) {
+    h = maxH;
+    w = h * aspect;
+  }
+  return { w: Math.round(w), h: Math.round(h) };
+}
+
+/**
+ * Inline frame-and-preview editor for a per-skin Locker image (issue #208).
+ *
+ * Lives in the left pane of the unified image picker. The chosen image would
+ * otherwise be `object-cover`-stretched onto its surface (the 3:4 card, or the
+ * wide hero-detail backdrop) with no say in framing, and a card image can clash
+ * with art that bakes the hero name in. This editor fixes both: the user frames
+ * the image inside a viewport locked to the target aspect (pan + zoom). In card
+ * mode it also overlays the real hero-name label exactly as the card renders it,
+ * with a live toggle to hide it. On apply we export at the target aspect so the
+ * downstream `object-cover` is a clean, undistorted scale. With no source picked
+ * yet the viewport renders empty so the framing surface is previewed up front.
+ */
+export default function LockerImageCropper({
+  imageDataUrl,
+  aspect = 3 / 4,
+  heroName = '',
+  nameControls = true,
+  namePosition = 'card',
+  initialHideHeroName = false,
+  emptyHint,
+  busy = false,
+  onApply,
+}: LockerImageCropperProps) {
+  const { t } = useTranslation();
+
+  // Fit the viewport once per aspect (the editor is remounted on tab switch).
+  const [view] = useState(() => fitView(aspect));
+  const VIEW_W = view.w;
+  const VIEW_H = view.h;
+  const previewScale = VIEW_W / REFERENCE_CARD_W;
+  // Card name label: w-[70%] h-7 (28px) with p-3 (12px) padding on the real card.
+  const NAME_HEIGHT = Math.round(28 * previewScale);
+  const NAME_PADDING = Math.round(12 * previewScale);
+  const NAME_FALLBACK_FONT = Math.round(14 * previewScale);
+  // Backdrop name logo sits top-left; size it as a small fraction of the wide
+  // viewport, roughly matching the focus view's h-8 logo over the full backdrop.
+  const BD_NAME_HEIGHT = Math.round(VIEW_W * 0.08);
+  const BD_NAME_PADDING = Math.round(VIEW_W * 0.05);
+
+  const [img, setImg] = useState<HTMLImageElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(1);
+  // Top-left of the drawn image relative to the viewport, in CSS px (<= 0).
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [hideHeroName, setHideHeroName] = useState(initialHideHeroName);
+  const [nameFailed, setNameFailed] = useState(false);
+  const drag = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
+
+  // Scale at which the source just covers the viewport (zoom 1 == cover).
+  const coverScale = img ? Math.max(VIEW_W / img.naturalWidth, VIEW_H / img.naturalHeight) : 1;
+  const drawnW = img ? img.naturalWidth * coverScale * zoom : VIEW_W;
+  const drawnH = img ? img.naturalHeight * coverScale * zoom : VIEW_H;
+
+  const clamp = useCallback(
+    (x: number, y: number) => ({
+      x: Math.min(0, Math.max(VIEW_W - drawnW, x)),
+      y: Math.min(0, Math.max(VIEW_H - drawnH, y)),
+    }),
+    [VIEW_W, VIEW_H, drawnW, drawnH]
+  );
+
+  // Load the source image to learn its natural size, then center it at cover.
+  // A null source clears any prior framing back to the empty viewport.
+  useEffect(() => {
+    if (!imageDataUrl) {
+      setImg(null);
+      setZoom(1);
+      setOffset({ x: 0, y: 0 });
+      setError(null);
+      return;
+    }
+    let active = true;
+    const el = new Image();
+    el.onload = () => {
+      if (!active) return;
+      setImg(el);
+      const cs = Math.max(VIEW_W / el.naturalWidth, VIEW_H / el.naturalHeight);
+      setOffset({ x: (VIEW_W - el.naturalWidth * cs) / 2, y: (VIEW_H - el.naturalHeight * cs) / 2 });
+      setZoom(1);
+      setError(null);
+    };
+    el.onerror = () => {
+      if (active) setError(t('locker.crop.imageLoadFailed'));
+    };
+    el.src = imageDataUrl;
+    return () => {
+      active = false;
+    };
+  }, [imageDataUrl, t, VIEW_W, VIEW_H]);
+
+  // Zoom around the viewport center so the framed subject stays put.
+  const applyZoom = useCallback(
+    (nextZoom: number) => {
+      const z = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+      if (!img) {
+        setZoom(z);
+        return;
+      }
+      const cx = (VIEW_W / 2 - offset.x) / (coverScale * zoom);
+      const cy = (VIEW_H / 2 - offset.y) / (coverScale * zoom);
+      const nx = VIEW_W / 2 - cx * coverScale * z;
+      const ny = VIEW_H / 2 - cy * coverScale * z;
+      const newDrawnW = img.naturalWidth * coverScale * z;
+      const newDrawnH = img.naturalHeight * coverScale * z;
+      setZoom(z);
+      setOffset({
+        x: Math.min(0, Math.max(VIEW_W - newDrawnW, nx)),
+        y: Math.min(0, Math.max(VIEW_H - newDrawnH, ny)),
+      });
+    },
+    [img, offset, zoom, coverScale, VIEW_W, VIEW_H]
+  );
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!img) return;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    drag.current = { startX: e.clientX, startY: e.clientY, ox: offset.x, oy: offset.y };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    setOffset(
+      clamp(
+        drag.current.ox + (e.clientX - drag.current.startX),
+        drag.current.oy + (e.clientY - drag.current.startY)
+      )
+    );
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+  const onWheel = (e: React.WheelEvent) => {
+    if (!img) return;
+    e.preventDefault();
+    applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+  };
+
+  const handleApply = () => {
+    if (!img) return;
+    const scale = coverScale * zoom;
+    // The viewport maps to this rect in source-image natural coordinates.
+    const srcX = -offset.x / scale;
+    const srcY = -offset.y / scale;
+    const srcW = VIEW_W / scale;
+    const srcH = VIEW_H / scale;
+    // Bake at the crop's own resolution (capped on the long edge), preserving aspect.
+    const longSrc = Math.max(srcW, srcH);
+    const k = longSrc > MAX_OUTPUT_LONG ? MAX_OUTPUT_LONG / longSrc : 1;
+    const outW = Math.max(1, Math.round(srcW * k));
+    const outH = Math.max(1, Math.round(srcH * k));
+    const canvas = document.createElement('canvas');
+    canvas.width = outW;
+    canvas.height = outH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      setError(t('locker.crop.noCanvasContext'));
+      return;
+    }
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, outW, outH);
+    onApply({ dataUrl: canvas.toDataURL('image/png'), hideHeroName });
+  };
+
+  const namePath = getHeroNamePath(heroName);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-400">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span className="break-words">{error}</span>
+        </div>
+      )}
+
+      <div className="flex justify-center">
+        {/* Viewport doubles as a live preview: same gradient, and (card mode)
+            the hero-name overlay the real card renders. Empty until a source is
+            chosen, but still at the target shape so the framing is previewed. */}
+        <div
+          className="relative touch-none select-none overflow-hidden rounded-xl border border-border bg-bg-primary/60"
+          style={{ width: VIEW_W, height: VIEW_H, cursor: img ? 'grab' : 'default' }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onWheel={onWheel}
+        >
+          {img ? (
+            <img
+              src={imageDataUrl ?? undefined}
+              alt=""
+              draggable={false}
+              className="pointer-events-none absolute max-w-none"
+              style={{ left: offset.x, top: offset.y, width: drawnW, height: drawnH }}
+            />
+          ) : (
+            <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-text-secondary">
+              <ImagePlus className="h-6 w-6 opacity-70" />
+              {emptyHint && <span className="text-[11px] leading-snug">{emptyHint}</span>}
+            </div>
+          )}
+
+          {/* Chrome preview (pointer-events-none so it never blocks drag). */}
+          <div className="pointer-events-none absolute inset-0">
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
+            {nameControls && !hideHeroName && namePosition === 'card' && (
+              <div
+                className="absolute bottom-0 left-0 right-0 flex flex-col items-end text-right"
+                style={{ padding: NAME_PADDING }}
+              >
+                {nameFailed ? (
+                  <div
+                    className="font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                    style={{ fontSize: NAME_FALLBACK_FONT }}
+                  >
+                    {heroName}
+                  </div>
+                ) : (
+                  <div className="relative ml-auto w-[70%]" style={{ height: NAME_HEIGHT }}>
+                    <img
+                      src={namePath}
+                      alt={heroName}
+                      className="absolute inset-0 h-full w-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                      onError={() => setNameFailed(true)}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+            {nameControls && !hideHeroName && namePosition === 'backdrop' && (
+              <div className="absolute left-0 top-0" style={{ padding: BD_NAME_PADDING }}>
+                {nameFailed ? (
+                  <div
+                    className="font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                    style={{ fontSize: Math.round(BD_NAME_HEIGHT * 0.9) }}
+                  >
+                    {heroName}
+                  </div>
+                ) : (
+                  <img
+                    src={namePath}
+                    alt={heroName}
+                    className="w-auto object-contain object-left drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                    style={{ height: BD_NAME_HEIGHT }}
+                    onError={() => setNameFailed(true)}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <ZoomIn className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+        <input
+          type="range"
+          min={1}
+          max={MAX_ZOOM}
+          step={0.01}
+          value={zoom}
+          disabled={!img}
+          onChange={(e) => applyZoom(Number(e.target.value))}
+          className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-border accent-accent disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        <span className="w-10 text-right text-[11px] tabular-nums text-text-secondary">
+          {zoom.toFixed(1)}x
+        </span>
+        <button
+          type="button"
+          disabled={!img}
+          onClick={() => applyZoom(1)}
+          title={t('locker.crop.resetZoom')}
+          className="cursor-pointer rounded-md border border-border/60 p-1 text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {nameControls && (
+        <Toggle
+          checked={hideHeroName}
+          onChange={setHideHeroName}
+          label={t('locker.modImage.hideHeroName')}
+          description={t('locker.modImage.hideHeroNameHint')}
+        />
+      )}
+
+      <button
+        type="button"
+        disabled={!img || !!error || busy}
+        onClick={handleApply}
+        className="inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent px-3 py-2 text-xs font-semibold text-accent-foreground transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Crop className="h-3.5 w-3.5" />}
+        {t('locker.modImage.useImage')}
+      </button>
+    </div>
+  );
+}

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -25,11 +25,23 @@ interface LockerImageCropperProps {
   namePosition?: 'card' | 'backdrop';
   /** Initial state of the "hide hero name label" toggle. */
   initialHideHeroName?: boolean;
+  /** Restore the previous framing (normalized source-fraction rect) when reopening
+   *  on a stored original source, instead of centering at cover. Applied on each
+   *  (re)load of `imageDataUrl`; clear it when staging a freshly picked source so
+   *  the new pick centers. The rect's aspect should match `aspect`. */
+  initialCrop?: { sx: number; sy: number; sw: number; sh: number };
   /** Hint shown over the empty viewport before a source is chosen. */
   emptyHint?: string;
   busy?: boolean;
-  /** Receives the framed image (PNG data URL at `aspect`) and the name choice. */
-  onApply: (result: { dataUrl: string; hideHeroName: boolean }) => void;
+  /** Receives the framed image (PNG data URL at `aspect`), the name choice, and
+   *  the ORIGINAL source + normalized crop rect so the edit can be persisted for
+   *  a full-fidelity reopen. */
+  onApply: (result: {
+    dataUrl: string;
+    hideHeroName: boolean;
+    source: string;
+    crop: { sx: number; sy: number; sw: number; sh: number };
+  }) => void;
 }
 
 /** The editing viewport keeps the target aspect; the source is scaled to cover it
@@ -87,6 +99,7 @@ export default function LockerImageCropper({
   allowHideName,
   namePosition = 'card',
   initialHideHeroName = false,
+  initialCrop,
   emptyHint,
   busy = false,
   onApply,
@@ -144,9 +157,27 @@ export default function LockerImageCropper({
     el.onload = () => {
       if (!active) return;
       setImg(el);
-      const cs = Math.max(VIEW_W / el.naturalWidth, VIEW_H / el.naturalHeight);
-      setOffset({ x: (VIEW_W - el.naturalWidth * cs) / 2, y: (VIEW_H - el.naturalHeight * cs) / 2 });
-      setZoom(1);
+      const natW = el.naturalWidth;
+      const natH = el.naturalHeight;
+      const cs = Math.max(VIEW_W / natW, VIEW_H / natH);
+      if (initialCrop && natW > 0 && natH > 0 && initialCrop.sw > 0) {
+        // Restore the previous framing. The viewport spans `initialCrop.sw * natW`
+        // source px, so the needed render scale is VIEW_W / that. Express it as a
+        // zoom multiple of cover, clamped, then derive the clamped offset.
+        const rawScale = VIEW_W / (initialCrop.sw * natW);
+        const z = Math.min(MAX_ZOOM, Math.max(1, rawScale / cs));
+        const scale = cs * z;
+        const drawnWNow = natW * scale;
+        const drawnHNow = natH * scale;
+        setZoom(z);
+        setOffset({
+          x: Math.min(0, Math.max(VIEW_W - drawnWNow, -initialCrop.sx * natW * scale)),
+          y: Math.min(0, Math.max(VIEW_H - drawnHNow, -initialCrop.sy * natH * scale)),
+        });
+      } else {
+        setOffset({ x: (VIEW_W - natW * cs) / 2, y: (VIEW_H - natH * cs) / 2 });
+        setZoom(1);
+      }
       setError(null);
     };
     el.onerror = () => {
@@ -156,7 +187,7 @@ export default function LockerImageCropper({
     return () => {
       active = false;
     };
-  }, [imageDataUrl, t, VIEW_W, VIEW_H]);
+  }, [imageDataUrl, initialCrop, t, VIEW_W, VIEW_H]);
 
   // Zoom around the viewport center so the framed subject stays put.
   const applyZoom = useCallback(
@@ -205,13 +236,18 @@ export default function LockerImageCropper({
   };
 
   const handleApply = () => {
-    if (!img) return;
+    if (!img || !imageDataUrl) return;
     const scale = coverScale * zoom;
     // The viewport maps to this rect in source-image natural coordinates.
     const srcX = -offset.x / scale;
     const srcY = -offset.y / scale;
     const srcW = VIEW_W / scale;
     const srcH = VIEW_H / scale;
+    // Normalized (source-fraction) crop rect, persisted alongside the original
+    // source so reopening restores this exact framing (and can reveal more).
+    const natW = img.naturalWidth;
+    const natH = img.naturalHeight;
+    const crop = { sx: srcX / natW, sy: srcY / natH, sw: srcW / natW, sh: srcH / natH };
     // Bake at the crop's own resolution (capped on the long edge), preserving aspect.
     const longSrc = Math.max(srcW, srcH);
     const k = longSrc > MAX_OUTPUT_LONG ? MAX_OUTPUT_LONG / longSrc : 1;
@@ -227,7 +263,7 @@ export default function LockerImageCropper({
     }
     ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, outW, outH);
-    onApply({ dataUrl: canvas.toDataURL('image/png'), hideHeroName });
+    onApply({ dataUrl: canvas.toDataURL('image/png'), hideHeroName, source: imageDataUrl, crop });
   };
 
   const namePath = getHeroNamePath(heroName);

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Loader2, Upload, Trash2, Copy } from 'lucide-react';
 import type { Mod } from '../../types/mod';
@@ -9,7 +9,10 @@ import {
   readImageDataUrl,
   showOpenDialog,
   fetchLockerImageDataUrl,
+  getLockerModImageEdit,
+  setLockerModImageEdit,
 } from '../../lib/api';
+import type { CropRect } from '../../types/electron';
 import { useAppStore } from '../../stores/appStore';
 import LockerImageCropper from './LockerImageCropper';
 
@@ -150,14 +153,73 @@ export function LockerModImagePicker({
   const [cropSource, setCropSource] = useState<string | null>(
     () => overrideFor(initialVariant) ?? null
   );
+  // When the active surface has a stored full-fidelity edit (original source +
+  // crop), this holds its crop rect so the cropper restores the exact framing
+  // (and the user can zoom out / pan to reveal area cropped outside the baked
+  // frame). Undefined = no stored edit; the cropper centers the baked seed / a
+  // freshly picked source instead.
+  const [restoredCrop, setRestoredCrop] = useState<CropRect | undefined>(undefined);
+
+  // Identifies the latest edit-load request so a slow fetch from a previous tab
+  // can't clobber the current one (the cropper remounts per tab via key={tab},
+  // but the async result still has to be discarded if the tab changed again).
+  // Also flipped to a fresh value on unmount via `mounted` so a late resolve is a
+  // no-op rather than a setState on an unmounted component.
+  const editLoadId = useRef(0);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // Load the stored full-fidelity edit (original source + crop) for a tab. If
+  // present, swap the cropper onto the original at the saved framing; if absent,
+  // leave the synchronous baked-seed behavior and clear any restored crop.
+  const loadEdit = (variant: PickerVariant) => {
+    const reqId = ++editLoadId.current;
+    getLockerModImageEdit(variant, skinKey)
+      .then((edit) => {
+        if (!mounted.current || editLoadId.current !== reqId) return; // stale
+        if (edit) {
+          setCropSource(edit.source);
+          setRestoredCrop(edit.crop);
+        } else {
+          setRestoredCrop(undefined);
+        }
+      })
+      .catch(() => {
+        // Non-fatal: degrade to the baked-seed framing already in cropSource.
+        if (mounted.current && editLoadId.current === reqId) setRestoredCrop(undefined);
+      });
+  };
+
+  // On open, try to upgrade the initial tab's baked seed to its full edit.
+  useEffect(() => {
+    loadEdit(initialVariant);
+    // Runs once on mount; subsequent tab loads go through switchTab.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Switching tabs swaps the target aspect, so any staged framing no longer
-  // applies; reseed with the new surface's stored image (or empty if none).
+  // applies; reseed with the new surface's stored image (or empty if none), then
+  // try to upgrade to its full-fidelity edit.
   const switchTab = (next: PickerVariant) => {
     if (next === tab) return;
     setTab(next);
     setCropSource(overrideFor(next) ?? null);
+    setRestoredCrop(undefined);
     setError(null);
+    loadEdit(next);
+  };
+
+  // Picking a NEW source (gallery / upload / mirror) discards the restored crop
+  // so the cropper centers the new pick instead of forcing the old framing.
+  const stageSource = (dataUrl: string) => {
+    editLoadId.current++; // cancel any in-flight edit load for this tab
+    setRestoredCrop(undefined);
+    setCropSource(dataUrl);
   };
 
   // Pull the mod's gallery from GameBanana. Local-only mods (no id) skip this
@@ -189,7 +251,7 @@ export function LockerModImagePicker({
     setError(null);
     try {
       const dataUrl = url.startsWith('data:') ? url : await fetchLockerImageDataUrl(url);
-      setCropSource(dataUrl);
+      stageSource(dataUrl);
     } catch (err) {
       console.error('Failed to load gallery image for cropping', err);
       setError(t('locker.modImage.applyError'));
@@ -207,7 +269,7 @@ export function LockerModImagePicker({
     if (!path) return;
     try {
       const dataUrl = await readImageDataUrl(path);
-      setCropSource(dataUrl);
+      stageSource(dataUrl);
     } catch (err) {
       console.error('Failed to read custom image', err);
       setError(t('locker.modImage.applyError'));
@@ -215,12 +277,18 @@ export function LockerModImagePicker({
   };
 
   // Commit the framed image (+ the hero-name choice) for the active tab, close.
+  // Also persists the ORIGINAL source + normalized crop rect so the editor can be
+  // reopened on the exact framing and reveal area cropped outside the baked frame.
   const applyCrop = async ({
     dataUrl,
     hideHeroName,
+    source,
+    crop,
   }: {
     dataUrl: string;
     hideHeroName: boolean;
+    source: string;
+    crop: CropRect;
   }) => {
     if (busy) return;
     setBusy(true);
@@ -228,6 +296,15 @@ export function LockerModImagePicker({
     try {
       await surface.setImage(skinKey, dataUrl);
       await surface.setHide(skinKey, hideHeroName);
+      // The full-fidelity edit (original + crop) is a best-effort resume aid; if
+      // it fails to store, the baked image + hide flag still persisted above, so
+      // don't let it block the save or the close (the editor just degrades to a
+      // baked seed on the next open).
+      try {
+        await setLockerModImageEdit(tab, skinKey, source, crop);
+      } catch (editErr) {
+        console.error('Failed to store Locker image edit (resume framing)', editErr);
+      }
       onClose();
     } catch (err) {
       console.error('Failed to set Locker skin image', err);
@@ -341,6 +418,7 @@ export function LockerModImagePicker({
             namePosition={surface.namePosition}
             heroName={heroName}
             initialHideHeroName={initialHideHeroName}
+            initialCrop={restoredCrop}
             emptyHint={t('locker.modImage.cropEmptyHint')}
             busy={busy}
             onApply={applyCrop}
@@ -352,7 +430,10 @@ export function LockerModImagePicker({
           {showMirror && (
             <button
               type="button"
-              onClick={() => !busy && setCropSource(lockerImageDataUrl ?? null)}
+              onClick={() => {
+                // Mirror only renders when lockerImageDataUrl is present.
+                if (!busy && lockerImageDataUrl) stageSource(lockerImageDataUrl);
+              }}
               disabled={busy}
               className="mb-2 flex w-full items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/5 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent/70 hover:bg-accent/10 disabled:opacity-50"
             >

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -1,40 +1,130 @@
 import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Loader2, Upload, Trash2 } from 'lucide-react';
+import { Check, Loader2, Upload, Trash2, Copy } from 'lucide-react';
 import type { Mod } from '../../types/mod';
 import type { GameBananaImage } from '../../types/gamebanana';
 import { Modal } from '../common/Modal';
-import { getModDetails, readImageDataUrl, showOpenDialog } from '../../lib/api';
+import {
+  getModDetails,
+  readImageDataUrl,
+  showOpenDialog,
+  fetchLockerImageDataUrl,
+} from '../../lib/api';
 import { useAppStore } from '../../stores/appStore';
+import LockerImageCropper from './LockerImageCropper';
+
+/** Which surface the picker is choosing an image for. The card is the 3:4
+ *  skin-panel card; the thumbnail is the 3:4 image on the main Locker hero-grid
+ *  card; the background is the wide 16:9 hero-detail backdrop. The thumbnail and
+ *  background can both mirror the card selection in one click. */
+type PickerVariant = 'card' | 'thumbnail' | 'background';
 
 /**
- * Issue #208: pick the image that represents a skin in the Locker. Sources are
- * the mod's own GameBanana gallery (fetched on demand) plus a custom upload.
- * The chosen image is stored locally (per skin) and used for the skin's card +
- * the hero card backdrop when this skin is active.
+ * Issue #208: pick the image that represents a skin in the Locker. A single
+ * tabbed surface covers the skin's 3:4 panel card (with the hero-name overlay),
+ * the 3:4 thumbnail on the main hero grid, and the hero-detail backdrop (16:9),
+ * so the formerly-separate menus are unified per skin. Sources are the mod's own
+ * GameBanana gallery (shown at full aspect so nothing is cropped before you
+ * choose) plus a custom upload, and (thumbnail / background) a one-click mirror
+ * of the card image. The left pane is a live crop adjuster locked to the active
+ * tab's shape; it shows the framing surface up front (empty) and frames whatever
+ * source you pick on the right. The framed image is stored locally per skin.
  */
 export function LockerModImagePicker({
   mod,
   skinKey,
+  heroName,
+  initialVariant = 'card',
+  cardImageDataUrl,
   onClose,
 }: {
   mod: Mod;
   skinKey: string;
+  heroName: string;
+  /** Which tab opens first. */
+  initialVariant?: PickerVariant;
+  /** The skin's current card image, offered as a "Use Locker image" mirror in
+   *  the thumbnail and background tabs. */
+  cardImageDataUrl?: string;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
   const titleId = useId();
-  const hasOverride = useAppStore((s) => Boolean(s.lockerModImages[skinKey]));
-  const setImage = useAppStore((s) => s.setLockerModImage);
-  const removeImage = useAppStore((s) => s.removeLockerModImage);
+
+  const [tab, setTab] = useState<PickerVariant>(initialVariant);
+
+  // Read every per-surface store slice up front (hooks can't be conditional),
+  // then resolve the ones the active tab needs below.
+  const lockerModImages = useAppStore((s) => s.lockerModImages);
+  const lockerModThumbnails = useAppStore((s) => s.lockerModThumbnails);
+  const lockerModBackgrounds = useAppStore((s) => s.lockerModBackgrounds);
+  const lockerHideHeroName = useAppStore((s) => s.lockerHideHeroName);
+  const lockerThumbHideHeroName = useAppStore((s) => s.lockerThumbHideHeroName);
+  const lockerBgHideHeroName = useAppStore((s) => s.lockerBgHideHeroName);
+  const setCardImage = useAppStore((s) => s.setLockerModImage);
+  const setThumbnail = useAppStore((s) => s.setLockerModThumbnail);
+  const setBackground = useAppStore((s) => s.setLockerModBackground);
+  const setCardHideName = useAppStore((s) => s.setLockerModImageHideName);
+  const setThumbHideName = useAppStore((s) => s.setLockerModThumbnailHideName);
+  const setBgHideName = useAppStore((s) => s.setLockerModBackgroundHideName);
+  const removeCardImage = useAppStore((s) => s.removeLockerModImage);
+  const removeThumbnail = useAppStore((s) => s.removeLockerModThumbnail);
+  const removeBackground = useAppStore((s) => s.removeLockerModBackground);
+
+  // Per-surface config, resolved for the active tab.
+  const surface = {
+    card: {
+      aspect: 3 / 4,
+      namePosition: 'card' as const,
+      override: lockerModImages[skinKey],
+      hideName: lockerHideHeroName[skinKey],
+      setImage: setCardImage,
+      setHide: setCardHideName,
+      remove: removeCardImage,
+    },
+    thumbnail: {
+      aspect: 3 / 4,
+      namePosition: 'card' as const,
+      override: lockerModThumbnails[skinKey],
+      hideName: lockerThumbHideHeroName[skinKey],
+      setImage: setThumbnail,
+      setHide: setThumbHideName,
+      remove: removeThumbnail,
+    },
+    background: {
+      aspect: 16 / 9,
+      namePosition: 'backdrop' as const,
+      override: lockerModBackgrounds[skinKey],
+      hideName: lockerBgHideHeroName[skinKey],
+      setImage: setBackground,
+      setHide: setBgHideName,
+      remove: removeBackground,
+    },
+  }[tab];
+
+  const hasOverride = Boolean(surface.override);
+  const initialHideHeroName = Boolean(surface.hideName);
+  // The card image can be mirrored into the thumbnail and backdrop in one click.
+  const showMirror = tab !== 'card' && Boolean(cardImageDataUrl);
 
   const [images, setImages] = useState<GameBananaImage[]>([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The image being framed in the crop adjuster (as a data URL), null = none.
+  const [cropSource, setCropSource] = useState<string | null>(null);
+
+  // Switching tabs swaps the target aspect, so any staged framing no longer
+  // applies; clear it back to the empty preview for the new surface.
+  const switchTab = (next: PickerVariant) => {
+    if (next === tab) return;
+    setTab(next);
+    setCropSource(null);
+    setError(null);
+  };
 
   // Pull the mod's gallery from GameBanana. Local-only mods (no id) skip this
-  // and just offer the custom upload + current thumbnail.
+  // and just offer the custom upload + current thumbnail. Shared across tabs.
   useEffect(() => {
     if (typeof mod.gameBananaId !== 'number' || mod.gameBananaId <= 0) return;
     let cancelled = false;
@@ -55,15 +145,16 @@ export function LockerModImagePicker({
     };
   }, [mod.gameBananaId, mod.sourceSection, t]);
 
-  const apply = async (source: string) => {
+  // Stage a chosen gallery image (a remote URL or data URL) into the adjuster.
+  const stageGallery = async (url: string) => {
     if (busy) return;
     setBusy(true);
     setError(null);
     try {
-      await setImage(skinKey, source);
-      onClose();
+      const dataUrl = url.startsWith('data:') ? url : await fetchLockerImageDataUrl(url);
+      setCropSource(dataUrl);
     } catch (err) {
-      console.error('Failed to set Locker skin image', err);
+      console.error('Failed to load gallery image for cropping', err);
       setError(t('locker.modImage.applyError'));
     } finally {
       setBusy(false);
@@ -79,10 +170,34 @@ export function LockerModImagePicker({
     if (!path) return;
     try {
       const dataUrl = await readImageDataUrl(path);
-      await apply(dataUrl);
+      setCropSource(dataUrl);
     } catch (err) {
       console.error('Failed to read custom image', err);
       setError(t('locker.modImage.applyError'));
+    }
+  };
+
+  // Commit the framed image (+ the hero-name choice) for the active tab, close.
+  const applyCrop = async ({
+    dataUrl,
+    hideHeroName,
+  }: {
+    dataUrl: string;
+    hideHeroName: boolean;
+  }) => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await surface.setImage(skinKey, dataUrl);
+      await surface.setHide(skinKey, hideHeroName);
+      onClose();
+    } catch (err) {
+      console.error('Failed to set Locker skin image', err);
+      setError(t('locker.modImage.applyError'));
+      setCropSource(null);
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -91,7 +206,7 @@ export function LockerModImagePicker({
     setBusy(true);
     setError(null);
     try {
-      await removeImage(skinKey);
+      await surface.remove(skinKey);
       onClose();
     } catch (err) {
       console.error('Failed to remove Locker skin image', err);
@@ -114,8 +229,20 @@ export function LockerModImagePicker({
         ? [{ full: mod.thumbnailUrl, thumb: mod.thumbnailUrl }]
         : [];
 
+  const tabClass = (active: boolean) =>
+    `relative -mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+      active
+        ? 'border-accent text-text-primary'
+        : 'border-transparent text-text-secondary hover:text-text-primary'
+    }`;
+
   return (
-    <Modal onClose={onClose} labelledBy={titleId} size="lg" panelClassName="flex max-h-[80vh] flex-col">
+    <Modal
+      onClose={onClose}
+      labelledBy={titleId}
+      size="none"
+      panelClassName="flex max-h-[90vh] w-full max-w-3xl flex-col"
+    >
       <div className="flex items-start justify-between gap-3 border-b border-border p-4">
         <div className="min-w-0">
           <h2 id={titleId} className="truncate text-base font-semibold text-text-primary">
@@ -138,56 +265,113 @@ export function LockerModImagePicker({
         )}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+      {/* Tabs: the skin-panel card (3:4) is the default; the grid thumbnail
+          (3:4) and the backdrop (16:9) are independent per-skin surfaces. */}
+      <div className="flex gap-1 overflow-x-auto border-b border-border px-4">
+        <button type="button" onClick={() => switchTab('card')} className={tabClass(tab === 'card')}>
+          {t('locker.modImage.tabCard')}
+        </button>
         <button
           type="button"
-          onClick={pickCustom}
-          disabled={busy}
-          className="mb-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border py-3 text-sm font-medium text-text-secondary transition-colors hover:border-accent/60 hover:text-text-primary disabled:opacity-50"
+          onClick={() => switchTab('thumbnail')}
+          className={tabClass(tab === 'thumbnail')}
         >
-          <Upload className="h-4 w-4" />
-          {t('locker.modImage.uploadCustom')}
+          {t('locker.modImage.tabThumbnail')}
         </button>
+        <button
+          type="button"
+          onClick={() => switchTab('background')}
+          className={tabClass(tab === 'background')}
+        >
+          {t('locker.modImage.tabBackground')}
+        </button>
+      </div>
 
-        {loading ? (
-          <div className="flex items-center justify-center gap-2 py-10 text-sm text-text-secondary">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('locker.modImage.loadingGallery')}
-          </div>
-        ) : error ? (
-          <div className="py-6 text-center text-sm text-red-400">{error}</div>
-        ) : choices.length > 0 ? (
-          <>
-            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
-              {t('locker.modImage.fromMod')}
+      <div className="flex min-h-0 flex-1 gap-4 p-4">
+        {/* Left pane: live crop adjuster, locked to the active tab's shape. Shown
+            empty up front so the framing surface is previewed before a pick.
+            Sized to the window by the cropper; scrolls itself only as a fallback
+            on very short windows so it never clips. */}
+        <div className="flex-shrink-0 overflow-y-auto">
+          <LockerImageCropper
+            key={tab}
+            imageDataUrl={cropSource}
+            aspect={surface.aspect}
+            nameControls
+            namePosition={surface.namePosition}
+            heroName={heroName}
+            initialHideHeroName={initialHideHeroName}
+            emptyHint={t('locker.modImage.cropEmptyHint')}
+            busy={busy}
+            onApply={applyCrop}
+          />
+        </div>
+
+        {/* Right pane: source picker (upload + gallery), scrolls independently. */}
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          {showMirror && (
+            <button
+              type="button"
+              onClick={() => !busy && setCropSource(cardImageDataUrl ?? null)}
+              disabled={busy}
+              className="mb-2 flex w-full items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/5 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent/70 hover:bg-accent/10 disabled:opacity-50"
+            >
+              <Copy className="h-4 w-4" />
+              {t('locker.modImage.useLockerImage')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={pickCustom}
+            disabled={busy}
+            className="mb-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border py-3 text-sm font-medium text-text-secondary transition-colors hover:border-accent/60 hover:text-text-primary disabled:opacity-50"
+          >
+            <Upload className="h-4 w-4" />
+            {t('locker.modImage.uploadCustom')}
+          </button>
+
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-text-secondary">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('locker.modImage.loadingGallery')}
             </div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-              {choices.map((choice) => (
-                <button
-                  key={choice.full}
-                  type="button"
-                  onClick={() => apply(choice.full)}
-                  disabled={busy}
-                  className="group relative aspect-video overflow-hidden rounded-lg border border-border bg-bg-tertiary transition-colors hover:border-accent focus-visible:border-accent focus-visible:outline-none disabled:opacity-50"
-                >
-                  <img
-                    src={choice.thumb}
-                    alt=""
-                    className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                    loading="lazy"
-                  />
-                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-opacity group-hover:bg-black/40 group-hover:opacity-100">
-                    <Check className="h-6 w-6 text-white" />
-                  </span>
-                </button>
-              ))}
+          ) : error ? (
+            <div className="py-6 text-center text-sm text-red-400">{error}</div>
+          ) : choices.length > 0 ? (
+            <>
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                {t('locker.modImage.fromMod')}
+              </div>
+              {/* Masonry: each image at its natural aspect so nothing is cropped
+                  before you pick. Framing happens in the crop adjuster after. */}
+              <div className="columns-2 gap-2 [&>*]:mb-2">
+                {choices.map((choice) => (
+                  <button
+                    key={choice.full}
+                    type="button"
+                    onClick={() => stageGallery(choice.full)}
+                    disabled={busy}
+                    className="group relative block w-full break-inside-avoid overflow-hidden rounded-lg border border-border bg-bg-tertiary transition-colors hover:border-accent focus-visible:border-accent focus-visible:outline-none disabled:opacity-50"
+                  >
+                    <img
+                      src={choice.thumb}
+                      alt=""
+                      className="block h-auto w-full transition-transform duration-200 group-hover:scale-105"
+                      loading="lazy"
+                    />
+                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-opacity group-hover:bg-black/40 group-hover:opacity-100">
+                      <Check className="h-6 w-6 text-white" />
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="py-6 text-center text-sm text-text-secondary">
+              {t('locker.modImage.noGallery')}
             </div>
-          </>
-        ) : (
-          <div className="py-6 text-center text-sm text-text-secondary">
-            {t('locker.modImage.noGallery')}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -13,15 +13,21 @@ import {
 import { useAppStore } from '../../stores/appStore';
 import LockerImageCropper from './LockerImageCropper';
 
-/** Which surface the picker is choosing an image for. The card is the 3:4
- *  skin-panel card; the thumbnail is the 3:4 image on the main Locker hero-grid
- *  card; the background is the wide 16:9 hero-detail backdrop. The thumbnail and
- *  background can both mirror the card selection in one click. */
+/** Which surface the picker is choosing an image for. NOTE the display labels
+ *  are inverted from these internal names (the names map to the storage dirs and
+ *  can't change without migrating saved images):
+ *    - `thumbnail` -> labelled "Locker image": the 3:4 image on the main Locker
+ *      hero-grid card. The prominent surface, so it's the default tab.
+ *    - `card`      -> labelled "Card thumbnail": the 16:9 skin-panel card
+ *      (aspect-video media) in the hero detail view.
+ *    - `background`-> labelled "Background": the wide 16:9 hero-detail backdrop.
+ *  The card and background tabs can both mirror the "Locker image" (thumbnail)
+ *  selection in one click. */
 type PickerVariant = 'card' | 'thumbnail' | 'background';
 
 /**
  * Issue #208: pick the image that represents a skin in the Locker. A single
- * tabbed surface covers the skin's 3:4 panel card (with the hero-name overlay),
+ * tabbed surface covers the skin's 16:9 panel card (with the hero-name overlay),
  * the 3:4 thumbnail on the main hero grid, and the hero-detail backdrop (16:9),
  * so the formerly-separate menus are unified per skin. Sources are the mod's own
  * GameBanana gallery (shown at full aspect so nothing is cropped before you
@@ -34,8 +40,8 @@ export function LockerModImagePicker({
   mod,
   skinKey,
   heroName,
-  initialVariant = 'card',
-  cardImageDataUrl,
+  initialVariant = 'thumbnail',
+  lockerImageDataUrl,
   onClose,
 }: {
   mod: Mod;
@@ -43,9 +49,10 @@ export function LockerModImagePicker({
   heroName: string;
   /** Which tab opens first. */
   initialVariant?: PickerVariant;
-  /** The skin's current card image, offered as a "Use Locker image" mirror in
-   *  the thumbnail and background tabs. */
-  cardImageDataUrl?: string;
+  /** The skin's current "Locker image" (the grid-thumbnail surface), offered as
+   *  a one-click "Use Locker image" mirror on the Card thumbnail and Background
+   *  tabs. */
+  lockerImageDataUrl?: string;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
@@ -71,11 +78,21 @@ export function LockerModImagePicker({
   const removeThumbnail = useAppStore((s) => s.removeLockerModThumbnail);
   const removeBackground = useAppStore((s) => s.removeLockerModBackground);
 
-  // Per-surface config, resolved for the active tab.
+  // Per-surface config, resolved for the active tab. `namePreview` shows the
+  // hero-name overlay in the cropper where the real surface renders one;
+  // `allowHideName` shows the "hide hero name" toggle. The hero name is only
+  // baked over the image on the main hero-grid card (the thumbnail surface), so
+  // that's the only tab with the toggle. The skin-panel card prints its title as
+  // separate text (no overlay), and the backdrop always shows its name logo.
   const surface = {
     card: {
-      aspect: 3 / 4,
+      // The skin-panel card media is aspect-video (16:9), so frame to match it
+      // (issue #208 follow-up). The baked 16:9 output then drops cleanly into the
+      // card's object-cover with no re-crop.
+      aspect: 16 / 9,
       namePosition: 'card' as const,
+      namePreview: false,
+      allowHideName: false,
       override: lockerModImages[skinKey],
       hideName: lockerHideHeroName[skinKey],
       setImage: setCardImage,
@@ -85,6 +102,8 @@ export function LockerModImagePicker({
     thumbnail: {
       aspect: 3 / 4,
       namePosition: 'card' as const,
+      namePreview: true,
+      allowHideName: true,
       override: lockerModThumbnails[skinKey],
       hideName: lockerThumbHideHeroName[skinKey],
       setImage: setThumbnail,
@@ -94,6 +113,8 @@ export function LockerModImagePicker({
     background: {
       aspect: 16 / 9,
       namePosition: 'backdrop' as const,
+      namePreview: true,
+      allowHideName: false,
       override: lockerModBackgrounds[skinKey],
       hideName: lockerBgHideHeroName[skinKey],
       setImage: setBackground,
@@ -104,22 +125,38 @@ export function LockerModImagePicker({
 
   const hasOverride = Boolean(surface.override);
   const initialHideHeroName = Boolean(surface.hideName);
-  // The card image can be mirrored into the thumbnail and backdrop in one click.
-  const showMirror = tab !== 'card' && Boolean(cardImageDataUrl);
+  // The Locker image (grid thumbnail) can be mirrored into the card and backdrop
+  // in one click; it's the only surface that never shows the mirror (you can't
+  // mirror it onto itself).
+  const showMirror = tab !== 'thumbnail' && Boolean(lockerImageDataUrl);
+
+  // The stored (baked) override for a given surface, used to seed the editor so
+  // reopening shows the last crop instead of an empty frame and the user can
+  // adjust from there (issue #208 follow-up).
+  const overrideFor = (v: PickerVariant) =>
+    v === 'card'
+      ? lockerModImages[skinKey]
+      : v === 'thumbnail'
+        ? lockerModThumbnails[skinKey]
+        : lockerModBackgrounds[skinKey];
 
   const [images, setImages] = useState<GameBananaImage[]>([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // The image being framed in the crop adjuster (as a data URL), null = none.
-  const [cropSource, setCropSource] = useState<string | null>(null);
+  // Seeded with the active surface's existing image so the editor opens on the
+  // last crop rather than empty.
+  const [cropSource, setCropSource] = useState<string | null>(
+    () => overrideFor(initialVariant) ?? null
+  );
 
   // Switching tabs swaps the target aspect, so any staged framing no longer
-  // applies; clear it back to the empty preview for the new surface.
+  // applies; reseed with the new surface's stored image (or empty if none).
   const switchTab = (next: PickerVariant) => {
     if (next === tab) return;
     setTab(next);
-    setCropSource(null);
+    setCropSource(overrideFor(next) ?? null);
     setError(null);
   };
 
@@ -265,18 +302,20 @@ export function LockerModImagePicker({
         )}
       </div>
 
-      {/* Tabs: the skin-panel card (3:4) is the default; the grid thumbnail
-          (3:4) and the backdrop (16:9) are independent per-skin surfaces. */}
+      {/* Tabs: the grid thumbnail (3:4) leads as the default since it's the most
+          visible surface (and the only one that bakes the hero name over the
+          image); the skin-panel card (16:9) and the backdrop (16:9) follow as
+          independent per-skin surfaces. */}
       <div className="flex gap-1 overflow-x-auto border-b border-border px-4">
-        <button type="button" onClick={() => switchTab('card')} className={tabClass(tab === 'card')}>
-          {t('locker.modImage.tabCard')}
-        </button>
         <button
           type="button"
           onClick={() => switchTab('thumbnail')}
           className={tabClass(tab === 'thumbnail')}
         >
           {t('locker.modImage.tabThumbnail')}
+        </button>
+        <button type="button" onClick={() => switchTab('card')} className={tabClass(tab === 'card')}>
+          {t('locker.modImage.tabCard')}
         </button>
         <button
           type="button"
@@ -297,7 +336,8 @@ export function LockerModImagePicker({
             key={tab}
             imageDataUrl={cropSource}
             aspect={surface.aspect}
-            nameControls
+            nameControls={surface.namePreview}
+            allowHideName={surface.allowHideName}
             namePosition={surface.namePosition}
             heroName={heroName}
             initialHideHeroName={initialHideHeroName}
@@ -312,7 +352,7 @@ export function LockerModImagePicker({
           {showMirror && (
             <button
               type="button"
-              onClick={() => !busy && setCropSource(cardImageDataUrl ?? null)}
+              onClick={() => !busy && setCropSource(lockerImageDataUrl ?? null)}
               disabled={busy}
               className="mb-2 flex w-full items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/5 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent/70 hover:bg-accent/10 disabled:opacity-50"
             >

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Loader2, Upload, Trash2 } from 'lucide-react';
+import type { Mod } from '../../types/mod';
+import type { GameBananaImage } from '../../types/gamebanana';
+import { Modal } from '../common/Modal';
+import { getModDetails, readImageDataUrl, showOpenDialog } from '../../lib/api';
+import { useAppStore } from '../../stores/appStore';
+
+/**
+ * Issue #208: pick the image that represents a skin in the Locker. Sources are
+ * the mod's own GameBanana gallery (fetched on demand) plus a custom upload.
+ * The chosen image is stored locally (per skin) and used for the skin's card +
+ * the hero card backdrop when this skin is active.
+ */
+export function LockerModImagePicker({
+  mod,
+  skinKey,
+  onClose,
+}: {
+  mod: Mod;
+  skinKey: string;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const hasOverride = useAppStore((s) => Boolean(s.lockerModImages[skinKey]));
+  const setImage = useAppStore((s) => s.setLockerModImage);
+  const removeImage = useAppStore((s) => s.removeLockerModImage);
+
+  const [images, setImages] = useState<GameBananaImage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Pull the mod's gallery from GameBanana. Local-only mods (no id) skip this
+  // and just offer the custom upload + current thumbnail.
+  useEffect(() => {
+    if (typeof mod.gameBananaId !== 'number' || mod.gameBananaId <= 0) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getModDetails(mod.gameBananaId, mod.sourceSection)
+      .then((details) => {
+        if (!cancelled) setImages(details.previewMedia?.images ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setError(t('locker.modImage.galleryError'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mod.gameBananaId, mod.sourceSection, t]);
+
+  const apply = async (source: string) => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await setImage(skinKey, source);
+      onClose();
+    } catch (err) {
+      console.error('Failed to set Locker skin image', err);
+      setError(t('locker.modImage.applyError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const pickCustom = async () => {
+    if (busy) return;
+    const path = await showOpenDialog({
+      title: t('locker.modImage.dialogTitle'),
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
+    });
+    if (!path) return;
+    try {
+      const dataUrl = await readImageDataUrl(path);
+      await apply(dataUrl);
+    } catch (err) {
+      console.error('Failed to read custom image', err);
+      setError(t('locker.modImage.applyError'));
+    }
+  };
+
+  const clear = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await removeImage(skinKey);
+      onClose();
+    } catch (err) {
+      console.error('Failed to remove Locker skin image', err);
+      setError(t('locker.modImage.applyError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Gallery choices, plus the mod's own thumbnail if it isn't already the first
+  // gallery image (local mods often have only the thumbnail).
+  const galleryUrls = images.map((img) => ({
+    full: `${img.baseUrl}/${img.file}`,
+    thumb: `${img.baseUrl}/${img.file530 || img.file}`,
+  }));
+  const choices =
+    galleryUrls.length > 0
+      ? galleryUrls
+      : mod.thumbnailUrl
+        ? [{ full: mod.thumbnailUrl, thumb: mod.thumbnailUrl }]
+        : [];
+
+  return (
+    <Modal onClose={onClose} labelledBy={titleId} size="lg" panelClassName="flex max-h-[80vh] flex-col">
+      <div className="flex items-start justify-between gap-3 border-b border-border p-4">
+        <div className="min-w-0">
+          <h2 id={titleId} className="truncate text-base font-semibold text-text-primary">
+            {t('locker.modImage.title')}
+          </h2>
+          <p className="truncate text-xs text-text-secondary" title={mod.name}>
+            {mod.name}
+          </p>
+        </div>
+        {hasOverride && (
+          <button
+            type="button"
+            onClick={clear}
+            disabled={busy}
+            className="flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-red-500/60 hover:text-red-400 disabled:opacity-50"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            {t('locker.modImage.reset')}
+          </button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <button
+          type="button"
+          onClick={pickCustom}
+          disabled={busy}
+          className="mb-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border py-3 text-sm font-medium text-text-secondary transition-colors hover:border-accent/60 hover:text-text-primary disabled:opacity-50"
+        >
+          <Upload className="h-4 w-4" />
+          {t('locker.modImage.uploadCustom')}
+        </button>
+
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-text-secondary">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t('locker.modImage.loadingGallery')}
+          </div>
+        ) : error ? (
+          <div className="py-6 text-center text-sm text-red-400">{error}</div>
+        ) : choices.length > 0 ? (
+          <>
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+              {t('locker.modImage.fromMod')}
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {choices.map((choice) => (
+                <button
+                  key={choice.full}
+                  type="button"
+                  onClick={() => apply(choice.full)}
+                  disabled={busy}
+                  className="group relative aspect-video overflow-hidden rounded-lg border border-border bg-bg-tertiary transition-colors hover:border-accent focus-visible:border-accent focus-visible:outline-none disabled:opacity-50"
+                >
+                  <img
+                    src={choice.thumb}
+                    alt=""
+                    className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                    loading="lazy"
+                  />
+                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-opacity group-hover:bg-black/40 group-hover:opacity-100">
+                    <Check className="h-6 w-6 text-white" />
+                  </span>
+                </button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="py-6 text-center text-sm text-text-secondary">
+            {t('locker.modImage.noGallery')}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -86,7 +86,8 @@ export function LockerModImagePicker({
   // `allowHideName` shows the "hide hero name" toggle. The hero name is only
   // baked over the image on the main hero-grid card (the thumbnail surface), so
   // that's the only tab with the toggle. The skin-panel card prints its title as
-  // separate text (no overlay), and the backdrop always shows its name logo.
+  // separate text (no overlay), and the backdrop's name logo is its own page
+  // layer (not part of the framed image), so neither previews a name.
   const surface = {
     card: {
       // The skin-panel card media is aspect-video (16:9), so frame to match it
@@ -116,7 +117,11 @@ export function LockerModImagePicker({
     background: {
       aspect: 16 / 9,
       namePosition: 'backdrop' as const,
-      namePreview: true,
+      // The hero-detail page draws the hero-name logo as its own layer over the
+      // backdrop, never baked into the backdrop image. So previewing a name over
+      // the background you're framing is misleading: the framed image carries no
+      // name. Don't overlay one here.
+      namePreview: false,
       allowHideName: false,
       override: lockerModBackgrounds[skinKey],
       hideName: lockerBgHideHeroName[skinKey],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -425,6 +425,18 @@ export async function readImageDataUrl(imagePath: string): Promise<string> {
   return window.electronAPI.readImageDataUrl(imagePath);
 }
 
+export async function getLockerModImages(): Promise<Record<string, string>> {
+  return window.electronAPI.getLockerModImages();
+}
+
+export async function setLockerModImage(skinKey: string, source: string): Promise<string> {
+  return window.electronAPI.setLockerModImage(skinKey, source);
+}
+
+export async function removeLockerModImage(skinKey: string): Promise<void> {
+  return window.electronAPI.removeLockerModImage(skinKey);
+}
+
 export async function mergeMods(args: MergeModsArgs): Promise<Mod> {
   return window.electronAPI.mergeMods(args);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -489,6 +489,22 @@ export async function setLockerModThumbnailHideName(skinKey: string, hide: boole
   return window.electronAPI.setLockerModThumbnailHideName(skinKey, hide);
 }
 
+export async function getLockerModImageEdit(
+  variant: LockerImageVariant,
+  skinKey: string
+): Promise<LockerImageEdit | null> {
+  return window.electronAPI.getLockerModImageEdit(variant, skinKey);
+}
+
+export async function setLockerModImageEdit(
+  variant: LockerImageVariant,
+  skinKey: string,
+  source: string,
+  crop: CropRect
+): Promise<void> {
+  return window.electronAPI.setLockerModImageEdit(variant, skinKey, source, crop);
+}
+
 export async function mergeMods(args: MergeModsArgs): Promise<Mod> {
   return window.electronAPI.mergeMods(args);
 }
@@ -770,7 +786,7 @@ export function conflictPairKey(a: string, b: string): string {
 // Profile wire types are single-sourced in types/electron.ts; re-exported
 // here to preserve this module's existing import surface.
 export type { Profile, ProfileMod, ProfileCrosshairSettings } from '../types/electron';
-import type { Profile, ProfileCrosshairSettings, PerformanceConfigStatus, EditorCandidate } from '../types/electron';
+import type { Profile, ProfileCrosshairSettings, PerformanceConfigStatus, EditorCandidate, LockerImageVariant, LockerImageEdit, CropRect } from '../types/electron';
 
 export async function getProfiles(): Promise<Profile[]> {
   return window.electronAPI.getProfiles();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -437,6 +437,58 @@ export async function removeLockerModImage(skinKey: string): Promise<void> {
   return window.electronAPI.removeLockerModImage(skinKey);
 }
 
+export async function getLockerModImageFlags(): Promise<Record<string, boolean>> {
+  return window.electronAPI.getLockerModImageFlags();
+}
+
+export async function setLockerModImageHideName(skinKey: string, hide: boolean): Promise<void> {
+  return window.electronAPI.setLockerModImageHideName(skinKey, hide);
+}
+
+export async function fetchLockerImageDataUrl(url: string): Promise<string> {
+  return window.electronAPI.fetchLockerImageDataUrl(url);
+}
+
+export async function getLockerModBackgrounds(): Promise<Record<string, string>> {
+  return window.electronAPI.getLockerModBackgrounds();
+}
+
+export async function setLockerModBackground(skinKey: string, source: string): Promise<string> {
+  return window.electronAPI.setLockerModBackground(skinKey, source);
+}
+
+export async function removeLockerModBackground(skinKey: string): Promise<void> {
+  return window.electronAPI.removeLockerModBackground(skinKey);
+}
+
+export async function getLockerModBackgroundFlags(): Promise<Record<string, boolean>> {
+  return window.electronAPI.getLockerModBackgroundFlags();
+}
+
+export async function setLockerModBackgroundHideName(skinKey: string, hide: boolean): Promise<void> {
+  return window.electronAPI.setLockerModBackgroundHideName(skinKey, hide);
+}
+
+export async function getLockerModThumbnails(): Promise<Record<string, string>> {
+  return window.electronAPI.getLockerModThumbnails();
+}
+
+export async function setLockerModThumbnail(skinKey: string, source: string): Promise<string> {
+  return window.electronAPI.setLockerModThumbnail(skinKey, source);
+}
+
+export async function removeLockerModThumbnail(skinKey: string): Promise<void> {
+  return window.electronAPI.removeLockerModThumbnail(skinKey);
+}
+
+export async function getLockerModThumbnailFlags(): Promise<Record<string, boolean>> {
+  return window.electronAPI.getLockerModThumbnailFlags();
+}
+
+export async function setLockerModThumbnailHideName(skinKey: string, hide: boolean): Promise<void> {
+  return window.electronAPI.setLockerModThumbnailHideName(skinKey, hide);
+}
+
 export async function mergeMods(args: MergeModsArgs): Promise<Mod> {
   return window.electronAPI.mergeMods(args);
 }

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -369,6 +369,18 @@ export function modLoadOrder(mod: Mod): number {
   return folderIndex * 100 + mod.priority;
 }
 
+/**
+ * The "active" skin for a hero: the highest-priority enabled mod (lowest load
+ * order, i.e. the one that wins file conflicts). Used to decide which skin's
+ * chosen Locker image represents the hero on its card / detail backdrop
+ * (issue #208). Returns undefined when nothing is enabled.
+ */
+export function activeLockerSkin(mods: Mod[]): Mod | undefined {
+  return mods
+    .filter((m) => m.enabled)
+    .sort((a, b) => modLoadOrder(a) - modLoadOrder(b))[0];
+}
+
 export function groupLockerSkins(mods: Mod[]): LockerSkin[] {
   const bySkin = new Map<string, Mod[]>();
   for (const mod of mods) {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -950,6 +950,18 @@
     "empty": {
       "noGamePath": "Set your Deadlock path or enable dev mode."
     },
+    "modImage": {
+      "set": "Set Locker image for {{name}}",
+      "title": "Choose a Locker image",
+      "dialogTitle": "Choose a custom image",
+      "uploadCustom": "Upload a custom image",
+      "fromMod": "From this mod",
+      "loadingGallery": "Loading images...",
+      "galleryError": "Could not load this mod's images.",
+      "applyError": "Could not set the image. Please try again.",
+      "noGallery": "No images available. Upload a custom one above.",
+      "reset": "Reset to default"
+    },
     "global": {
       "activeBadgeTitle": "This soul container is active and loaded in-game",
       "disabledBadge": "Disabled",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -953,8 +953,8 @@
     "modImage": {
       "set": "Set Locker image for {{name}}",
       "title": "Choose a Locker image",
-      "tabCard": "Locker image",
-      "tabThumbnail": "Card thumbnail",
+      "tabCard": "Card thumbnail",
+      "tabThumbnail": "Locker image",
       "tabBackground": "Background",
       "cropEmptyHint": "Pick an image to frame it here.",
       "dialogTitle": "Choose a custom image",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -953,6 +953,10 @@
     "modImage": {
       "set": "Set Locker image for {{name}}",
       "title": "Choose a Locker image",
+      "tabCard": "Locker image",
+      "tabThumbnail": "Card thumbnail",
+      "tabBackground": "Background",
+      "cropEmptyHint": "Pick an image to frame it here.",
       "dialogTitle": "Choose a custom image",
       "uploadCustom": "Upload a custom image",
       "fromMod": "From this mod",
@@ -960,7 +964,11 @@
       "galleryError": "Could not load this mod's images.",
       "applyError": "Could not set the image. Please try again.",
       "noGallery": "No images available. Upload a custom one above.",
-      "reset": "Reset to default"
+      "reset": "Reset to default",
+      "useImage": "Use image",
+      "useLockerImage": "Use Locker image",
+      "hideHeroName": "Hide hero name label",
+      "hideHeroNameHint": "Turn on when the image already shows the hero's name."
     },
     "global": {
       "activeBadgeTitle": "This soul container is active and loaded in-game",
@@ -1315,6 +1323,7 @@
       "downloadASkinForThisHero": "Download a skin for this hero to manage it here.",
       "hide3dModel": "Hide 3D model",
       "showLive3dModel": "Show live 3D model",
+      "lockerImages": "Locker images",
       "back": "Back",
       "favorite": "Favorite",
       "lockerSections": "Locker sections",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1630,
+  "totalKeys": 1640,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1630,
+      "translatedKeys": 1640,
       "pct": 100
     }
   ]

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1640,
+  "totalKeys": 1649,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1640,
+      "translatedKeys": 1649,
       "pct": 100
     }
   ]

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -132,7 +132,7 @@ function RainbowPaletteIcon({ className = '', title }: { className?: string; tit
 
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, loadLockerModImages } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(
@@ -360,9 +360,27 @@ export default function Locker() {
   const heroCardImage = useCallback(
     (heroId: number): string | undefined => {
       const active = activeLockerSkin(heroMods.map.get(heroId) ?? []);
-      return active ? lockerModImages[getLockerSkinKey(active)] : undefined;
+      if (!active) return undefined;
+      // The grid thumbnail is an independent override; fall back to the card
+      // image when a skin has no thumbnail of its own (issue #208).
+      const key = getLockerSkinKey(active);
+      return lockerModThumbnails[key] ?? lockerModImages[key];
     },
-    [heroMods, lockerModImages]
+    [heroMods, lockerModThumbnails, lockerModImages]
+  );
+  // Whether the active skin's image already shows the hero name, so the card's
+  // own name label should be hidden (issue #208). Keyed to the active skin, and
+  // to whichever surface is actually showing (thumbnail wins over card).
+  const heroHideName = useCallback(
+    (heroId: number): boolean => {
+      const active = activeLockerSkin(heroMods.map.get(heroId) ?? []);
+      if (!active) return false;
+      const key = getLockerSkinKey(active);
+      return Boolean(
+        lockerModThumbnails[key] ? lockerThumbHideHeroName[key] : lockerHideHeroName[key]
+      );
+    },
+    [heroMods, lockerModThumbnails, lockerThumbHideHeroName, lockerHideHeroName]
   );
   const installedSkinCount = useMemo(() => countLockerSkins(lockerMods), [lockerMods]);
   const installedSoundCount = useMemo(() => countLockerSkins(lockerSounds), [lockerSounds]);
@@ -750,6 +768,7 @@ export default function Locker() {
               soundCount={countLockerSkins(heroSounds.map.get(hero.id) ?? [])}
               hasAbilityRecolor={Boolean(abilityRecolorSupport[hero.name])}
               cardImage={heroCardImage(hero.id)}
+              hideHeroName={heroHideName(hero.id)}
               isFavorite={favoriteHeroes.includes(hero.id)}
               onNavigate={() => goToHero(hero)}
               onBrowse={() => openHeroInBrowse(hero)}
@@ -1014,6 +1033,9 @@ interface HeroGalleryCardProps {
   /** Issue #208: the active skin's chosen Locker image (data URL), shown as the
    *  card backdrop in place of the hero render. Undefined = use the render. */
   cardImage?: string;
+  /** Issue #208: hide the hero name label because the active skin's image
+   *  already shows the hero name. Only meaningful when cardImage is set. */
+  hideHeroName?: boolean;
   isFavorite: boolean;
   onNavigate: () => void;
   onBrowse: () => void;
@@ -1565,6 +1587,7 @@ function HeroGalleryCard({
   soundCount,
   hasAbilityRecolor,
   cardImage,
+  hideHeroName,
   isFavorite,
   onNavigate,
   onBrowse,
@@ -1725,24 +1748,28 @@ function HeroGalleryCard({
           )}
         </div>
       )}
-      <div className="absolute bottom-0 left-0 right-0 p-2 sm:p-3 flex flex-col items-end text-right">
-        {nameFailed ? (
-          <div className="text-sm font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">{hero.name}</div>
-        ) : (
-          <div className="relative w-[70%] h-6 sm:h-7 ml-auto">
-            <img
-              src={namePath}
-              alt={hero.name}
-              className="absolute inset-0 w-full h-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] will-change-transform backface-visibility-hidden group-hover:scale-105 scale-100 transition-transform duration-300"
-              style={{ transform: 'translateZ(0)' }}
-              decoding="sync"
-              loading="eager"
-              onLoad={() => rememberLockerImageLoaded(namePath)}
-              onError={() => setNameFailed(true)}
-            />
-          </div>
-        )}
-      </div>
+      {/* Issue #208: hide the name label when the active skin's image already
+          shows the hero name. Without an override image the label always shows. */}
+      {!(hideHeroName && cardImage) && (
+        <div className="absolute bottom-0 left-0 right-0 p-2 sm:p-3 flex flex-col items-end text-right">
+          {nameFailed ? (
+            <div className="text-sm font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">{hero.name}</div>
+          ) : (
+            <div className="relative w-[70%] h-6 sm:h-7 ml-auto">
+              <img
+                src={namePath}
+                alt={hero.name}
+                className="absolute inset-0 w-full h-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] will-change-transform backface-visibility-hidden group-hover:scale-105 scale-100 transition-transform duration-300"
+                style={{ transform: 'translateZ(0)' }}
+                decoding="sync"
+                loading="eager"
+                onLoad={() => rememberLockerImageLoaded(namePath)}
+                onError={() => setNameFailed(true)}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -33,9 +33,11 @@ import {
   FAVORITE_HEROES_KEY,
   GLOBAL_MOD_TYPE_LABELS,
   GLOBAL_MOD_TYPE_ORDER,
+  activeLockerSkin,
   buildHeroList,
   countGlobalMods,
   countLockerSkins,
+  getLockerSkinKey,
   getEffectiveGlobalType,
   getHeroFacePosition,
   getHeroNamePath,
@@ -130,7 +132,7 @@ function RainbowPaletteIcon({ className = '', title }: { className?: string; tit
 
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, loadLockerModImages } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(
@@ -186,6 +188,11 @@ export default function Locker() {
   useEffect(() => {
     loadSettings();
   }, [loadSettings]);
+
+  // Issue #208: per-mod (per-skin) Locker view images (display only).
+  useEffect(() => {
+    loadLockerModImages();
+  }, [loadLockerModImages]);
 
   useEffect(() => {
     if (activeDeadlockPath) {
@@ -347,6 +354,16 @@ export default function Locker() {
   const heroSounds = useMemo(() => {
     return groupModsByCategory(lockerSounds, baseHeroList);
   }, [lockerSounds, baseHeroList]);
+  // Issue #208: the image shown on a hero's card/backdrop is the active
+  // (highest-priority enabled) skin's chosen Locker image, if the user picked
+  // one. Otherwise undefined and the card falls back to the hero render.
+  const heroCardImage = useCallback(
+    (heroId: number): string | undefined => {
+      const active = activeLockerSkin(heroMods.map.get(heroId) ?? []);
+      return active ? lockerModImages[getLockerSkinKey(active)] : undefined;
+    },
+    [heroMods, lockerModImages]
+  );
   const installedSkinCount = useMemo(() => countLockerSkins(lockerMods), [lockerMods]);
   const installedSoundCount = useMemo(() => countLockerSkins(lockerSounds), [lockerSounds]);
   const unassignedSkins = useMemo(() => groupLockerSkins(heroMods.unassigned), [heroMods]);
@@ -732,6 +749,7 @@ export default function Locker() {
               skinCount={countLockerSkins(heroMods.map.get(hero.id) ?? [])}
               soundCount={countLockerSkins(heroSounds.map.get(hero.id) ?? [])}
               hasAbilityRecolor={Boolean(abilityRecolorSupport[hero.name])}
+              cardImage={heroCardImage(hero.id)}
               isFavorite={favoriteHeroes.includes(hero.id)}
               onNavigate={() => goToHero(hero)}
               onBrowse={() => openHeroInBrowse(hero)}
@@ -785,6 +803,7 @@ export default function Locker() {
               mods={heroMods.map.get(hero.id) ?? []}
               sounds={heroSounds.map.get(hero.id) ?? []}
               hasAbilityRecolor={Boolean(abilityRecolorSupport[hero.name])}
+              cardImage={heroCardImage(hero.id)}
               expanded={expandedHeroes.has(hero.id)}
               onToggleExpanded={() => toggleHeroExpanded(hero.id)}
               onBrowseSkins={() => openHeroInBrowse(hero)}
@@ -973,6 +992,9 @@ interface HeroCardProps {
   mods: Mod[];
   sounds: Mod[];
   hasAbilityRecolor: boolean;
+  /** Issue #208: the active skin's chosen Locker image (data URL), shown as the
+   *  card backdrop in place of the hero render. Undefined = use the render. */
+  cardImage?: string;
   expanded: boolean;
   onToggleExpanded: () => void;
   onBrowseSkins: () => void;
@@ -989,6 +1011,9 @@ interface HeroGalleryCardProps {
   skinCount: number;
   soundCount: number;
   hasAbilityRecolor: boolean;
+  /** Issue #208: the active skin's chosen Locker image (data URL), shown as the
+   *  card backdrop in place of the hero render. Undefined = use the render. */
+  cardImage?: string;
   isFavorite: boolean;
   onNavigate: () => void;
   onBrowse: () => void;
@@ -1539,6 +1564,7 @@ function HeroGalleryCard({
   skinCount,
   soundCount,
   hasAbilityRecolor,
+  cardImage,
   isFavorite,
   onNavigate,
   onBrowse,
@@ -1553,14 +1579,16 @@ function HeroGalleryCard({
   const [nameFailed, setNameFailed] = useState(false);
   const [, setImageCacheVersion] = useState(0);
 
-  const renderSrc = fallbackStep === 0
+  // A user-provided card image (issue #208) wins over the render chain. Data
+  // URLs paint immediately, so they skip the loaded-image gate / skeleton.
+  const renderSrc = cardImage ?? (fallbackStep === 0
     ? renderLocal
     : fallbackStep === 1
       ? wikiUrl
       : fallbackStep === 2
         ? (hero.iconUrl ?? '')
-        : '';
-  const isRenderReady = !!renderSrc && lockerLoadedImageUrls.has(renderSrc);
+        : '');
+  const isRenderReady = !!cardImage || (!!renderSrc && lockerLoadedImageUrls.has(renderSrc));
 
   useEffect(() => {
     const tick = () => setImageCacheVersion((version) => version + 1);
@@ -1604,7 +1632,7 @@ function HeroGalleryCard({
               className="absolute inset-0 h-full w-full bg-cover will-change-transform backface-visibility-hidden group-hover:scale-[1.06] scale-100 transition-transform duration-500"
               style={{
                 backgroundImage: `url(${JSON.stringify(renderSrc)})`,
-                backgroundPosition: `${facePositionX}% 20%`,
+                backgroundPosition: cardImage ? 'center' : `${facePositionX}% 20%`,
                 imageRendering: 'auto',
                 transform: 'translateZ(0)',
               }}
@@ -1617,8 +1645,10 @@ function HeroGalleryCard({
               aria-hidden
               className="pointer-events-none absolute h-px w-px opacity-0"
               decoding="async"
-              onLoad={() => rememberLockerImageLoaded(renderSrc)}
-              onError={handleRenderError}
+              onLoad={() => {
+                if (!cardImage) rememberLockerImageLoaded(renderSrc);
+              }}
+              onError={cardImage ? undefined : handleRenderError}
             />
           </>
         )}
@@ -1722,6 +1752,7 @@ function HeroCard({
   mods,
   sounds,
   hasAbilityRecolor,
+  cardImage,
   expanded,
   onToggleExpanded,
   onBrowseSkins,
@@ -1748,14 +1779,17 @@ function HeroCard({
   const activeSection = section === 'sounds' && !hasSounds ? 'skins' : section;
   const activeList = activeSection === 'sounds' ? sounds : mods;
 
+  // A user-provided card image (issue #208) wins outright; otherwise fall back
+  // through the render chain: local render -> wiki render -> GameBanana icon.
   const bgSrc =
-    bgFallbackStep === 0
+    cardImage ??
+    (bgFallbackStep === 0
       ? localUrl
       : bgFallbackStep === 1
         ? wikiUrl
         : bgFallbackStep === 2
           ? (hero.iconUrl ?? '')
-          : '';
+          : '');
 
   const handleBgError = () => {
     if (bgFallbackStep === 0) {
@@ -1791,9 +1825,9 @@ function HeroCard({
           aria-hidden
           decoding="async"
           onLoad={() => rememberLockerImageLoaded(bgSrc)}
-          onError={handleBgError}
+          onError={cardImage ? undefined : handleBgError}
           className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-          style={{ objectPosition: `${facePositionX}% 18%` }}
+          style={{ objectPosition: cardImage ? 'center' : `${facePositionX}% 18%` }}
         />
       )}
       <div

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -9,9 +9,11 @@ import {
   Box,
   Loader2,
   Sparkles,
+  ImageIcon,
   type LucideIcon,
 } from 'lucide-react';
 import HeroSkinsPanel, { SkinLoadOrderStrip } from '../components/locker/HeroSkinsPanel';
+import { LockerModImagePicker } from '../components/locker/LockerModImagePicker';
 import HeroCardPicker from '../components/locker/HeroCardPicker';
 import HeroSoundPicker from '../components/locker/HeroSoundPicker';
 import HeroEffectsPanel from '../components/locker/HeroEffectsPanel';
@@ -87,10 +89,19 @@ export function LockerHeroView({
   // Issue #208: the backdrop reflects the active skin's chosen Locker image, if
   // the user picked one (set per skin in the skins list below).
   const lockerModImages = useAppStore((s) => s.lockerModImages);
-  const cardImage = useMemo(() => {
-    const active = activeLockerSkin(skinList);
-    return active ? lockerModImages[getLockerSkinKey(active)] : undefined;
-  }, [skinList, lockerModImages]);
+  const lockerModBackgrounds = useAppStore((s) => s.lockerModBackgrounds);
+  const lockerBgHideHeroName = useAppStore((s) => s.lockerBgHideHeroName);
+  const activeSkin = useMemo(() => activeLockerSkin(skinList), [skinList]);
+  const activeSkinKey = activeSkin ? getLockerSkinKey(activeSkin) : undefined;
+  const cardImage = activeSkinKey ? lockerModImages[activeSkinKey] : undefined;
+  // The full-bleed backdrop is its own per-skin image (issue #208), independent
+  // of the 3:4 card image. Unset = the hero render. The card image is shown only
+  // on the grid card, never here.
+  const backdropImage = activeSkinKey ? lockerModBackgrounds[activeSkinKey] : undefined;
+  // Hide the hero name logo when the active skin's backdrop already shows the
+  // name (only meaningful when a custom backdrop is in play).
+  const hideHeroName = activeSkinKey ? Boolean(lockerBgHideHeroName[activeSkinKey]) : false;
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [renderFallbackStep, setRenderFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
   const [view3d, setView3d] = useState(false);
@@ -156,7 +167,7 @@ export function LockerHeroView({
   ];
 
   const renderSrc =
-    cardImage ??
+    backdropImage ??
     (renderFallbackStep === 0
       ? getHeroRenderPath(hero.name)
       : renderFallbackStep === 1
@@ -255,11 +266,11 @@ export function LockerHeroView({
             src={renderSrc}
             alt={hero.name}
             className={
-              cardImage
+              backdropImage
                 ? 'absolute inset-0 h-full w-full object-cover'
                 : 'absolute top-0 right-0 h-full w-auto max-w-none'
             }
-            onError={cardImage ? undefined : handleRenderError}
+            onError={backdropImage ? undefined : handleRenderError}
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center text-text-secondary text-2xl">
@@ -270,24 +281,37 @@ export function LockerHeroView({
         <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
       </div>
 
-      {/* Live 3D model toggle. Opens/closes the floating model panel rather than
-          swapping the backdrop, so the 2D portrait stays put and the model can
-          float over it at any window size. Shown at every width (the floating
-          panel works without the lg+ backdrop too). */}
-      <button
-        type="button"
-        onClick={() => setView3d((v) => !v)}
-        aria-pressed={view3d}
-        title={view3d ? t('locker.hero.hide3dModel') : t('locker.hero.showLive3dModel')}
-        className={`absolute top-4 right-4 z-20 flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors cursor-pointer ${
-          view3d
-            ? 'border-accent/60 bg-accent/20 text-text-primary'
-            : 'border-border/70 bg-bg-secondary/70 text-text-secondary hover:text-text-primary backdrop-blur'
-        }`}
-      >
-        <Box className="h-3.5 w-3.5" />
-        3D
-      </button>
+      {/* Top-right controls: adjust the hero-detail backdrop image, and the live
+          3D model toggle. The 3D toggle opens/closes the floating model panel
+          rather than swapping the backdrop, so the 2D portrait stays put and the
+          model can float over it at any window size. */}
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+        {activeSkin && activeSkinKey && (
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            title={t('locker.hero.lockerImages')}
+            aria-label={t('locker.hero.lockerImages')}
+            className="flex items-center gap-1.5 rounded-full border border-border/70 bg-bg-secondary/70 px-3 py-1.5 text-xs font-semibold text-text-secondary transition-colors hover:text-text-primary backdrop-blur cursor-pointer"
+          >
+            <ImageIcon className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setView3d((v) => !v)}
+          aria-pressed={view3d}
+          title={view3d ? t('locker.hero.hide3dModel') : t('locker.hero.showLive3dModel')}
+          className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors cursor-pointer ${
+            view3d
+              ? 'border-accent/60 bg-accent/20 text-text-primary'
+              : 'border-border/70 bg-bg-secondary/70 text-text-secondary hover:text-text-primary backdrop-blur'
+          }`}
+        >
+          <Box className="h-3.5 w-3.5" />
+          3D
+        </button>
+      </div>
 
       {/* Progressive frosted-glass background — every layer (including the
           base heavy blur) is masked with a long, smooth taper so nothing has
@@ -366,8 +390,9 @@ export function LockerHeroView({
           </button>
         </div>
 
-        {/* Hero Name */}
-        {nameFailed ? (
+        {/* Hero Name. Hidden when the active skin's backdrop already shows the
+            hero name (issue #208). */}
+        {hideHeroName && backdropImage ? null : nameFailed ? (
           <h2 className="text-2xl font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
             {hero.name}
           </h2>
@@ -455,6 +480,18 @@ export function LockerHeroView({
             />
           </Suspense>
         </FloatingModelPanel>
+      )}
+
+      {/* Unified per-skin image picker (issue #208): tabbed for the 3:4 card and
+          the 16:9 backdrop, opening on the card tab. */}
+      {pickerOpen && activeSkin && activeSkinKey && (
+        <LockerModImagePicker
+          mod={activeSkin}
+          skinKey={activeSkinKey}
+          heroName={hero.name}
+          cardImageDataUrl={cardImage}
+          onClose={() => setPickerOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -88,12 +88,13 @@ export function LockerHeroView({
   const { t } = useTranslation();
   // Issue #208: the backdrop reflects the active skin's chosen Locker image, if
   // the user picked one (set per skin in the skins list below).
-  const lockerModImages = useAppStore((s) => s.lockerModImages);
+  const lockerModThumbnails = useAppStore((s) => s.lockerModThumbnails);
   const lockerModBackgrounds = useAppStore((s) => s.lockerModBackgrounds);
   const lockerBgHideHeroName = useAppStore((s) => s.lockerBgHideHeroName);
   const activeSkin = useMemo(() => activeLockerSkin(skinList), [skinList]);
   const activeSkinKey = activeSkin ? getLockerSkinKey(activeSkin) : undefined;
-  const cardImage = activeSkinKey ? lockerModImages[activeSkinKey] : undefined;
+  // The "Locker image" (grid-thumbnail surface) the picker mirrors from.
+  const thumbnailImage = activeSkinKey ? lockerModThumbnails[activeSkinKey] : undefined;
   // The full-bleed backdrop is its own per-skin image (issue #208), independent
   // of the 3:4 card image. Unset = the hero render. The card image is shown only
   // on the grid card, never here.
@@ -482,14 +483,15 @@ export function LockerHeroView({
         </FloatingModelPanel>
       )}
 
-      {/* Unified per-skin image picker (issue #208): tabbed for the 3:4 card and
-          the 16:9 backdrop, opening on the card tab. */}
+      {/* Unified per-skin image picker (issue #208): tabbed for the 3:4 grid
+          thumbnail, the 16:9 skin-panel card and the 16:9 backdrop, opening on
+          the thumbnail tab. */}
       {pickerOpen && activeSkin && activeSkinKey && (
         <LockerModImagePicker
           mod={activeSkin}
           skinKey={activeSkinKey}
           heroName={hero.name}
-          cardImageDataUrl={cardImage}
+          lockerImageDataUrl={thumbnailImage}
           onClose={() => setPickerOpen(false)}
         />
       )}

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -18,14 +18,17 @@ import HeroEffectsPanel from '../components/locker/HeroEffectsPanel';
 import FloatingModelPanel from '../components/locker/FloatingModelPanel';
 // three.js viewer is heavy; only pull the chunk when the user flips to 3D.
 const HeroPoseViewer = lazy(() => import('../components/locker/HeroPoseViewer'));
+import { useAppStore } from '../stores/appStore';
 import { useTrippyPreviewStore } from '../stores/trippyPreviewStore';
 import type { Mod } from '../types/mod';
 import type { HeroPoseSkinSource } from '../types/portrait';
 import {
+  activeLockerSkin,
   countLockerSkins,
   getHeroNamePath,
   getHeroRenderPath,
   getHeroWikiUrl,
+  getLockerSkinKey,
   type HeroCategory,
 } from '../lib/lockerUtils';
 
@@ -81,6 +84,13 @@ export function LockerHeroView({
   hideNsfwPreviews = false,
 }: LockerHeroViewProps) {
   const { t } = useTranslation();
+  // Issue #208: the backdrop reflects the active skin's chosen Locker image, if
+  // the user picked one (set per skin in the skins list below).
+  const lockerModImages = useAppStore((s) => s.lockerModImages);
+  const cardImage = useMemo(() => {
+    const active = activeLockerSkin(skinList);
+    return active ? lockerModImages[getLockerSkinKey(active)] : undefined;
+  }, [skinList, lockerModImages]);
   const [renderFallbackStep, setRenderFallbackStep] = useState(0);
   const [nameFailed, setNameFailed] = useState(false);
   const [view3d, setView3d] = useState(false);
@@ -146,13 +156,14 @@ export function LockerHeroView({
   ];
 
   const renderSrc =
-    renderFallbackStep === 0
+    cardImage ??
+    (renderFallbackStep === 0
       ? getHeroRenderPath(hero.name)
       : renderFallbackStep === 1
         ? getHeroWikiUrl(hero.name)
         : renderFallbackStep === 2
           ? (hero.iconUrl ?? '')
-          : '';
+          : '');
 
   const handleRenderError = () => {
     if (renderFallbackStep === 0) {
@@ -243,8 +254,12 @@ export function LockerHeroView({
           <img
             src={renderSrc}
             alt={hero.name}
-            className="absolute top-0 right-0 h-full w-auto max-w-none"
-            onError={handleRenderError}
+            className={
+              cardImage
+                ? 'absolute inset-0 h-full w-full object-cover'
+                : 'absolute top-0 right-0 h-full w-auto max-w-none'
+            }
+            onError={cardImage ? undefined : handleRenderError}
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center text-text-secondary text-2xl">

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -201,6 +201,12 @@ interface AppState {
   // Presence can show the viewed hero. Renderer-only, never persisted.
   lockerHeroName: string | null;
 
+  // Issue #208: per-mod (per-skin) Locker view images (display override).
+  // Map is { skinKey -> data URL }, loaded lazily when the Locker opens. Keyed
+  // by getLockerSkinKey(mod). A skin without an entry falls back to its
+  // GameBanana thumbnail; a hero card falls back to the hero render.
+  lockerModImages: Record<string, string>;
+
   // Actions
   loadSettings: () => Promise<void>;
   saveSettings: (settings: AppSettings) => Promise<void>;
@@ -241,6 +247,10 @@ interface AppState {
   setBrowseSession: (cache: BrowseSessionCache | null) => void;
   setInstalledScrollTop: (scrollTop: number) => void;
   setLockerHeroName: (name: string | null) => void;
+  loadLockerModImages: () => Promise<void>;
+  /** `source` is a `data:` URL (custom upload) or an `http(s)` gallery URL. */
+  setLockerModImage: (skinKey: string, source: string) => Promise<void>;
+  removeLockerModImage: (skinKey: string) => Promise<void>;
 }
 
 // The main process throws this exact phrase from every "out of enabled slots"
@@ -268,6 +278,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   browseSession: null,
   installedScrollTop: 0,
   lockerHeroName: null,
+  lockerModImages: {},
 
   // Load settings from backend
   loadSettings: async () => {
@@ -297,6 +308,30 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (err) {
       set({ settingsError: String(err), settingsLoading: false });
     }
+  },
+
+  // Issue #208: per-mod (per-skin) Locker view image overrides (display only).
+  loadLockerModImages: async () => {
+    try {
+      const images = await api.getLockerModImages();
+      set({ lockerModImages: images });
+    } catch {
+      // Non-fatal: skins just fall back to their GameBanana thumbnail.
+    }
+  },
+  setLockerModImage: async (skinKey: string, source: string) => {
+    const dataUrl = await api.setLockerModImage(skinKey, source);
+    set((state) => ({
+      lockerModImages: { ...state.lockerModImages, [skinKey]: dataUrl },
+    }));
+  },
+  removeLockerModImage: async (skinKey: string) => {
+    await api.removeLockerModImage(skinKey);
+    set((state) => {
+      const next = { ...state.lockerModImages };
+      delete next[skinKey];
+      return { lockerModImages: next };
+    });
   },
 
   // Auto-detect Deadlock installation

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -207,6 +207,29 @@ interface AppState {
   // GameBanana thumbnail; a hero card falls back to the hero render.
   lockerModImages: Record<string, string>;
 
+  // Per-skin "hide the hero name label" flags for the Locker image override.
+  // Map is { skinKey -> true } (sparse: only hidden skins are present), loaded
+  // alongside lockerModImages. Used when the art already shows the hero's name.
+  lockerHideHeroName: Record<string, boolean>;
+
+  // Issue #208: per-skin hero-detail backdrop images (framed to 16:9). Map is
+  // { skinKey -> data URL }. Independent of the card image; a skin without an
+  // entry falls back to the hero render in the focus view.
+  lockerModBackgrounds: Record<string, string>;
+
+  // Per-skin "hide the hero name logo" flags for the focus-view backdrop, the
+  // backdrop counterpart of lockerHideHeroName. Sparse { skinKey -> true }.
+  lockerBgHideHeroName: Record<string, boolean>;
+
+  // Per-skin grid thumbnail images (framed 3:4) for the main Locker hero-grid
+  // card. Map is { skinKey -> data URL }. Independent of the card image; the
+  // grid card falls back to the card image, then the hero render.
+  lockerModThumbnails: Record<string, string>;
+
+  // Per-skin "hide the hero name label" flags for the grid thumbnail, the
+  // thumbnail counterpart of lockerHideHeroName. Sparse { skinKey -> true }.
+  lockerThumbHideHeroName: Record<string, boolean>;
+
   // Actions
   loadSettings: () => Promise<void>;
   saveSettings: (settings: AppSettings) => Promise<void>;
@@ -251,6 +274,16 @@ interface AppState {
   /** `source` is a `data:` URL (custom upload) or an `http(s)` gallery URL. */
   setLockerModImage: (skinKey: string, source: string) => Promise<void>;
   removeLockerModImage: (skinKey: string) => Promise<void>;
+  /** Hide (or show) the hero name label for this skin's Locker card. */
+  setLockerModImageHideName: (skinKey: string, hide: boolean) => Promise<void>;
+  setLockerModBackground: (skinKey: string, source: string) => Promise<void>;
+  removeLockerModBackground: (skinKey: string) => Promise<void>;
+  /** Hide (or show) the hero name logo over this skin's focus-view backdrop. */
+  setLockerModBackgroundHideName: (skinKey: string, hide: boolean) => Promise<void>;
+  setLockerModThumbnail: (skinKey: string, source: string) => Promise<void>;
+  removeLockerModThumbnail: (skinKey: string) => Promise<void>;
+  /** Hide (or show) the hero name label over this skin's grid thumbnail. */
+  setLockerModThumbnailHideName: (skinKey: string, hide: boolean) => Promise<void>;
 }
 
 // The main process throws this exact phrase from every "out of enabled slots"
@@ -279,6 +312,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   installedScrollTop: 0,
   lockerHeroName: null,
   lockerModImages: {},
+  lockerHideHeroName: {},
+  lockerModBackgrounds: {},
+  lockerBgHideHeroName: {},
+  lockerModThumbnails: {},
+  lockerThumbHideHeroName: {},
 
   // Load settings from backend
   loadSettings: async () => {
@@ -313,8 +351,22 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Issue #208: per-mod (per-skin) Locker view image overrides (display only).
   loadLockerModImages: async () => {
     try {
-      const images = await api.getLockerModImages();
-      set({ lockerModImages: images });
+      const [images, flags, backgrounds, bgFlags, thumbnails, thumbFlags] = await Promise.all([
+        api.getLockerModImages(),
+        api.getLockerModImageFlags(),
+        api.getLockerModBackgrounds(),
+        api.getLockerModBackgroundFlags(),
+        api.getLockerModThumbnails(),
+        api.getLockerModThumbnailFlags(),
+      ]);
+      set({
+        lockerModImages: images,
+        lockerHideHeroName: flags,
+        lockerModBackgrounds: backgrounds,
+        lockerBgHideHeroName: bgFlags,
+        lockerModThumbnails: thumbnails,
+        lockerThumbHideHeroName: thumbFlags,
+      });
     } catch {
       // Non-fatal: skins just fall back to their GameBanana thumbnail.
     }
@@ -330,7 +382,71 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((state) => {
       const next = { ...state.lockerModImages };
       delete next[skinKey];
-      return { lockerModImages: next };
+      // The flag is metadata about the image; removing one clears the other.
+      const nextFlags = { ...state.lockerHideHeroName };
+      delete nextFlags[skinKey];
+      return { lockerModImages: next, lockerHideHeroName: nextFlags };
+    });
+  },
+  setLockerModImageHideName: async (skinKey: string, hide: boolean) => {
+    await api.setLockerModImageHideName(skinKey, hide);
+    set((state) => {
+      const nextFlags = { ...state.lockerHideHeroName };
+      if (hide) nextFlags[skinKey] = true;
+      else delete nextFlags[skinKey];
+      return { lockerHideHeroName: nextFlags };
+    });
+  },
+  setLockerModBackground: async (skinKey: string, source: string) => {
+    const dataUrl = await api.setLockerModBackground(skinKey, source);
+    set((state) => ({
+      lockerModBackgrounds: { ...state.lockerModBackgrounds, [skinKey]: dataUrl },
+    }));
+  },
+  removeLockerModBackground: async (skinKey: string) => {
+    await api.removeLockerModBackground(skinKey);
+    set((state) => {
+      const next = { ...state.lockerModBackgrounds };
+      delete next[skinKey];
+      // The flag is metadata about the backdrop; removing one clears the other.
+      const nextFlags = { ...state.lockerBgHideHeroName };
+      delete nextFlags[skinKey];
+      return { lockerModBackgrounds: next, lockerBgHideHeroName: nextFlags };
+    });
+  },
+  setLockerModBackgroundHideName: async (skinKey: string, hide: boolean) => {
+    await api.setLockerModBackgroundHideName(skinKey, hide);
+    set((state) => {
+      const nextFlags = { ...state.lockerBgHideHeroName };
+      if (hide) nextFlags[skinKey] = true;
+      else delete nextFlags[skinKey];
+      return { lockerBgHideHeroName: nextFlags };
+    });
+  },
+  setLockerModThumbnail: async (skinKey: string, source: string) => {
+    const dataUrl = await api.setLockerModThumbnail(skinKey, source);
+    set((state) => ({
+      lockerModThumbnails: { ...state.lockerModThumbnails, [skinKey]: dataUrl },
+    }));
+  },
+  removeLockerModThumbnail: async (skinKey: string) => {
+    await api.removeLockerModThumbnail(skinKey);
+    set((state) => {
+      const next = { ...state.lockerModThumbnails };
+      delete next[skinKey];
+      // The flag is metadata about the thumbnail; removing one clears the other.
+      const nextFlags = { ...state.lockerThumbHideHeroName };
+      delete nextFlags[skinKey];
+      return { lockerModThumbnails: next, lockerThumbHideHeroName: nextFlags };
+    });
+  },
+  setLockerModThumbnailHideName: async (skinKey: string, hide: boolean) => {
+    await api.setLockerModThumbnailHideName(skinKey, hide);
+    set((state) => {
+      const nextFlags = { ...state.lockerThumbHideHeroName };
+      if (hide) nextFlags[skinKey] = true;
+      else delete nextFlags[skinKey];
+      return { lockerThumbHideHeroName: nextFlags };
     });
   },
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -574,6 +574,33 @@ export interface ElectronAPI {
     getLockerModImages: () => Promise<Record<string, string>>;
     setLockerModImage: (skinKey: string, source: string) => Promise<string>;
     removeLockerModImage: (skinKey: string) => Promise<void>;
+    /** Per-skin display flags for the Locker image override. Map is
+     *  { skinKey -> true } for skins whose hero name label should be hidden
+     *  (the art already shows the name). Cleared when the image is removed. */
+    getLockerModImageFlags: () => Promise<Record<string, boolean>>;
+    setLockerModImageHideName: (skinKey: string, hide: boolean) => Promise<void>;
+    /** Fetch a remote gallery image as a data URL (no storage) to seed the crop
+     *  editor; a renderer canvas can't read pixels from a cross-origin image. */
+    fetchLockerImageDataUrl: (url: string) => Promise<string>;
+    /** Issue #208: per-skin hero-detail backdrop images (framed to 16:9). Same
+     *  shape as the card images; the backdrop falls back to the card image when
+     *  a skin has no background override. */
+    getLockerModBackgrounds: () => Promise<Record<string, string>>;
+    setLockerModBackground: (skinKey: string, source: string) => Promise<string>;
+    removeLockerModBackground: (skinKey: string) => Promise<void>;
+    /** Per-skin backdrop hide-name flags (sparse { skinKey -> true }); hides the
+     *  hero name logo in the focus view when the backdrop art already shows it. */
+    getLockerModBackgroundFlags: () => Promise<Record<string, boolean>>;
+    setLockerModBackgroundHideName: (skinKey: string, hide: boolean) => Promise<void>;
+    /** Per-skin grid thumbnail images (framed 3:4) for the main Locker hero-grid
+     *  card. Independent of the skin-panel card image; the grid card falls back
+     *  to the card image, then the hero render, when a skin has no thumbnail. */
+    getLockerModThumbnails: () => Promise<Record<string, string>>;
+    setLockerModThumbnail: (skinKey: string, source: string) => Promise<string>;
+    removeLockerModThumbnail: (skinKey: string) => Promise<void>;
+    /** Per-skin grid-thumbnail hide-name flags (sparse { skinKey -> true }). */
+    getLockerModThumbnailFlags: () => Promise<Record<string, boolean>>;
+    setLockerModThumbnailHideName: (skinKey: string, hide: boolean) => Promise<void>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
     extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -425,6 +425,27 @@ export interface SaltIngestStatus {
     lastError: string | null;
 }
 
+/** Which Locker surface a per-skin image override applies to. Maps 1:1 to the
+ *  storage dirs in lockerModImages.ts (issue #208). */
+export type LockerImageVariant = 'card' | 'thumbnail' | 'background';
+
+/** A viewport-independent crop rectangle in source-image fractions (each 0..1):
+ *  sx/sy = top-left, sw/sh = width/height. Persisted alongside the original
+ *  source so the crop editor can be reopened on the exact framing. */
+export interface CropRect {
+    sx: number;
+    sy: number;
+    sw: number;
+    sh: number;
+}
+
+/** The persisted editable state for a per-skin Locker image override: the
+ *  ORIGINAL (pre-crop) source as a data URL plus the normalized crop rect. */
+export interface LockerImageEdit {
+    source: string;
+    crop: CropRect;
+}
+
 export interface ElectronAPI {
     // Host platform ('win32', 'linux', ...), captured in the preload. The
     // renderer uses it to decide whether to draw the custom Windows title
@@ -601,6 +622,21 @@ export interface ElectronAPI {
     /** Per-skin grid-thumbnail hide-name flags (sparse { skinKey -> true }). */
     getLockerModThumbnailFlags: () => Promise<Record<string, boolean>>;
     setLockerModThumbnailHideName: (skinKey: string, hide: boolean) => Promise<void>;
+    /** Full-fidelity crop persistence (issue #208 follow-up): the ORIGINAL source
+     *  (data URL) + a viewport-independent crop rect for a surface, so reopening
+     *  the crop editor restores the exact framing and lets the user zoom out / pan
+     *  to recover area cropped outside the last baked frame. Returns null when a
+     *  skin has no stored edit (legacy overrides predate this). */
+    getLockerModImageEdit: (
+        variant: LockerImageVariant,
+        skinKey: string
+    ) => Promise<LockerImageEdit | null>;
+    setLockerModImageEdit: (
+        variant: LockerImageVariant,
+        skinKey: string,
+        source: string,
+        crop: CropRect
+    ) => Promise<void>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
     extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -568,6 +568,12 @@ export interface ElectronAPI {
     previewSoulContainerGlb: (args: PreviewSoulContainerGlbArgs) => Promise<SoulContainerPreview>;
     readGlbFile: (glbPath: string) => Promise<string>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
+    /** Issue #208: per-mod (per-skin) Locker view images (display override).
+     *  Map is { skinKey -> data URL }; `source` is a `data:` URL (custom upload)
+     *  or an `http(s)` gallery URL to download. Setter returns the new data URL. */
+    getLockerModImages: () => Promise<Record<string, string>>;
+    setLockerModImage: (skinKey: string, source: string) => Promise<string>;
+    removeLockerModImage: (skinKey: string) => Promise<void>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
     extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;


### PR DESCRIPTION
## What

Adds a unified, tabbed per-skin image picker to the Locker (issue #208) and refines its framing/preview behavior.

Each skin can set its own image for three surfaces from one modal:
- **Locker image** (3:4 grid-card thumbnail, the default tab; bakes the hero-name label over the image with a hide toggle)
- **Card thumbnail** (16:9 skin-panel card)
- **Background** (16:9 hero-detail backdrop)

Sources are the mod's own GameBanana gallery, a custom upload, or a one-click mirror of the Locker image. A live crop adjuster (pan/zoom) locked to each tab's aspect frames the pick; the original source + normalized crop rect are persisted so reopening restores the exact framing and can reveal area cropped outside the baked frame.

## Latest fix

The **Background** tab no longer overlays a hero-name label on the cropper preview. The hero-detail page draws the name logo as its own layer over the backdrop (`LockerHero.tsx`), never baked into the backdrop image, so previewing a name on the image you're framing was misleading.

## Test plan

- Open a skin's image picker from the Locker; set images on all three tabs from gallery + custom upload.
- Confirm the Background tab preview shows no hero-name overlay; the Locker image tab still previews + hides the name.
- Reopen the picker and confirm the last crop is restored per surface.