### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ icon-32.png
 .codex-run/
 reports/
 
+# Local dev helper: register a prebuilt VPK as a named local mod
+scripts/import-local-mod.mjs
+
 # Project summary (LaTeX source + build artifacts)
 docs/grimoire-project-summary.*
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.15.0';
+const VPKMERGE_VERSION = 'v0.16.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'a0cd8b505142a2970f3133df1d6b37f10404096bd1057932d65810500785a652' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '91018e0db3299caa9efb80ccc9eeedd09f80164bbc0a1d5034f2252e08929e63' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: 'd046399f5093714dc7fdd1976693ba2147b089254ba2119a7cd228f747ccc54a' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '113ef79fe771df40cdda390db42a4e949f593da82021bb0f4c6a36ff3fa3b0ab' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '23060cf72c953f7b07924b92d6efc0a1e94c73dd100e2816fa48c3bba464f3f2' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '89c4f42582dfcf9c7e17206dd1f6618916ac89a8f114c7d39af70a227728f4df' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Release prep for **v1.21.0**.

## Changes in this PR
- Bump \`version\` 1.20.0 -> 1.21.0
- Bump vpkmerge pin v0.15.0 -> v0.16.0 (published, not draft; linux sha256 verified against the published binary)
- gitignore the local \`scripts/import-local-mod.mjs\` dev helper

## What's in v1.21.0 (13 commits since v1.20.0)
- feat(appearance): unified launcher & sidebar art, drop-zone crop editor, real-surface previews (#216)
- feat(locker): per-skin Locker images, unified tabbed picker (#215)
- feat(locker): skin load ordering, per-skin/global delete, soul card fixes (#205)
- feat(locker, browse): hide empty heroes + multi-file install picker (#213)
- feat(browse): float card tags onto thumbnail on hover (#214)
- refactor(ui): unify post-v1.20.0 popups on shared primitives (#218)
- fix(locker): keep image picker open after applying a surface (#219)
- plus browse download-order tweak, null-state guard, footer layout, CONTRIBUTING AI guidelines

## Gates (all green locally)
- \`pnpm typecheck\` ✓
- \`pnpm lint\` ✓
- \`pnpm i18n:check\` ✓
- locale manifest up to date ✓

After merge: tag \`v1.21.0\` from main to trigger release.yml, then replace the auto-generated release body with the structured template.