### PR TITLE
feat(appearance): unified launcher & sidebar art (dual-use launch button, drop-zone crop editor, real-surface previews)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -82,6 +82,7 @@ import './ipc/abilityColors';
 import './ipc/trippyEffects';
 import './ipc/locker';
 import './ipc/lockerModImages';
+import './ipc/appearanceImages';
 import './ipc/previewCache';
 import './ipc/discord';
 import './ipc/saltIngest';

--- a/electron/main/ipc/appearanceImages.ts
+++ b/electron/main/ipc/appearanceImages.ts
@@ -1,0 +1,46 @@
+import { ipcMain } from 'electron';
+import {
+    getAppearanceImages,
+    setAppearanceImage,
+    removeAppearanceImage,
+    setAppearanceImageEdit,
+    getAppearanceImageEdit,
+} from '../services/appearanceImages';
+import type { AppearanceSurface } from '../../../src/types/mod';
+import type { CropRect } from '../services/lockerModImages';
+
+// Custom launcher / sidebar background images (issue: unify launcher backgrounds).
+// Display-only overrides for four Sidebar surfaces; no game/VPK involvement.
+// See the service for storage layout.
+
+ipcMain.handle(
+    'get-appearance-images',
+    (): Promise<Partial<Record<AppearanceSurface, string>>> => {
+        return getAppearanceImages();
+    }
+);
+
+ipcMain.handle(
+    'set-appearance-image',
+    (_, surface: AppearanceSurface, source: string): Promise<string> => {
+        return setAppearanceImage(surface, source);
+    }
+);
+
+ipcMain.handle('remove-appearance-image', (_, surface: AppearanceSurface): Promise<void> => {
+    return removeAppearanceImage(surface);
+});
+
+ipcMain.handle(
+    'set-appearance-image-edit',
+    (_, surface: AppearanceSurface, source: string, crop: CropRect): Promise<void> => {
+        return setAppearanceImageEdit(surface, source, crop);
+    }
+);
+
+ipcMain.handle(
+    'get-appearance-image-edit',
+    (_, surface: AppearanceSurface): Promise<{ source: string; crop: CropRect } | null> => {
+        return getAppearanceImageEdit(surface);
+    }
+);

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,6 +1,6 @@
 import { ipcMain, shell } from 'electron';
 import { promises as fs, existsSync } from 'fs';
-import { extname, basename } from 'path';
+import { extname, basename, join, resolve, sep } from 'path';
 import { loadSettings, saveSettings, getActiveDeadlockPath } from '../services/settings';
 import {
     scanMods,
@@ -829,6 +829,29 @@ ipcMain.handle('read-image-data-url', async (_, imagePath: string): Promise<stri
         throw new Error('Image file not found');
     }
     return readImageAsDataUrl(imagePath);
+});
+
+// read-renderer-asset
+// Reads a BUNDLED renderer asset (e.g. built-in launcher art, a hero render) as a
+// data URL. The Appearance crop editor needs the bytes to bake/frame a built-in
+// image, but a packaged renderer is served from file:// where fetch() of a file://
+// asset is blocked and a file:// <img> taints the canvas. Main reads it instead.
+// Confined to the renderer output dir, traversal guarded.
+const RENDERER_ASSET_ROOT = resolve(join(__dirname, '../renderer'));
+ipcMain.handle('read-renderer-asset', async (_, relPath: string): Promise<string> => {
+    if (typeof relPath !== 'string' || !relPath) {
+        throw new Error('Invalid asset path');
+    }
+    // Drop any query/hash, then strip leading ./ or / so it resolves under the root.
+    const clean = relPath.split(/[?#]/)[0].replace(/^[./]+/, '');
+    const resolved = resolve(RENDERER_ASSET_ROOT, clean);
+    if (resolved !== RENDERER_ASSET_ROOT && !resolved.startsWith(RENDERER_ASSET_ROOT + sep)) {
+        throw new Error('Asset path escapes the renderer root');
+    }
+    if (!existsSync(resolved)) {
+        throw new Error('Asset not found');
+    }
+    return readImageAsDataUrl(resolved);
 });
 
 // import-custom-mod

--- a/electron/main/services/appearanceImages.ts
+++ b/electron/main/services/appearanceImages.ts
@@ -1,0 +1,234 @@
+/**
+ * Custom launcher / sidebar background images (issue: unify launcher backgrounds).
+ *
+ * The user can give any of four Sidebar surfaces (the Launch Modded button, the
+ * Launch Vanilla button, the active-tab highlight, and the preview-volume popup)
+ * a custom uploaded image instead of the built-in art or a hero render. This
+ * service owns those uploads: it stores the bytes locally so the app stays
+ * offline-capable and hands them back as base64 data URLs (CSP already allows
+ * `data:` in img-src).
+ *
+ * The *choice* per surface (default / hero / custom / none) lives in AppSettings
+ * (`appearanceBackgrounds`); this service only stores the custom image bytes.
+ *
+ * Layout: userData/appearance-backgrounds/<surface>.<ext>      (baked override)
+ *         userData/appearance-backgrounds/sources/<surface>.<ext> + meta.json
+ *                                                              (original + crop)
+ *
+ * The crop editor bakes the framed image client-side; we store that as the baked
+ * override AND keep the original source + a normalized crop rect so the editor can
+ * be reopened on the exact framing. This mirrors lockerModImages.ts, but keyed by
+ * the four fixed surface ids instead of per-skin keys (so it's a sibling, not a
+ * fourth Locker variant).
+ */
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { join, extname, basename } from 'path';
+import { app } from 'electron';
+import type { AppearanceSurface } from '../../../src/types/mod';
+import type { CropRect } from './lockerModImages';
+
+const MIME_BY_EXT: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+};
+
+const EXT_BY_MIME: Record<string, string> = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+};
+
+/** The four valid surface ids, guarded so a malformed renderer call can never
+ *  write outside the expected filenames. */
+const SURFACES: readonly AppearanceSurface[] = [
+    'launchModded',
+    'launchVanilla',
+    'activeTab',
+    'volume',
+];
+
+function isSurface(value: string): value is AppearanceSurface {
+    return (SURFACES as readonly string[]).includes(value);
+}
+
+function rootDir(): string {
+    return join(app.getPath('userData'), 'appearance-backgrounds');
+}
+
+function sourcesDir(): string {
+    return join(rootDir(), 'sources');
+}
+
+function metaPath(): string {
+    return join(rootDir(), 'meta.json');
+}
+
+async function ensureDir(dir: string): Promise<void> {
+    await fs.mkdir(dir, { recursive: true });
+}
+
+async function readAsDataUrl(filePath: string): Promise<string> {
+    const mime = MIME_BY_EXT[extname(filePath).toLowerCase()];
+    if (!mime) throw new Error(`Unsupported image type: ${extname(filePath)}`);
+    const buf = await fs.readFile(filePath);
+    return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+/** Decode a `data:<mime>;base64,...` URL into bytes + a file extension. */
+function decodeDataUrl(source: string): { buf: Buffer; ext: string } {
+    const match = /^data:([^;,]+)(;base64)?,(.*)$/s.exec(source);
+    if (!match) throw new Error('Malformed data URL');
+    const mime = match[1].toLowerCase();
+    const ext = EXT_BY_MIME[mime];
+    if (!ext) throw new Error(`Unsupported image type: ${mime}`);
+    const buf = match[2]
+        ? Buffer.from(match[3], 'base64')
+        : Buffer.from(decodeURIComponent(match[3]), 'utf8');
+    return { buf, ext };
+}
+
+/** Resolve `source` (a `data:` URL) into bytes + a file extension. The renderer
+ *  always supplies a data URL here (file picks are read via readImageDataUrl, the
+ *  crop editor bakes a data URL), so remote fetching is intentionally not needed. */
+function resolveImageBytes(source: string): { buf: Buffer; ext: string } {
+    if (!source) throw new Error('Missing image source');
+    if (source.startsWith('data:')) return decodeDataUrl(source);
+    throw new Error('Unsupported image source');
+}
+
+/** Delete any stored image for `stem` (any extension) directly under `dir`. */
+async function clearKey(dir: string, stem: string): Promise<void> {
+    let entries: string[] = [];
+    try {
+        entries = await fs.readdir(dir);
+    } catch {
+        return;
+    }
+    await Promise.all(
+        entries
+            .filter(
+                (name) =>
+                    name !== 'sources' &&
+                    MIME_BY_EXT[extname(name).toLowerCase()] &&
+                    basename(name, extname(name)) === stem
+            )
+            .map((name) => fs.rm(join(dir, name), { force: true }))
+    );
+}
+
+type FlagsFile = Partial<Record<AppearanceSurface, { crop?: CropRect }>>;
+
+async function readFlags(): Promise<FlagsFile> {
+    try {
+        const raw = await fs.readFile(metaPath(), 'utf8');
+        const parsed: unknown = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? (parsed as FlagsFile) : {};
+    } catch {
+        return {};
+    }
+}
+
+async function writeFlags(flags: FlagsFile): Promise<void> {
+    await ensureDir(rootDir());
+    await fs.writeFile(metaPath(), JSON.stringify(flags), 'utf8');
+}
+
+/** All stored baked overrides as { surface -> data URL }. */
+export async function getAppearanceImages(): Promise<Partial<Record<AppearanceSurface, string>>> {
+    const dir = rootDir();
+    if (!existsSync(dir)) return {};
+    const entries = await fs.readdir(dir);
+    const out: Partial<Record<AppearanceSurface, string>> = {};
+    for (const name of entries) {
+        const ext = extname(name).toLowerCase();
+        if (!MIME_BY_EXT[ext]) continue;
+        const stem = basename(name, ext);
+        if (!isSurface(stem)) continue;
+        try {
+            out[stem] = await readAsDataUrl(join(dir, name));
+        } catch {
+            // unreadable file; leave the surface without a custom override
+        }
+    }
+    return out;
+}
+
+/** Store `source` (a `data:` URL) as the baked override for `surface`, replacing
+ *  any existing one. Returns the new data URL. */
+export async function setAppearanceImage(
+    surface: AppearanceSurface,
+    source: string
+): Promise<string> {
+    if (!isSurface(surface)) throw new Error(`Unknown appearance surface: ${surface}`);
+    const { buf, ext } = resolveImageBytes(source);
+    const dir = rootDir();
+    await ensureDir(dir);
+    await clearKey(dir, surface);
+    const dest = join(dir, `${surface}${ext}`);
+    await fs.writeFile(dest, buf);
+    return readAsDataUrl(dest);
+}
+
+/** Remove the baked override, the stored original source, and the crop rect for
+ *  `surface` (called when the surface switches away from `custom`). */
+export async function removeAppearanceImage(surface: AppearanceSurface): Promise<void> {
+    if (!isSurface(surface)) return;
+    await clearKey(rootDir(), surface);
+    await clearKey(sourcesDir(), surface);
+    const flags = await readFlags();
+    if (flags[surface]) {
+        delete flags[surface];
+        await writeFlags(flags);
+    }
+}
+
+/** Persist the editable state for `surface`: the ORIGINAL source bytes (under
+ *  `sources/`) plus a normalized crop rect (in meta.json), so the crop editor can
+ *  reopen on the exact framing. Independent of the baked-override write. */
+export async function setAppearanceImageEdit(
+    surface: AppearanceSurface,
+    source: string,
+    crop: CropRect
+): Promise<void> {
+    if (!isSurface(surface)) throw new Error(`Unknown appearance surface: ${surface}`);
+    const { buf, ext } = resolveImageBytes(source);
+    const sub = sourcesDir();
+    await ensureDir(sub);
+    await clearKey(sub, surface);
+    await fs.writeFile(join(sub, `${surface}${ext}`), buf);
+    const flags = await readFlags();
+    flags[surface] = { crop };
+    await writeFlags(flags);
+}
+
+/** Read back the editable state for `surface` (original source data URL + crop
+ *  rect), or null if either piece is missing. */
+export async function getAppearanceImageEdit(
+    surface: AppearanceSurface
+): Promise<{ source: string; crop: CropRect } | null> {
+    if (!isSurface(surface)) return null;
+    const sub = sourcesDir();
+    let entries: string[] = [];
+    try {
+        entries = await fs.readdir(sub);
+    } catch {
+        return null;
+    }
+    const match = entries.find(
+        (name) => MIME_BY_EXT[extname(name).toLowerCase()] && basename(name, extname(name)) === surface
+    );
+    if (!match) return null;
+    const crop = (await readFlags())[surface]?.crop;
+    if (!crop) return null;
+    try {
+        const source = await readAsDataUrl(join(sub, match));
+        return { source, crop };
+    } catch {
+        return null;
+    }
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -229,6 +229,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('read-glb-file', glbPath),
     readImageDataUrl: (imagePath: string) =>
         ipcRenderer.invoke('read-image-data-url', imagePath),
+    readRendererAsset: (relPath: string) =>
+        ipcRenderer.invoke('read-renderer-asset', relPath),
     getLockerModImages: () => ipcRenderer.invoke('get-locker-mod-images'),
     setLockerModImage: (skinKey: string, source: string) =>
         ipcRenderer.invoke('set-locker-mod-image', skinKey, source),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -55,6 +55,7 @@ import type {
     LockerImageVariant,
     CropRect,
 } from '../../src/types/electron';
+import type { AppearanceSurface } from '../../src/types/mod';
 import type { DeadworksConnectProgress } from '../../src/types/deadworks';
 import type {
     ProfileSort,
@@ -262,6 +263,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
         source: string,
         crop: CropRect
     ) => ipcRenderer.invoke('set-locker-mod-image-edit', variant, skinKey, source, crop),
+    getAppearanceImages: () => ipcRenderer.invoke('get-appearance-images'),
+    setAppearanceImage: (surface: AppearanceSurface, source: string) =>
+        ipcRenderer.invoke('set-appearance-image', surface, source),
+    removeAppearanceImage: (surface: AppearanceSurface) =>
+        ipcRenderer.invoke('remove-appearance-image', surface),
+    setAppearanceImageEdit: (surface: AppearanceSurface, source: string, crop: CropRect) =>
+        ipcRenderer.invoke('set-appearance-image-edit', surface, source, crop),
+    getAppearanceImageEdit: (surface: AppearanceSurface) =>
+        ipcRenderer.invoke('get-appearance-image-edit', surface),
     mergeMods: (args: MergeModsArgs) => ipcRenderer.invoke('merge-mods', args),
     unmergeMod: (mergedModId: string) => ipcRenderer.invoke('unmerge-mod', mergedModId),
     extractMergeSource: (mergedModId: string, sourceFileName: string) =>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -41,9 +41,11 @@ export default function Layout() {
   // even when the user has picked a different accent.
   const accentColor = useAppStore((s) => s.settings?.accentColor);
   const loadStoreSettings = useAppStore((s) => s.loadSettings);
+  const loadAppearanceImages = useAppStore((s) => s.loadAppearanceImages);
   useEffect(() => {
     loadStoreSettings();
-  }, [loadStoreSettings]);
+    loadAppearanceImages();
+  }, [loadStoreSettings, loadAppearanceImages]);
   useEffect(() => {
     applyAccentColor(accentColor);
   }, [accentColor]);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -177,9 +177,11 @@ function LaunchButtonBackdrop({
 }
 
 /** Render a launch-button / volume-popup backdrop from its resolved descriptor
- *  (issue: unify launcher backgrounds). `none` -> no art; `hero` -> a hero render
- *  with the shared face crop; `custom` -> the user's uploaded image (falling back
- *  to the built-in art if its bytes are missing); `default` -> the built-in art. */
+ *  (issue: unify launcher backgrounds). `none` -> no art. Otherwise, if the user
+ *  framed this surface, a baked image (`customSrc`) is stored for ANY kind and is
+ *  rendered centered (the framing is baked in). With no baked image we fall back
+ *  to the live source: `hero` -> a hero render with the shared face crop; anything
+ *  else -> the built-in art (this also covers legacy installs that never framed). */
 function SurfaceBackdrop({
   bg,
   defaultSrc,
@@ -194,6 +196,10 @@ function SurfaceBackdrop({
   customSrc?: string;
 }) {
   if (bg.kind === 'none') return null;
+  // A framed surface bakes its crop into customSrc, regardless of source kind.
+  if (customSrc) {
+    return <LaunchButtonBackdrop src={customSrc} position="center" warm={warm} />;
+  }
   if (bg.kind === 'hero') {
     const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
     return (
@@ -203,9 +209,6 @@ function SurfaceBackdrop({
         warm={warm}
       />
     );
-  }
-  if (bg.kind === 'custom' && customSrc) {
-    return <LaunchButtonBackdrop src={customSrc} position="center" warm={warm} />;
   }
   return <LaunchButtonBackdrop src={defaultSrc} position={defaultPosition} warm={warm} />;
 }
@@ -335,17 +338,15 @@ export default function Sidebar() {
   const launchVanillaBg = resolveAppearanceBg(settings, 'launchVanilla');
   const volumeBg = resolveAppearanceBg(settings, 'volume');
   const activeTabBg = resolveAppearanceBg(settings, 'activeTab');
-  // The active-tab highlight only ever paints an image (hero/custom) or the plain
-  // accent glow (default/none). A truthy src drives the image styling; null keeps
-  // today's accent-border active state.
+  // The active-tab highlight either paints an image (a framed/baked surface, or a
+  // live hero render) or the plain accent glow (default). A baked image wins for
+  // any kind; otherwise a hero render; otherwise null keeps the accent-border state.
+  const activeTabBaked = appearanceImages.activeTab ?? null;
   const sidebarHeroHighlightSrc =
-    activeTabBg.kind === 'hero'
-      ? getHeroRenderPath(activeTabBg.hero ?? DEFAULT_SIDEBAR_HERO)
-      : activeTabBg.kind === 'custom'
-        ? appearanceImages.activeTab ?? null
-        : null;
+    activeTabBaked ??
+    (activeTabBg.kind === 'hero' ? getHeroRenderPath(activeTabBg.hero ?? DEFAULT_SIDEBAR_HERO) : null);
   const sidebarHeroImageStyle: CSSProperties =
-    activeTabBg.kind === 'hero'
+    !activeTabBaked && activeTabBg.kind === 'hero'
       ? getSidebarHeroImageStyle(activeTabBg.hero ?? DEFAULT_SIDEBAR_HERO)
       : { objectPosition: 'center' };
   const settingsActive = location.pathname.startsWith('/settings');

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -43,10 +43,10 @@ import {
 import { getAssetPath } from '../lib/assetPath';
 import { rollMemeTooltip } from '../lib/easterEggs';
 import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath, resolveAppearanceBg } from '../lib/lockerUtils';
-import type { AppearanceBg } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
 import Tx from './translation/Tx';
+import { SidebarActiveBackdrop, SurfaceBackdrop } from './sidebar/surfaceArt';
 
 const COLLAPSED_KEY = 'grimoire:sidebar-collapsed';
 const LAUNCH_MODE_KEY = 'grimoire:launch-mode';
@@ -118,110 +118,6 @@ function GrimoireTitleIcon() {
       className="h-6 w-6 flex-shrink-0 opacity-90"
     />
   );
-}
-
-function SidebarActiveBackdrop({
-  heroSrc,
-  heroImageStyle,
-}: {
-  heroSrc: string | null;
-  heroImageStyle: CSSProperties;
-}) {
-  if (heroSrc) {
-    return (
-      <span aria-hidden className="sidebar-active-backdrop pointer-events-none absolute inset-0">
-        <img
-          src={heroSrc}
-          alt=""
-          className="sidebar-active-backdrop__image h-full w-full object-cover opacity-75"
-          style={heroImageStyle}
-        />
-        <span className="absolute inset-0 bg-gradient-to-r from-bg-primary/90 via-bg-primary/55 to-bg-primary/20" />
-        <span className="absolute inset-0 bg-black/20" />
-      </span>
-    );
-  }
-
-  return (
-    <span
-      aria-hidden
-      className="sidebar-active-backdrop pointer-events-none absolute inset-0 bg-accent/10"
-    >
-      <span className="absolute inset-0 bg-gradient-to-r from-accent/20 via-accent/8 to-transparent" />
-    </span>
-  );
-}
-
-function LaunchButtonBackdrop({
-  src,
-  position = 'center',
-  warm = false,
-  imageStyle,
-}: {
-  src: string;
-  position?: string;
-  warm?: boolean;
-  /** Full object-position/margin override (used for hero renders, which need the
-   *  shared face-crop framing). Takes precedence over `position`. */
-  imageStyle?: CSSProperties;
-}) {
-  return (
-    <span aria-hidden className="pointer-events-none absolute inset-0">
-      <img
-        src={src}
-        alt=""
-        className={`h-full w-full object-cover opacity-65 transition-transform duration-300 group-hover:scale-[1.04] ${
-          warm ? 'saturate-[0.95]' : 'saturate-[1.05]'
-        }`}
-        style={imageStyle ?? { objectPosition: position }}
-      />
-      <span
-        className={`absolute inset-0 ${
-          warm
-            ? 'bg-gradient-to-r from-bg-primary/85 via-bg-primary/55 to-amber-950/25'
-            : 'bg-gradient-to-r from-bg-primary/82 via-bg-primary/50 to-emerald-950/20'
-        }`}
-      />
-      <span className="absolute inset-0 bg-black/20" />
-    </span>
-  );
-}
-
-/** Render a launch-button / volume-popup backdrop from its resolved descriptor
- *  (issue: unify launcher backgrounds). `none` -> no art. Otherwise, if the user
- *  framed this surface, a baked image (`customSrc`) is stored for ANY kind and is
- *  rendered centered (the framing is baked in). With no baked image we fall back
- *  to the live source: `hero` -> a hero render with the shared face crop; anything
- *  else -> the built-in art (this also covers legacy installs that never framed). */
-function SurfaceBackdrop({
-  bg,
-  defaultSrc,
-  defaultPosition = 'center',
-  warm = false,
-  customSrc,
-}: {
-  bg: AppearanceBg;
-  defaultSrc: string;
-  defaultPosition?: string;
-  warm?: boolean;
-  customSrc?: string;
-}) {
-  if (bg.kind === 'none') return null;
-  // A framed surface bakes its crop into customSrc, regardless of source kind.
-  if (customSrc) {
-    return <LaunchButtonBackdrop src={customSrc} position="center" warm={warm} />;
-  }
-  if (bg.kind === 'hero') {
-    const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
-    return (
-      <LaunchButtonBackdrop
-        src={getHeroRenderPath(hero)}
-        imageStyle={getSidebarHeroImageStyle(hero)}
-        warm={warm}
-      />
-    );
-  }
-  return <LaunchButtonBackdrop src={defaultSrc} position={defaultPosition} warm={warm} />;
 }
 
 export default function Sidebar() {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Settings2,
   AlertTriangle,
   ArrowRight,
+  ArrowRightLeft,
   Download,
   Play,
   Wand2,
@@ -48,6 +49,7 @@ import UpdateModal from './UpdateModal';
 import Tx from './translation/Tx';
 
 const COLLAPSED_KEY = 'grimoire:sidebar-collapsed';
+const LAUNCH_MODE_KEY = 'grimoire:launch-mode';
 const LABEL_TRANSITION_MS = 180;
 const DISCOVER_LAST_SEEN_KEY = 'grimoire:discover:last-seen-created-at';
 const DISCOVER_BADGE_POLL_MS = 2 * 60 * 1000;
@@ -60,6 +62,15 @@ const PREVIEW_VOLUME_BG = getAssetPath('/sidebar/preview-volume-bg.jpg');
 function readCollapsedPreference(): boolean {
   if (typeof window === 'undefined') return false;
   return localStorage.getItem(COLLAPSED_KEY) === '1';
+}
+
+// Which mode the single dual-use launch button fires (issue: unify launch
+// buttons). Persisted like the collapse preference; defaults to modded.
+type LaunchMode = 'modded' | 'vanilla';
+
+function readLaunchModePreference(): LaunchMode {
+  if (typeof window === 'undefined') return 'modded';
+  return localStorage.getItem(LAUNCH_MODE_KEY) === 'vanilla' ? 'vanilla' : 'modded';
 }
 
 function readDiscoverLastSeen(): number | null {
@@ -233,6 +244,7 @@ export default function Sidebar() {
 
   const [stashStatus, setStashStatus] = useState<VanillaStashStatus>({ active: false });
   const [launchPending, setLaunchPending] = useState<'modded' | 'vanilla' | null>(null);
+  const [launchMode, setLaunchMode] = useState<LaunchMode>(readLaunchModePreference);
   const [gameRunning, setGameRunning] = useState(false);
   const [stopPending, setStopPending] = useState(false);
   const [restorePending, setRestorePending] = useState(false);
@@ -800,6 +812,60 @@ export default function Sidebar() {
 
   const canLaunch = !!settings?.deadlockPath || !!settings?.devDeadlockPath;
 
+  // Single dual-use launch button (issue: unify launch buttons): one persisted
+  // mode drives the icon, label, art, handler, and enable/disable rules. The
+  // trailing swap control and right-click both flip between Modded and Vanilla.
+  const swapLaunchMode = useCallback(() => {
+    setLaunchMode((prev) => {
+      const next = prev === 'modded' ? 'vanilla' : 'modded';
+      try {
+        localStorage.setItem(LAUNCH_MODE_KEY, next);
+      } catch {
+        /* quota / private mode */
+      }
+      return next;
+    });
+  }, []);
+
+  const isModdedLaunch = launchMode === 'modded';
+  const LaunchIcon = isModdedLaunch ? Wand2 : Play;
+  const launchConfig = isModdedLaunch
+    ? {
+        onLaunch: handleLaunchModded,
+        labelKey: 'sidebar.launchModded',
+        bg: launchModdedBg,
+        defaultSrc: LAUNCH_MODDED_BG,
+        defaultPosition: 'center 45%',
+        warm: false,
+        customSrc: appearanceImages.launchModded,
+        // Modded is always available; it auto-restores a stash on the way in.
+        disabled: !canLaunch || !!launchPending || stopPending,
+        title: !canLaunch
+          ? t('sidebar.launch.noPath')
+          : stashStatus.active
+            ? t('sidebar.launch.moddedStash')
+            : t('sidebar.launch.moddedDefault'),
+        switchTitle: t('sidebar.launch.switchToVanilla'),
+      }
+    : {
+        onLaunch: handleLaunchVanilla,
+        labelKey: 'sidebar.launchVanilla',
+        bg: launchVanillaBg,
+        defaultSrc: LAUNCH_VANILLA_BG,
+        defaultPosition: 'center 48%',
+        warm: true,
+        customSrc: appearanceImages.launchVanilla,
+        // Vanilla is disabled while a stash is already active (restore first; the
+        // banner above explains it). Right-click can still swap back to Modded.
+        disabled: !canLaunch || !!launchPending || stopPending || stashStatus.active,
+        title: !canLaunch
+          ? t('sidebar.launch.noPath')
+          : stashStatus.active
+            ? t('sidebar.launch.vanillaStash')
+            : t('sidebar.launch.vanillaDefault'),
+        switchTitle: t('sidebar.launch.switchToModded'),
+      };
+
   return (
     <aside
       ref={asideRef}
@@ -1100,63 +1166,69 @@ export default function Sidebar() {
               )}
             </button>
           ) : (
-            <>
-          <button
-            onClick={handleLaunchModded}
-            disabled={!canLaunch || !!launchPending || stopPending}
-            title={
-              !canLaunch
-                ? t('sidebar.launch.noPath')
-                : stashStatus.active
-                  ? t('sidebar.launch.moddedStash')
-                  : t('sidebar.launch.moddedDefault')
-            }
-            className="group relative flex w-full h-10 items-center overflow-hidden rounded-sm bg-bg-tertiary text-text-primary ring-1 ring-white/10 hover:ring-white/25 text-sm font-semibold tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-white/35 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <SurfaceBackdrop bg={launchModdedBg} defaultSrc={LAUNCH_MODDED_BG} defaultPosition="center 45%" customSrc={appearanceImages.launchModded} />
-            <span className={`relative z-10 ${actionIconClass}`}>
-              {launchPending === 'modded' ? (
-                <Loader2 className="w-[18px] h-[18px] animate-spin" />
-              ) : (
-                <Wand2 className="w-[18px] h-[18px]" strokeWidth={2} />
-              )}
-            </span>
-            {labelMounted && (
-              <span className={`relative z-10 drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${actionLabelClass}`} aria-hidden={!labelsVisible}>
-                {t('sidebar.launchModded')}
-              </span>
-            )}
-          </button>
+            <div
+              className="group/launch relative"
+              onContextMenu={(e) => {
+                e.preventDefault();
+                if (launchPending || stopPending) return;
+                swapLaunchMode();
+              }}
+            >
+              <button
+                onClick={launchConfig.onLaunch}
+                disabled={launchConfig.disabled}
+                title={launchConfig.title}
+                className="group relative flex w-full h-10 items-center overflow-hidden rounded-sm bg-bg-tertiary text-text-primary ring-1 ring-white/10 hover:ring-white/25 text-sm font-semibold tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-white/35 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <SurfaceBackdrop
+                  bg={launchConfig.bg}
+                  defaultSrc={launchConfig.defaultSrc}
+                  defaultPosition={launchConfig.defaultPosition}
+                  warm={launchConfig.warm}
+                  customSrc={launchConfig.customSrc}
+                />
+                <span className={`relative z-10 ${actionIconClass}`}>
+                  {launchPending ? (
+                    <Loader2 className="w-[18px] h-[18px] animate-spin" />
+                  ) : (
+                    <LaunchIcon className="w-[18px] h-[18px]" strokeWidth={2} />
+                  )}
+                </span>
+                {labelMounted && (
+                  <span
+                    className={`relative z-10 drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${actionLabelClass}`}
+                    aria-hidden={!labelsVisible}
+                  >
+                    {t(launchConfig.labelKey)}
+                  </span>
+                )}
+              </button>
 
-          <button
-            onClick={handleLaunchVanilla}
-            disabled={!canLaunch || !!launchPending || stopPending || stashStatus.active}
-            title={
-              !canLaunch
-                ? t('sidebar.launch.noPath')
-                : stashStatus.active
-                  ? t('sidebar.launch.vanillaStash')
-                  : t('sidebar.launch.vanillaDefault')
-            }
-            className={`group relative flex w-full h-8 items-center overflow-hidden rounded-sm text-text-primary/85 ring-1 ring-white/10 hover:text-text-primary hover:ring-amber-400/35 text-xs font-medium tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-accent/40 disabled:opacity-60 disabled:cursor-not-allowed ${
-              launchVanillaBg.kind === 'none' ? 'bg-bg-tertiary' : ''
-            }`}
-          >
-            <SurfaceBackdrop bg={launchVanillaBg} defaultSrc={LAUNCH_VANILLA_BG} defaultPosition="center 48%" warm customSrc={appearanceImages.launchVanilla} />
-            <span className={`relative z-10 ${actionIconClass}`}>
-              {launchPending === 'vanilla' ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+              {/* Swap affordance (issue: unify launch buttons). Expanded: a faint
+                  trailing icon that brightens on hover and flips the mode WITHOUT
+                  launching (it sits in its own zone, so it never eats a launch
+                  click). Collapsed: a hover-only hint glyph; the swap itself is the
+                  wrapper's right-click. Right-click anywhere always swaps. */}
+              {labelMounted ? (
+                <button
+                  type="button"
+                  onClick={swapLaunchMode}
+                  disabled={!!launchPending || stopPending}
+                  title={launchConfig.switchTitle}
+                  aria-label={launchConfig.switchTitle}
+                  className="absolute right-1.5 top-1/2 z-20 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-sm text-text-primary/45 opacity-70 drop-shadow-[0_1px_3px_rgba(0,0,0,0.85)] transition-all duration-200 hover:bg-black/30 hover:text-text-primary hover:opacity-100 group-hover/launch:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 disabled:cursor-not-allowed disabled:opacity-30 cursor-pointer"
+                >
+                  <ArrowRightLeft className="h-3.5 w-3.5" />
+                </button>
               ) : (
-                <Play className="w-4 h-4" strokeWidth={2} />
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute right-0.5 top-0.5 z-20 text-text-primary/0 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)] transition-colors duration-200 group-hover/launch:text-text-primary/70"
+                >
+                  <ArrowRightLeft className="h-3 w-3" />
+                </span>
               )}
-            </span>
-            {labelMounted && (
-              <span className={`relative z-10 drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${actionLabelClass}`} aria-hidden={!labelsVisible}>
-                {t('sidebar.launchVanilla')}
-              </span>
-            )}
-          </button>
-            </>
+            </div>
           )}
         </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -245,6 +245,10 @@ export default function Sidebar() {
     action?: { label: string; onClick: () => void | Promise<void> };
   } | null>(null);
   const [updateModalOpen, setUpdateModalOpen] = useState(false);
+  // One-shot "spin into place" for the Settings gear on click. Cleared on
+  // animationend so a re-click can restart it. Hover does a lighter rotate via
+  // CSS; this is the punchier nav-commit flourish.
+  const [gearSpinning, setGearSpinning] = useState(false);
 
   // Persisted via localStorage so it survives reloads without round-tripping
   // through the main-process settings file. This is pure UI state.
@@ -256,10 +260,18 @@ export default function Sidebar() {
   const collapseTimerRef = useRef<number | null>(null);
   const previewVolumeHideTimerRef = useRef<number | null>(null);
   const labelFrameRef = useRef<number | null>(null);
+  const asideRef = useRef<HTMLElement | null>(null);
+  const navScrollRef = useRef<HTMLElement | null>(null);
   const navListRef = useRef<HTMLUListElement | null>(null);
   const navItemRefs = useRef<Array<HTMLLIElement | null>>([]);
+  const settingsItemRef = useRef<HTMLButtonElement | null>(null);
+  // Measured relative to the <aside> (not the nav list) so the single sliding
+  // highlight can travel between a nav tab and the footer Settings button, which
+  // live in different containers with different padding. Hence left/width too.
   const [activeNavMetrics, setActiveNavMetrics] = useState<{
     top: number;
+    left: number;
+    width: number;
     height: number;
   } | null>(null);
 
@@ -602,44 +614,93 @@ export default function Sidebar() {
   );
   const activeNavTone = activeNavIndex >= 0 ? navItems[activeNavIndex]?.tone : undefined;
 
-  const measureActiveNavItem = useCallback(() => {
-    const list = navListRef.current;
-    const item = activeNavIndex >= 0 ? navItemRefs.current[activeNavIndex] : null;
+  // The active target is either the highlighted nav tab or, when on /settings,
+  // the footer Settings button. We measure it against the <aside> so one indicator
+  // can slide across both regions (offsetTop won't work: they have different
+  // offset parents). getBoundingClientRect deltas give aside-relative box coords.
+  const activeTargetEl = (): HTMLElement | null =>
+    settingsActive
+      ? settingsItemRef.current
+      : activeNavIndex >= 0
+        ? navItemRefs.current[activeNavIndex]
+        : null;
 
-    if (!list || !item) {
+  const measureActiveTarget = useCallback(() => {
+    const aside = asideRef.current;
+    const el = activeTargetEl();
+
+    if (!aside || !el) {
       setActiveNavMetrics(null);
       return;
     }
 
+    const asideRect = aside.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
     const next = {
-      top: item.offsetTop,
-      height: item.offsetHeight,
+      top: elRect.top - asideRect.top,
+      left: elRect.left - asideRect.left,
+      width: elRect.width,
+      height: elRect.height,
     };
 
     setActiveNavMetrics((prev) =>
-      prev && prev.top === next.top && prev.height === next.height ? prev : next
+      prev &&
+      prev.top === next.top &&
+      prev.left === next.left &&
+      prev.width === next.width &&
+      prev.height === next.height
+        ? prev
+        : next
     );
-  }, [activeNavIndex]);
+    // activeTargetEl is read fresh each call; deps cover what selects it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNavIndex, settingsActive]);
 
   useLayoutEffect(() => {
-    measureActiveNavItem();
-  }, [measureActiveNavItem, navItems.length, collapsed]);
+    measureActiveTarget();
+  }, [measureActiveTarget, navItems.length, collapsed]);
+
+  // Enable the glide transition only briefly around an active-target change, so
+  // selecting a tab/settings animates the highlight, while nav-list scrolling
+  // (same target, new position) tracks instantly with no trailing ease.
+  const [indicatorSliding, setIndicatorSliding] = useState(false);
+  const slideTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    setIndicatorSliding(true);
+    if (slideTimerRef.current !== null) window.clearTimeout(slideTimerRef.current);
+    slideTimerRef.current = window.setTimeout(() => {
+      setIndicatorSliding(false);
+      slideTimerRef.current = null;
+    }, 300);
+    return () => {
+      if (slideTimerRef.current !== null) {
+        window.clearTimeout(slideTimerRef.current);
+        slideTimerRef.current = null;
+      }
+    };
+  }, [activeNavIndex, settingsActive]);
 
   useEffect(() => {
-    const list = navListRef.current;
-    const item = activeNavIndex >= 0 ? navItemRefs.current[activeNavIndex] : null;
-    if (!list || !item || typeof ResizeObserver === 'undefined') return;
+    const aside = asideRef.current;
+    const el = activeTargetEl();
+    if (!aside || !el || typeof ResizeObserver === 'undefined') return;
 
-    const observer = new ResizeObserver(measureActiveNavItem);
-    observer.observe(list);
-    observer.observe(item);
-    window.addEventListener('resize', measureActiveNavItem);
+    const observer = new ResizeObserver(measureActiveTarget);
+    observer.observe(aside);
+    observer.observe(el);
+    // Re-measure when the nav list scrolls: nav-tab targets shift relative to the
+    // aside (the Settings target is in the fixed footer and is unaffected).
+    const nav = navScrollRef.current;
+    nav?.addEventListener('scroll', measureActiveTarget, { passive: true });
+    window.addEventListener('resize', measureActiveTarget);
 
     return () => {
       observer.disconnect();
-      window.removeEventListener('resize', measureActiveNavItem);
+      nav?.removeEventListener('scroll', measureActiveTarget);
+      window.removeEventListener('resize', measureActiveTarget);
     };
-  }, [activeNavIndex, measureActiveNavItem]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNavIndex, settingsActive, measureActiveTarget]);
 
   const handleLaunchModded = async () => {
     if (launchPending || stopPending) return;
@@ -741,9 +802,32 @@ export default function Sidebar() {
 
   return (
     <aside
+      ref={asideRef}
       data-collapsed={collapsed}
-      className="grimoire-sidebar bg-bg-secondary border-r border-border flex flex-col h-full min-h-0 shrink-0 overflow-hidden"
+      className="grimoire-sidebar relative bg-bg-secondary border-r border-border flex flex-col h-full min-h-0 shrink-0 overflow-hidden"
     >
+      {/* Single sliding highlight, positioned against the <aside> so it can glide
+          between a nav tab and the footer Settings button. Sits at z-0 behind the
+          nav list (z-10) and the footer buttons (which paint later in the DOM), so
+          their transparent active surfaces reveal it. */}
+      {activeNavMetrics && activeNavTone !== 'test' && (
+        <div
+          aria-hidden
+          className={`sidebar-active-indicator pointer-events-none absolute left-0 top-0 z-0 overflow-hidden rounded-sm ${
+            indicatorSliding ? 'sidebar-active-indicator--sliding' : ''
+          }`}
+          style={{
+            width: activeNavMetrics.width,
+            height: activeNavMetrics.height,
+            transform: `translate3d(${activeNavMetrics.left}px, ${activeNavMetrics.top}px, 0)`,
+          }}
+        >
+          <SidebarActiveBackdrop
+            heroSrc={sidebarHeroHighlightSrc}
+            heroImageStyle={sidebarHeroImageStyle}
+          />
+        </div>
+      )}
       <div className="relative flex h-11 flex-shrink-0 items-center overflow-hidden border-b border-border px-3">
         {labelMounted && !collapsed && (
           <div
@@ -776,23 +860,8 @@ export default function Sidebar() {
         </button>
       </div>
 
-      <nav className="flex-1 min-h-0 overflow-y-auto p-2">
+      <nav ref={navScrollRef} className="flex-1 min-h-0 overflow-y-auto p-2">
         <div className="relative">
-          {activeNavIndex >= 0 && activeNavMetrics && activeNavTone !== 'test' && (
-            <div
-              aria-hidden
-              className="sidebar-active-indicator pointer-events-none absolute left-0 right-0 z-0 overflow-hidden rounded-sm"
-              style={{
-                height: activeNavMetrics.height,
-                transform: `translate3d(0, ${activeNavMetrics.top}px, 0)`,
-              }}
-            >
-              <SidebarActiveBackdrop
-                heroSrc={sidebarHeroHighlightSrc}
-                heroImageStyle={sidebarHeroImageStyle}
-              />
-            </div>
-          )}
           <ul ref={navListRef} className="relative z-10 space-y-0.5">
             {navItems.map(({ to, icon: Icon, labelKey, label, tooltip, tone, badge, badgeTone }, index) => {
               // Style from the optimistic index, not the router's isActive:
@@ -1130,8 +1199,12 @@ export default function Sidebar() {
             Always visible, including collapsed (gear only), since it's now the
             bottom rail's anchor rather than an afterthought. */}
         <button
+          ref={settingsItemRef}
           type="button"
-          onClick={() => navigate('/settings')}
+          onClick={() => {
+            setGearSpinning(true);
+            navigate('/settings');
+          }}
           title={memeTooltip?.to === '/settings' ? memeTooltip.text : t('sidebar.openSettings')}
           onMouseEnter={() => {
             const meme = rollMemeTooltip('/settings');
@@ -1142,19 +1215,17 @@ export default function Sidebar() {
           className={`group relative flex w-full h-10 items-center overflow-hidden rounded-sm border text-sm transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 ${
             settingsActive
               ? sidebarHeroHighlightSrc
-                ? 'border-white/15 bg-bg-tertiary text-text-primary font-semibold shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03)]'
-                : 'border-accent/40 bg-bg-tertiary text-text-primary font-semibold hover:border-accent/60'
-              : 'border-border bg-bg-tertiary/30 text-text-secondary hover:bg-accent/5 hover:border-accent/30 hover:text-text-primary'
+                ? 'border-white/15 bg-transparent text-text-primary font-semibold shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03)]'
+                : 'border-accent/40 bg-transparent text-text-primary font-semibold hover:border-accent/60'
+              : 'border-accent/25 bg-bg-tertiary text-text-primary/90 hover:bg-accent/10 hover:border-accent/45 hover:text-text-primary'
           }`}
         >
-          {settingsActive && (
-            <SidebarActiveBackdrop
-              heroSrc={sidebarHeroHighlightSrc}
-              heroImageStyle={sidebarHeroImageStyle}
-            />
-          )}
           <span className={`relative z-10 ${actionIconClass}`}>
-            <Settings2 className="w-[18px] h-[18px]" strokeWidth={settingsActive ? 2 : 1.75} />
+            <Settings2
+              className={`settings-gear w-[18px] h-[18px] ${gearSpinning ? 'settings-gear--spin' : ''}`}
+              strokeWidth={settingsActive ? 2 : 1.75}
+              onAnimationEnd={() => setGearSpinning(false)}
+            />
           </span>
           {labelMounted && (
             <span className={`relative z-10 font-medium ${actionLabelClass}`} aria-hidden={!labelsVisible}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,10 +24,7 @@ import {
   Square,
   Volume2,
   VolumeX,
-  Image,
-  ImageOff,
 } from 'lucide-react';
-import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from './common/menu';
 import {
   getConflicts,
   getGameRunningStatus,
@@ -44,13 +41,13 @@ import {
 
 import { getAssetPath } from '../lib/assetPath';
 import { rollMemeTooltip } from '../lib/easterEggs';
-import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath } from '../lib/lockerUtils';
+import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath, resolveAppearanceBg } from '../lib/lockerUtils';
+import type { AppearanceBg } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import UpdateModal from './UpdateModal';
 import Tx from './translation/Tx';
 
 const COLLAPSED_KEY = 'grimoire:sidebar-collapsed';
-const LAUNCH_BG_HIDDEN_KEY = 'grimoire:launch-bg-hidden';
 const LABEL_TRANSITION_MS = 180;
 const DISCOVER_LAST_SEEN_KEY = 'grimoire:discover:last-seen-created-at';
 const DISCOVER_BADGE_POLL_MS = 2 * 60 * 1000;
@@ -63,11 +60,6 @@ const PREVIEW_VOLUME_BG = getAssetPath('/sidebar/preview-volume-bg.jpg');
 function readCollapsedPreference(): boolean {
   if (typeof window === 'undefined') return false;
   return localStorage.getItem(COLLAPSED_KEY) === '1';
-}
-
-function readLaunchBgHiddenPreference(): boolean {
-  if (typeof window === 'undefined') return false;
-  return localStorage.getItem(LAUNCH_BG_HIDDEN_KEY) === '1';
 }
 
 function readDiscoverLastSeen(): number | null {
@@ -153,10 +145,14 @@ function LaunchButtonBackdrop({
   src,
   position = 'center',
   warm = false,
+  imageStyle,
 }: {
   src: string;
   position?: string;
   warm?: boolean;
+  /** Full object-position/margin override (used for hero renders, which need the
+   *  shared face-crop framing). Takes precedence over `position`. */
+  imageStyle?: CSSProperties;
 }) {
   return (
     <span aria-hidden className="pointer-events-none absolute inset-0">
@@ -166,7 +162,7 @@ function LaunchButtonBackdrop({
         className={`h-full w-full object-cover opacity-65 transition-transform duration-300 group-hover:scale-[1.04] ${
           warm ? 'saturate-[0.95]' : 'saturate-[1.05]'
         }`}
-        style={{ objectPosition: position }}
+        style={imageStyle ?? { objectPosition: position }}
       />
       <span
         className={`absolute inset-0 ${
@@ -180,6 +176,40 @@ function LaunchButtonBackdrop({
   );
 }
 
+/** Render a launch-button / volume-popup backdrop from its resolved descriptor
+ *  (issue: unify launcher backgrounds). `none` -> no art; `hero` -> a hero render
+ *  with the shared face crop; `custom` -> the user's uploaded image (falling back
+ *  to the built-in art if its bytes are missing); `default` -> the built-in art. */
+function SurfaceBackdrop({
+  bg,
+  defaultSrc,
+  defaultPosition = 'center',
+  warm = false,
+  customSrc,
+}: {
+  bg: AppearanceBg;
+  defaultSrc: string;
+  defaultPosition?: string;
+  warm?: boolean;
+  customSrc?: string;
+}) {
+  if (bg.kind === 'none') return null;
+  if (bg.kind === 'hero') {
+    const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
+    return (
+      <LaunchButtonBackdrop
+        src={getHeroRenderPath(hero)}
+        imageStyle={getSidebarHeroImageStyle(hero)}
+        warm={warm}
+      />
+    );
+  }
+  if (bg.kind === 'custom' && customSrc) {
+    return <LaunchButtonBackdrop src={customSrc} position="center" warm={warm} />;
+  }
+  return <LaunchButtonBackdrop src={defaultSrc} position={defaultPosition} warm={warm} />;
+}
+
 export default function Sidebar() {
   const { t } = useTranslation();
   const [conflictCount, setConflictCount] = useState(0);
@@ -187,6 +217,7 @@ export default function Sidebar() {
   const [appVersion, setAppVersion] = useState('');
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const settings = useAppStore((state) => state.settings);
+  const appearanceImages = useAppStore((state) => state.appearanceImages);
   const mods = useAppStore((state) => state.mods);
   const loadMods = useAppStore((state) => state.loadMods);
   const soundVolume = useAppStore((state) => state.soundVolume);
@@ -216,7 +247,6 @@ export default function Sidebar() {
   // through the main-process settings file. This is pure UI state.
   const [collapsed, setCollapsed] = useState<boolean>(readCollapsedPreference);
   const [memeTooltip, setMemeTooltip] = useState<{ to: string; text: string } | null>(null);
-  const [launchBgHidden, setLaunchBgHidden] = useState<boolean>(readLaunchBgHiddenPreference);
   const [labelsVisible, setLabelsVisible] = useState<boolean>(() => !readCollapsedPreference());
   const [labelMounted, setLabelMounted] = useState<boolean>(() => !readCollapsedPreference());
   const [showPreviewVolume, setShowPreviewVolume] = useState(false);
@@ -299,15 +329,25 @@ export default function Sidebar() {
   const navLabelClass = `flex-1 ${labelTransitionClass}`;
   const actionLabelClass = `flex-1 text-left ${labelTransitionClass}`;
   const actionIconClass = 'flex h-full w-10 flex-shrink-0 items-center justify-center';
-  const configuredSidebarHero = settings?.sidebarHeroHighlight;
-  const sidebarHeroHighlight =
-    configuredSidebarHero === null || configuredSidebarHero === ''
-      ? null
-      : configuredSidebarHero ?? DEFAULT_SIDEBAR_HERO;
-  const sidebarHeroHighlightSrc = sidebarHeroHighlight
-    ? getHeroRenderPath(sidebarHeroHighlight)
-    : null;
-  const sidebarHeroImageStyle = getSidebarHeroImageStyle(sidebarHeroHighlight);
+  // Resolve each customizable surface's background (issue: unify launcher
+  // backgrounds). resolveAppearanceBg owns the default + legacy fallback rules.
+  const launchModdedBg = resolveAppearanceBg(settings, 'launchModded');
+  const launchVanillaBg = resolveAppearanceBg(settings, 'launchVanilla');
+  const volumeBg = resolveAppearanceBg(settings, 'volume');
+  const activeTabBg = resolveAppearanceBg(settings, 'activeTab');
+  // The active-tab highlight only ever paints an image (hero/custom) or the plain
+  // accent glow (default/none). A truthy src drives the image styling; null keeps
+  // today's accent-border active state.
+  const sidebarHeroHighlightSrc =
+    activeTabBg.kind === 'hero'
+      ? getHeroRenderPath(activeTabBg.hero ?? DEFAULT_SIDEBAR_HERO)
+      : activeTabBg.kind === 'custom'
+        ? appearanceImages.activeTab ?? null
+        : null;
+  const sidebarHeroImageStyle: CSSProperties =
+    activeTabBg.kind === 'hero'
+      ? getSidebarHeroImageStyle(activeTabBg.hero ?? DEFAULT_SIDEBAR_HERO)
+      : { objectPosition: 'center' };
   const settingsActive = location.pathname.startsWith('/settings');
   const discoverActive = location.pathname.startsWith('/discover');
 
@@ -599,18 +639,6 @@ export default function Sidebar() {
       window.removeEventListener('resize', measureActiveNavItem);
     };
   }, [activeNavIndex, measureActiveNavItem]);
-
-  const toggleLaunchBg = () => {
-    setLaunchBgHidden((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(LAUNCH_BG_HIDDEN_KEY, next ? '1' : '0');
-      } catch {
-        /* quota / private mode */
-      }
-      return next;
-    });
-  };
 
   const handleLaunchModded = async () => {
     if (launchPending || stopPending) return;
@@ -932,12 +960,8 @@ export default function Sidebar() {
           </div>
         )}
 
-        {/* flex+gap rather than space-y: the launch context-menu trigger is a
-            display:contents span around both launch buttons, so space-y's
-            direct-child margin selector skips them while flex gap still
-            applies (they participate in the parent's layout individually).
-            gap-2 matches the footer rail's space-y-2 rhythm (launch buttons,
-            update flag, and Settings all sit 8px apart). */}
+        {/* flex+gap matches the footer rail's space-y-2 rhythm: the launch
+            buttons, update flag, and Settings all sit 8px apart. */}
         <div className="flex flex-col gap-2">
           {showPreviewVolume && (collapsed ? (
             <button
@@ -947,7 +971,7 @@ export default function Sidebar() {
               aria-label={t('sidebar.previewVolume.levelLabel', { percent: Math.round(soundVolume * 100) })}
               className="group relative flex h-8 w-full items-center justify-center overflow-hidden rounded-sm border border-white/10 bg-bg-tertiary text-text-primary/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition-colors hover:border-accent/35 hover:text-text-primary cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60 animate-fade-in"
             >
-              <LaunchButtonBackdrop src={PREVIEW_VOLUME_BG} position="center 43%" />
+              <SurfaceBackdrop bg={volumeBg} defaultSrc={PREVIEW_VOLUME_BG} defaultPosition="center 43%" customSrc={appearanceImages.volume} />
               {soundVolume > 0 ? (
                 <Volume2 className="relative z-10 h-4 w-4 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]" />
               ) : (
@@ -956,7 +980,7 @@ export default function Sidebar() {
             </button>
           ) : (
             <div className="group relative flex h-10 w-full items-center overflow-hidden rounded-sm border border-white/10 bg-bg-tertiary text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] animate-fade-in">
-              <LaunchButtonBackdrop src={PREVIEW_VOLUME_BG} position="center 43%" />
+              <SurfaceBackdrop bg={volumeBg} defaultSrc={PREVIEW_VOLUME_BG} defaultPosition="center 43%" customSrc={appearanceImages.volume} />
               <button
                 type="button"
                 onClick={() => setSoundVolume(soundVolume > 0 ? 0 : 0.7)}
@@ -1006,9 +1030,7 @@ export default function Sidebar() {
               )}
             </button>
           ) : (
-            <MenuRoot>
-              <MenuTrigger asChild>
-                <span className="contents">
+            <>
           <button
             onClick={handleLaunchModded}
             disabled={!canLaunch || !!launchPending || stopPending}
@@ -1021,7 +1043,7 @@ export default function Sidebar() {
             }
             className="group relative flex w-full h-10 items-center overflow-hidden rounded-sm bg-bg-tertiary text-text-primary ring-1 ring-white/10 hover:ring-white/25 text-sm font-semibold tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-white/35 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {!launchBgHidden && <LaunchButtonBackdrop src={LAUNCH_MODDED_BG} position="center 45%" />}
+            <SurfaceBackdrop bg={launchModdedBg} defaultSrc={LAUNCH_MODDED_BG} defaultPosition="center 45%" customSrc={appearanceImages.launchModded} />
             <span className={`relative z-10 ${actionIconClass}`}>
               {launchPending === 'modded' ? (
                 <Loader2 className="w-[18px] h-[18px] animate-spin" />
@@ -1047,10 +1069,10 @@ export default function Sidebar() {
                   : t('sidebar.launch.vanillaDefault')
             }
             className={`group relative flex w-full h-8 items-center overflow-hidden rounded-sm text-text-primary/85 ring-1 ring-white/10 hover:text-text-primary hover:ring-amber-400/35 text-xs font-medium tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-accent/40 disabled:opacity-60 disabled:cursor-not-allowed ${
-              launchBgHidden ? 'bg-bg-tertiary' : ''
+              launchVanillaBg.kind === 'none' ? 'bg-bg-tertiary' : ''
             }`}
           >
-            {!launchBgHidden && <LaunchButtonBackdrop src={LAUNCH_VANILLA_BG} position="center 48%" warm />}
+            <SurfaceBackdrop bg={launchVanillaBg} defaultSrc={LAUNCH_VANILLA_BG} defaultPosition="center 48%" warm customSrc={appearanceImages.launchVanilla} />
             <span className={`relative z-10 ${actionIconClass}`}>
               {launchPending === 'vanilla' ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -1064,14 +1086,7 @@ export default function Sidebar() {
               </span>
             )}
           </button>
-                </span>
-              </MenuTrigger>
-              <MenuContent>
-                <MenuItem icon={launchBgHidden ? Image : ImageOff} onSelect={toggleLaunchBg}>
-                  {launchBgHidden ? t('sidebar.launch.showArt') : t('sidebar.launch.hideArt')}
-                </MenuItem>
-              </MenuContent>
-            </MenuRoot>
+            </>
           )}
         </div>
 

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, AlertCircle, Crop, Maximize2, RotateCcw, ImagePlus } from 'lucide-react';
+import { Loader2, AlertCircle, Crop, ZoomIn, RotateCcw, ImagePlus } from 'lucide-react';
 import { Toggle } from '../common/ui';
 import { getHeroNamePath } from '../../lib/lockerUtils';
 
 interface LockerImageCropperProps {
   /** Source image to frame (any size), as a data URL. Null = nothing picked yet:
-   *  the stage renders empty so the framing surface is previewed up front. */
+   *  the frame renders empty so the framing surface is previewed up front. */
   imageDataUrl: string | null;
   /** Output/preview aspect ratio (width / height). Card = 3/4, backdrop = 16/9. */
   aspect?: number;
@@ -26,12 +26,18 @@ interface LockerImageCropperProps {
   /** Initial state of the "hide hero name label" toggle. */
   initialHideHeroName?: boolean;
   /** Restore the previous framing (normalized source-fraction rect) when reopening
-   *  on a stored original source, instead of defaulting to the largest centered
-   *  selection. Applied on each (re)load of `imageDataUrl`; clear it when staging
-   *  a freshly picked source so the new pick centers. Aspect should match `aspect`. */
+   *  on a stored original source, instead of defaulting to centered cover. Applied
+   *  on each (re)load of `imageDataUrl`; clear it when staging a freshly picked
+   *  source so the new pick centers. Aspect should match `aspect`. */
   initialCrop?: { sx: number; sy: number; sw: number; sh: number };
-  /** Hint shown over the empty stage before a source is chosen. */
+  /** Hint shown over the empty frame before a source is chosen. */
   emptyHint?: string;
+  /** When set, the empty frame acts as an upload drop zone: clicking it invokes
+   *  this (e.g. opens the native file picker) and dropping an image file invokes
+   *  `onDropFile`. Without it the empty frame is a passive placeholder. */
+  onPickClick?: () => void;
+  /** Receives an image file dropped onto the empty frame (paired with onPickClick). */
+  onDropFile?: (file: File) => void;
   busy?: boolean;
   /** Receives the framed image (PNG data URL at `aspect`), the name choice, and
    *  the ORIGINAL source + normalized crop rect so the edit can be persisted for
@@ -46,88 +52,65 @@ interface LockerImageCropperProps {
 
 /** Cap the baked output so we never upscale a small source past this long edge. */
 const MAX_OUTPUT_LONG = 1280;
-/** Smallest selectable crop box edge, in display px. */
-const MIN_BOX = 36;
+/** Closest the image may be zoomed in (1 = "cover" the frame). */
+const MAX_ZOOM = 5;
 
 /** A real Locker grid card is ~230px wide; its name label and padding are fixed
- *  px tuned to that width. The crop box differs, so the overlay's fixed-px chrome
- *  would render off-scale. Reproduce it as a proportion of the crop box instead,
- *  so the preview is to scale with the card. */
+ *  px tuned to that width. The frame differs, so the overlay's fixed-px chrome
+ *  would render off-scale. Reproduce it as a proportion of the frame instead, so
+ *  the preview is to scale with the card. */
 const REFERENCE_CARD_W = 230;
 
-/** Editor sizing. The stage is bounded by a fraction of the live viewport (not a
+/** Editor sizing. The frame is bounded by a fraction of the live viewport (not a
  *  hardcoded chrome budget) so it never scales past the window: width shrinks with
  *  narrow windows, height with short ones. The modal around it also scrolls, so
  *  these are caps, not exact fits. */
-const STAGE_MAX_W = 320;
-const STAGE_MIN_W = 160;
-const STAGE_MAX_H = 420;
-const STAGE_MIN_H = 160;
+const FRAME_MAX_W = 320;
+const FRAME_MIN_W = 160;
+const FRAME_MAX_H = 420;
+const FRAME_MIN_H = 160;
 /** Horizontal room the surrounding modal padding/margins take. */
-const STAGE_MARGIN_W = 96;
-/** Share of the window height the stage may occupy. */
-const STAGE_VH = 0.4;
+const FRAME_MARGIN_W = 96;
+/** Share of the window height the frame may occupy. */
+const FRAME_VH = 0.4;
 
-/** The box (in CSS px) the image is contained within, clamped to the viewport. */
-function stageBudget(): { w: number; h: number } {
+/** The box (in CSS px) the frame is bounded within, clamped to the viewport. */
+function frameBudget(): { w: number; h: number } {
   const winW = typeof window !== 'undefined' ? window.innerWidth : 1280;
   const winH = typeof window !== 'undefined' ? window.innerHeight : 800;
   return {
-    w: Math.max(STAGE_MIN_W, Math.min(STAGE_MAX_W, winW - STAGE_MARGIN_W)),
-    h: Math.max(STAGE_MIN_H, Math.min(STAGE_MAX_H, Math.round(winH * STAGE_VH))),
+    w: Math.max(FRAME_MIN_W, Math.min(FRAME_MAX_W, winW - FRAME_MARGIN_W)),
+    h: Math.max(FRAME_MIN_H, Math.min(FRAME_MAX_H, Math.round(winH * FRAME_VH))),
   };
 }
 
-/** Largest box at the given aspect that fits the budget (centered framing area). */
+/** Largest box at the given aspect that fits the budget: this is the crop frame. */
 function fitAspect(aspect: number): { w: number; h: number } {
-  const { w: maxW, h: maxH } = stageBudget();
+  const { w: maxW, h: maxH } = frameBudget();
   let w = maxW;
   let h = w / aspect;
   if (h > maxH) {
     h = maxH;
     w = h * aspect;
   }
-  return { w: Math.round(w), h: Math.round(h) };
+  return { w: Math.max(1, Math.round(w)), h: Math.max(1, Math.round(h)) };
 }
 
-/** Placeholder stage (at the target aspect) shown before a source is picked. */
-function emptyStage(aspect: number): { w: number; h: number } {
-  return fitAspect(aspect);
-}
-
-/** Contain a natural-size image within the viewport budget. */
-function containStage(natW: number, natH: number): { w: number; h: number } {
-  const { w: maxW, h: maxH } = stageBudget();
-  const s = Math.min(maxW / natW, maxH / natH);
-  return { w: Math.max(1, Math.round(natW * s)), h: Math.max(1, Math.round(natH * s)) };
-}
-
-/** Largest aspect-locked box that fits the stage, centered. */
-function maxBox(stageW: number, stageH: number, aspect: number) {
-  let w = stageW;
-  let h = w / aspect;
-  if (h > stageH) {
-    h = stageH;
-    w = h * aspect;
-  }
-  return { x: (stageW - w) / 2, y: (stageH - h) / 2, w, h };
-}
-
-type Box = { x: number; y: number; w: number; h: number };
-type Corner = 'nw' | 'ne' | 'sw' | 'se';
+type Offset = { x: number; y: number };
 
 /**
  * Inline frame-and-preview editor for a per-skin Locker / sidebar image.
  *
- * Crop-box model (cropperjs-style): the whole source image is shown fit-to-contain
- * inside the stage, and an aspect-locked selection box is overlaid on top. The box
- * can be dragged to move and resized from any corner; everything outside it is
- * dimmed. This lets the user see the entire image and box the exact portion they
- * want, instead of panning a cover-cropped frame blind. In card mode the box also
- * overlays the real hero-name label exactly as the card renders it, with a live
- * toggle to hide it. On apply we export the selection at the target aspect so the
- * downstream `object-cover` is a clean, undistorted scale. With no source picked
- * yet the stage renders empty at the target shape so the surface is previewed.
+ * Fixed-frame model (the same one `CardCropper` uses): the crop frame is locked to
+ * the target aspect and stays put; the source image is drawn behind it scaled to
+ * "cover" (zoom 1) and the user drags to reposition and zooms (wheel / slider) to
+ * frame the exact portion they want. Everything outside the frame is hidden by the
+ * frame's `overflow-hidden`, so what you see in the frame is exactly what bakes.
+ * In card mode the frame also overlays the real hero-name label exactly as the card
+ * renders it, with a live toggle to hide it. On apply we export the framed region at
+ * the target aspect so the downstream `object-cover` is a clean, undistorted scale.
+ * With no source picked yet the frame renders empty at the target shape so the
+ * surface is previewed.
  */
 export default function LockerImageCropper({
   imageDataUrl,
@@ -139,55 +122,57 @@ export default function LockerImageCropper({
   initialHideHeroName = false,
   initialCrop,
   emptyHint,
+  onPickClick,
+  onDropFile,
   busy = false,
   onApply,
 }: LockerImageCropperProps) {
   const { t } = useTranslation();
 
   const [img, setImg] = useState<HTMLImageElement | null>(null);
-  // The stage is the displayed image rect (image contained, so stage === image,
-  // no letterbox). Defaults to a target-aspect placeholder while empty.
-  const [stage, setStage] = useState(() => emptyStage(aspect));
-  const [box, setBox] = useState<Box>(() => maxBox(stage.w, stage.h, aspect));
+  // The crop frame (target aspect), responsive to the live viewport.
+  const [frame, setFrame] = useState(() => fitAspect(aspect));
+  const [zoom, setZoom] = useState(1);
+  // Top-left of the drawn image relative to the frame, in CSS px (<= 0).
+  const [offset, setOffset] = useState<Offset>({ x: 0, y: 0 });
   const [error, setError] = useState<string | null>(null);
   const [hideHeroName, setHideHeroName] = useState(initialHideHeroName);
   const [nameFailed, setNameFailed] = useState(false);
+  // Highlight the empty frame while an image file is dragged over it.
+  const [dropActive, setDropActive] = useState(false);
 
-  const stageRef = useRef<HTMLDivElement | null>(null);
-  // Active pointer gesture: a move (drag the whole box) or a corner resize.
-  const drag = useRef<
-    | { mode: 'move'; startX: number; startY: number; bx: number; by: number }
-    | { mode: 'resize'; corner: Corner; ax: number; ay: number }
-    | null
-  >(null);
+  const drag = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
 
-  const STAGE_W = stage.w;
-  const STAGE_H = stage.h;
-  // Mirror the stage size for the resize handler (avoids a stale-closure read).
-  const stageSizeRef = useRef(stage);
-  useEffect(() => {
-    stageSizeRef.current = stage;
-  }, [stage]);
+  // The empty frame doubles as an upload drop zone when the caller wires it up.
+  const dropZone = !img && !!(onPickClick || onDropFile);
 
-  // Clamp a move so the box stays fully inside the stage.
-  const clampMove = useCallback(
-    (b: Box): Box => ({
-      ...b,
-      x: Math.min(Math.max(0, b.x), STAGE_W - b.w),
-      y: Math.min(Math.max(0, b.y), STAGE_H - b.h),
+  const FRAME_W = frame.w;
+  const FRAME_H = frame.h;
+
+  // Scale at which the source just covers the frame (zoom 1 == cover), and the
+  // drawn image size at the current zoom.
+  const coverScale = img ? Math.max(FRAME_W / img.naturalWidth, FRAME_H / img.naturalHeight) : 1;
+  const drawnW = img ? img.naturalWidth * coverScale * zoom : FRAME_W;
+  const drawnH = img ? img.naturalHeight * coverScale * zoom : FRAME_H;
+
+  // Keep the image fully covering the frame (offset within [frame - drawn, 0]).
+  const clamp = useCallback(
+    (x: number, y: number): Offset => ({
+      x: Math.min(0, Math.max(FRAME_W - drawnW, x)),
+      y: Math.min(0, Math.max(FRAME_H - drawnH, y)),
     }),
-    [STAGE_W, STAGE_H]
+    [FRAME_W, FRAME_H, drawnW, drawnH]
   );
 
-  // Load the source to learn its natural size, contain it in the stage budget,
-  // then place the selection (restored framing, or the largest centered box).
-  // A null source clears back to the empty placeholder stage.
+  // Load the source to learn its natural size, then place it: restored framing
+  // (normalized crop rect) if provided, otherwise centered at cover. A null source
+  // clears back to the empty placeholder frame.
   useEffect(() => {
     if (!imageDataUrl) {
       setImg(null);
-      const s = emptyStage(aspect);
-      setStage(s);
-      setBox(maxBox(s.w, s.h, aspect));
+      setFrame(fitAspect(aspect));
+      setZoom(1);
+      setOffset({ x: 0, y: 0 });
       setError(null);
       return;
     }
@@ -195,23 +180,28 @@ export default function LockerImageCropper({
     const el = new Image();
     el.onload = () => {
       if (!active) return;
-      const { w: sw, h: sh } = containStage(el.naturalWidth, el.naturalHeight);
+      const fr = fitAspect(aspect);
+      const cover = Math.max(fr.w / el.naturalWidth, fr.h / el.naturalHeight);
       setImg(el);
-      setStage({ w: sw, h: sh });
-      if (initialCrop && initialCrop.sw > 0) {
-        // Restore previous framing. Width drives the box (aspect-locked); clamp
-        // both size and position into the stage.
-        let w = Math.min(Math.max(MIN_BOX, initialCrop.sw * sw), sw);
-        let h = w / aspect;
-        if (h > sh) {
-          h = sh;
-          w = h * aspect;
-        }
-        const x = Math.min(Math.max(0, initialCrop.sx * sw), sw - w);
-        const y = Math.min(Math.max(0, initialCrop.sy * sh), sh - h);
-        setBox({ x, y, w, h });
+      setFrame(fr);
+      if (initialCrop && initialCrop.sw > 0 && initialCrop.sh > 0) {
+        // Restore: the frame spans `sw` of the source width, anchored at (sx, sy).
+        const scale = fr.w / (initialCrop.sw * el.naturalWidth);
+        const z = Math.min(MAX_ZOOM, Math.max(1, scale / cover));
+        const s = cover * z;
+        const dW = el.naturalWidth * s;
+        const dH = el.naturalHeight * s;
+        setZoom(z);
+        setOffset({
+          x: Math.min(0, Math.max(fr.w - dW, -initialCrop.sx * el.naturalWidth * s)),
+          y: Math.min(0, Math.max(fr.h - dH, -initialCrop.sy * el.naturalHeight * s)),
+        });
       } else {
-        setBox(maxBox(sw, sh, aspect));
+        setZoom(1);
+        setOffset({
+          x: (fr.w - el.naturalWidth * cover) / 2,
+          y: (fr.h - el.naturalHeight * cover) / 2,
+        });
       }
       setError(null);
     };
@@ -224,153 +214,105 @@ export default function LockerImageCropper({
     };
   }, [imageDataUrl, initialCrop, aspect, t]);
 
-  // Keep the stage within the window when it resizes, re-deriving the box from
-  // its current normalized framing so the selection follows.
+  // Keep the frame within the window when it resizes. Aspect is fixed, so the
+  // frame scales uniformly; scale the offset by the same factor to hold framing.
   useEffect(() => {
     const onResize = () => {
-      if (!img) {
-        setStage(emptyStage(aspect));
-        return;
-      }
-      const prev = stageSizeRef.current;
-      const next = containStage(img.naturalWidth, img.naturalHeight);
-      setBox((b) => {
-        const fx = b.x / prev.w;
-        const fy = b.y / prev.h;
-        const fw = b.w / prev.w;
-        let w = Math.min(Math.max(MIN_BOX, fw * next.w), next.w);
-        let h = w / aspect;
-        if (h > next.h) {
-          h = next.h;
-          w = h * aspect;
+      const next = fitAspect(aspect);
+      setFrame((prev) => {
+        if (img && prev.w > 0) {
+          const factor = next.w / prev.w;
+          setOffset((o) => ({ x: o.x * factor, y: o.y * factor }));
         }
-        return {
-          x: Math.min(Math.max(0, fx * next.w), next.w - w),
-          y: Math.min(Math.max(0, fy * next.h), next.h - h),
-          w,
-          h,
-        };
+        return next;
       });
-      setStage(next);
     };
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, [img, aspect]);
 
-  // Stage-local pointer coords, clamped to the stage.
-  const localPoint = useCallback((clientX: number, clientY: number) => {
-    const rect = stageRef.current?.getBoundingClientRect();
-    if (!rect) return { x: 0, y: 0 };
-    return {
-      x: Math.min(Math.max(0, clientX - rect.left), rect.width),
-      y: Math.min(Math.max(0, clientY - rect.top), rect.height),
-    };
-  }, []);
-
-  // Resize from a corner: the opposite corner (ax, ay) is the anchor; build the
-  // largest aspect-locked box from anchor toward the pointer, clamped to bounds.
-  const resizeFrom = useCallback(
-    (ax: number, ay: number, px: number, py: number): Box => {
-      const dirX = px >= ax ? 1 : -1;
-      const dirY = py >= ay ? 1 : -1;
-      const maxW = dirX > 0 ? STAGE_W - ax : ax;
-      const maxH = dirY > 0 ? STAGE_H - ay : ay;
-      let w = Math.abs(px - ax);
-      let h = Math.abs(py - ay);
-      // Lock aspect to the governing dimension, then clamp to bounds + min size.
-      if (w / h > aspect) h = w / aspect;
-      else w = h * aspect;
-      if (w > maxW) {
-        w = maxW;
-        h = w / aspect;
+  // Zoom around the frame center so the framed subject stays put.
+  const applyZoom = useCallback(
+    (nextZoom: number) => {
+      const z = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+      if (!img) {
+        setZoom(z);
+        return;
       }
-      if (h > maxH) {
-        h = maxH;
-        w = h * aspect;
-      }
-      if (w < MIN_BOX) {
-        w = MIN_BOX;
-        h = w / aspect;
-      }
-      const x = dirX > 0 ? ax : ax - w;
-      const y = dirY > 0 ? ay : ay - h;
-      return { x, y, w, h };
+      // Source point currently under the frame center, then re-place it there.
+      const cx = (FRAME_W / 2 - offset.x) / (coverScale * zoom);
+      const cy = (FRAME_H / 2 - offset.y) / (coverScale * zoom);
+      const nx = FRAME_W / 2 - cx * coverScale * z;
+      const ny = FRAME_H / 2 - cy * coverScale * z;
+      const newDrawnW = img.naturalWidth * coverScale * z;
+      const newDrawnH = img.naturalHeight * coverScale * z;
+      setZoom(z);
+      setOffset({
+        x: Math.min(0, Math.max(FRAME_W - newDrawnW, nx)),
+        y: Math.min(0, Math.max(FRAME_H - newDrawnH, ny)),
+      });
     },
-    [STAGE_W, STAGE_H, aspect]
+    [img, offset, zoom, coverScale, FRAME_W, FRAME_H]
   );
 
-  const onPointerDownBox = (e: React.PointerEvent) => {
+  const onPointerDown = (e: React.PointerEvent) => {
     if (!img) return;
-    e.stopPropagation();
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    drag.current = { mode: 'move', startX: e.clientX, startY: e.clientY, bx: box.x, by: box.y };
+    drag.current = { startX: e.clientX, startY: e.clientY, ox: offset.x, oy: offset.y };
   };
-
-  const onPointerDownHandle = (corner: Corner) => (e: React.PointerEvent) => {
-    if (!img) return;
-    e.stopPropagation();
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    // Anchor = the corner opposite the one grabbed.
-    const ax = corner === 'nw' || corner === 'sw' ? box.x + box.w : box.x;
-    const ay = corner === 'nw' || corner === 'ne' ? box.y + box.h : box.y;
-    drag.current = { mode: 'resize', corner, ax, ay };
-  };
-
   const onPointerMove = (e: React.PointerEvent) => {
-    const d = drag.current;
-    if (!d) return;
-    if (d.mode === 'move') {
-      setBox((b) => clampMove({ ...b, x: d.bx + (e.clientX - d.startX), y: d.by + (e.clientY - d.startY) }));
-    } else {
-      const p = localPoint(e.clientX, e.clientY);
-      setBox(resizeFrom(d.ax, d.ay, p.x, p.y));
-    }
+    if (!drag.current) return;
+    setOffset(clamp(drag.current.ox + (e.clientX - drag.current.startX), drag.current.oy + (e.clientY - drag.current.startY)));
   };
-
   const onPointerUp = () => {
     drag.current = null;
   };
-
-  // Scale the selection around its center (slider + wheel), clamped to the stage.
-  const setBoxWidth = useCallback(
-    (targetW: number) => {
-      setBox((b) => {
-        const maxW = Math.min(STAGE_W, STAGE_H * aspect);
-        let w = Math.min(Math.max(MIN_BOX, targetW), maxW);
-        let h = w / aspect;
-        if (h > STAGE_H) {
-          h = STAGE_H;
-          w = h * aspect;
-        }
-        const cx = b.x + b.w / 2;
-        const cy = b.y + b.h / 2;
-        return clampMove({ x: cx - w / 2, y: cy - h / 2, w, h });
-      });
-    },
-    [STAGE_W, STAGE_H, aspect, clampMove]
-  );
-
   const onWheel = (e: React.WheelEvent) => {
     if (!img) return;
     e.preventDefault();
-    setBoxWidth(box.w * (e.deltaY < 0 ? 1 / 1.08 : 1.08));
+    applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
   };
 
-  const maxBoxW = Math.min(STAGE_W, STAGE_H * aspect);
-  // Slider position (0..1) from the current box width.
-  const sizeValue = maxBoxW > MIN_BOX ? (box.w - MIN_BOX) / (maxBoxW - MIN_BOX) : 1;
+  // Empty-frame upload drop zone (only while no source is staged).
+  const onDropZoneOver = (e: React.DragEvent) => {
+    if (!dropZone || busy) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (!dropActive) setDropActive(true);
+  };
+  const onDropZoneLeave = () => {
+    if (dropActive) setDropActive(false);
+  };
+  const onDropZoneDrop = (e: React.DragEvent) => {
+    if (!dropZone || busy) return;
+    e.preventDefault();
+    setDropActive(false);
+    const file = Array.from(e.dataTransfer.files).find((f) => f.type.startsWith('image/'));
+    if (file) onDropFile?.(file);
+  };
+
+  const reset = () => {
+    if (!img) return;
+    setZoom(1);
+    setOffset({
+      x: (FRAME_W - img.naturalWidth * coverScale) / 2,
+      y: (FRAME_H - img.naturalHeight * coverScale) / 2,
+    });
+  };
 
   const handleApply = () => {
     if (!img || !imageDataUrl) return;
     const natW = img.naturalWidth;
     const natH = img.naturalHeight;
-    // Normalized (source-fraction) crop rect: the stage maps 1:1 to the source.
-    const crop = { sx: box.x / STAGE_W, sy: box.y / STAGE_H, sw: box.w / STAGE_W, sh: box.h / STAGE_H };
-    const srcX = crop.sx * natW;
-    const srcY = crop.sy * natH;
-    const srcW = crop.sw * natW;
-    const srcH = crop.sh * natH;
-    // Bake at the crop's own resolution (capped on the long edge), preserving aspect.
+    const scale = coverScale * zoom;
+    // The frame maps to this rect in source-image natural coordinates.
+    const srcX = -offset.x / scale;
+    const srcY = -offset.y / scale;
+    const srcW = FRAME_W / scale;
+    const srcH = FRAME_H / scale;
+    // Normalized (source-fraction) crop rect, persisted for a full-fidelity reopen.
+    const crop = { sx: srcX / natW, sy: srcY / natH, sw: srcW / natW, sh: srcH / natH };
+    // Bake at the framed region's own resolution (capped on the long edge).
     const longSrc = Math.max(srcW, srcH);
     const k = longSrc > MAX_OUTPUT_LONG ? MAX_OUTPUT_LONG / longSrc : 1;
     const outW = Math.max(1, Math.round(srcW * k));
@@ -390,20 +332,13 @@ export default function LockerImageCropper({
 
   const namePath = getHeroNamePath(heroName);
 
-  // Name chrome scales with the crop box (its baked surface), not the stage.
-  const previewScale = box.w / REFERENCE_CARD_W;
+  // Name chrome scales with the frame (its baked surface), not a reference card.
+  const previewScale = FRAME_W / REFERENCE_CARD_W;
   const NAME_HEIGHT = Math.round(28 * previewScale);
   const NAME_PADDING = Math.round(12 * previewScale);
   const NAME_FALLBACK_FONT = Math.round(14 * previewScale);
-  const BD_NAME_HEIGHT = Math.round(box.w * 0.08);
-  const BD_NAME_PADDING = Math.round(box.w * 0.05);
-
-  const cornerCursor: Record<Corner, string> = {
-    nw: 'nwse-resize',
-    se: 'nwse-resize',
-    ne: 'nesw-resize',
-    sw: 'nesw-resize',
-  };
+  const BD_NAME_HEIGHT = Math.round(FRAME_W * 0.08);
+  const BD_NAME_PADDING = Math.round(FRAME_W * 0.05);
 
   return (
     <div className="flex flex-col gap-3">
@@ -415,118 +350,106 @@ export default function LockerImageCropper({
       )}
 
       <div className="flex justify-center">
-        {/* Stage: the whole image contained, with the aspect-locked selection box
-            overlaid. Outside the box is dimmed; the box overlays the hero-name
-            chrome so the preview is to scale. Empty (target shape) until picked. */}
+        {/* Crop frame (target aspect): the source is drawn behind it and pans /
+            zooms; the frame clips to what bakes, and overlays the hero-name chrome
+            so the preview is to scale. Empty (target shape) until a source picked. */}
         <div
-          ref={stageRef}
-          className="relative touch-none select-none overflow-hidden rounded-xl border border-border bg-bg-primary/60"
-          style={{ width: STAGE_W, height: STAGE_H }}
+          className={`relative touch-none select-none overflow-hidden rounded-xl border bg-bg-primary/60 transition-colors ${
+            dropActive ? 'border-accent bg-accent/10' : dropZone ? 'border-dashed border-border hover:border-accent/60' : 'border-border'
+          }`}
+          style={{ width: FRAME_W, height: FRAME_H, cursor: img ? 'grab' : dropZone ? 'pointer' : 'default' }}
+          role={dropZone ? 'button' : undefined}
+          tabIndex={dropZone ? 0 : undefined}
+          aria-label={dropZone ? (emptyHint ?? t('locker.modImage.useImage')) : undefined}
+          onClick={dropZone && !busy ? onPickClick : undefined}
+          onKeyDown={
+            dropZone && !busy
+              ? (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onPickClick?.();
+                  }
+                }
+              : undefined
+          }
+          onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onWheel={onWheel}
+          onDragOver={onDropZoneOver}
+          onDragLeave={onDropZoneLeave}
+          onDrop={onDropZoneDrop}
         >
           {img ? (
             <img
               src={imageDataUrl ?? undefined}
               alt=""
               draggable={false}
-              className="pointer-events-none absolute inset-0 h-full w-full"
+              className="pointer-events-none absolute max-w-none"
+              style={{ left: offset.x, top: offset.y, width: drawnW, height: drawnH }}
             />
           ) : (
-            <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-text-secondary">
-              <ImagePlus className="h-6 w-6 opacity-70" />
+            <div className="pointer-events-none flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-text-secondary">
+              <ImagePlus className={`h-6 w-6 ${dropActive ? 'text-accent opacity-100' : 'opacity-70'}`} />
               {emptyHint && <span className="text-[11px] leading-snug">{emptyHint}</span>}
             </div>
           )}
 
           {img && (
-            <div
-              className="absolute cursor-move"
-              style={{
-                left: box.x,
-                top: box.y,
-                width: box.w,
-                height: box.h,
-                // Dim everything outside the selection.
-                boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)',
-                outline: '1px solid rgba(255,255,255,0.9)',
-              }}
-              onPointerDown={onPointerDownBox}
-            >
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
               {/* Rule-of-thirds guides. */}
-              <div className="pointer-events-none absolute inset-0">
-                <div className="absolute left-1/3 top-0 bottom-0 w-px bg-white/25" />
-                <div className="absolute left-2/3 top-0 bottom-0 w-px bg-white/25" />
-                <div className="absolute top-1/3 left-0 right-0 h-px bg-white/25" />
-                <div className="absolute top-2/3 left-0 right-0 h-px bg-white/25" />
-              </div>
+              <div className="absolute left-1/3 top-0 bottom-0 w-px bg-white/25" />
+              <div className="absolute left-2/3 top-0 bottom-0 w-px bg-white/25" />
+              <div className="absolute top-1/3 left-0 right-0 h-px bg-white/25" />
+              <div className="absolute top-2/3 left-0 right-0 h-px bg-white/25" />
 
-              {/* Name + gradient chrome preview (to scale with the box). */}
-              <div className="pointer-events-none absolute inset-0 overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
-                {nameControls && !hideHeroName && namePosition === 'card' && (
-                  <div
-                    className="absolute bottom-0 left-0 right-0 flex flex-col items-end text-right"
-                    style={{ padding: NAME_PADDING }}
-                  >
-                    {nameFailed ? (
-                      <div
-                        className="font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                        style={{ fontSize: NAME_FALLBACK_FONT }}
-                      >
-                        {heroName}
-                      </div>
-                    ) : (
-                      <div className="relative ml-auto w-[70%]" style={{ height: NAME_HEIGHT }}>
-                        <img
-                          src={namePath}
-                          alt={heroName}
-                          className="absolute inset-0 h-full w-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                          onError={() => setNameFailed(true)}
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-                {nameControls && !hideHeroName && namePosition === 'backdrop' && (
-                  <div className="absolute left-0 top-0" style={{ padding: BD_NAME_PADDING }}>
-                    {nameFailed ? (
-                      <div
-                        className="font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                        style={{ fontSize: Math.round(BD_NAME_HEIGHT * 0.9) }}
-                      >
-                        {heroName}
-                      </div>
-                    ) : (
+              {/* Name + gradient chrome preview (to scale with the frame). */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
+              {nameControls && !hideHeroName && namePosition === 'card' && (
+                <div
+                  className="absolute bottom-0 left-0 right-0 flex flex-col items-end text-right"
+                  style={{ padding: NAME_PADDING }}
+                >
+                  {nameFailed ? (
+                    <div
+                      className="font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                      style={{ fontSize: NAME_FALLBACK_FONT }}
+                    >
+                      {heroName}
+                    </div>
+                  ) : (
+                    <div className="relative ml-auto w-[70%]" style={{ height: NAME_HEIGHT }}>
                       <img
                         src={namePath}
                         alt={heroName}
-                        className="w-auto object-contain object-left drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                        style={{ height: BD_NAME_HEIGHT }}
+                        className="absolute inset-0 h-full w-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
                         onError={() => setNameFailed(true)}
                       />
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Corner resize handles. */}
-              {(['nw', 'ne', 'sw', 'se'] as const).map((corner) => (
-                <div
-                  key={corner}
-                  onPointerDown={onPointerDownHandle(corner)}
-                  className="absolute h-3 w-3 rounded-sm border border-black/40 bg-white"
-                  style={{
-                    cursor: cornerCursor[corner],
-                    left: corner === 'nw' || corner === 'sw' ? -6 : undefined,
-                    right: corner === 'ne' || corner === 'se' ? -6 : undefined,
-                    top: corner === 'nw' || corner === 'ne' ? -6 : undefined,
-                    bottom: corner === 'sw' || corner === 'se' ? -6 : undefined,
-                  }}
-                />
-              ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              {nameControls && !hideHeroName && namePosition === 'backdrop' && (
+                <div className="absolute left-0 top-0" style={{ padding: BD_NAME_PADDING }}>
+                  {nameFailed ? (
+                    <div
+                      className="font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                      style={{ fontSize: Math.round(BD_NAME_HEIGHT * 0.9) }}
+                    >
+                      {heroName}
+                    </div>
+                  ) : (
+                    <img
+                      src={namePath}
+                      alt={heroName}
+                      className="w-auto object-contain object-left drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                      style={{ height: BD_NAME_HEIGHT }}
+                      onError={() => setNameFailed(true)}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -534,29 +457,29 @@ export default function LockerImageCropper({
 
       {img && (
         <p className="text-center text-[11px] leading-snug text-text-secondary">
-          {t('locker.crop.boxHint')}
+          {t('locker.crop.instructions')}
         </p>
       )}
 
       <div className="flex items-center gap-3">
-        <Maximize2 className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+        <ZoomIn className="h-4 w-4 flex-shrink-0 text-text-secondary" />
         <input
           type="range"
-          min={0}
-          max={1}
+          min={1}
+          max={MAX_ZOOM}
           step={0.01}
-          value={Math.min(1, Math.max(0, sizeValue))}
+          value={zoom}
           disabled={!img}
-          onChange={(e) => setBoxWidth(MIN_BOX + Number(e.target.value) * (maxBoxW - MIN_BOX))}
-          aria-label={t('locker.crop.selectionSize')}
+          onChange={(e) => applyZoom(Number(e.target.value))}
           className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-border accent-accent disabled:cursor-not-allowed disabled:opacity-50"
         />
+        <span className="w-10 text-right text-[11px] tabular-nums text-text-secondary">{zoom.toFixed(1)}x</span>
         <button
           type="button"
           disabled={!img}
-          onClick={() => setBox(maxBox(STAGE_W, STAGE_H, aspect))}
-          title={t('locker.crop.resetCrop')}
-          aria-label={t('locker.crop.resetCrop')}
+          onClick={reset}
+          title={t('locker.crop.resetZoom')}
+          aria-label={t('locker.crop.resetZoom')}
           className="cursor-pointer rounded-md border border-border/60 p-1 text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           <RotateCcw className="h-3.5 w-3.5" />

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, AlertCircle, Crop, ZoomIn, RotateCcw, ImagePlus } from 'lucide-react';
+import { Loader2, AlertCircle, Crop, Maximize2, RotateCcw, ImagePlus } from 'lucide-react';
 import { Toggle } from '../common/ui';
 import { getHeroNamePath } from '../../lib/lockerUtils';
 
 interface LockerImageCropperProps {
   /** Source image to frame (any size), as a data URL. Null = nothing picked yet:
-   *  the viewport renders empty so the framing surface is previewed up front. */
+   *  the stage renders empty so the framing surface is previewed up front. */
   imageDataUrl: string | null;
   /** Output/preview aspect ratio (width / height). Card = 3/4, backdrop = 16/9. */
   aspect?: number;
@@ -26,11 +26,11 @@ interface LockerImageCropperProps {
   /** Initial state of the "hide hero name label" toggle. */
   initialHideHeroName?: boolean;
   /** Restore the previous framing (normalized source-fraction rect) when reopening
-   *  on a stored original source, instead of centering at cover. Applied on each
-   *  (re)load of `imageDataUrl`; clear it when staging a freshly picked source so
-   *  the new pick centers. The rect's aspect should match `aspect`. */
+   *  on a stored original source, instead of defaulting to the largest centered
+   *  selection. Applied on each (re)load of `imageDataUrl`; clear it when staging
+   *  a freshly picked source so the new pick centers. Aspect should match `aspect`. */
   initialCrop?: { sx: number; sy: number; sw: number; sh: number };
-  /** Hint shown over the empty viewport before a source is chosen. */
+  /** Hint shown over the empty stage before a source is chosen. */
   emptyHint?: string;
   busy?: boolean;
   /** Receives the framed image (PNG data URL at `aspect`), the name choice, and
@@ -44,32 +44,44 @@ interface LockerImageCropperProps {
   }) => void;
 }
 
-/** The editing viewport keeps the target aspect; the source is scaled to cover it
- *  and pans/zooms within. */
-const MAX_ZOOM = 5;
 /** Cap the baked output so we never upscale a small source past this long edge. */
 const MAX_OUTPUT_LONG = 1280;
+/** Smallest selectable crop box edge, in display px. */
+const MIN_BOX = 36;
 
 /** A real Locker grid card is ~230px wide; its name label and padding are fixed
- *  px tuned to that width. The crop viewport differs, so the overlay's fixed-px
- *  chrome would render off-scale. Reproduce it as a proportion of the viewport
- *  instead, so the preview is to scale with the card. */
+ *  px tuned to that width. The crop box differs, so the overlay's fixed-px chrome
+ *  would render off-scale. Reproduce it as a proportion of the crop box instead,
+ *  so the preview is to scale with the card. */
 const REFERENCE_CARD_W = 230;
 
-/** Sizing for the side-by-side pane the editor lives in. */
-const PANE_MAX_W = 300;
-const PANE_MAX_H = 400;
-const PANE_MIN_H = 180;
-/** Vertical space the modal chrome around the preview needs (header, tabs, the
- *  zoom/toggle/button stack below, paddings + gaps). Used so the preview shrinks
- *  on short windows instead of overflowing them. */
-const CHROME_BUDGET = 360;
+/** Editor sizing. The stage is bounded by a fraction of the live viewport (not a
+ *  hardcoded chrome budget) so it never scales past the window: width shrinks with
+ *  narrow windows, height with short ones. The modal around it also scrolls, so
+ *  these are caps, not exact fits. */
+const STAGE_MAX_W = 320;
+const STAGE_MIN_W = 160;
+const STAGE_MAX_H = 420;
+const STAGE_MIN_H = 160;
+/** Horizontal room the surrounding modal padding/margins take. */
+const STAGE_MARGIN_W = 96;
+/** Share of the window height the stage may occupy. */
+const STAGE_VH = 0.4;
 
-/** Largest viewport at `aspect` that fits the pane width and the window height. */
-function fitView(aspect: number): { w: number; h: number } {
+/** The box (in CSS px) the image is contained within, clamped to the viewport. */
+function stageBudget(): { w: number; h: number } {
+  const winW = typeof window !== 'undefined' ? window.innerWidth : 1280;
   const winH = typeof window !== 'undefined' ? window.innerHeight : 800;
-  const maxH = Math.max(PANE_MIN_H, Math.min(PANE_MAX_H, winH - CHROME_BUDGET));
-  let w = PANE_MAX_W;
+  return {
+    w: Math.max(STAGE_MIN_W, Math.min(STAGE_MAX_W, winW - STAGE_MARGIN_W)),
+    h: Math.max(STAGE_MIN_H, Math.min(STAGE_MAX_H, Math.round(winH * STAGE_VH))),
+  };
+}
+
+/** Largest box at the given aspect that fits the budget (centered framing area). */
+function fitAspect(aspect: number): { w: number; h: number } {
+  const { w: maxW, h: maxH } = stageBudget();
+  let w = maxW;
   let h = w / aspect;
   if (h > maxH) {
     h = maxH;
@@ -78,18 +90,44 @@ function fitView(aspect: number): { w: number; h: number } {
   return { w: Math.round(w), h: Math.round(h) };
 }
 
+/** Placeholder stage (at the target aspect) shown before a source is picked. */
+function emptyStage(aspect: number): { w: number; h: number } {
+  return fitAspect(aspect);
+}
+
+/** Contain a natural-size image within the viewport budget. */
+function containStage(natW: number, natH: number): { w: number; h: number } {
+  const { w: maxW, h: maxH } = stageBudget();
+  const s = Math.min(maxW / natW, maxH / natH);
+  return { w: Math.max(1, Math.round(natW * s)), h: Math.max(1, Math.round(natH * s)) };
+}
+
+/** Largest aspect-locked box that fits the stage, centered. */
+function maxBox(stageW: number, stageH: number, aspect: number) {
+  let w = stageW;
+  let h = w / aspect;
+  if (h > stageH) {
+    h = stageH;
+    w = h * aspect;
+  }
+  return { x: (stageW - w) / 2, y: (stageH - h) / 2, w, h };
+}
+
+type Box = { x: number; y: number; w: number; h: number };
+type Corner = 'nw' | 'ne' | 'sw' | 'se';
+
 /**
- * Inline frame-and-preview editor for a per-skin Locker image (issue #208).
+ * Inline frame-and-preview editor for a per-skin Locker / sidebar image.
  *
- * Lives in the left pane of the unified image picker. The chosen image would
- * otherwise be `object-cover`-stretched onto its surface (the 3:4 card, or the
- * wide hero-detail backdrop) with no say in framing, and a card image can clash
- * with art that bakes the hero name in. This editor fixes both: the user frames
- * the image inside a viewport locked to the target aspect (pan + zoom). In card
- * mode it also overlays the real hero-name label exactly as the card renders it,
- * with a live toggle to hide it. On apply we export at the target aspect so the
+ * Crop-box model (cropperjs-style): the whole source image is shown fit-to-contain
+ * inside the stage, and an aspect-locked selection box is overlaid on top. The box
+ * can be dragged to move and resized from any corner; everything outside it is
+ * dimmed. This lets the user see the entire image and box the exact portion they
+ * want, instead of panning a cover-cropped frame blind. In card mode the box also
+ * overlays the real hero-name label exactly as the card renders it, with a live
+ * toggle to hide it. On apply we export the selection at the target aspect so the
  * downstream `object-cover` is a clean, undistorted scale. With no source picked
- * yet the viewport renders empty so the framing surface is previewed up front.
+ * yet the stage renders empty at the target shape so the surface is previewed.
  */
 export default function LockerImageCropper({
   imageDataUrl,
@@ -106,49 +144,50 @@ export default function LockerImageCropper({
 }: LockerImageCropperProps) {
   const { t } = useTranslation();
 
-  // Fit the viewport once per aspect (the editor is remounted on tab switch).
-  const [view] = useState(() => fitView(aspect));
-  const VIEW_W = view.w;
-  const VIEW_H = view.h;
-  const previewScale = VIEW_W / REFERENCE_CARD_W;
-  // Card name label: w-[70%] h-7 (28px) with p-3 (12px) padding on the real card.
-  const NAME_HEIGHT = Math.round(28 * previewScale);
-  const NAME_PADDING = Math.round(12 * previewScale);
-  const NAME_FALLBACK_FONT = Math.round(14 * previewScale);
-  // Backdrop name logo sits top-left; size it as a small fraction of the wide
-  // viewport, roughly matching the focus view's h-8 logo over the full backdrop.
-  const BD_NAME_HEIGHT = Math.round(VIEW_W * 0.08);
-  const BD_NAME_PADDING = Math.round(VIEW_W * 0.05);
-
   const [img, setImg] = useState<HTMLImageElement | null>(null);
+  // The stage is the displayed image rect (image contained, so stage === image,
+  // no letterbox). Defaults to a target-aspect placeholder while empty.
+  const [stage, setStage] = useState(() => emptyStage(aspect));
+  const [box, setBox] = useState<Box>(() => maxBox(stage.w, stage.h, aspect));
   const [error, setError] = useState<string | null>(null);
-  const [zoom, setZoom] = useState(1);
-  // Top-left of the drawn image relative to the viewport, in CSS px (<= 0).
-  const [offset, setOffset] = useState({ x: 0, y: 0 });
   const [hideHeroName, setHideHeroName] = useState(initialHideHeroName);
   const [nameFailed, setNameFailed] = useState(false);
-  const drag = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
 
-  // Scale at which the source just covers the viewport (zoom 1 == cover).
-  const coverScale = img ? Math.max(VIEW_W / img.naturalWidth, VIEW_H / img.naturalHeight) : 1;
-  const drawnW = img ? img.naturalWidth * coverScale * zoom : VIEW_W;
-  const drawnH = img ? img.naturalHeight * coverScale * zoom : VIEW_H;
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  // Active pointer gesture: a move (drag the whole box) or a corner resize.
+  const drag = useRef<
+    | { mode: 'move'; startX: number; startY: number; bx: number; by: number }
+    | { mode: 'resize'; corner: Corner; ax: number; ay: number }
+    | null
+  >(null);
 
-  const clamp = useCallback(
-    (x: number, y: number) => ({
-      x: Math.min(0, Math.max(VIEW_W - drawnW, x)),
-      y: Math.min(0, Math.max(VIEW_H - drawnH, y)),
+  const STAGE_W = stage.w;
+  const STAGE_H = stage.h;
+  // Mirror the stage size for the resize handler (avoids a stale-closure read).
+  const stageSizeRef = useRef(stage);
+  useEffect(() => {
+    stageSizeRef.current = stage;
+  }, [stage]);
+
+  // Clamp a move so the box stays fully inside the stage.
+  const clampMove = useCallback(
+    (b: Box): Box => ({
+      ...b,
+      x: Math.min(Math.max(0, b.x), STAGE_W - b.w),
+      y: Math.min(Math.max(0, b.y), STAGE_H - b.h),
     }),
-    [VIEW_W, VIEW_H, drawnW, drawnH]
+    [STAGE_W, STAGE_H]
   );
 
-  // Load the source image to learn its natural size, then center it at cover.
-  // A null source clears any prior framing back to the empty viewport.
+  // Load the source to learn its natural size, contain it in the stage budget,
+  // then place the selection (restored framing, or the largest centered box).
+  // A null source clears back to the empty placeholder stage.
   useEffect(() => {
     if (!imageDataUrl) {
       setImg(null);
-      setZoom(1);
-      setOffset({ x: 0, y: 0 });
+      const s = emptyStage(aspect);
+      setStage(s);
+      setBox(maxBox(s.w, s.h, aspect));
       setError(null);
       return;
     }
@@ -156,27 +195,23 @@ export default function LockerImageCropper({
     const el = new Image();
     el.onload = () => {
       if (!active) return;
+      const { w: sw, h: sh } = containStage(el.naturalWidth, el.naturalHeight);
       setImg(el);
-      const natW = el.naturalWidth;
-      const natH = el.naturalHeight;
-      const cs = Math.max(VIEW_W / natW, VIEW_H / natH);
-      if (initialCrop && natW > 0 && natH > 0 && initialCrop.sw > 0) {
-        // Restore the previous framing. The viewport spans `initialCrop.sw * natW`
-        // source px, so the needed render scale is VIEW_W / that. Express it as a
-        // zoom multiple of cover, clamped, then derive the clamped offset.
-        const rawScale = VIEW_W / (initialCrop.sw * natW);
-        const z = Math.min(MAX_ZOOM, Math.max(1, rawScale / cs));
-        const scale = cs * z;
-        const drawnWNow = natW * scale;
-        const drawnHNow = natH * scale;
-        setZoom(z);
-        setOffset({
-          x: Math.min(0, Math.max(VIEW_W - drawnWNow, -initialCrop.sx * natW * scale)),
-          y: Math.min(0, Math.max(VIEW_H - drawnHNow, -initialCrop.sy * natH * scale)),
-        });
+      setStage({ w: sw, h: sh });
+      if (initialCrop && initialCrop.sw > 0) {
+        // Restore previous framing. Width drives the box (aspect-locked); clamp
+        // both size and position into the stage.
+        let w = Math.min(Math.max(MIN_BOX, initialCrop.sw * sw), sw);
+        let h = w / aspect;
+        if (h > sh) {
+          h = sh;
+          w = h * aspect;
+        }
+        const x = Math.min(Math.max(0, initialCrop.sx * sw), sw - w);
+        const y = Math.min(Math.max(0, initialCrop.sy * sh), sh - h);
+        setBox({ x, y, w, h });
       } else {
-        setOffset({ x: (VIEW_W - natW * cs) / 2, y: (VIEW_H - natH * cs) / 2 });
-        setZoom(1);
+        setBox(maxBox(sw, sh, aspect));
       }
       setError(null);
     };
@@ -187,67 +222,154 @@ export default function LockerImageCropper({
     return () => {
       active = false;
     };
-  }, [imageDataUrl, initialCrop, t, VIEW_W, VIEW_H]);
+  }, [imageDataUrl, initialCrop, aspect, t]);
 
-  // Zoom around the viewport center so the framed subject stays put.
-  const applyZoom = useCallback(
-    (nextZoom: number) => {
-      const z = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+  // Keep the stage within the window when it resizes, re-deriving the box from
+  // its current normalized framing so the selection follows.
+  useEffect(() => {
+    const onResize = () => {
       if (!img) {
-        setZoom(z);
+        setStage(emptyStage(aspect));
         return;
       }
-      const cx = (VIEW_W / 2 - offset.x) / (coverScale * zoom);
-      const cy = (VIEW_H / 2 - offset.y) / (coverScale * zoom);
-      const nx = VIEW_W / 2 - cx * coverScale * z;
-      const ny = VIEW_H / 2 - cy * coverScale * z;
-      const newDrawnW = img.naturalWidth * coverScale * z;
-      const newDrawnH = img.naturalHeight * coverScale * z;
-      setZoom(z);
-      setOffset({
-        x: Math.min(0, Math.max(VIEW_W - newDrawnW, nx)),
-        y: Math.min(0, Math.max(VIEW_H - newDrawnH, ny)),
+      const prev = stageSizeRef.current;
+      const next = containStage(img.naturalWidth, img.naturalHeight);
+      setBox((b) => {
+        const fx = b.x / prev.w;
+        const fy = b.y / prev.h;
+        const fw = b.w / prev.w;
+        let w = Math.min(Math.max(MIN_BOX, fw * next.w), next.w);
+        let h = w / aspect;
+        if (h > next.h) {
+          h = next.h;
+          w = h * aspect;
+        }
+        return {
+          x: Math.min(Math.max(0, fx * next.w), next.w - w),
+          y: Math.min(Math.max(0, fy * next.h), next.h - h),
+          w,
+          h,
+        };
       });
+      setStage(next);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [img, aspect]);
+
+  // Stage-local pointer coords, clamped to the stage.
+  const localPoint = useCallback((clientX: number, clientY: number) => {
+    const rect = stageRef.current?.getBoundingClientRect();
+    if (!rect) return { x: 0, y: 0 };
+    return {
+      x: Math.min(Math.max(0, clientX - rect.left), rect.width),
+      y: Math.min(Math.max(0, clientY - rect.top), rect.height),
+    };
+  }, []);
+
+  // Resize from a corner: the opposite corner (ax, ay) is the anchor; build the
+  // largest aspect-locked box from anchor toward the pointer, clamped to bounds.
+  const resizeFrom = useCallback(
+    (ax: number, ay: number, px: number, py: number): Box => {
+      const dirX = px >= ax ? 1 : -1;
+      const dirY = py >= ay ? 1 : -1;
+      const maxW = dirX > 0 ? STAGE_W - ax : ax;
+      const maxH = dirY > 0 ? STAGE_H - ay : ay;
+      let w = Math.abs(px - ax);
+      let h = Math.abs(py - ay);
+      // Lock aspect to the governing dimension, then clamp to bounds + min size.
+      if (w / h > aspect) h = w / aspect;
+      else w = h * aspect;
+      if (w > maxW) {
+        w = maxW;
+        h = w / aspect;
+      }
+      if (h > maxH) {
+        h = maxH;
+        w = h * aspect;
+      }
+      if (w < MIN_BOX) {
+        w = MIN_BOX;
+        h = w / aspect;
+      }
+      const x = dirX > 0 ? ax : ax - w;
+      const y = dirY > 0 ? ay : ay - h;
+      return { x, y, w, h };
     },
-    [img, offset, zoom, coverScale, VIEW_W, VIEW_H]
+    [STAGE_W, STAGE_H, aspect]
   );
 
-  const onPointerDown = (e: React.PointerEvent) => {
+  const onPointerDownBox = (e: React.PointerEvent) => {
     if (!img) return;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    drag.current = { startX: e.clientX, startY: e.clientY, ox: offset.x, oy: offset.y };
+    e.stopPropagation();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    drag.current = { mode: 'move', startX: e.clientX, startY: e.clientY, bx: box.x, by: box.y };
   };
+
+  const onPointerDownHandle = (corner: Corner) => (e: React.PointerEvent) => {
+    if (!img) return;
+    e.stopPropagation();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    // Anchor = the corner opposite the one grabbed.
+    const ax = corner === 'nw' || corner === 'sw' ? box.x + box.w : box.x;
+    const ay = corner === 'nw' || corner === 'ne' ? box.y + box.h : box.y;
+    drag.current = { mode: 'resize', corner, ax, ay };
+  };
+
   const onPointerMove = (e: React.PointerEvent) => {
-    if (!drag.current) return;
-    setOffset(
-      clamp(
-        drag.current.ox + (e.clientX - drag.current.startX),
-        drag.current.oy + (e.clientY - drag.current.startY)
-      )
-    );
+    const d = drag.current;
+    if (!d) return;
+    if (d.mode === 'move') {
+      setBox((b) => clampMove({ ...b, x: d.bx + (e.clientX - d.startX), y: d.by + (e.clientY - d.startY) }));
+    } else {
+      const p = localPoint(e.clientX, e.clientY);
+      setBox(resizeFrom(d.ax, d.ay, p.x, p.y));
+    }
   };
+
   const onPointerUp = () => {
     drag.current = null;
   };
+
+  // Scale the selection around its center (slider + wheel), clamped to the stage.
+  const setBoxWidth = useCallback(
+    (targetW: number) => {
+      setBox((b) => {
+        const maxW = Math.min(STAGE_W, STAGE_H * aspect);
+        let w = Math.min(Math.max(MIN_BOX, targetW), maxW);
+        let h = w / aspect;
+        if (h > STAGE_H) {
+          h = STAGE_H;
+          w = h * aspect;
+        }
+        const cx = b.x + b.w / 2;
+        const cy = b.y + b.h / 2;
+        return clampMove({ x: cx - w / 2, y: cy - h / 2, w, h });
+      });
+    },
+    [STAGE_W, STAGE_H, aspect, clampMove]
+  );
+
   const onWheel = (e: React.WheelEvent) => {
     if (!img) return;
     e.preventDefault();
-    applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+    setBoxWidth(box.w * (e.deltaY < 0 ? 1 / 1.08 : 1.08));
   };
+
+  const maxBoxW = Math.min(STAGE_W, STAGE_H * aspect);
+  // Slider position (0..1) from the current box width.
+  const sizeValue = maxBoxW > MIN_BOX ? (box.w - MIN_BOX) / (maxBoxW - MIN_BOX) : 1;
 
   const handleApply = () => {
     if (!img || !imageDataUrl) return;
-    const scale = coverScale * zoom;
-    // The viewport maps to this rect in source-image natural coordinates.
-    const srcX = -offset.x / scale;
-    const srcY = -offset.y / scale;
-    const srcW = VIEW_W / scale;
-    const srcH = VIEW_H / scale;
-    // Normalized (source-fraction) crop rect, persisted alongside the original
-    // source so reopening restores this exact framing (and can reveal more).
     const natW = img.naturalWidth;
     const natH = img.naturalHeight;
-    const crop = { sx: srcX / natW, sy: srcY / natH, sw: srcW / natW, sh: srcH / natH };
+    // Normalized (source-fraction) crop rect: the stage maps 1:1 to the source.
+    const crop = { sx: box.x / STAGE_W, sy: box.y / STAGE_H, sw: box.w / STAGE_W, sh: box.h / STAGE_H };
+    const srcX = crop.sx * natW;
+    const srcY = crop.sy * natH;
+    const srcW = crop.sw * natW;
+    const srcH = crop.sh * natH;
     // Bake at the crop's own resolution (capped on the long edge), preserving aspect.
     const longSrc = Math.max(srcW, srcH);
     const k = longSrc > MAX_OUTPUT_LONG ? MAX_OUTPUT_LONG / longSrc : 1;
@@ -268,6 +390,21 @@ export default function LockerImageCropper({
 
   const namePath = getHeroNamePath(heroName);
 
+  // Name chrome scales with the crop box (its baked surface), not the stage.
+  const previewScale = box.w / REFERENCE_CARD_W;
+  const NAME_HEIGHT = Math.round(28 * previewScale);
+  const NAME_PADDING = Math.round(12 * previewScale);
+  const NAME_FALLBACK_FONT = Math.round(14 * previewScale);
+  const BD_NAME_HEIGHT = Math.round(box.w * 0.08);
+  const BD_NAME_PADDING = Math.round(box.w * 0.05);
+
+  const cornerCursor: Record<Corner, string> = {
+    nw: 'nwse-resize',
+    se: 'nwse-resize',
+    ne: 'nesw-resize',
+    sw: 'nesw-resize',
+  };
+
   return (
     <div className="flex flex-col gap-3">
       {error && (
@@ -278,13 +415,13 @@ export default function LockerImageCropper({
       )}
 
       <div className="flex justify-center">
-        {/* Viewport doubles as a live preview: same gradient, and (card mode)
-            the hero-name overlay the real card renders. Empty until a source is
-            chosen, but still at the target shape so the framing is previewed. */}
+        {/* Stage: the whole image contained, with the aspect-locked selection box
+            overlaid. Outside the box is dimmed; the box overlays the hero-name
+            chrome so the preview is to scale. Empty (target shape) until picked. */}
         <div
+          ref={stageRef}
           className="relative touch-none select-none overflow-hidden rounded-xl border border-border bg-bg-primary/60"
-          style={{ width: VIEW_W, height: VIEW_H, cursor: img ? 'grab' : 'default' }}
-          onPointerDown={onPointerDown}
+          style={{ width: STAGE_W, height: STAGE_H }}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
@@ -295,8 +432,7 @@ export default function LockerImageCropper({
               src={imageDataUrl ?? undefined}
               alt=""
               draggable={false}
-              className="pointer-events-none absolute max-w-none"
-              style={{ left: offset.x, top: offset.y, width: drawnW, height: drawnH }}
+              className="pointer-events-none absolute inset-0 h-full w-full"
             />
           ) : (
             <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-text-secondary">
@@ -305,77 +441,122 @@ export default function LockerImageCropper({
             </div>
           )}
 
-          {/* Chrome preview (pointer-events-none so it never blocks drag). */}
-          <div className="pointer-events-none absolute inset-0">
-            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
-            {nameControls && !hideHeroName && namePosition === 'card' && (
-              <div
-                className="absolute bottom-0 left-0 right-0 flex flex-col items-end text-right"
-                style={{ padding: NAME_PADDING }}
-              >
-                {nameFailed ? (
+          {img && (
+            <div
+              className="absolute cursor-move"
+              style={{
+                left: box.x,
+                top: box.y,
+                width: box.w,
+                height: box.h,
+                // Dim everything outside the selection.
+                boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)',
+                outline: '1px solid rgba(255,255,255,0.9)',
+              }}
+              onPointerDown={onPointerDownBox}
+            >
+              {/* Rule-of-thirds guides. */}
+              <div className="pointer-events-none absolute inset-0">
+                <div className="absolute left-1/3 top-0 bottom-0 w-px bg-white/25" />
+                <div className="absolute left-2/3 top-0 bottom-0 w-px bg-white/25" />
+                <div className="absolute top-1/3 left-0 right-0 h-px bg-white/25" />
+                <div className="absolute top-2/3 left-0 right-0 h-px bg-white/25" />
+              </div>
+
+              {/* Name + gradient chrome preview (to scale with the box). */}
+              <div className="pointer-events-none absolute inset-0 overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent opacity-80" />
+                {nameControls && !hideHeroName && namePosition === 'card' && (
                   <div
-                    className="font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                    style={{ fontSize: NAME_FALLBACK_FONT }}
+                    className="absolute bottom-0 left-0 right-0 flex flex-col items-end text-right"
+                    style={{ padding: NAME_PADDING }}
                   >
-                    {heroName}
+                    {nameFailed ? (
+                      <div
+                        className="font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                        style={{ fontSize: NAME_FALLBACK_FONT }}
+                      >
+                        {heroName}
+                      </div>
+                    ) : (
+                      <div className="relative ml-auto w-[70%]" style={{ height: NAME_HEIGHT }}>
+                        <img
+                          src={namePath}
+                          alt={heroName}
+                          className="absolute inset-0 h-full w-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                          onError={() => setNameFailed(true)}
+                        />
+                      </div>
+                    )}
                   </div>
-                ) : (
-                  <div className="relative ml-auto w-[70%]" style={{ height: NAME_HEIGHT }}>
-                    <img
-                      src={namePath}
-                      alt={heroName}
-                      className="absolute inset-0 h-full w-full object-contain object-right drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                      onError={() => setNameFailed(true)}
-                    />
+                )}
+                {nameControls && !hideHeroName && namePosition === 'backdrop' && (
+                  <div className="absolute left-0 top-0" style={{ padding: BD_NAME_PADDING }}>
+                    {nameFailed ? (
+                      <div
+                        className="font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                        style={{ fontSize: Math.round(BD_NAME_HEIGHT * 0.9) }}
+                      >
+                        {heroName}
+                      </div>
+                    ) : (
+                      <img
+                        src={namePath}
+                        alt={heroName}
+                        className="w-auto object-contain object-left drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+                        style={{ height: BD_NAME_HEIGHT }}
+                        onError={() => setNameFailed(true)}
+                      />
+                    )}
                   </div>
                 )}
               </div>
-            )}
-            {nameControls && !hideHeroName && namePosition === 'backdrop' && (
-              <div className="absolute left-0 top-0" style={{ padding: BD_NAME_PADDING }}>
-                {nameFailed ? (
-                  <div
-                    className="font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                    style={{ fontSize: Math.round(BD_NAME_HEIGHT * 0.9) }}
-                  >
-                    {heroName}
-                  </div>
-                ) : (
-                  <img
-                    src={namePath}
-                    alt={heroName}
-                    className="w-auto object-contain object-left drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
-                    style={{ height: BD_NAME_HEIGHT }}
-                    onError={() => setNameFailed(true)}
-                  />
-                )}
-              </div>
-            )}
-          </div>
+
+              {/* Corner resize handles. */}
+              {(['nw', 'ne', 'sw', 'se'] as const).map((corner) => (
+                <div
+                  key={corner}
+                  onPointerDown={onPointerDownHandle(corner)}
+                  className="absolute h-3 w-3 rounded-sm border border-black/40 bg-white"
+                  style={{
+                    cursor: cornerCursor[corner],
+                    left: corner === 'nw' || corner === 'sw' ? -6 : undefined,
+                    right: corner === 'ne' || corner === 'se' ? -6 : undefined,
+                    top: corner === 'nw' || corner === 'ne' ? -6 : undefined,
+                    bottom: corner === 'sw' || corner === 'se' ? -6 : undefined,
+                  }}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
+      {img && (
+        <p className="text-center text-[11px] leading-snug text-text-secondary">
+          {t('locker.crop.boxHint')}
+        </p>
+      )}
+
       <div className="flex items-center gap-3">
-        <ZoomIn className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+        <Maximize2 className="h-4 w-4 flex-shrink-0 text-text-secondary" />
         <input
           type="range"
-          min={1}
-          max={MAX_ZOOM}
+          min={0}
+          max={1}
           step={0.01}
-          value={zoom}
+          value={Math.min(1, Math.max(0, sizeValue))}
           disabled={!img}
-          onChange={(e) => applyZoom(Number(e.target.value))}
+          onChange={(e) => setBoxWidth(MIN_BOX + Number(e.target.value) * (maxBoxW - MIN_BOX))}
+          aria-label={t('locker.crop.selectionSize')}
           className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-border accent-accent disabled:cursor-not-allowed disabled:opacity-50"
         />
-        <span className="w-10 text-right text-[11px] tabular-nums text-text-secondary">
-          {zoom.toFixed(1)}x
-        </span>
         <button
           type="button"
           disabled={!img}
-          onClick={() => applyZoom(1)}
-          title={t('locker.crop.resetZoom')}
+          onClick={() => setBox(maxBox(STAGE_W, STAGE_H, aspect))}
+          title={t('locker.crop.resetCrop')}
+          aria-label={t('locker.crop.resetCrop')}
           className="cursor-pointer rounded-md border border-border/60 p-1 text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           <RotateCcw className="h-3.5 w-3.5" />

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -1,0 +1,462 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Check, Image as ImageIcon, Ban, Upload, X } from 'lucide-react';
+import { useAppStore } from '../../stores/appStore';
+import { getAssetPath } from '../../lib/assetPath';
+import {
+  DEFAULT_SIDEBAR_HERO,
+  HERO_NAMES_SORTED,
+  getHeroChipIconPath,
+  getHeroRenderPath,
+  getSidebarHeroImageStyle,
+  resolveAppearanceBg,
+} from '../../lib/lockerUtils';
+import { getAppearanceImageEdit, setAppearanceImageEdit, readImageDataUrl, showOpenDialog } from '../../lib/api';
+import type { AppearanceBg, AppearanceBgKind, AppearanceSurface, AppSettings } from '../../types/mod';
+import type { CropRect } from '../../types/electron';
+import { Button } from '../common/ui';
+import Tx from '../translation/Tx';
+import LockerImageCropper from '../locker/LockerImageCropper';
+
+// The launch buttons / volume bar are wide-and-short banners; frame custom
+// uploads to roughly that shape so the crop preview matches what's rendered.
+// (The Sidebar backdrops use object-cover, so the exact ratio is forgiving.)
+const SURFACE_ASPECT = 11 / 2;
+
+interface SurfaceConfig {
+  id: AppearanceSurface;
+  labelKey: string;
+  fallbackLabel: string;
+  /** Built-in art shown for the `default` kind (none for activeTab: its default
+   *  is the plain accent glow). */
+  defaultSrc: string | null;
+  defaultPosition: string;
+  /** Surfaces that can be fully hidden. The active tab always needs a visible
+   *  highlight, so its `default` IS the accent glow and `none` is omitted. */
+  allowNone: boolean;
+}
+
+const SURFACES: readonly SurfaceConfig[] = [
+  {
+    id: 'launchModded',
+    labelKey: 'settings.appearance.art.surface.launchModded',
+    fallbackLabel: 'Launch Modded',
+    defaultSrc: getAssetPath('/locker/launch-modded-bg.webp'),
+    defaultPosition: 'center 45%',
+    allowNone: true,
+  },
+  {
+    id: 'launchVanilla',
+    labelKey: 'settings.appearance.art.surface.launchVanilla',
+    fallbackLabel: 'Launch Vanilla',
+    defaultSrc: getAssetPath('/locker/launch-vanilla-bg.jpg'),
+    defaultPosition: 'center 48%',
+    allowNone: true,
+  },
+  {
+    id: 'activeTab',
+    labelKey: 'settings.appearance.art.surface.activeTab',
+    fallbackLabel: 'Active tab',
+    defaultSrc: null,
+    defaultPosition: 'center',
+    allowNone: false,
+  },
+  {
+    id: 'volume',
+    labelKey: 'settings.appearance.art.surface.volume',
+    fallbackLabel: 'Volume bar',
+    defaultSrc: getAssetPath('/sidebar/preview-volume-bg.jpg'),
+    defaultPosition: 'center 43%',
+    allowNone: true,
+  },
+];
+
+/** The source-kind buttons offered for a surface (activeTab drops `none`). */
+function kindsFor(surface: SurfaceConfig): AppearanceBgKind[] {
+  return surface.allowNone
+    ? ['default', 'hero', 'custom', 'none']
+    : ['default', 'hero', 'custom'];
+}
+
+/** A small live preview of how a surface's chosen background looks. */
+function SurfacePreview({
+  bg,
+  config,
+  customSrc,
+  className = '',
+}: {
+  bg: AppearanceBg;
+  config: SurfaceConfig;
+  customSrc?: string;
+  className?: string;
+}) {
+  const base = `relative overflow-hidden rounded-sm border border-white/10 bg-bg-tertiary ${className}`;
+  if (bg.kind === 'none') {
+    return (
+      <span className={`${base} flex items-center justify-center`} aria-hidden>
+        <Ban className="h-4 w-4 text-text-secondary" />
+      </span>
+    );
+  }
+  let src: string | null = null;
+  let style: CSSProperties = { objectPosition: config.defaultPosition };
+  if (bg.kind === 'hero') {
+    const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
+    src = getHeroRenderPath(hero);
+    style = getSidebarHeroImageStyle(hero);
+  } else if (bg.kind === 'custom') {
+    src = customSrc ?? config.defaultSrc;
+    style = { objectPosition: 'center' };
+  } else {
+    src = config.defaultSrc;
+  }
+  if (!src) {
+    // activeTab default: the plain accent glow.
+    return (
+      <span className={`${base} bg-accent/15`} aria-hidden>
+        <span className="absolute inset-0 bg-gradient-to-r from-accent/25 via-accent/10 to-transparent" />
+      </span>
+    );
+  }
+  return (
+    <span className={base} aria-hidden>
+      <img src={src} alt="" className="h-full w-full object-cover opacity-80" style={style} />
+      <span className="absolute inset-0 bg-gradient-to-r from-bg-primary/70 via-bg-primary/30 to-transparent" />
+    </span>
+  );
+}
+
+/**
+ * Launcher & sidebar art customization (issue: unify launcher backgrounds).
+ *
+ * One place to set the background of all four customizable Sidebar surfaces:
+ * the Launch Modded / Launch Vanilla buttons, the active-tab highlight, and the
+ * preview-volume bar. Each independently picks built-in art, a hero render, a
+ * custom upload (full crop editor), or none. Replaces the old split between the
+ * Appearance hero chip and the launch buttons' right-click "hide art" toggle.
+ */
+export default function AppearanceArtSection() {
+  const { t } = useTranslation();
+  const settings = useAppStore((s) => s.settings);
+  const appearanceImages = useAppStore((s) => s.appearanceImages);
+  const saveSettings = useAppStore((s) => s.saveSettings);
+  const setAppearanceImage = useAppStore((s) => s.setAppearanceImage);
+  const removeAppearanceImage = useAppStore((s) => s.removeAppearanceImage);
+
+  const [editing, setEditing] = useState<AppearanceSurface | null>(null);
+  const editingConfig = SURFACES.find((s) => s.id === editing) ?? null;
+
+  // Custom-image crop flow state (only meaningful while the custom kind is shown).
+  const [cropSource, setCropSource] = useState<string | null>(null);
+  const [restoredCrop, setRestoredCrop] = useState<CropRect | undefined>(undefined);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Which kind tab is shown inside the modal (separate from the saved kind so the
+  // user can preview a different source before committing).
+  const [draftKind, setDraftKind] = useState<AppearanceBgKind>('default');
+  const editLoadId = useRef(0);
+
+  const close = useCallback(() => {
+    setEditing(null);
+    setCropSource(null);
+    setRestoredCrop(undefined);
+    setError(null);
+    setBusy(false);
+  }, []);
+
+  // Close the modal on Escape.
+  useEffect(() => {
+    if (!editing) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [editing, close]);
+
+  const openEditor = (surface: AppearanceSurface) => {
+    const current = resolveAppearanceBg(settings, surface);
+    setEditing(surface);
+    setError(null);
+    setBusy(false);
+    setDraftKind(current.kind);
+    setCropSource(null);
+    setRestoredCrop(undefined);
+    if (current.kind === 'custom') void loadEdit(surface);
+  };
+
+  // Seed the cropper with the stored original + crop so reopening restores the
+  // exact framing (best-effort: falls back to the baked image, then empty).
+  const loadEdit = async (surface: AppearanceSurface) => {
+    const loadId = ++editLoadId.current;
+    try {
+      const edit = await getAppearanceImageEdit(surface);
+      if (editLoadId.current !== loadId) return;
+      if (edit) {
+        setCropSource(edit.source);
+        setRestoredCrop(edit.crop);
+      } else {
+        setCropSource(appearanceImages[surface] ?? null);
+        setRestoredCrop(undefined);
+      }
+    } catch {
+      if (editLoadId.current === loadId) setCropSource(appearanceImages[surface] ?? null);
+    }
+  };
+
+  const persist = async (surface: AppearanceSurface, bg: AppearanceBg) => {
+    if (!settings) return;
+    const nextBackgrounds = { ...(settings.appearanceBackgrounds ?? {}), [surface]: bg };
+    const patch: Partial<AppSettings> = { appearanceBackgrounds: nextBackgrounds };
+    // Keep the legacy field roughly in sync so any older read path stays sane.
+    if (surface === 'activeTab') {
+      patch.sidebarHeroHighlight =
+        bg.kind === 'hero' ? bg.hero ?? DEFAULT_SIDEBAR_HERO : bg.kind === 'none' ? null : settings.sidebarHeroHighlight;
+    }
+    await saveSettings({ ...settings, ...patch });
+  };
+
+  // Default / None apply immediately and close; if leaving custom, drop the
+  // stored bytes so they don't linger.
+  const chooseKind = async (kind: AppearanceBgKind) => {
+    if (!editing || !editingConfig) return;
+    setDraftKind(kind);
+    setError(null);
+    if (kind === 'default' || kind === 'none') {
+      if (resolveAppearanceBg(settings, editing).kind === 'custom') {
+        await removeAppearanceImage(editing);
+      }
+      await persist(editing, { kind });
+      close();
+      return;
+    }
+    if (kind === 'hero') {
+      setCropSource(null);
+      return;
+    }
+    // custom: load any prior edit to seed the cropper.
+    setCropSource(null);
+    setRestoredCrop(undefined);
+    void loadEdit(editing);
+  };
+
+  const chooseHero = async (hero: string) => {
+    if (!editing) return;
+    await persist(editing, { kind: 'hero', hero });
+    close();
+  };
+
+  // Picking a NEW source discards the restored crop so the cropper centers it.
+  const stageSource = (dataUrl: string) => {
+    editLoadId.current++;
+    setRestoredCrop(undefined);
+    setCropSource(dataUrl);
+  };
+
+  const pickCustom = async () => {
+    if (busy) return;
+    const path = await showOpenDialog({
+      title: t('settings.appearance.art.uploadImage', 'Upload image'),
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
+    });
+    if (!path) return;
+    try {
+      const dataUrl = await readImageDataUrl(path);
+      stageSource(dataUrl);
+    } catch (err) {
+      console.error('Failed to read custom image', err);
+      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+    }
+  };
+
+  const applyCrop = async ({
+    dataUrl,
+    source,
+    crop,
+  }: {
+    dataUrl: string;
+    hideHeroName: boolean;
+    source: string;
+    crop: CropRect;
+  }) => {
+    if (!editing || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await setAppearanceImage(editing, dataUrl);
+      // Resume aid; non-fatal if it fails to store.
+      try {
+        await setAppearanceImageEdit(editing, source, crop);
+      } catch (editErr) {
+        console.error('Failed to store appearance image edit (resume framing)', editErr);
+      }
+      await persist(editing, { kind: 'custom' });
+      close();
+    } catch (err) {
+      console.error('Failed to set appearance image', err);
+      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-text-primary">
+          <Tx k="settings.appearance.art.title" fallback="Launcher & sidebar art" />
+        </h3>
+        <p className="text-xs text-text-secondary">
+          <Tx
+            k="settings.appearance.art.description"
+            fallback="Set the background for each launch button, the active tab, and the volume bar."
+          />
+        </p>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        {SURFACES.map((config) => {
+          const bg = resolveAppearanceBg(settings, config.id);
+          const kindLabel = t(`settings.appearance.art.kind.${bg.kind}`);
+          const detail = bg.kind === 'hero' ? bg.hero ?? DEFAULT_SIDEBAR_HERO : kindLabel;
+          return (
+            <button
+              key={config.id}
+              type="button"
+              onClick={() => openEditor(config.id)}
+              className="group flex items-center gap-3 rounded-sm border border-white/10 bg-bg-tertiary/40 p-2 text-left transition-colors hover:border-accent/40 hover:bg-accent/5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <SurfacePreview
+                bg={bg}
+                config={config}
+                customSrc={appearanceImages[config.id]}
+                className="h-9 w-16 flex-shrink-0"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-text-primary">
+                  {t(config.labelKey, config.fallbackLabel)}
+                </span>
+                <span className="block truncate text-xs text-text-secondary">{detail}</span>
+              </span>
+              <ImageIcon className="h-4 w-4 flex-shrink-0 text-text-secondary group-hover:text-accent" aria-hidden />
+            </button>
+          );
+        })}
+      </div>
+
+      {editing && editingConfig && createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm animate-fade-in"
+          onClick={close}
+          role="presentation"
+        >
+          <div
+            className="relative w-full max-w-md overflow-hidden rounded-sm border border-white/10 bg-bg-secondary p-5 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t('settings.appearance.art.editNamed', {
+              surface: t(editingConfig.labelKey, editingConfig.fallbackLabel),
+            })}
+          >
+            <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h3 className="text-lg font-semibold text-text-primary tracking-wide font-reaver">
+                {t(editingConfig.labelKey, editingConfig.fallbackLabel)}
+              </h3>
+              <button
+                type="button"
+                onClick={close}
+                title={t('common.actions.close')}
+                aria-label={t('common.actions.close')}
+                className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/10 text-text-secondary transition-colors hover:border-white/25 hover:bg-white/5 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+
+            {/* Source-kind tabs */}
+            <div className="mb-4 flex flex-wrap gap-1.5">
+              {kindsFor(editingConfig).map((kind) => {
+                const active = draftKind === kind;
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => void chooseKind(kind)}
+                    aria-pressed={active}
+                    className={`rounded-sm border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      active
+                        ? 'border-accent/70 bg-accent/15 text-text-primary'
+                        : 'border-white/10 bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'
+                    }`}
+                  >
+                    {t(`settings.appearance.art.kind.${kind}`)}
+                  </button>
+                );
+              })}
+            </div>
+
+            {draftKind === 'hero' && (
+              <div className="grid max-h-[50vh] grid-cols-5 gap-2 overflow-y-auto sm:grid-cols-6">
+                {HERO_NAMES_SORTED.map((heroName) => {
+                  const current = resolveAppearanceBg(settings, editing);
+                  const active = current.kind === 'hero' && (current.hero ?? DEFAULT_SIDEBAR_HERO) === heroName;
+                  return (
+                    <button
+                      key={heroName}
+                      type="button"
+                      onClick={() => void chooseHero(heroName)}
+                      title={heroName}
+                      aria-label={heroName}
+                      aria-pressed={active}
+                      className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                        active
+                          ? 'border-accent/70 bg-accent/15'
+                          : 'border-white/10 hover:border-accent/50 hover:bg-accent/10'
+                      }`}
+                    >
+                      <img
+                        src={getHeroChipIconPath(heroName)}
+                        alt=""
+                        aria-hidden
+                        className="h-8 w-8 object-contain"
+                        loading="lazy"
+                      />
+                      {active && (
+                        <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
+                          <Check className="h-2.5 w-2.5" aria-hidden />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {draftKind === 'custom' && (
+              <div className="space-y-3">
+                <LockerImageCropper
+                  imageDataUrl={cropSource}
+                  aspect={SURFACE_ASPECT}
+                  initialCrop={restoredCrop}
+                  emptyHint={t('settings.appearance.art.uploadHint', 'Upload an image to frame it.')}
+                  busy={busy}
+                  onApply={applyCrop}
+                />
+                <Button variant="secondary" size="sm" onClick={() => void pickCustom()} disabled={busy}>
+                  <Upload className="h-4 w-4" />
+                  <Tx k="settings.appearance.art.uploadImage" fallback="Upload image" />
+                </Button>
+              </div>
+            )}
+
+            {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
-import { createPortal } from 'react-dom';
+import { useCallback, useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Image as ImageIcon, Ban, Upload, X } from 'lucide-react';
 import { useAppStore } from '../../stores/appStore';
@@ -24,11 +23,46 @@ import type { CropRect } from '../../types/electron';
 import { Button } from '../common/ui';
 import Tx from '../translation/Tx';
 import LockerImageCropper from '../locker/LockerImageCropper';
+import { Modal } from '../common/Modal';
 
 // The launch buttons / volume bar are wide-and-short banners; frame custom
 // uploads to roughly that shape so the crop preview matches what's rendered.
 // (The Sidebar backdrops use object-cover, so the exact ratio is forgiving.)
 const SURFACE_ASPECT = 11 / 2;
+
+/** Cap a freshly picked upload's long edge before it's framed/stored. The baked
+ *  output is already capped (in the cropper), but the ORIGINAL source is kept for
+ *  a faithful reopen; without this a 40MP photo would round-trip through IPC and
+ *  sit in memory + on disk at full size. */
+const MAX_SOURCE_LONG = 2560;
+
+/** Downscale a data URL so its long edge is <= MAX_SOURCE_LONG, re-encoding in a
+ *  size-appropriate format (preserve PNG/WebP alpha; everything else -> JPEG).
+ *  Returns the input untouched when already within bounds or on any failure. */
+async function capSourceImage(dataUrl: string): Promise<string> {
+  const img = await new Promise<HTMLImageElement | null>((resolve) => {
+    const el = new Image();
+    el.onload = () => resolve(el);
+    el.onerror = () => resolve(null);
+    el.src = dataUrl;
+  });
+  if (!img) return dataUrl;
+  const long = Math.max(img.naturalWidth, img.naturalHeight);
+  if (long <= MAX_SOURCE_LONG) return dataUrl;
+  const k = MAX_SOURCE_LONG / long;
+  const w = Math.max(1, Math.round(img.naturalWidth * k));
+  const h = Math.max(1, Math.round(img.naturalHeight * k));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return dataUrl;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(img, 0, 0, w, h);
+  const mime = dataUrl.slice(5, Math.max(5, dataUrl.indexOf(';')));
+  const outType = mime === 'image/png' || mime === 'image/webp' ? mime : 'image/jpeg';
+  return canvas.toDataURL(outType, outType === 'image/jpeg' ? 0.9 : undefined);
+}
 
 interface SurfaceConfig {
   id: AppearanceSurface;
@@ -193,16 +227,6 @@ export default function AppearanceArtSection() {
     setBusy(false);
   }, []);
 
-  // Close the modal on Escape.
-  useEffect(() => {
-    if (!editing) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [editing, close]);
-
   const openEditor = (surface: AppearanceSurface) => {
     const current = resolveAppearanceBg(settings, surface);
     const config = SURFACES.find((s) => s.id === surface);
@@ -263,7 +287,7 @@ export default function AppearanceArtSection() {
     } catch (err) {
       if (editLoadId.current !== loadId) return;
       console.error('Failed to load appearance source', err);
-      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+      setError(t('settings.appearance.art.applyError'));
     }
   };
 
@@ -332,18 +356,18 @@ export default function AppearanceArtSection() {
   const pickCustom = async () => {
     if (busy) return;
     const path = await showOpenDialog({
-      title: t('settings.appearance.art.uploadImage', 'Upload image'),
+      title: t('settings.appearance.art.uploadImage'),
       filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
     });
     if (!path) return;
     try {
-      const dataUrl = await readImageDataUrl(path);
+      const dataUrl = await capSourceImage(await readImageDataUrl(path));
       editLoadId.current++;
       setRestoredCrop(undefined);
       setCropSource(dataUrl);
     } catch (err) {
       console.error('Failed to read custom image', err);
-      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+      setError(t('settings.appearance.art.applyError'));
     }
   };
 
@@ -375,7 +399,7 @@ export default function AppearanceArtSection() {
       close();
     } catch (err) {
       console.error('Failed to set appearance image', err);
-      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+      setError(t('settings.appearance.art.applyError'));
     } finally {
       setBusy(false);
     }
@@ -434,26 +458,23 @@ export default function AppearanceArtSection() {
         })}
       </div>
 
-      {editing && editingConfig && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm animate-fade-in"
-          onClick={close}
-          role="presentation"
+      {editing && editingConfig && (
+        <Modal
+          onClose={close}
+          size="sm"
+          dismissable={!busy}
+          labelledBy="appearance-art-modal-title"
+          backdropClassName="backdrop-blur-sm"
+          panelClassName="relative flex max-h-[90vh] flex-col overflow-hidden"
         >
-          <div
-            className="relative flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-sm border border-white/10 bg-bg-secondary shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-            role="dialog"
-            aria-modal="true"
-            aria-label={t('settings.appearance.art.editNamed', {
-              surface: t(editingConfig.labelKey, editingConfig.fallbackLabel),
-            })}
-          >
             <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
 
             {/* Header (pinned) */}
             <div className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pt-5 pb-4">
-              <h3 className="text-lg font-semibold text-text-primary tracking-wide font-reaver">
+              <h3
+                id="appearance-art-modal-title"
+                className="text-lg font-semibold text-text-primary tracking-wide font-reaver"
+              >
                 {t(editingConfig.labelKey, editingConfig.fallbackLabel)}
               </h3>
               <button
@@ -495,7 +516,7 @@ export default function AppearanceArtSection() {
               {showFooter && (
                 <div className="mb-4">
                   <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-text-secondary">
-                    {t('settings.appearance.art.preview', 'Preview')}
+                    {t('settings.appearance.art.preview')}
                   </span>
                   <SurfacePreview bg={draftBg} config={editingConfig} customSrc={appearanceImages[editing]} className="h-16 w-full" />
                   <p className="mt-3 text-center text-sm text-text-secondary">
@@ -550,7 +571,7 @@ export default function AppearanceArtSection() {
                     aspect={SURFACE_ASPECT}
                     nameControls={false}
                     initialCrop={restoredCrop}
-                    emptyHint={t('settings.appearance.art.uploadHint', 'Upload an image to frame it.')}
+                    emptyHint={t('settings.appearance.art.uploadHint')}
                     busy={busy}
                     onApply={applyCrop}
                   />
@@ -571,7 +592,7 @@ export default function AppearanceArtSection() {
                       }}
                       disabled={busy}
                     >
-                      {t('settings.appearance.art.changeHero', 'Choose a different hero')}
+                      {t('settings.appearance.art.changeHero')}
                     </Button>
                   )}
                 </div>
@@ -592,9 +613,7 @@ export default function AppearanceArtSection() {
                 </Button>
               </div>
             )}
-          </div>
-        </div>,
-        document.body
+        </Modal>
       )}
     </div>
   );

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -12,7 +12,13 @@ import {
   getSidebarHeroImageStyle,
   resolveAppearanceBg,
 } from '../../lib/lockerUtils';
-import { getAppearanceImageEdit, setAppearanceImageEdit, readImageDataUrl, showOpenDialog } from '../../lib/api';
+import {
+  getAppearanceImageEdit,
+  setAppearanceImageEdit,
+  readImageDataUrl,
+  readRendererAsset,
+  showOpenDialog,
+} from '../../lib/api';
 import type { AppearanceBg, AppearanceBgKind, AppearanceSurface, AppSettings } from '../../types/mod';
 import type { CropRect } from '../../types/electron';
 import { Button } from '../common/ui';
@@ -77,6 +83,26 @@ function kindsFor(surface: SurfaceConfig): AppearanceBgKind[] {
   return surface.allowNone
     ? ['default', 'hero', 'custom', 'none']
     : ['default', 'hero', 'custom'];
+}
+
+/** Read an in-app asset URL (built-in art, hero render) as a data URL so it can be
+ *  fed to the cropper and baked via canvas without tainting. A packaged renderer is
+ *  served from file://, where fetch() of a file:// asset is blocked and a file://
+ *  <img> taints the canvas, so there we round-trip through the main process (which
+ *  mirrors how getAssetPath gates on the file: protocol). In dev (http) fetch works. */
+async function urlToDataUrl(url: string): Promise<string> {
+  if (typeof window !== 'undefined' && window.location.protocol === 'file:') {
+    return readRendererAsset(url);
+  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to load ${url}: ${res.status}`);
+  const blob = await res.blob();
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
 }
 
 /** A small live preview of how a surface's chosen background looks. */
@@ -153,8 +179,10 @@ export default function AppearanceArtSection() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Which kind tab is shown inside the modal (separate from the saved kind so the
-  // user can preview a different source before committing).
+  // user can preview a different source before committing). Nothing is persisted
+  // until the user hits Apply (custom commits through the cropper's own button).
   const [draftKind, setDraftKind] = useState<AppearanceBgKind>('default');
+  const [draftHero, setDraftHero] = useState<string>(DEFAULT_SIDEBAR_HERO);
   const editLoadId = useRef(0);
 
   const close = useCallback(() => {
@@ -177,19 +205,70 @@ export default function AppearanceArtSection() {
 
   const openEditor = (surface: AppearanceSurface) => {
     const current = resolveAppearanceBg(settings, surface);
+    const config = SURFACES.find((s) => s.id === surface);
+    const hero = current.kind === 'hero' ? current.hero ?? DEFAULT_SIDEBAR_HERO : DEFAULT_SIDEBAR_HERO;
     setEditing(surface);
     setError(null);
     setBusy(false);
     setDraftKind(current.kind);
+    setDraftHero(hero);
     setCropSource(null);
     setRestoredCrop(undefined);
-    if (current.kind === 'custom') void loadEdit(surface);
+    // Restore framing for the saved selection (image kinds only).
+    if (config) void seedForKind(surface, config, current.kind, hero, true);
   };
 
-  // Seed the cropper with the stored original + crop so reopening restores the
-  // exact framing (best-effort: falls back to the baked image, then empty).
-  const loadEdit = async (surface: AppearanceSurface) => {
+  // Seed the cropper with the source for a kind: the stored original + crop when
+  // it matches the saved selection (so reopening restores the exact framing), or
+  // the fresh source for that kind (built-in art / hero render). `custom` waits
+  // for an upload; `none` and the activeTab accent-glow `default` have no source.
+  const seedForKind = async (
+    surface: AppearanceSurface,
+    config: SurfaceConfig,
+    kind: AppearanceBgKind,
+    hero: string,
+    restore: boolean
+  ) => {
+    setError(null);
     const loadId = ++editLoadId.current;
+    setCropSource(null);
+    setRestoredCrop(undefined);
+    if (kind === 'none') return;
+    if (kind === 'custom') {
+      // Restore a stored custom upload only when the surface was already custom.
+      if (restore && resolveAppearanceBg(settings, surface).kind === 'custom') void loadEdit(surface, loadId);
+      return;
+    }
+    if (kind === 'default' && !config.defaultSrc) return; // accent glow, nothing to frame
+
+    const saved = resolveAppearanceBg(settings, surface);
+    const matches =
+      restore && saved.kind === kind && (kind !== 'hero' || (saved.hero ?? DEFAULT_SIDEBAR_HERO) === hero);
+    try {
+      if (matches) {
+        const edit = await getAppearanceImageEdit(surface);
+        if (editLoadId.current !== loadId) return;
+        if (edit) {
+          setCropSource(edit.source);
+          setRestoredCrop(edit.crop);
+          return;
+        }
+      }
+      // Fresh source for the kind.
+      const url = kind === 'default' ? config.defaultSrc! : getHeroRenderPath(hero);
+      const dataUrl = await urlToDataUrl(url);
+      if (editLoadId.current !== loadId) return;
+      setRestoredCrop(undefined);
+      setCropSource(dataUrl);
+    } catch (err) {
+      if (editLoadId.current !== loadId) return;
+      console.error('Failed to load appearance source', err);
+      setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
+    }
+  };
+
+  // Restore a stored custom edit (original + crop), falling back to the baked image.
+  const loadEdit = async (surface: AppearanceSurface, loadId = ++editLoadId.current) => {
     try {
       const edit = await getAppearanceImageEdit(surface);
       if (editLoadId.current !== loadId) return;
@@ -217,41 +296,37 @@ export default function AppearanceArtSection() {
     await saveSettings({ ...settings, ...patch });
   };
 
-  // Default / None apply immediately and close; if leaving custom, drop the
-  // stored bytes so they don't linger.
-  const chooseKind = async (kind: AppearanceBgKind) => {
+  // Tabs only switch the draft kind (no auto-apply). Hero opens to its grid; the
+  // other kinds seed the cropper (or, for none / accent-glow default, nothing).
+  const selectKind = (kind: AppearanceBgKind) => {
     if (!editing || !editingConfig) return;
     setDraftKind(kind);
     setError(null);
-    if (kind === 'default' || kind === 'none') {
-      if (resolveAppearanceBg(settings, editing).kind === 'custom') {
-        await removeAppearanceImage(editing);
-      }
-      await persist(editing, { kind });
-      close();
-      return;
-    }
     if (kind === 'hero') {
+      // Show the hero grid first; picking a hero loads it into the cropper.
+      editLoadId.current++;
       setCropSource(null);
+      setRestoredCrop(undefined);
       return;
     }
-    // custom: load any prior edit to seed the cropper.
-    setCropSource(null);
-    setRestoredCrop(undefined);
-    void loadEdit(editing);
+    void seedForKind(editing, editingConfig, kind, draftHero, false);
   };
 
-  const chooseHero = async (hero: string) => {
-    if (!editing) return;
-    await persist(editing, { kind: 'hero', hero });
+  const selectHero = (hero: string) => {
+    if (!editing || !editingConfig) return;
+    setDraftHero(hero);
+    void seedForKind(editing, editingConfig, 'hero', hero, false);
+  };
+
+  // Commit a non-image draft (none, or the activeTab accent-glow default). Drops
+  // any baked image so the live/glow render takes over. Image kinds commit through
+  // the cropper's own "use image" button (it has to bake first).
+  const applyDraft = async () => {
+    if (!editing || busy) return;
+    if (appearanceImages[editing]) await removeAppearanceImage(editing);
+    const bg: AppearanceBg = draftKind === 'hero' ? { kind: 'hero', hero: draftHero } : { kind: draftKind };
+    await persist(editing, bg);
     close();
-  };
-
-  // Picking a NEW source discards the restored crop so the cropper centers it.
-  const stageSource = (dataUrl: string) => {
-    editLoadId.current++;
-    setRestoredCrop(undefined);
-    setCropSource(dataUrl);
   };
 
   const pickCustom = async () => {
@@ -263,13 +338,17 @@ export default function AppearanceArtSection() {
     if (!path) return;
     try {
       const dataUrl = await readImageDataUrl(path);
-      stageSource(dataUrl);
+      editLoadId.current++;
+      setRestoredCrop(undefined);
+      setCropSource(dataUrl);
     } catch (err) {
       console.error('Failed to read custom image', err);
       setError(t('settings.appearance.art.applyError', 'Could not apply that image.'));
     }
   };
 
+  // Any framed image kind (default / hero / custom) bakes here and stores the
+  // result as the surface image, plus the original + crop for a faithful reopen.
   const applyCrop = async ({
     dataUrl,
     source,
@@ -291,7 +370,8 @@ export default function AppearanceArtSection() {
       } catch (editErr) {
         console.error('Failed to store appearance image edit (resume framing)', editErr);
       }
-      await persist(editing, { kind: 'custom' });
+      const bg: AppearanceBg = draftKind === 'hero' ? { kind: 'hero', hero: draftHero } : { kind: draftKind };
+      await persist(editing, bg);
       close();
     } catch (err) {
       console.error('Failed to set appearance image', err);
@@ -300,6 +380,15 @@ export default function AppearanceArtSection() {
       setBusy(false);
     }
   };
+
+  // What the modal body shows for the current draft.
+  const hasDefaultArt = !!editingConfig?.defaultSrc;
+  const showHeroGrid = draftKind === 'hero' && !cropSource;
+  const showCropper =
+    draftKind === 'custom' || (draftKind === 'default' && hasDefaultArt) || (draftKind === 'hero' && !!cropSource);
+  const showFooter = !showCropper && !showHeroGrid; // none, or the activeTab accent-glow default
+  // The preview header reflects the live draft (used when no cropper is shown).
+  const draftBg: AppearanceBg = draftKind === 'hero' ? { kind: 'hero', hero: draftHero } : { kind: draftKind };
 
   return (
     <div>
@@ -352,7 +441,7 @@ export default function AppearanceArtSection() {
           role="presentation"
         >
           <div
-            className="relative w-full max-w-md overflow-hidden rounded-sm border border-white/10 bg-bg-secondary p-5 shadow-2xl"
+            className="relative flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-sm border border-white/10 bg-bg-secondary shadow-2xl"
             onClick={(e) => e.stopPropagation()}
             role="dialog"
             aria-modal="true"
@@ -361,7 +450,9 @@ export default function AppearanceArtSection() {
             })}
           >
             <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
-            <div className="mb-4 flex items-center justify-between gap-3">
+
+            {/* Header (pinned) */}
+            <div className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pt-5 pb-4">
               <h3 className="text-lg font-semibold text-text-primary tracking-wide font-reaver">
                 {t(editingConfig.labelKey, editingConfig.fallbackLabel)}
               </h3>
@@ -376,83 +467,131 @@ export default function AppearanceArtSection() {
               </button>
             </div>
 
-            {/* Source-kind tabs */}
-            <div className="mb-4 flex flex-wrap gap-1.5">
-              {kindsFor(editingConfig).map((kind) => {
-                const active = draftKind === kind;
-                return (
-                  <button
-                    key={kind}
-                    type="button"
-                    onClick={() => void chooseKind(kind)}
-                    aria-pressed={active}
-                    className={`rounded-sm border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                      active
-                        ? 'border-accent/70 bg-accent/15 text-text-primary'
-                        : 'border-white/10 bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'
-                    }`}
-                  >
-                    {t(`settings.appearance.art.kind.${kind}`)}
-                  </button>
-                );
-              })}
-            </div>
-
-            {draftKind === 'hero' && (
-              <div className="grid max-h-[50vh] grid-cols-5 gap-2 overflow-y-auto sm:grid-cols-6">
-                {HERO_NAMES_SORTED.map((heroName) => {
-                  const current = resolveAppearanceBg(settings, editing);
-                  const active = current.kind === 'hero' && (current.hero ?? DEFAULT_SIDEBAR_HERO) === heroName;
+            {/* Body (scrolls) */}
+            <div className="min-h-0 flex-1 overflow-y-auto px-5">
+              {/* Source-kind tabs (selection only; nothing is saved until Apply) */}
+              <div className="mb-4 flex flex-wrap gap-1.5">
+                {kindsFor(editingConfig).map((kind) => {
+                  const active = draftKind === kind;
                   return (
                     <button
-                      key={heroName}
+                      key={kind}
                       type="button"
-                      onClick={() => void chooseHero(heroName)}
-                      title={heroName}
-                      aria-label={heroName}
+                      onClick={() => selectKind(kind)}
                       aria-pressed={active}
-                      className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      className={`rounded-sm border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                         active
-                          ? 'border-accent/70 bg-accent/15'
-                          : 'border-white/10 hover:border-accent/50 hover:bg-accent/10'
+                          ? 'border-accent/70 bg-accent/15 text-text-primary'
+                          : 'border-white/10 bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'
                       }`}
                     >
-                      <img
-                        src={getHeroChipIconPath(heroName)}
-                        alt=""
-                        aria-hidden
-                        className="h-8 w-8 object-contain"
-                        loading="lazy"
-                      />
-                      {active && (
-                        <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
-                          <Check className="h-2.5 w-2.5" aria-hidden />
-                        </span>
-                      )}
+                      {t(`settings.appearance.art.kind.${kind}`)}
                     </button>
                   );
                 })}
               </div>
-            )}
 
-            {draftKind === 'custom' && (
-              <div className="space-y-3">
-                <LockerImageCropper
-                  imageDataUrl={cropSource}
-                  aspect={SURFACE_ASPECT}
-                  initialCrop={restoredCrop}
-                  emptyHint={t('settings.appearance.art.uploadHint', 'Upload an image to frame it.')}
-                  busy={busy}
-                  onApply={applyCrop}
-                />
-                <Button variant="secondary" size="sm" onClick={() => void pickCustom()} disabled={busy}>
-                  <Upload className="h-4 w-4" />
-                  <Tx k="settings.appearance.art.uploadImage" fallback="Upload image" />
+              {/* Preview header only when there's no cropper acting as the preview. */}
+              {showFooter && (
+                <div className="mb-4">
+                  <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+                    {t('settings.appearance.art.preview', 'Preview')}
+                  </span>
+                  <SurfacePreview bg={draftBg} config={editingConfig} customSrc={appearanceImages[editing]} className="h-16 w-full" />
+                  <p className="mt-3 text-center text-sm text-text-secondary">
+                    {t(draftKind === 'none' ? 'settings.appearance.art.noneHint' : 'settings.appearance.art.defaultHint')}
+                  </p>
+                </div>
+              )}
+
+              {showHeroGrid && (
+                <>
+                  <p className="mb-2 text-xs text-text-secondary">{t('settings.appearance.art.heroHint')}</p>
+                  <div className="grid max-h-[44vh] grid-cols-5 gap-2 overflow-y-auto sm:grid-cols-6">
+                    {HERO_NAMES_SORTED.map((heroName) => {
+                      const active = draftHero === heroName;
+                      return (
+                        <button
+                          key={heroName}
+                          type="button"
+                          onClick={() => selectHero(heroName)}
+                          title={heroName}
+                          aria-label={heroName}
+                          aria-pressed={active}
+                          className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                            active
+                              ? 'border-accent/70 bg-accent/15'
+                              : 'border-white/10 hover:border-accent/50 hover:bg-accent/10'
+                          }`}
+                        >
+                          <img
+                            src={getHeroChipIconPath(heroName)}
+                            alt=""
+                            aria-hidden
+                            className="h-8 w-8 object-contain"
+                            loading="lazy"
+                          />
+                          {active && (
+                            <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
+                              <Check className="h-2.5 w-2.5" aria-hidden />
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+
+              {showCropper && (
+                <div className="space-y-3 pb-1">
+                  <LockerImageCropper
+                    imageDataUrl={cropSource}
+                    aspect={SURFACE_ASPECT}
+                    nameControls={false}
+                    initialCrop={restoredCrop}
+                    emptyHint={t('settings.appearance.art.uploadHint', 'Upload an image to frame it.')}
+                    busy={busy}
+                    onApply={applyCrop}
+                  />
+                  {draftKind === 'custom' && (
+                    <Button variant="secondary" size="sm" onClick={() => void pickCustom()} disabled={busy}>
+                      <Upload className="h-4 w-4" />
+                      <Tx k="settings.appearance.art.uploadImage" fallback="Upload image" />
+                    </Button>
+                  )}
+                  {draftKind === 'hero' && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        editLoadId.current++;
+                        setCropSource(null);
+                        setRestoredCrop(undefined);
+                      }}
+                      disabled={busy}
+                    >
+                      {t('settings.appearance.art.changeHero', 'Choose a different hero')}
+                    </Button>
+                  )}
+                </div>
+              )}
+
+              {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+            </div>
+
+            {/* Footer (pinned). Image kinds commit through the cropper's own button,
+                so only the non-image states (none / accent-glow default) get Apply. */}
+            {showFooter && (
+              <div className="flex flex-shrink-0 justify-end gap-2 border-t border-white/10 px-5 py-4">
+                <Button variant="secondary" size="sm" onClick={close} disabled={busy}>
+                  {t('common.actions.cancel')}
+                </Button>
+                <Button size="sm" onClick={() => void applyDraft()} disabled={busy}>
+                  {t('common.actions.apply')}
                 </Button>
               </div>
             )}
-
-            {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
           </div>
         </div>,
         document.body

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Image as ImageIcon, Ban, Upload, X } from 'lucide-react';
+import { Check, Image as ImageIcon, X, Play, Wand2, Volume2, type LucideIcon } from 'lucide-react';
 import { useAppStore } from '../../stores/appStore';
 import { getAssetPath } from '../../lib/assetPath';
 import {
@@ -11,6 +11,7 @@ import {
   getSidebarHeroImageStyle,
   resolveAppearanceBg,
 } from '../../lib/lockerUtils';
+import { SidebarActiveBackdrop, SurfaceBackdrop } from '../sidebar/surfaceArt';
 import {
   getAppearanceImageEdit,
   setAppearanceImageEdit,
@@ -75,16 +76,25 @@ interface SurfaceConfig {
   /** Surfaces that can be fully hidden. The active tab always needs a visible
    *  highlight, so its `default` IS the accent glow and `none` is omitted. */
   allowNone: boolean;
+  /** How the preview reproduces this surface's real chrome (icon, fade, slider). */
+  surfaceKind: 'launch' | 'activeTab' | 'volume';
+  /** Launch surfaces tint warm (vanilla) vs cool (modded); matches the Sidebar. */
+  warm?: boolean;
+  /** The icon the real surface shows (launch glyph / volume glyph). */
+  icon?: LucideIcon;
+  /** Label baked onto the real surface (launch buttons), shown in the preview. */
+  innerLabelKey?: string;
 }
 
 const SURFACES: readonly SurfaceConfig[] = [
   {
-    id: 'launchModded',
-    labelKey: 'settings.appearance.art.surface.launchModded',
-    fallbackLabel: 'Launch Modded',
-    defaultSrc: getAssetPath('/locker/launch-modded-bg.webp'),
-    defaultPosition: 'center 45%',
-    allowNone: true,
+    id: 'activeTab',
+    labelKey: 'settings.appearance.art.surface.activeTab',
+    fallbackLabel: 'Active tab',
+    defaultSrc: null,
+    defaultPosition: 'center',
+    allowNone: false,
+    surfaceKind: 'activeTab',
   },
   {
     id: 'launchVanilla',
@@ -93,14 +103,22 @@ const SURFACES: readonly SurfaceConfig[] = [
     defaultSrc: getAssetPath('/locker/launch-vanilla-bg.jpg'),
     defaultPosition: 'center 48%',
     allowNone: true,
+    surfaceKind: 'launch',
+    warm: true,
+    icon: Play,
+    innerLabelKey: 'sidebar.launchVanilla',
   },
   {
-    id: 'activeTab',
-    labelKey: 'settings.appearance.art.surface.activeTab',
-    fallbackLabel: 'Active tab',
-    defaultSrc: null,
-    defaultPosition: 'center',
-    allowNone: false,
+    id: 'launchModded',
+    labelKey: 'settings.appearance.art.surface.launchModded',
+    fallbackLabel: 'Launch Modded',
+    defaultSrc: getAssetPath('/locker/launch-modded-bg.webp'),
+    defaultPosition: 'center 45%',
+    allowNone: true,
+    surfaceKind: 'launch',
+    warm: false,
+    icon: Wand2,
+    innerLabelKey: 'sidebar.launchModded',
   },
   {
     id: 'volume',
@@ -109,6 +127,8 @@ const SURFACES: readonly SurfaceConfig[] = [
     defaultSrc: getAssetPath('/sidebar/preview-volume-bg.jpg'),
     defaultPosition: 'center 43%',
     allowNone: true,
+    surfaceKind: 'volume',
+    icon: Volume2,
   },
 ];
 
@@ -139,7 +159,10 @@ async function urlToDataUrl(url: string): Promise<string> {
   });
 }
 
-/** A small live preview of how a surface's chosen background looks. */
+/** A miniature of the REAL surface (not a bare thumbnail), so the choice reads as
+ *  "this is exactly what the launch button / active tab / volume bar will look
+ *  like". Reuses the Sidebar's own backdrop primitives, then layers the surface's
+ *  signature foreground chrome (launch icon + label, nav row, volume slider). */
 function SurfacePreview({
   bg,
   config,
@@ -151,38 +174,70 @@ function SurfacePreview({
   customSrc?: string;
   className?: string;
 }) {
-  const base = `relative overflow-hidden rounded-sm border border-white/10 bg-bg-tertiary ${className}`;
-  if (bg.kind === 'none') {
+  const { t } = useTranslation();
+  const base = `group relative flex items-center overflow-hidden rounded-sm ${className}`;
+
+  if (config.surfaceKind === 'activeTab') {
+    // Mirror the Sidebar's active-tab highlight: a baked image / hero render under
+    // the left fade, or the plain accent glow. The foreground evokes a nav row.
+    const heroSrc =
+      customSrc ?? (bg.kind === 'hero' ? getHeroRenderPath(bg.hero ?? DEFAULT_SIDEBAR_HERO) : null);
+    const heroImageStyle: CSSProperties =
+      !customSrc && bg.kind === 'hero'
+        ? getSidebarHeroImageStyle(bg.hero ?? DEFAULT_SIDEBAR_HERO)
+        : { objectPosition: 'center' };
     return (
-      <span className={`${base} flex items-center justify-center`} aria-hidden>
-        <Ban className="h-4 w-4 text-text-secondary" />
+      <span className={`${base} ${heroSrc ? '' : 'bg-bg-tertiary'} border border-white/10`} aria-hidden>
+        <SidebarActiveBackdrop heroSrc={heroSrc} heroImageStyle={heroImageStyle} />
+        <span className="relative z-10 flex items-center gap-1.5 pl-2">
+          <span className="h-3.5 w-3.5 flex-shrink-0 rounded-sm bg-text-primary/40" />
+          <span className="h-1.5 w-10 rounded-full bg-text-primary/35" />
+        </span>
       </span>
     );
   }
-  let src: string | null = null;
-  let style: CSSProperties = { objectPosition: config.defaultPosition };
-  if (bg.kind === 'hero') {
-    const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
-    src = getHeroRenderPath(hero);
-    style = getSidebarHeroImageStyle(hero);
-  } else if (bg.kind === 'custom') {
-    src = customSrc ?? config.defaultSrc;
-    style = { objectPosition: 'center' };
-  } else {
-    src = config.defaultSrc;
-  }
-  if (!src) {
-    // activeTab default: the plain accent glow.
+
+  const Icon = config.icon;
+  if (config.surfaceKind === 'volume') {
+    // Mirror the preview-volume bar: backdrop, volume glyph, then a slider line.
     return (
-      <span className={`${base} bg-accent/15`} aria-hidden>
-        <span className="absolute inset-0 bg-gradient-to-r from-accent/25 via-accent/10 to-transparent" />
+      <span className={`${base} bg-bg-tertiary border border-white/10`} aria-hidden>
+        <SurfaceBackdrop
+          bg={bg}
+          defaultSrc={config.defaultSrc!}
+          defaultPosition={config.defaultPosition}
+          customSrc={customSrc}
+        />
+        {Icon && (
+          <Icon className="relative z-10 ml-2 h-3.5 w-3.5 flex-shrink-0 text-text-primary/85 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]" />
+        )}
+        <span className="relative z-10 mx-2 h-1 flex-1 rounded-full bg-text-primary/30">
+          <span className="block h-full w-2/3 rounded-full bg-accent" />
+        </span>
       </span>
     );
   }
+
+  // Launch button: backdrop (warm/cool tint), launch glyph, and the baked label.
+  // `none` renders the plain button (SurfaceBackdrop returns nothing), exactly as
+  // the real button looks with art turned off.
   return (
-    <span className={base} aria-hidden>
-      <img src={src} alt="" className="h-full w-full object-cover opacity-80" style={style} />
-      <span className="absolute inset-0 bg-gradient-to-r from-bg-primary/70 via-bg-primary/30 to-transparent" />
+    <span className={`${base} bg-bg-tertiary ring-1 ring-white/10`} aria-hidden>
+      <SurfaceBackdrop
+        bg={bg}
+        defaultSrc={config.defaultSrc!}
+        defaultPosition={config.defaultPosition}
+        warm={config.warm}
+        customSrc={customSrc}
+      />
+      {Icon && (
+        <Icon className="relative z-10 ml-2 h-3.5 w-3.5 flex-shrink-0 text-text-primary drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)]" />
+      )}
+      {config.innerLabelKey && (
+        <span className="relative z-10 ml-1.5 truncate text-[11px] font-semibold tracking-wide text-text-primary drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)]">
+          {t(config.innerLabelKey)}
+        </span>
+      )}
     </span>
   );
 }
@@ -353,6 +408,21 @@ export default function AppearanceArtSection() {
     close();
   };
 
+  // Stage a freshly chosen custom source (from the native picker or a drop) into
+  // the cropper: cap its size and clear any restored framing so it centers.
+  const stageCustomSource = async (dataUrl: string) => {
+    try {
+      const capped = await capSourceImage(dataUrl);
+      editLoadId.current++;
+      setRestoredCrop(undefined);
+      setCropSource(capped);
+    } catch (err) {
+      console.error('Failed to read custom image', err);
+      setError(t('settings.appearance.art.applyError'));
+    }
+  };
+
+  // Open the native file picker (invoked by clicking the empty crop frame).
   const pickCustom = async () => {
     if (busy) return;
     const path = await showOpenDialog({
@@ -360,15 +430,16 @@ export default function AppearanceArtSection() {
       filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
     });
     if (!path) return;
-    try {
-      const dataUrl = await capSourceImage(await readImageDataUrl(path));
-      editLoadId.current++;
-      setRestoredCrop(undefined);
-      setCropSource(dataUrl);
-    } catch (err) {
-      console.error('Failed to read custom image', err);
-      setError(t('settings.appearance.art.applyError'));
-    }
+    await stageCustomSource(await readImageDataUrl(path));
+  };
+
+  // Read an image file dropped onto the empty crop frame.
+  const dropCustom = (file: File) => {
+    if (busy) return;
+    const reader = new FileReader();
+    reader.onload = () => void stageCustomSource(reader.result as string);
+    reader.onerror = () => setError(t('settings.appearance.art.applyError'));
+    reader.readAsDataURL(file);
   };
 
   // Any framed image kind (default / hero / custom) bakes here and stores the
@@ -444,7 +515,7 @@ export default function AppearanceArtSection() {
                 bg={bg}
                 config={config}
                 customSrc={appearanceImages[config.id]}
-                className="h-9 w-16 flex-shrink-0"
+                className="h-9 w-36 flex-shrink-0"
               />
               <span className="min-w-0 flex-1">
                 <span className="block truncate text-sm font-medium text-text-primary">
@@ -572,15 +643,11 @@ export default function AppearanceArtSection() {
                     nameControls={false}
                     initialCrop={restoredCrop}
                     emptyHint={t('settings.appearance.art.uploadHint')}
+                    onPickClick={draftKind === 'custom' ? () => void pickCustom() : undefined}
+                    onDropFile={draftKind === 'custom' ? dropCustom : undefined}
                     busy={busy}
                     onApply={applyCrop}
                   />
-                  {draftKind === 'custom' && (
-                    <Button variant="secondary" size="sm" onClick={() => void pickCustom()} disabled={busy}>
-                      <Upload className="h-4 w-4" />
-                      <Tx k="settings.appearance.art.uploadImage" fallback="Upload image" />
-                    </Button>
-                  )}
                   {draftKind === 'hero' && (
                     <Button
                       variant="secondary"

--- a/src/components/sidebar/surfaceArt.tsx
+++ b/src/components/sidebar/surfaceArt.tsx
@@ -1,0 +1,115 @@
+import type { CSSProperties } from 'react';
+import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath } from '../../lib/lockerUtils';
+import type { AppearanceBg } from '../../types/mod';
+
+// Surface art primitives shared by the live Sidebar and the Appearance art
+// settings previews, so the previews render the EXACT same surfaces the user
+// gets (no drift between "what I picked" and "what shows up"). The Sidebar owns
+// the layout/foreground (icons, labels, slider); these render only the backdrop
+// layer (image + gradients) from a resolved appearance descriptor.
+
+/** The active-tab highlight backdrop: a hero render under a left-to-right fade,
+ *  or the plain accent glow when there's no hero/image. */
+export function SidebarActiveBackdrop({
+  heroSrc,
+  heroImageStyle,
+}: {
+  heroSrc: string | null;
+  heroImageStyle: CSSProperties;
+}) {
+  if (heroSrc) {
+    return (
+      <span aria-hidden className="sidebar-active-backdrop pointer-events-none absolute inset-0">
+        <img
+          src={heroSrc}
+          alt=""
+          className="sidebar-active-backdrop__image h-full w-full object-cover opacity-75"
+          style={heroImageStyle}
+        />
+        <span className="absolute inset-0 bg-gradient-to-r from-bg-primary/90 via-bg-primary/55 to-bg-primary/20" />
+        <span className="absolute inset-0 bg-black/20" />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden
+      className="sidebar-active-backdrop pointer-events-none absolute inset-0 bg-accent/10"
+    >
+      <span className="absolute inset-0 bg-gradient-to-r from-accent/20 via-accent/8 to-transparent" />
+    </span>
+  );
+}
+
+export function LaunchButtonBackdrop({
+  src,
+  position = 'center',
+  warm = false,
+  imageStyle,
+}: {
+  src: string;
+  position?: string;
+  warm?: boolean;
+  /** Full object-position/margin override (used for hero renders, which need the
+   *  shared face-crop framing). Takes precedence over `position`. */
+  imageStyle?: CSSProperties;
+}) {
+  return (
+    <span aria-hidden className="pointer-events-none absolute inset-0">
+      <img
+        src={src}
+        alt=""
+        className={`h-full w-full object-cover opacity-65 transition-transform duration-300 group-hover:scale-[1.04] ${
+          warm ? 'saturate-[0.95]' : 'saturate-[1.05]'
+        }`}
+        style={imageStyle ?? { objectPosition: position }}
+      />
+      <span
+        className={`absolute inset-0 ${
+          warm
+            ? 'bg-gradient-to-r from-bg-primary/85 via-bg-primary/55 to-amber-950/25'
+            : 'bg-gradient-to-r from-bg-primary/82 via-bg-primary/50 to-emerald-950/20'
+        }`}
+      />
+      <span className="absolute inset-0 bg-black/20" />
+    </span>
+  );
+}
+
+/** Render a launch-button / volume-popup backdrop from its resolved descriptor
+ *  (issue: unify launcher backgrounds). `none` -> no art. Otherwise, if the user
+ *  framed this surface, a baked image (`customSrc`) is stored for ANY kind and is
+ *  rendered centered (the framing is baked in). With no baked image we fall back
+ *  to the live source: `hero` -> a hero render with the shared face crop; anything
+ *  else -> the built-in art (this also covers legacy installs that never framed). */
+export function SurfaceBackdrop({
+  bg,
+  defaultSrc,
+  defaultPosition = 'center',
+  warm = false,
+  customSrc,
+}: {
+  bg: AppearanceBg;
+  defaultSrc: string;
+  defaultPosition?: string;
+  warm?: boolean;
+  customSrc?: string;
+}) {
+  if (bg.kind === 'none') return null;
+  // A framed surface bakes its crop into customSrc, regardless of source kind.
+  if (customSrc) {
+    return <LaunchButtonBackdrop src={customSrc} position="center" warm={warm} />;
+  }
+  if (bg.kind === 'hero') {
+    const hero = bg.hero ?? DEFAULT_SIDEBAR_HERO;
+    return (
+      <LaunchButtonBackdrop
+        src={getHeroRenderPath(hero)}
+        imageStyle={getSidebarHeroImageStyle(hero)}
+        warm={warm}
+      />
+    );
+  }
+  return <LaunchButtonBackdrop src={defaultSrc} position={defaultPosition} warm={warm} />;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -992,8 +992,16 @@ body {
 
 .sidebar-active-indicator {
   contain: paint;
-  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
   will-change: transform;
+}
+
+/* Transition only while gliding between targets (tab/settings select). Off by
+   default so the indicator tracks nav-list scroll instantly instead of trailing
+   it by the ease duration. */
+.sidebar-active-indicator--sliding {
+  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 260ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .sidebar-offset-transition {
@@ -1006,6 +1014,30 @@ body {
 
 .sidebar-active-backdrop__image {
   will-change: transform;
+}
+
+/* Settings gear: rotates on hover (light tease) and does a one-shot "spin into
+   place" on click (the .settings-gear--spin flourish), which lands just as the
+   route commits. .settings-gear only exists inside the Settings button, so the
+   generic .group:hover scope is effectively settings-only. */
+.settings-gear {
+  transform-origin: 50% 50%;
+  transition: transform 480ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.group:hover .settings-gear {
+  transform: rotate(90deg);
+}
+
+/* One-shot mechanical spin: a touch past a full turn, then settles back, like a
+   gear clicking into its seat. Overrides the hover rotate while it runs. */
+.settings-gear--spin {
+  animation: settingsGearSpin 640ms cubic-bezier(0.34, 1.45, 0.5, 1);
+}
+
+@keyframes settingsGearSpin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 /* Skeleton shimmer — used for async-loading placeholders. Surfaces apply
@@ -1324,6 +1356,7 @@ body {
   .sidebar-title-text,
   .sidebar-collapsible-label,
   .sidebar-active-indicator,
+  .sidebar-active-indicator--sliding,
   .sidebar-offset-transition {
     transition-duration: 0.01ms;
   }
@@ -1351,6 +1384,19 @@ body {
 
   /* Keep the stripe pattern visible (it carries meaning) but stop the slide. */
   .update-stripes::before {
+    animation: none;
+  }
+
+  /* Settings gear: drop the rotate/spin motion. */
+  .settings-gear {
+    transition-duration: 0.01ms;
+  }
+
+  .group:hover .settings-gear {
+    transform: none;
+  }
+
+  .settings-gear--spin {
     animation: none;
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -425,6 +425,10 @@ export async function readImageDataUrl(imagePath: string): Promise<string> {
   return window.electronAPI.readImageDataUrl(imagePath);
 }
 
+export async function readRendererAsset(relPath: string): Promise<string> {
+  return window.electronAPI.readRendererAsset(relPath);
+}
+
 export async function getLockerModImages(): Promise<Record<string, string>> {
   return window.electronAPI.getLockerModImages();
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, ActiveTrippySkin, ApplyTrippySkinResult, ApplyTrippyVfxResult, TrippySpriteOptions, TrippySpriteResult, TrippyVfxChoice, LockerOverview, LockerCardThumbnail, LockerClearScope } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, ActiveTrippySkin, ApplyTrippySkinResult, ApplyTrippyVfxResult, TrippySpriteOptions, TrippySpriteResult, TrippyVfxChoice, LockerOverview, LockerCardThumbnail, LockerClearScope, AppearanceSurface } from '../types/mod';
 import type {
   HeroPortrait,
   CustomCardSlot,
@@ -503,6 +503,36 @@ export async function setLockerModImageEdit(
   crop: CropRect
 ): Promise<void> {
   return window.electronAPI.setLockerModImageEdit(variant, skinKey, source, crop);
+}
+
+// Custom launcher / sidebar background images (issue: unify launcher backgrounds).
+export async function getAppearanceImages(): Promise<Partial<Record<AppearanceSurface, string>>> {
+  return window.electronAPI.getAppearanceImages();
+}
+
+export async function setAppearanceImage(
+  surface: AppearanceSurface,
+  source: string,
+): Promise<string> {
+  return window.electronAPI.setAppearanceImage(surface, source);
+}
+
+export async function removeAppearanceImage(surface: AppearanceSurface): Promise<void> {
+  return window.electronAPI.removeAppearanceImage(surface);
+}
+
+export async function setAppearanceImageEdit(
+  surface: AppearanceSurface,
+  source: string,
+  crop: CropRect,
+): Promise<void> {
+  return window.electronAPI.setAppearanceImageEdit(surface, source, crop);
+}
+
+export async function getAppearanceImageEdit(
+  surface: AppearanceSurface,
+): Promise<LockerImageEdit | null> {
+  return window.electronAPI.getAppearanceImageEdit(surface);
 }
 
 export async function mergeMods(args: MergeModsArgs): Promise<Mod> {

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
-import type { GlobalModType, Mod } from '../types/mod';
+import type { AppearanceBg, AppearanceSurface, AppSettings, GlobalModType, Mod } from '../types/mod';
 import { getAssetPath } from './assetPath';
 import {
   HERO_NAMES as SHARED_HERO_NAMES,
@@ -155,6 +155,35 @@ export const HERO_NAMES_SORTED: readonly string[] = Array.from(
 ).sort((a, b) => a.localeCompare(b));
 
 export const DEFAULT_SIDEBAR_HERO = HERO_NAMES_SORTED[0] ?? 'Abrams';
+
+/**
+ * Resolve the background descriptor for a launcher / sidebar surface, applying
+ * defaults so callers never deal with `undefined` (issue: unify launcher
+ * backgrounds). One place owns the per-surface fallback rules:
+ *
+ * - When `appearanceBackgrounds[surface]` is set, use it verbatim.
+ * - `activeTab` otherwise migrates the legacy `sidebarHeroHighlight` field:
+ *   null/'' -> none, a hero name -> that hero, undefined -> the default hero.
+ *   (So existing installs keep the highlight they already chose.)
+ * - The launch buttons and volume popup otherwise default to their built-in art.
+ */
+export function resolveAppearanceBg(
+  settings: AppSettings | null | undefined,
+  surface: AppearanceSurface,
+): AppearanceBg {
+  const explicit = settings?.appearanceBackgrounds?.[surface];
+  if (explicit) return explicit;
+
+  if (surface === 'activeTab') {
+    const legacy = settings?.sidebarHeroHighlight;
+    if (legacy === null || legacy === '') return { kind: 'none' };
+    if (legacy && HERO_NAMES_SORTED.includes(legacy)) return { kind: 'hero', hero: legacy };
+    if (legacy) return { kind: 'hero', hero: legacy };
+    return { kind: 'hero', hero: DEFAULT_SIDEBAR_HERO };
+  }
+
+  return { kind: 'default' };
+}
 
 /**
  * Infer the Deadlock hero associated with a mod title. Re-exported from the

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -177,7 +177,6 @@ export function resolveAppearanceBg(
   if (surface === 'activeTab') {
     const legacy = settings?.sidebarHeroHighlight;
     if (legacy === null || legacy === '') return { kind: 'none' };
-    if (legacy && HERO_NAMES_SORTED.includes(legacy)) return { kind: 'hero', hero: legacy };
     if (legacy) return { kind: 'hero', hero: legacy };
     return { kind: 'hero', hero: DEFAULT_SIDEBAR_HERO };
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -512,7 +512,7 @@
         "title": "Launcher & sidebar art",
         "description": "Set the background for each launch button, the active tab, and the volume bar.",
         "uploadImage": "Upload image",
-        "uploadHint": "Upload an image to frame it.",
+        "uploadHint": "Click to choose an image, or drag one here.",
         "applyError": "Could not apply that image.",
         "defaultHint": "Use Grimoire's built-in look for this surface.",
         "noneHint": "Hide this surface's background entirely.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -511,7 +511,6 @@
       "art": {
         "title": "Launcher & sidebar art",
         "description": "Set the background for each launch button, the active tab, and the volume bar.",
-        "editNamed": "Customize {{surface}}",
         "uploadImage": "Upload image",
         "uploadHint": "Upload an image to frame it.",
         "applyError": "Could not apply that image.",
@@ -1774,7 +1773,9 @@
       "moddedDefault": "Launch Deadlock with mods active",
       "vanillaStash": "A vanilla session is already active. Restore mods first.",
       "vanillaDefault": "Temporarily stash mods, launch Deadlock via Steam, then auto-restore after the game starts",
-      "stopTitle": "Stop the running Deadlock process"
+      "stopTitle": "Stop the running Deadlock process",
+      "switchToModded": "Switch to Launch Modded",
+      "switchToVanilla": "Switch to Launch Vanilla"
     },
     "vanilla": {
       "stashed": "Vanilla: {{count}} stashed",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -505,13 +505,29 @@
       "accentNamed": "Use {{name}} accent color",
       "pickCustomColor": "Pick custom color",
       "accentCustom": "Custom accent",
-      "sidebarHighlightNamed": "Sidebar highlight: {{hero}}",
-      "sidebarHighlightNone": "No sidebar highlight",
       "customAccentColor": "Custom accent color",
       "selectedColorPreview": "Selected color preview",
-      "closeSidebarHighlightPicker": "Close sidebar highlight picker",
       "customAccent": "Custom Accent",
-      "sidebarHighlight": "Sidebar Highlight"
+      "art": {
+        "title": "Launcher & sidebar art",
+        "description": "Set the background for each launch button, the active tab, and the volume bar.",
+        "editNamed": "Customize {{surface}}",
+        "uploadImage": "Upload image",
+        "uploadHint": "Upload an image to frame it.",
+        "applyError": "Could not apply that image.",
+        "surface": {
+          "launchModded": "Launch Modded",
+          "launchVanilla": "Launch Vanilla",
+          "activeTab": "Active tab",
+          "volume": "Volume bar"
+        },
+        "kind": {
+          "default": "Default",
+          "hero": "Hero",
+          "custom": "Custom image",
+          "none": "None"
+        }
+      }
     },
     "preferences": {
       "hideNsfw": "Hide NSFW Content",
@@ -1750,9 +1766,7 @@
       "moddedDefault": "Launch Deadlock with mods active",
       "vanillaStash": "A vanilla session is already active. Restore mods first.",
       "vanillaDefault": "Temporarily stash mods, launch Deadlock via Steam, then auto-restore after the game starts",
-      "stopTitle": "Stop the running Deadlock process",
-      "hideArt": "Hide background art",
-      "showArt": "Show background art"
+      "stopTitle": "Stop the running Deadlock process"
     },
     "vanilla": {
       "stashed": "Vanilla: {{count}} stashed",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -515,6 +515,11 @@
         "uploadImage": "Upload image",
         "uploadHint": "Upload an image to frame it.",
         "applyError": "Could not apply that image.",
+        "defaultHint": "Use Grimoire's built-in look for this surface.",
+        "noneHint": "Hide this surface's background entirely.",
+        "heroHint": "Pick a hero, then frame their render below.",
+        "changeHero": "Choose a different hero",
+        "preview": "Preview",
         "surface": {
           "launchModded": "Launch Modded",
           "launchVanilla": "Launch Vanilla",
@@ -1251,7 +1256,10 @@
       "resetZoom": "Reset zoom",
       "upscaleWarning": "Source is {{sourceWidth}} x {{sourceHeight}}, smaller than the {{targetWidth}} x {{targetHeight}} target, so it will be upscaled and may look soft.",
       "instructions": "Drag to reposition, scroll or use the slider to zoom. The frame is locked to the card's aspect so the result is not stretched.",
-      "useCrop": "Use crop"
+      "useCrop": "Use crop",
+      "boxHint": "Drag the box to move it, drag a corner to resize. The selection is locked to the surface's shape.",
+      "selectionSize": "Selection size",
+      "resetCrop": "Reset selection"
     },
     "model": {
       "close3d": "Close 3D model",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1665,
+  "totalKeys": 1666,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1665,
+      "translatedKeys": 1666,
       "pct": 100
     }
   ]

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1649,
+  "totalKeys": 1657,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1649,
+      "translatedKeys": 1657,
       "pct": 100
     }
   ]

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1657,
+  "totalKeys": 1665,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1657,
+      "translatedKeys": 1665,
       "pct": 100
     }
   ]

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -874,7 +874,7 @@ export default function Settings() {
         <Card
           title={<Tx k="settings.sections.appearance" fallback="Appearance" />}
           icon={Palette}
-          className="lg:col-span-2 bg-[radial-gradient(120%_90%_at_0%_0%,rgba(244,114,182,0.12),transparent_55%),radial-gradient(120%_90%_at_100%_0%,rgba(56,189,248,0.12),transparent_55%),radial-gradient(150%_120%_at_50%_140%,rgba(52,211,153,0.10),transparent_60%)]"
+          className="lg:col-span-2"
           action={
             <div className="flex flex-wrap gap-2 items-center justify-end">
               {(() => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Ban, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy, ChevronDown } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
@@ -22,7 +22,7 @@ import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import LanguageSelector from '../components/settings/LanguageSelector';
 import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
-import { DEFAULT_SIDEBAR_HERO, HERO_NAMES_SORTED, getHeroChipIconPath } from '../lib/lockerUtils';
+import AppearanceArtSection from '../components/settings/AppearanceArtSection';
 import SocialAccountSection from '../components/social/SocialAccountSection';
 import PerformanceConfigCard from '../components/performance/PerformanceConfigCard';
 import KofiSupportButton from '../components/KofiSupportButton';
@@ -88,7 +88,6 @@ export default function Settings() {
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [resetResult, setResetResult] = useState<string | null>(null);
   const [saltIngestStatus, setSaltIngestStatus] = useState<SaltIngestStatus | null>(null);
-  const [heroPickerOpen, setHeroPickerOpen] = useState(false);
 
   // Updater state
   const [appVersion, setAppVersion] = useState<string>('');
@@ -119,12 +118,6 @@ export default function Settings() {
 
   const isDevMode = settings?.devMode ?? false;
   const activeDeadlockPath = getActiveDeadlockPath(settings);
-  const selectedSidebarHero = useMemo(() => {
-    const configuredHero = settings?.sidebarHeroHighlight;
-    if (configuredHero === null || configuredHero === '') return null;
-    if (configuredHero && HERO_NAMES_SORTED.includes(configuredHero)) return configuredHero;
-    return DEFAULT_SIDEBAR_HERO;
-  }, [settings?.sidebarHeroHighlight]);
 
   // The displayed path: local override or settings value
   const displayPath = isDevMode
@@ -243,13 +236,6 @@ export default function Settings() {
     }
   };
 
-  const handleSidebarHeroHighlightChange = async (heroName: string | null) => {
-    setHeroPickerOpen(false);
-    if (settings) {
-      await saveSettings({ ...settings, sidebarHeroHighlight: heroName });
-    }
-  };
-
   // Custom color picker state. While the modal is open, picker drags only
   // update CSS vars + draft locally; the settings file is written once on
   // commit (Done, backdrop click, Escape) so we don't hammer it 60x/sec
@@ -283,15 +269,6 @@ export default function Settings() {
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [customPickerOpen, commitCustomDraft]);
-
-  useEffect(() => {
-    if (!heroPickerOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setHeroPickerOpen(false);
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [heroPickerOpen]);
 
   const handleHideNsfwChange = async (checked: boolean) => {
     if (settings) {
@@ -897,7 +874,7 @@ export default function Settings() {
         <Card
           title={<Tx k="settings.sections.appearance" fallback="Appearance" />}
           icon={Palette}
-          className="lg:col-span-2"
+          className="lg:col-span-2 bg-[radial-gradient(120%_90%_at_0%_0%,rgba(244,114,182,0.12),transparent_55%),radial-gradient(120%_90%_at_100%_0%,rgba(56,189,248,0.12),transparent_55%),radial-gradient(150%_120%_at_50%_140%,rgba(52,211,153,0.10),transparent_60%)]"
           action={
             <div className="flex flex-wrap gap-2 items-center justify-end">
               {(() => {
@@ -948,44 +925,6 @@ export default function Settings() {
                       }
                     >
                       <Pipette className="w-3.5 h-3.5 text-black/70 drop-shadow-[0_1px_0_rgba(255,255,255,0.5)]" />
-                    </button>
-
-                    <span aria-hidden className="mx-1 h-9 w-px bg-white/10" />
-
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setCustomPickerOpen(false);
-                        setHeroPickerOpen(true);
-                      }}
-                      title={
-                        selectedSidebarHero
-                          ? t('settings.appearance.sidebarHighlightNamed', { hero: selectedSidebarHero })
-                          : t('settings.appearance.sidebarHighlightNone')
-                      }
-                      aria-label={
-                        selectedSidebarHero
-                          ? t('settings.appearance.sidebarHighlightNamed', { hero: selectedSidebarHero })
-                          : t('settings.appearance.sidebarHighlightNone')
-                      }
-                      aria-haspopup="dialog"
-                      className={`${swatchBase} bg-bg-tertiary ${
-                        selectedSidebarHero
-                          ? 'border-white/40'
-                          : 'border-accent/60 hover:border-accent/80'
-                      }`}
-                    >
-                      {selectedSidebarHero ? (
-                        <img
-                          src={getHeroChipIconPath(selectedSidebarHero)}
-                          alt=""
-                          aria-hidden
-                          className="h-7 w-7 object-contain"
-                        />
-                      ) : (
-                        <Ban className="h-4 w-4 text-text-secondary" aria-hidden />
-                      )}
-                      <ChevronDown className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5 text-text-primary/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.85)]" aria-hidden />
                     </button>
 
                     {customPickerOpen && createPortal(
@@ -1050,102 +989,14 @@ export default function Settings() {
                       </div>,
                       document.body
                     )}
-
-                    {heroPickerOpen && createPortal(
-                      <div
-                        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm animate-fade-in"
-                        onClick={() => setHeroPickerOpen(false)}
-                        role="presentation"
-                      >
-                        <div
-                          className="relative w-full max-w-md overflow-hidden rounded-sm border border-white/10 bg-bg-secondary p-5 shadow-2xl"
-                          onClick={(e) => e.stopPropagation()}
-                          role="dialog"
-                          aria-modal="true"
-                          aria-labelledby="sidebar-hero-picker-title"
-                        >
-                          <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
-                          <div className="mb-4 flex items-center justify-between gap-3">
-                            <div className="min-w-0">
-                              <h3 id="sidebar-hero-picker-title" className="text-lg font-semibold text-text-primary tracking-wide font-reaver">
-                                <Tx k="settings.appearance.sidebarHighlight" fallback="Sidebar Highlight" />
-                              </h3>
-                              <p className="text-xs text-text-secondary">
-                                {selectedSidebarHero ?? t('common.none')}
-                              </p>
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => setHeroPickerOpen(false)}
-                              title={t('common.actions.close')}
-                              aria-label={t('settings.appearance.closeSidebarHighlightPicker')}
-                              className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/10 text-text-secondary transition-colors hover:border-white/25 hover:bg-white/5 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                            >
-                              <X className="h-4 w-4" aria-hidden />
-                            </button>
-                          </div>
-                          <div className="grid grid-cols-5 gap-2 sm:grid-cols-6">
-                            <button
-                              type="button"
-                              onClick={() => void handleSidebarHeroHighlightChange(null)}
-                              title={t('common.none')}
-                              aria-label={t('settings.appearance.sidebarHighlightNone')}
-                              aria-pressed={selectedSidebarHero === null}
-                              className={`relative flex aspect-square items-center justify-center rounded-sm border transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                                selectedSidebarHero === null
-                                  ? 'border-accent/70 bg-accent/15'
-                                  : 'border-white/10 bg-bg-tertiary hover:border-accent/50 hover:bg-accent/10'
-                              }`}
-                            >
-                              <Ban className="h-5 w-5 text-text-secondary" aria-hidden />
-                              {selectedSidebarHero === null && (
-                                <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
-                                  <Check className="h-2.5 w-2.5" aria-hidden />
-                                </span>
-                              )}
-                            </button>
-                            {HERO_NAMES_SORTED.map((heroName) => {
-                              const active = selectedSidebarHero === heroName;
-                              return (
-                                <button
-                                  key={heroName}
-                                  type="button"
-                                  onClick={() => void handleSidebarHeroHighlightChange(heroName)}
-                                  title={heroName}
-                                  aria-label={t('settings.appearance.sidebarHighlightNamed', { hero: heroName })}
-                                  aria-pressed={active}
-                                  className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                                    active
-                                      ? 'border-accent/70 bg-accent/15'
-                                      : 'border-white/10 hover:border-accent/50 hover:bg-accent/10'
-                                  }`}
-                                >
-                                  <img
-                                    src={getHeroChipIconPath(heroName)}
-                                    alt=""
-                                    aria-hidden
-                                    className="h-8 w-8 object-contain"
-                                    loading="lazy"
-                                  />
-                                  {active && (
-                                    <span className="absolute right-0.5 top-0.5 rounded-sm bg-accent p-0.5 text-accent-foreground">
-                                      <Check className="h-2.5 w-2.5" aria-hidden />
-                                    </span>
-                                  )}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      </div>,
-                      document.body
-                    )}
                   </>
                 );
               })()}
             </div>
           }
-        />
+        >
+          <AppearanceArtSection />
+        </Card>
 
         {/* Grimoire Social */}
         {settings?.experimentalSocial && (

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Mod, AppSettings, EditLocalModArgs, GlobalModType } from '../types/mod';
+import type { Mod, AppSettings, AppearanceSurface, EditLocalModArgs, GlobalModType } from '../types/mod';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { setDateFormat } from '../lib/dateFormat';
 import { applyLanguagePreference } from '../i18n';
@@ -230,6 +230,12 @@ interface AppState {
   // thumbnail counterpart of lockerHideHeroName. Sparse { skinKey -> true }.
   lockerThumbHideHeroName: Record<string, boolean>;
 
+  // Custom launcher / sidebar background images (issue: unify launcher
+  // backgrounds). Map is { surface -> data URL } of user uploads, loaded on app
+  // start (the Sidebar is always mounted). The per-surface *choice* lives in
+  // settings.appearanceBackgrounds; this only holds the custom image bytes.
+  appearanceImages: Partial<Record<AppearanceSurface, string>>;
+
   // Actions
   loadSettings: () => Promise<void>;
   saveSettings: (settings: AppSettings) => Promise<void>;
@@ -284,6 +290,13 @@ interface AppState {
   removeLockerModThumbnail: (skinKey: string) => Promise<void>;
   /** Hide (or show) the hero name label over this skin's grid thumbnail. */
   setLockerModThumbnailHideName: (skinKey: string, hide: boolean) => Promise<void>;
+
+  /** Load all custom launcher / sidebar background images from the main process. */
+  loadAppearanceImages: () => Promise<void>;
+  /** Store a custom image (baked data URL) for a surface and refresh the map. */
+  setAppearanceImage: (surface: AppearanceSurface, source: string) => Promise<void>;
+  /** Drop the custom image for a surface (e.g. switching away from `custom`). */
+  removeAppearanceImage: (surface: AppearanceSurface) => Promise<void>;
 }
 
 // The main process throws this exact phrase from every "out of enabled slots"
@@ -317,6 +330,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   lockerBgHideHeroName: {},
   lockerModThumbnails: {},
   lockerThumbHideHeroName: {},
+  appearanceImages: {},
 
   // Load settings from backend
   loadSettings: async () => {
@@ -447,6 +461,30 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (hide) nextFlags[skinKey] = true;
       else delete nextFlags[skinKey];
       return { lockerThumbHideHeroName: nextFlags };
+    });
+  },
+
+  // Custom launcher / sidebar background images (issue: unify launcher backgrounds).
+  loadAppearanceImages: async () => {
+    try {
+      const images = await api.getAppearanceImages();
+      set({ appearanceImages: images });
+    } catch {
+      // Non-fatal: surfaces just fall back to their built-in art / hero render.
+    }
+  },
+  setAppearanceImage: async (surface: AppearanceSurface, source: string) => {
+    const dataUrl = await api.setAppearanceImage(surface, source);
+    set((state) => ({
+      appearanceImages: { ...state.appearanceImages, [surface]: dataUrl },
+    }));
+  },
+  removeAppearanceImage: async (surface: AppearanceSurface) => {
+    await api.removeAppearanceImage(surface);
+    set((state) => {
+      const next = { ...state.appearanceImages };
+      delete next[surface];
+      return { appearanceImages: next };
     });
   },
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -590,6 +590,10 @@ export interface ElectronAPI {
     previewSoulContainerGlb: (args: PreviewSoulContainerGlbArgs) => Promise<SoulContainerPreview>;
     readGlbFile: (glbPath: string) => Promise<string>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
+    /** Read a bundled renderer asset (built-in art, hero render) as a data URL.
+     *  Lets the Appearance crop editor frame built-in images without a file://
+     *  fetch (blocked in packaged builds). Path is confined to the renderer dir. */
+    readRendererAsset: (relPath: string) => Promise<string>;
     /** Issue #208: per-mod (per-skin) Locker view images (display override).
      *  Map is { skinKey -> data URL }; `source` is a `data:` URL (custom upload)
      *  or an `http(s)` gallery URL to download. Setter returns the new data URL. */

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -32,6 +32,7 @@ import type {
     LockerCardThumbnail,
     LockerClearScope,
     SoulImportStatus,
+    AppearanceSurface,
 } from './mod';
 import type {
     GameBananaModsResponse,
@@ -637,6 +638,24 @@ export interface ElectronAPI {
         source: string,
         crop: CropRect
     ) => Promise<void>;
+    /** Custom launcher / sidebar background images (issue: unify launcher
+     *  backgrounds). Map is { surface -> data URL } of baked overrides; `source`
+     *  is a `data:` URL. The *choice* per surface lives in AppSettings
+     *  (`appearanceBackgrounds`); these only store the custom image bytes. */
+    getAppearanceImages: () => Promise<Partial<Record<AppearanceSurface, string>>>;
+    setAppearanceImage: (surface: AppearanceSurface, source: string) => Promise<string>;
+    removeAppearanceImage: (surface: AppearanceSurface) => Promise<void>;
+    /** Full-fidelity crop persistence for a custom surface image: the ORIGINAL
+     *  source (data URL) + a normalized crop rect, so the crop editor reopens on
+     *  the exact framing. Returns null when the surface has no stored edit. */
+    setAppearanceImageEdit: (
+        surface: AppearanceSurface,
+        source: string,
+        crop: CropRect
+    ) => Promise<void>;
+    getAppearanceImageEdit: (
+        surface: AppearanceSurface
+    ) => Promise<LockerImageEdit | null>;
     mergeMods: (args: MergeModsArgs) => Promise<Mod>;
     unmergeMod: (mergedModId: string) => Promise<UnmergeModResult>;
     extractMergeSource: (mergedModId: string, sourceFileName: string) => Promise<ExtractMergeSourceResult>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -747,6 +747,25 @@ export interface ModConflict {
   details: string;
 }
 
+/** The customizable launcher/sidebar art surfaces (issue: unify launcher
+ *  backgrounds). Each maps to one rendered area in the Sidebar. */
+export type AppearanceSurface = 'launchModded' | 'launchVanilla' | 'activeTab' | 'volume';
+
+/** Where a surface's background art comes from:
+ *  - `default`: the built-in scenic art (launch buttons / volume popup) or, for
+ *    the active tab, the plain accent glow.
+ *  - `hero`: a hero render chosen by the user (`hero` holds the hero name).
+ *  - `custom`: a user-uploaded image, stored out-of-band by the appearanceImages
+ *    service and keyed by the surface id.
+ *  - `none`: no art (hidden). */
+export type AppearanceBgKind = 'default' | 'hero' | 'custom' | 'none';
+
+export interface AppearanceBg {
+  kind: AppearanceBgKind;
+  /** Hero name, only meaningful when `kind === 'hero'`. */
+  hero?: string | null;
+}
+
 export interface AppSettings {
   deadlockPath: string | null;
   devMode: boolean;
@@ -794,8 +813,17 @@ export interface AppSettings {
   /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
    *  focus rings throughout the app. */
   accentColor: string;
-  /** Hero render used as the active sidebar highlight background. */
+  /** Hero render used as the active sidebar highlight background.
+   *  @deprecated Superseded by `appearanceBackgrounds.activeTab`. Kept as a
+   *  legacy compat read so existing installs keep their chosen highlight; the
+   *  Appearance UI now writes `appearanceBackgrounds` instead. */
   sidebarHeroHighlight?: string | null;
+  /** Per-surface launcher / sidebar background art (issue: unify launcher
+   *  backgrounds). Each of the four surfaces independently chooses default art,
+   *  a hero render, a custom upload, or none. Custom image bytes live out-of-band
+   *  in the appearanceImages service (keyed by surface id), not here. Surfaces
+   *  absent from the map fall back to their defaults (see resolveAppearanceBg). */
+  appearanceBackgrounds?: Partial<Record<AppearanceSurface, AppearanceBg>>;
   /** Order used to render absolute dates (mod/file upload + update dates). */
   dateFormat: 'MM/DD/YYYY' | 'DD/MM/YYYY';
   /** Preferred UI language. Null uses the OS/browser language when available. */


### PR DESCRIPTION
## Unified launcher & sidebar art

One Appearance section to set the background of all four customizable Sidebar surfaces (Launch Modded, Launch Vanilla, active-tab highlight, volume bar), plus a reworked launch control and a rebuilt crop editor.

### Surfaces & customization
- Single Appearance section: each surface independently picks built-in art, any hero render, a custom upload (full crop editor), or none.
- Replaces the old split between the Appearance hero chip and the launch buttons' right-click hide-art toggle.
- Per-surface choice lives in `AppSettings.appearanceBackgrounds`; legacy `sidebarHeroHighlight` is read as an `activeTab` fallback so existing installs keep their highlight.
- Custom/baked images stored locally via a new `appearanceImages` main-process service (mirrors `lockerModImages`), served as data URLs.

### Sidebar launch control
- Stacked Launch Modded / Launch Vanilla buttons replaced by a single dual-use button: a persisted mode (default modded) drives icon, label, art, handler, and enable/disable rules. Swap via the trailing icon or right-click.
- Active-tab highlight lifted to the aside so the single sliding indicator glides between a nav tab and the footer Settings button; Settings gear spins on hover/click.

### Crop editor (shared LockerImageCropper, also used by the Locker per-skin picker)
- Fixed-frame pan/zoom model: the frame is locked to the target aspect and the image pans/zooms beneath it.
- Default and Hero now flow through the same crop box (bake-any-kind), each baking a PNG into the per-surface store plus the original + crop for a faithful reopen.
- Empty frame doubles as the upload target: click to choose a file or drag one onto it (no separate Upload button).
- Stage sized relative to the live viewport (recomputed on resize) so it never overflows the window.
- Bundled assets (built-in art / hero renders) read in main via a traversal-guarded `read-renderer-asset` IPC, since a packaged file:// renderer can't fetch them and a file:// `<img>` taints the canvas.

### Appearance section polish
- Rows render as miniatures of the REAL surfaces (launch button, active-tab highlight, volume bar) via a shared `sidebar/surfaceArt` module, so previews can't drift from the live UI.
- Surface grid reordered: Active tab leads; Launch Modded sits beside the volume bar.
- Migrated to the shared Modal primitive (focus hand-off, Escape, z-ladder); pinned header/footer with a scrolling body.

i18n catalog + manifest regenerated; typecheck / lint / i18n gates pass locally.
