### PR TITLE
fix(locker): tidy Choose a Locker image picker layout (v1.21.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -421,7 +421,7 @@ export function LockerModImagePicker({
             empty up front so the framing surface is previewed before a pick.
             Sized to the window by the cropper; scrolls itself only as a fallback
             on very short windows so it never clips. */}
-        <div className="flex-shrink-0 overflow-y-auto">
+        <div className="w-80 flex-shrink-0 overflow-y-auto">
           <LockerImageCropper
             key={tab}
             imageDataUrl={cropSource}


### PR DESCRIPTION
## What

The *Choose a Locker image* picker looked off: the crop-adjuster pane had no width constraint, so the long instruction text and full-width controls blew its column wide. That left the portrait crop frame floating with large dead margins on both sides, and squeezed the right-hand source picker so *Upload a custom image* wrapped to two lines and the *From this mod* thumbnails shrank.

## Fix

Pin the left (crop-adjuster) pane to `w-80` (320px), matching the crop frame's max width (`FRAME_MAX_W`). The instruction text now wraps within the column instead of forcing it wider, and the right pane (`flex-1`) reclaims its space: *Upload a custom image* fits on one line and the thumbnails render at a usable size.

Scoped to `LockerModImagePicker` only. The shared `LockerImageCropper` is untouched, so the Settings > Appearance art cropper surface is unaffected.

## Release

Bumps version to **1.21.1** (patch hotfix).