### PR TITLE
fix(locker): keep image picker open after applying a surface

### DIFF
--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -5,6 +5,7 @@ import type { Mod } from '../../types/mod';
 import type { GameBananaImage } from '../../types/gamebanana';
 import { Modal } from '../common/Modal';
 import { Button, ModalHeader, SegmentedControl } from '../common/ui';
+import { showToast } from '../../stores/toastStore';
 import {
   getModDetails,
   readImageDataUrl,
@@ -131,6 +132,16 @@ export function LockerModImagePicker({
       remove: removeBackground,
     },
   }[tab];
+
+  // The active tab's display label, used in the "applied" / "reset" toasts so
+  // the confirmation names the surface the user just changed.
+  const surfaceLabel = t(
+    tab === 'thumbnail'
+      ? 'locker.modImage.tabThumbnail'
+      : tab === 'card'
+        ? 'locker.modImage.tabCard'
+        : 'locker.modImage.tabBackground'
+  );
 
   const hasOverride = Boolean(surface.override);
   const initialHideHeroName = Boolean(surface.hideName);
@@ -282,9 +293,11 @@ export function LockerModImagePicker({
     }
   };
 
-  // Commit the framed image (+ the hero-name choice) for the active tab, close.
-  // Also persists the ORIGINAL source + normalized crop rect so the editor can be
-  // reopened on the exact framing and reveal area cropped outside the baked frame.
+  // Commit the framed image (+ the hero-name choice) for the active tab. The
+  // picker stays open (it spans several surfaces, so the user can set the next
+  // tab) and a toast confirms the apply. Also persists the ORIGINAL source +
+  // normalized crop rect so the editor can be reopened on the exact framing and
+  // reveal area cropped outside the baked frame.
   const applyCrop = async ({
     dataUrl,
     hideHeroName,
@@ -311,7 +324,10 @@ export function LockerModImagePicker({
       } catch (editErr) {
         console.error('Failed to store Locker image edit (resume framing)', editErr);
       }
-      onClose();
+      showToast(t('locker.modImage.appliedToast', { surface: surfaceLabel }), {
+        tone: 'success',
+        duration: 2200,
+      });
     } catch (err) {
       console.error('Failed to set Locker skin image', err);
       setError(t('locker.modImage.applyError'));
@@ -327,7 +343,15 @@ export function LockerModImagePicker({
     setError(null);
     try {
       await surface.remove(skinKey);
-      onClose();
+      // Stay open and reset the frame to empty so the user can pick a new image
+      // for this surface (or move to another tab) without reopening.
+      editLoadId.current++;
+      setCropSource(null);
+      setRestoredCrop(undefined);
+      showToast(t('locker.modImage.removedToast', { surface: surfaceLabel }), {
+        tone: 'success',
+        duration: 2200,
+      });
     } catch (err) {
       console.error('Failed to remove Locker skin image', err);
       setError(t('locker.modImage.applyError'));

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -986,6 +986,8 @@
       "noGallery": "No images available. Upload a custom one above.",
       "reset": "Reset to default",
       "useImage": "Use image",
+      "appliedToast": "{{surface}} applied",
+      "removedToast": "{{surface}} reset",
       "useLockerImage": "Use Locker image",
       "hideHeroName": "Hide hero name label",
       "hideHeroNameHint": "Turn on when the image already shows the hero's name."

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1666,
+  "totalKeys": 1668,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1666,
+      "translatedKeys": 1668,
       "pct": 100
     }
   ]


### PR DESCRIPTION
## What

The per-skin Locker image picker is a single tabbed popup covering three surfaces (Locker image, card thumbnail, background). Previously, hitting **Use image** saved and immediately closed the whole picker, so setting more than one surface meant reopening it each time.

Now **Use image** keeps the picker open and shows a success toast naming the surface that changed (e.g. "Locker image applied"), so the user can move to the next tab and keep working. **Reset** behaves the same way: it clears the frame in place and toasts, instead of closing.

## Notes
- Only affects `LockerModImagePicker`. The single-surface `AppearanceArtSection` editor still closes on apply (correct there: it's opened per surface).
- New i18n keys `locker.modImage.appliedToast` / `removedToast`; manifest regenerated.

## Verification
`pnpm i18n:check`, `pnpm typecheck`, `pnpm lint` all pass.