### PR TITLE
refactor(ui): unify post-v1.20.0 popups on shared primitives

### DIFF
--- a/src/components/BrowseFileQuickPicker.tsx
+++ b/src/components/BrowseFileQuickPicker.tsx
@@ -195,13 +195,13 @@ export default function BrowseFileQuickPicker({
               )}
               <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-secondary">
                 <span className="whitespace-nowrap">{formatFileSize(file.fileSize)}</span>
-                <span className="opacity-50">-</span>
+                <span className="opacity-50" aria-hidden>·</span>
                 <span className="whitespace-nowrap">
                   {t('browse.filePicker.downloads', { count: file.downloadCount })}
                 </span>
                 {file.dateAdded && file.dateAdded > 0 && (
                   <>
-                    <span className="opacity-50">-</span>
+                    <span className="opacity-50" aria-hidden>·</span>
                     <span className="flex items-center gap-1 whitespace-nowrap">
                       <Clock className="h-3 w-3" />
                       {formatDate(file.dateAdded)}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -71,6 +71,45 @@ export function Modal({
         return () => window.removeEventListener('keydown', onKey);
     }, [open, dismissable, onClose]);
 
+    // Trap Tab focus inside the panel while open. The WAI-ARIA dialog pattern
+    // (and Radix Dialog) keeps focus within a modal dialog; without this, Tab
+    // walks out to the page behind the backdrop. Cycle at the boundaries.
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key !== 'Tab') return;
+            const panel = panelRef.current;
+            if (!panel) return;
+            const focusable = panel.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            );
+            // No focusable children: keep focus on the panel itself.
+            if (focusable.length === 0) {
+                e.preventDefault();
+                panel.focus();
+                return;
+            }
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const active = document.activeElement;
+            // Focus escaped the panel (or sits on the panel shell): pull it back.
+            if (!panel.contains(active) || active === panel) {
+                e.preventDefault();
+                (e.shiftKey ? last : first).focus();
+                return;
+            }
+            if (e.shiftKey && active === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && active === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        };
+        window.addEventListener('keydown', onKey, true);
+        return () => window.removeEventListener('keydown', onKey, true);
+    }, [open]);
+
     useEffect(() => {
         if (!open) return;
         const previous = document.activeElement;

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type ReactNode } from 'react';
-import { Check, type LucideIcon } from 'lucide-react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Check, X, type LucideIcon } from 'lucide-react';
 import Tx from '../translation/Tx';
 
 interface CardProps {
@@ -379,5 +379,171 @@ export function Button({
             ) : null}
             {children}
         </button>
+    );
+}
+
+// ============================================================================
+// IconButton - square icon-only button (modal close X, inline actions). One
+// shape / size / focus treatment so every icon button across dialogs matches,
+// instead of each surface hand-rolling its own. `label` is required (icon-only
+// buttons need an accessible name) and doubles as the hover tooltip.
+// ============================================================================
+
+interface IconButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+    icon: LucideIcon;
+    /** Accessible name + hover tooltip (icon-only, so this is mandatory). */
+    label: string;
+    size?: 'sm' | 'md';
+    tone?: 'default' | 'danger';
+}
+
+export function IconButton({ icon: Icon, label, size = 'md', tone = 'default', className = '', ...props }: IconButtonProps) {
+    const sizes = {
+        sm: 'h-7 w-7',
+        md: 'h-8 w-8',
+    };
+    const tones = {
+        default: 'border-border text-text-secondary hover:border-white/25 hover:bg-white/5 hover:text-text-primary',
+        danger: 'border-border text-text-secondary hover:border-state-danger/60 hover:bg-state-danger/10 hover:text-state-danger',
+    };
+    const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+    return (
+        <button
+            type="button"
+            aria-label={label}
+            title={label}
+            className={`flex flex-shrink-0 items-center justify-center rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer ${sizes[size]} ${tones[tone]} ${className}`}
+            {...props}
+        >
+            <Icon className={iconSize} aria-hidden />
+        </button>
+    );
+}
+
+// ============================================================================
+// ModalHeader - the pinned title row shared by dialogs: display-font title,
+// optional subtitle, an optional actions slot (e.g. a Reset button), and a
+// uniform close button. Replaces the divergent per-modal headers.
+// ============================================================================
+
+interface ModalHeaderProps {
+    title: ReactNode;
+    /** id wired to the Modal's labelledBy for aria-labelledby. */
+    titleId?: string;
+    subtitle?: ReactNode;
+    /** Tooltip for a truncated subtitle (e.g. the full mod name). */
+    subtitleTitle?: string;
+    onClose: () => void;
+    closeLabel?: string;
+    closeDisabled?: boolean;
+    /** Extra controls rendered left of the close button (e.g. a Reset action). */
+    actions?: ReactNode;
+    className?: string;
+}
+
+export function ModalHeader({
+    title,
+    titleId,
+    subtitle,
+    subtitleTitle,
+    onClose,
+    closeLabel,
+    closeDisabled,
+    actions,
+    className = '',
+}: ModalHeaderProps) {
+    return (
+        <div className={`flex flex-shrink-0 items-start justify-between gap-3 border-b border-border px-5 py-4 ${className}`}>
+            <div className="min-w-0">
+                <h2 id={titleId} className="truncate text-lg font-semibold tracking-wide text-text-primary font-reaver">
+                    {title}
+                </h2>
+                {subtitle && (
+                    <p className="truncate text-xs text-text-secondary" title={subtitleTitle}>
+                        {subtitle}
+                    </p>
+                )}
+            </div>
+            <div className="flex flex-shrink-0 items-center gap-2">
+                {actions}
+                <IconButton
+                    icon={X}
+                    label={closeLabel ?? 'Close'}
+                    onClick={onClose}
+                    disabled={closeDisabled}
+                />
+            </div>
+        </div>
+    );
+}
+
+// ============================================================================
+// SegmentedControl - a single tab/segment language for "pick one option"
+// rows (image-picker surfaces, appearance source kinds). role=tablist with
+// roving arrow-key focus and aria-selected, so the two former divergent tab
+// styles (underline vs pill) collapse to one.
+// ============================================================================
+
+interface SegmentOption<T extends string> {
+    value: T;
+    label: ReactNode;
+}
+
+interface SegmentedControlProps<T extends string> {
+    options: readonly SegmentOption<T>[];
+    value: T;
+    onChange: (value: T) => void;
+    label?: string;
+    className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+    options,
+    value,
+    onChange,
+    label,
+    className = '',
+}: SegmentedControlProps<T>) {
+    const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+    const move = (from: number, dir: -1 | 1) => {
+        const next = (from + dir + options.length) % options.length;
+        onChange(options[next].value);
+        refs.current[next]?.focus();
+    };
+
+    return (
+        <div role="tablist" aria-label={label} className={`flex flex-wrap gap-1.5 ${className}`}>
+            {options.map((opt, i) => {
+                const active = opt.value === value;
+                return (
+                    <button
+                        key={opt.value}
+                        ref={(el) => { refs.current[i] = el; }}
+                        type="button"
+                        role="tab"
+                        aria-selected={active}
+                        tabIndex={active ? 0 : -1}
+                        onClick={() => onChange(opt.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                                e.preventDefault();
+                                move(i, 1);
+                            } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                                e.preventDefault();
+                                move(i, -1);
+                            }
+                        }}
+                        className={`whitespace-nowrap rounded-md border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                            active
+                                ? 'border-accent/70 bg-accent/15 text-text-primary'
+                                : 'border-border bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'
+                        }`}
+                    >
+                        {opt.label}
+                    </button>
+                );
+            })}
+        </div>
     );
 }

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -152,8 +152,8 @@ function LoadOrderRow({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={`flex touch-none items-center gap-2.5 rounded-md border px-2 py-1.5 transition-colors ${
         isDragging
-          ? 'z-10 cursor-grabbing border-accent/40 bg-[#1c1c1c] opacity-95 shadow-lg shadow-black/40'
-          : 'cursor-grab border-white/[0.08] bg-[#141414]/70 hover:border-white/[0.18] hover:bg-[#1a1a1a]/80'
+          ? 'z-10 cursor-grabbing border-accent/40 bg-bg-secondary opacity-95 shadow-lg shadow-black/40'
+          : 'cursor-grab border-white/[0.08] bg-bg-secondary/60 hover:border-white/[0.18] hover:bg-bg-secondary/80'
       }`}
     >
       <GripVertical className="h-4 w-4 flex-shrink-0 text-white/40" aria-hidden />
@@ -344,7 +344,7 @@ function SkinGroupCard({
       className={`group/card relative flex flex-col rounded-[10px] border p-2.5 transition-[border-color,background-color,box-shadow] duration-200 ${
         groupActive
           ? 'border-accent bg-white/[0.02] hover:bg-white/[0.04]'
-          : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
+          : 'border-white/[0.08] bg-bg-secondary/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
       } ${variantsOpen ? 'z-20' : ''}`}
     >
       {/* Glass backdrop: a blurred copy of the cover art bleeds behind the
@@ -471,7 +471,7 @@ function SkinGroupCard({
           }}
           aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
           title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className="absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-red-500/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100"
+          className="absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100"
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>
@@ -613,7 +613,7 @@ function SkinGroupRow({
           }}
           aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
           title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-red-500/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100"
+          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100"
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, AlertCircle, Crop, ZoomIn, RotateCcw, ImagePlus } from 'lucide-react';
-import { Toggle } from '../common/ui';
+import { AlertCircle, Crop, ZoomIn, RotateCcw, ImagePlus } from 'lucide-react';
+import { Button, Toggle } from '../common/ui';
 import { getHeroNamePath } from '../../lib/lockerUtils';
 
 interface LockerImageCropperProps {
@@ -495,15 +495,17 @@ export default function LockerImageCropper({
         />
       )}
 
-      <button
-        type="button"
+      <Button
+        variant="primary"
+        size="sm"
+        icon={Crop}
+        isLoading={busy}
         disabled={!img || !!error || busy}
         onClick={handleApply}
-        className="inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent px-3 py-2 text-xs font-semibold text-accent-foreground transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+        className="w-full"
       >
-        {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Crop className="h-3.5 w-3.5" />}
         {t('locker.modImage.useImage')}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -4,6 +4,7 @@ import { Check, Loader2, Upload, Trash2, Copy } from 'lucide-react';
 import type { Mod } from '../../types/mod';
 import type { GameBananaImage } from '../../types/gamebanana';
 import { Modal } from '../common/Modal';
+import { Button, ModalHeader, SegmentedControl } from '../common/ui';
 import {
   getModDetails,
   readImageDataUrl,
@@ -348,64 +349,47 @@ export function LockerModImagePicker({
         ? [{ full: mod.thumbnailUrl, thumb: mod.thumbnailUrl }]
         : [];
 
-  const tabClass = (active: boolean) =>
-    `relative -mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
-      active
-        ? 'border-accent text-text-primary'
-        : 'border-transparent text-text-secondary hover:text-text-primary'
-    }`;
+  // Tabs: the grid thumbnail (3:4) leads as the default since it's the most
+  // visible surface (and the only one that bakes the hero name over the image);
+  // the skin-panel card (16:9) and the backdrop (16:9) follow as independent
+  // per-skin surfaces.
+  const tabOptions: readonly { value: PickerVariant; label: string }[] = [
+    { value: 'thumbnail', label: t('locker.modImage.tabThumbnail') },
+    { value: 'card', label: t('locker.modImage.tabCard') },
+    { value: 'background', label: t('locker.modImage.tabBackground') },
+  ];
 
   return (
     <Modal
       onClose={onClose}
       labelledBy={titleId}
       size="none"
+      backdropClassName="backdrop-blur-sm"
       panelClassName="flex max-h-[90vh] w-full max-w-3xl flex-col"
     >
-      <div className="flex items-start justify-between gap-3 border-b border-border p-4">
-        <div className="min-w-0">
-          <h2 id={titleId} className="truncate text-base font-semibold text-text-primary">
-            {t('locker.modImage.title')}
-          </h2>
-          <p className="truncate text-xs text-text-secondary" title={mod.name}>
-            {mod.name}
-          </p>
-        </div>
-        {hasOverride && (
-          <button
-            type="button"
-            onClick={clear}
-            disabled={busy}
-            className="flex flex-shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-red-500/60 hover:text-red-400 disabled:opacity-50"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            {t('locker.modImage.reset')}
-          </button>
-        )}
-      </div>
+      <ModalHeader
+        title={t('locker.modImage.title')}
+        titleId={titleId}
+        subtitle={mod.name}
+        subtitleTitle={mod.name}
+        onClose={onClose}
+        closeLabel={t('common.actions.close')}
+        actions={
+          hasOverride ? (
+            <Button variant="danger" size="sm" icon={Trash2} onClick={clear} disabled={busy}>
+              {t('locker.modImage.reset')}
+            </Button>
+          ) : undefined
+        }
+      />
 
-      {/* Tabs: the grid thumbnail (3:4) leads as the default since it's the most
-          visible surface (and the only one that bakes the hero name over the
-          image); the skin-panel card (16:9) and the backdrop (16:9) follow as
-          independent per-skin surfaces. */}
-      <div className="flex gap-1 overflow-x-auto border-b border-border px-4">
-        <button
-          type="button"
-          onClick={() => switchTab('thumbnail')}
-          className={tabClass(tab === 'thumbnail')}
-        >
-          {t('locker.modImage.tabThumbnail')}
-        </button>
-        <button type="button" onClick={() => switchTab('card')} className={tabClass(tab === 'card')}>
-          {t('locker.modImage.tabCard')}
-        </button>
-        <button
-          type="button"
-          onClick={() => switchTab('background')}
-          className={tabClass(tab === 'background')}
-        >
-          {t('locker.modImage.tabBackground')}
-        </button>
+      <div className="border-b border-border px-4 py-2.5">
+        <SegmentedControl
+          options={tabOptions}
+          value={tab}
+          onChange={switchTab}
+          label={t('locker.modImage.title')}
+        />
       </div>
 
       <div className="flex min-h-0 flex-1 gap-4 p-4">

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Image as ImageIcon, X, Play, Wand2, Volume2, type LucideIcon } from 'lucide-react';
+import { Check, Image as ImageIcon, Play, Wand2, Volume2, type LucideIcon } from 'lucide-react';
 import { useAppStore } from '../../stores/appStore';
 import { getAssetPath } from '../../lib/assetPath';
 import {
@@ -21,7 +21,7 @@ import {
 } from '../../lib/api';
 import type { AppearanceBg, AppearanceBgKind, AppearanceSurface, AppSettings } from '../../types/mod';
 import type { CropRect } from '../../types/electron';
-import { Button } from '../common/ui';
+import { Button, ModalHeader, SegmentedControl } from '../common/ui';
 import Tx from '../translation/Tx';
 import LockerImageCropper from '../locker/LockerImageCropper';
 import { Modal } from '../common/Modal';
@@ -187,7 +187,7 @@ function SurfacePreview({
         ? getSidebarHeroImageStyle(bg.hero ?? DEFAULT_SIDEBAR_HERO)
         : { objectPosition: 'center' };
     return (
-      <span className={`${base} ${heroSrc ? '' : 'bg-bg-tertiary'} border border-white/10`} aria-hidden>
+      <span className={`${base} ${heroSrc ? '' : 'bg-bg-tertiary'} border border-border`} aria-hidden>
         <SidebarActiveBackdrop heroSrc={heroSrc} heroImageStyle={heroImageStyle} />
         <span className="relative z-10 flex items-center gap-1.5 pl-2">
           <span className="h-3.5 w-3.5 flex-shrink-0 rounded-sm bg-text-primary/40" />
@@ -201,7 +201,7 @@ function SurfacePreview({
   if (config.surfaceKind === 'volume') {
     // Mirror the preview-volume bar: backdrop, volume glyph, then a slider line.
     return (
-      <span className={`${base} bg-bg-tertiary border border-white/10`} aria-hidden>
+      <span className={`${base} bg-bg-tertiary border border-border`} aria-hidden>
         <SurfaceBackdrop
           bg={bg}
           defaultSrc={config.defaultSrc!}
@@ -509,7 +509,7 @@ export default function AppearanceArtSection() {
               key={config.id}
               type="button"
               onClick={() => openEditor(config.id)}
-              className="group flex items-center gap-3 rounded-sm border border-white/10 bg-bg-tertiary/40 p-2 text-left transition-colors hover:border-accent/40 hover:bg-accent/5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="group flex items-center gap-3 rounded-sm border border-border bg-bg-tertiary/40 p-2 text-left transition-colors hover:border-accent/40 hover:bg-accent/5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <SurfacePreview
                 bg={bg}
@@ -540,48 +540,28 @@ export default function AppearanceArtSection() {
         >
             <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent/60" />
 
-            {/* Header (pinned) */}
-            <div className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pt-5 pb-4">
-              <h3
-                id="appearance-art-modal-title"
-                className="text-lg font-semibold text-text-primary tracking-wide font-reaver"
-              >
-                {t(editingConfig.labelKey, editingConfig.fallbackLabel)}
-              </h3>
-              <button
-                type="button"
-                onClick={close}
-                title={t('common.actions.close')}
-                aria-label={t('common.actions.close')}
-                className="flex h-8 w-8 items-center justify-center rounded-sm border border-white/10 text-text-secondary transition-colors hover:border-white/25 hover:bg-white/5 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              >
-                <X className="h-4 w-4" aria-hidden />
-              </button>
-            </div>
+            {/* Header (pinned). Close is disabled while busy to match the blocked
+                Escape/backdrop (dismissable={!busy}). */}
+            <ModalHeader
+              title={t(editingConfig.labelKey, editingConfig.fallbackLabel)}
+              titleId="appearance-art-modal-title"
+              onClose={close}
+              closeLabel={t('common.actions.close')}
+              closeDisabled={busy}
+            />
 
             {/* Body (scrolls) */}
-            <div className="min-h-0 flex-1 overflow-y-auto px-5">
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-4">
               {/* Source-kind tabs (selection only; nothing is saved until Apply) */}
-              <div className="mb-4 flex flex-wrap gap-1.5">
-                {kindsFor(editingConfig).map((kind) => {
-                  const active = draftKind === kind;
-                  return (
-                    <button
-                      key={kind}
-                      type="button"
-                      onClick={() => selectKind(kind)}
-                      aria-pressed={active}
-                      className={`rounded-sm border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                        active
-                          ? 'border-accent/70 bg-accent/15 text-text-primary'
-                          : 'border-white/10 bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'
-                      }`}
-                    >
-                      {t(`settings.appearance.art.kind.${kind}`)}
-                    </button>
-                  );
-                })}
-              </div>
+              <SegmentedControl
+                className="mb-4"
+                options={kindsFor(editingConfig).map((kind) => ({
+                  value: kind,
+                  label: t(`settings.appearance.art.kind.${kind}`),
+                }))}
+                value={draftKind}
+                onChange={selectKind}
+              />
 
               {/* Preview header only when there's no cropper acting as the preview. */}
               {showFooter && (
@@ -613,7 +593,7 @@ export default function AppearanceArtSection() {
                           className={`relative flex aspect-square items-center justify-center overflow-hidden rounded-sm border bg-bg-tertiary transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                             active
                               ? 'border-accent/70 bg-accent/15'
-                              : 'border-white/10 hover:border-accent/50 hover:bg-accent/10'
+                              : 'border-border hover:border-accent/50 hover:bg-accent/10'
                           }`}
                         >
                           <img
@@ -671,7 +651,7 @@ export default function AppearanceArtSection() {
             {/* Footer (pinned). Image kinds commit through the cropper's own button,
                 so only the non-image states (none / accent-glow default) get Apply. */}
             {showFooter && (
-              <div className="flex flex-shrink-0 justify-end gap-2 border-t border-white/10 px-5 py-4">
+              <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border px-5 py-4">
                 <Button variant="secondary" size="sm" onClick={close} disabled={busy}>
                   {t('common.actions.cancel')}
                 </Button>


### PR DESCRIPTION
## What

The popup/modal surfaces added since v1.20.0 (file quick-picker, per-skin image picker, crop editor, launcher/sidebar art, skin load-order tray) drifted from the house UI kit, each reinventing close buttons, tabs, borders, and colors. This unifies them on one accessible, tokenized standard. No behavior changes beyond the a11y fixes noted below.

## Changes

**Accessibility**
- `Modal`: trap `Tab`/`Shift+Tab` focus within the panel (WAI-ARIA dialog pattern). Previously Tab could walk out to the page behind the backdrop. Fixes every `Modal`-based dialog at once.
- `LockerModImagePicker` now has a visible close button (it had none, relying only on Escape/backdrop).
- Close button is now disabled **iff** the modal blocks Escape (`dismissable={!busy}`), so the X behaves exactly like Escape in each dialog.

**Shared primitives (`common/ui.tsx`)**
- `IconButton` — one uniform square icon button (focus-visible ring, token border, mandatory accessible label). Replaces 3 divergent close buttons.
- `ModalHeader` — display-font title + subtitle + actions slot + close, matching the `Card` header treatment.
- `SegmentedControl` — one `role="tablist"` tab language with arrow-key roving focus. Replaces the underline-vs-pill split.

**Token / color cleanup**
- `HeroSkinsPanel`: raw `bg-[#1c1c1c]` / `#141414` / `#1a1a1a` -> `bg-bg-secondary/*` (theme-aware now); `red-500` delete hovers -> `state-danger`.
- `AppearanceArtSection`: `border-white/10` -> `border-border`.
- `LockerImageCropper`: hand-rolled solid-accent apply button -> house `Button`.
- `LockerModImagePicker`: danger `Button` for reset; backdrop blur to match `AppearanceArtSection`.
- Quick-picker metadata separators: hyphen -> middot.

## Verification
- `pnpm typecheck` + `pnpm lint` pass.
- No new i18n keys (all reused), manifest unchanged.

## Deferred (intentionally, noted for follow-up)
- Rebuilding `BrowseFileQuickPicker` on Radix `Popover` would add a new dependency (only `react-context-menu` is installed); the picker already has correct roving-focus/Escape/focus-restore a11y.
- Mount-stable `open`-driven exit animations for the two conditionally-rendered modals (control-flow change, no tests as a net).