### PR TITLE
feat(appearance): make unified launch button opt-in

### DIFF
--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     zoomFactor: 1,
     discordRpcEnabled: false,
     contributeMatchSalts: false,
+    unifiedLaunchButton: false,
 };
 
 /**

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -708,6 +708,11 @@ export default function Sidebar() {
 
   const canLaunch = !!settings?.deadlockPath || !!settings?.devDeadlockPath;
 
+  // Opt-in: combine the two launch buttons into one dual-use button. Off by
+  // default, so the sidebar keeps the stacked Launch Modded / Launch Vanilla
+  // buttons unless the user turns this on from Appearance.
+  const unifiedLaunch = settings?.unifiedLaunchButton ?? false;
+
   // Single dual-use launch button (issue: unify launch buttons): one persisted
   // mode drives the icon, label, art, handler, and enable/disable rules. The
   // trailing swap control and right-click both flip between Modded and Vanilla.
@@ -1061,6 +1066,77 @@ export default function Sidebar() {
                 </span>
               )}
             </button>
+          ) : !unifiedLaunch ? (
+            // Default: the two stacked launch buttons. Each paints its own
+            // appearance surface (issue: unify launcher backgrounds); the old
+            // right-click "hide art" menu is gone (the Appearance surfaces own
+            // that now).
+            <>
+              <button
+                onClick={handleLaunchModded}
+                disabled={!canLaunch || !!launchPending || stopPending}
+                title={
+                  !canLaunch
+                    ? t('sidebar.launch.noPath')
+                    : stashStatus.active
+                      ? t('sidebar.launch.moddedStash')
+                      : t('sidebar.launch.moddedDefault')
+                }
+                className="group relative flex w-full h-10 items-center overflow-hidden rounded-sm bg-bg-tertiary text-text-primary ring-1 ring-white/10 hover:ring-white/25 text-sm font-semibold tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-white/35 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <SurfaceBackdrop
+                  bg={launchModdedBg}
+                  defaultSrc={LAUNCH_MODDED_BG}
+                  defaultPosition="center 45%"
+                  customSrc={appearanceImages.launchModded}
+                />
+                <span className={`relative z-10 ${actionIconClass}`}>
+                  {launchPending === 'modded' ? (
+                    <Loader2 className="w-[18px] h-[18px] animate-spin" />
+                  ) : (
+                    <Wand2 className="w-[18px] h-[18px]" strokeWidth={2} />
+                  )}
+                </span>
+                {labelMounted && (
+                  <span className={`relative z-10 drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${actionLabelClass}`} aria-hidden={!labelsVisible}>
+                    {t('sidebar.launchModded')}
+                  </span>
+                )}
+              </button>
+
+              <button
+                onClick={handleLaunchVanilla}
+                disabled={!canLaunch || !!launchPending || stopPending || stashStatus.active}
+                title={
+                  !canLaunch
+                    ? t('sidebar.launch.noPath')
+                    : stashStatus.active
+                      ? t('sidebar.launch.vanillaStash')
+                      : t('sidebar.launch.vanillaDefault')
+                }
+                className="group relative flex w-full h-8 items-center overflow-hidden rounded-sm bg-bg-tertiary text-text-primary/85 ring-1 ring-white/10 hover:text-text-primary hover:ring-amber-400/35 text-xs font-medium tracking-wide transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-accent/40 disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                <SurfaceBackdrop
+                  bg={launchVanillaBg}
+                  defaultSrc={LAUNCH_VANILLA_BG}
+                  defaultPosition="center 48%"
+                  warm
+                  customSrc={appearanceImages.launchVanilla}
+                />
+                <span className={`relative z-10 ${actionIconClass}`}>
+                  {launchPending === 'vanilla' ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Play className="w-4 h-4" strokeWidth={2} />
+                  )}
+                </span>
+                {labelMounted && (
+                  <span className={`relative z-10 drop-shadow-[0_1px_4px_rgba(0,0,0,0.75)] ${actionLabelClass}`} aria-hidden={!labelsVisible}>
+                    {t('sidebar.launchVanilla')}
+                  </span>
+                )}
+              </button>
+            </>
           ) : (
             <div
               className="group/launch relative"

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../lib/api';
 import type { AppearanceBg, AppearanceBgKind, AppearanceSurface, AppSettings } from '../../types/mod';
 import type { CropRect } from '../../types/electron';
-import { Button, ModalHeader, SegmentedControl } from '../common/ui';
+import { Button, ModalHeader, SegmentedControl, Toggle } from '../common/ui';
 import Tx from '../translation/Tx';
 import LockerImageCropper from '../locker/LockerImageCropper';
 import { Modal } from '../common/Modal';
@@ -487,6 +487,19 @@ export default function AppearanceArtSection() {
 
   return (
     <div>
+      <Toggle
+        checked={settings?.unifiedLaunchButton ?? false}
+        onChange={(checked) => settings && void saveSettings({ ...settings, unifiedLaunchButton: checked })}
+        label={<Tx k="settings.appearance.launchButtons.combine" fallback="Combine launch buttons" />}
+        description={
+          <Tx
+            k="settings.appearance.launchButtons.combineDescription"
+            fallback="Use one launch button you switch between Modded and Vanilla (the swap icon or right-click), instead of two stacked buttons."
+          />
+        }
+        className="mb-5"
+      />
+
       <div className="mb-3">
         <h3 className="text-sm font-semibold text-text-primary">
           <Tx k="settings.appearance.art.title" fallback="Launcher & sidebar art" />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -508,6 +508,10 @@
       "customAccentColor": "Custom accent color",
       "selectedColorPreview": "Selected color preview",
       "customAccent": "Custom Accent",
+      "launchButtons": {
+        "combine": "Combine launch buttons",
+        "combineDescription": "Use one launch button you switch between Modded and Vanilla (the swap icon or right-click), instead of two stacked buttons."
+      },
       "art": {
         "title": "Launcher & sidebar art",
         "description": "Set the background for each launch button, the active tab, and the volume bar.",
@@ -1351,6 +1355,7 @@
       "lockerImages": "Locker images",
       "back": "Back",
       "favorite": "Favorite",
+      "unfavorite": "Unfavorite",
       "lockerSections": "Locker sections",
       "hero3dModel": "{{hero}} 3D model"
     }

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,11 +1,11 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1668,
+  "totalKeys": 1671,
   "languages": [
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1668,
+      "translatedKeys": 1671,
       "pct": 100
     }
   ]

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -387,7 +387,7 @@ export function LockerHeroView({
             }`}
           >
             <Star className="w-4 h-4" />
-            {isFavorite ? t('locker.hero.favorite') : t('common.actions.save')}
+            {isFavorite ? t('locker.hero.unfavorite') : t('locker.hero.favorite')}
           </button>
         </div>
 

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -818,6 +818,12 @@ export interface AppSettings {
    *  legacy compat read so existing installs keep their chosen highlight; the
    *  Appearance UI now writes `appearanceBackgrounds` instead. */
   sidebarHeroHighlight?: string | null;
+  /** Combine the separate Launch Modded / Launch Vanilla buttons into one
+   *  dual-use launch button (swap mode via the trailing icon or right-click).
+   *  Off by default: the sidebar keeps the two stacked buttons unless the user
+   *  opts in from Appearance. The chosen mode for the combined button is UI
+   *  state persisted in localStorage, not here. */
+  unifiedLaunchButton?: boolean;
   /** Per-surface launcher / sidebar background art (issue: unify launcher
    *  backgrounds). Each of the four surfaces independently chooses default art,
    *  a hero render, a custom upload, or none. Custom image bytes live out-of-band


### PR DESCRIPTION
## What

The unified dual-use launch button (shipped in #216 / v1.21) is now **opt-in** via a new Appearance toggle, rather than the default. Out of the box the sidebar keeps the original stacked **Launch Modded / Launch Vanilla** buttons.

## Why

The single-button unification was a default behavior change. This puts it behind a toggle so users who prefer the two separate buttons keep them, and those who want the combined button can opt in.

## Changes

- **New setting** `unifiedLaunchButton` (default `false`)
  - Added to `AppSettings` (`src/types/mod.ts`) and `DEFAULT_SETTINGS` (`electron/main/services/settings.ts`).
- **Appearance toggle** ("Combine launch buttons") in `AppearanceArtSection`, above the per-surface art grid.
- **Sidebar** now branches: Stop (running) → split stacked buttons (default) → unified dual-use button (opt-in). The unified button + swap/right-click logic is unchanged; it just only renders when the toggle is on.
- The default split buttons are rewired to the **new** per-surface appearance backgrounds (`SurfaceBackdrop` + `launchModded`/`launchVanilla` art + custom uploads) instead of the old right-click hide-art menu, which the Appearance surfaces now own. Both launch arts stay configurable in either mode.
- i18n: added `settings.appearance.launchButtons.combine` / `combineDescription`, regenerated `manifest.json`.

## Also included

- **fix(locker):** the hero favorite button now reads **Unfavorite** when a hero is already favorited (was always "Favorite"/generic "Save"), using the existing `locker.hero.unfavorite` key.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm i18n:check` — OK