### PR TITLE
i18n(settings): fix typo and tighten Combine launch buttons description

### DIFF
--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -494,7 +494,7 @@ export default function AppearanceArtSection() {
         description={
           <Tx
             k="settings.appearance.launchButtons.combineDescription"
-            fallback="Use one launch button you switch between Modded and Vanilla (the swap icon or right-click), instead of two stacked buttons."
+            fallback="Use a single launch button and switch between Modded and Vanilla with the swap icon or right-click, instead of two stacked buttons."
           />
         }
         className="mb-5"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -507,7 +507,7 @@
       "customAccent": "Custom Accent",
       "launchButtons": {
         "combine": "Combine launch buttons",
-        "combineDescription": "Use one launch button you switch between Modded and Vanilla (the swap icon or right-click), instead of two stacked buttons."
+        "combineDescription": "Use a single launch button and switch between Modded and Vanilla with the swap icon or right-click, instead of two stacked buttons."
       },
       "art": {
         "title": "Launcher & sidebar art",


### PR DESCRIPTION
## What

The description under the **Combine launch buttons** toggle (Settings > Appearance) was missing a word and read awkwardly:

> Before: "Use one launch button **you** switch between Modded and Vanilla (the swap icon or right-click), instead of two stacked buttons."
> After: "Use a single launch button and switch between Modded and Vanilla with the swap icon or right-click, instead of two stacked buttons."

Updates both the `settings.appearance.launchButtons.combineDescription` catalog string and the matching inline fallback in `AppearanceArtSection.tsx`.

## Why

A translator (Z.A.K) flagged the missing word. Kept the description rather than deleting it: when the toggle is on, the two stacked launch buttons collapse into one and the second mode is hidden behind a swap-icon / right-click gesture. That gesture is undiscoverable without this sentence, so the description is load-bearing, just needed cleaning up.

## Notes

- English-only string change; no new/removed keys, so `manifest.json` is unchanged.
- `pnpm i18n:check` passes.