### PR TITLE
UI uniformity: adopt design-system primitives + tokens

### DIFF
--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -1,0 +1,32 @@
+# UI conventions
+
+The house rules for building UI in the Grimoire renderer. The goal is uniformity by default: reach for an existing primitive before writing markup, and use tokens instead of raw values. New code that follows these keeps the design system honest; new code that doesn't is the "slop" we're paying down.
+
+Primitives live in `src/components/common/` (`ui.tsx`, `forms.tsx`, `PageComponents.tsx`, `Modal.tsx`, `menu.tsx`, `ToastStack.tsx`, `Skeleton.tsx`). Design tokens live in `src/index.css` under `@theme`.
+
+## Tokens, not raw values
+
+- **No raw hex** in `className`/`style`. Use a token utility (`bg-bg-secondary`, `text-text-primary`, `border-border`, `bg-accent`). If a value is genuinely new and reusable, add a token to `@theme` first.
+- **No raw Tailwind palette colors** (`green-500`, `red-400`, `zinc-300`, ...) where a semantic token exists. Status/state -> `state-success | state-warning | state-danger | state-info`. Brand -> `brand-discord | brand-kofi`.
+- Prefer `text-text-primary` over `text-white`. The accent foreground flips by luminance at runtime; literal whites can't.
+- Surfaces: app bg `bg-bg-primary`, cards/panels `bg-bg-secondary`, inputs/raised `bg-bg-tertiary`.
+
+## Components, not ad-hoc markup
+
+- **Buttons:** use `Button` (text + variants: primary/secondary/danger/success/warning/ghost; sizes sm/md/lg; `icon`, `isLoading`) or `IconButton` (icon-only, requires a `label`). Do not hand-roll `<button className="px-3 py-1.5 ...">`.
+- **Form controls:** use `Input`, `Textarea`, `Select`, and `FormField` from `forms.tsx`. Never style a raw `<input>`/`<textarea>`/`<select>` inline. Domain pickers (`HeroSelect`, `DynamicSelect`) are the exceptions and stay as-is.
+- **Page structure:** every page renders inside `PageLayout`. Title rows use `PageHeader`; "nothing here" states use `EmptyState`; loading uses `LoadingState`; top action bars use `PageToolbar`; view switching uses `ViewModeToggle`/`SegmentedControl`.
+- **Overlays:** dialogs use `Modal` (+ `ModalHeader`); confirmations use `ConfirmModal`; context menus use the `Menu` family; transient feedback uses the toast store. Pick z-index from the ladder documented at the top of `index.css` (never invent `z-[9999]`).
+- **Status chrome:** `Tag` (HUD-style card markers) and `Badge` (pills). `Skeleton` for placeholders.
+
+## Visual scale
+
+- **Radius:** `rounded-sm` is the default (cards, tags, inputs, buttons). `rounded-full` only for pills/avatars. Avoid mixing `rounded-md`/`rounded-lg`/`rounded-xl` for the same role.
+- **Focus:** `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`. Use `focus-visible`, not `focus` (the latter fires on click). Add `ring-offset-2 ring-offset-bg-secondary` on solid surfaces.
+- **Form-control surface (canonical):** `bg-bg-tertiary border border-white/5 rounded-sm` + the focus ring above + `disabled:opacity-60 disabled:cursor-not-allowed`. This is baked into the `forms.tsx` primitives; match it if you must go custom.
+
+## Other hard rules
+
+- **No em-dashes** anywhere (UI strings, comments). Use colon/period/parens.
+- **Visible strings are i18n keys.** Add real keys to `src/locales/en/translation.json` and run `pnpm i18n:manifest`. Never hardcode user-facing copy.
+- After UI changes: `pnpm typecheck` + `pnpm lint`.

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -313,7 +313,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                                 e.stopPropagation();
                                                 void handleCancelQueued(item.modId);
                                             }}
-                                            className="rounded-md p-1 text-text-secondary opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100 cursor-pointer"
+                                            className="rounded-md p-1 text-text-secondary opacity-0 transition-opacity hover:text-state-danger group-hover:opacity-100 cursor-pointer"
                                             title={t('downloadQueue.removeFromQueue')}
                                         >
                                             <X className="h-3 w-3" />

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -20,6 +20,7 @@ import {
   createProfileFromGameBananaIds,
 } from '../lib/api';
 import { Button } from './common/ui';
+import { Input } from './common/forms';
 import { Modal } from './common/Modal';
 import ModThumbnail from './ModThumbnail';
 import type {
@@ -820,20 +821,20 @@ export default function ImportCollectionModal({
             }}
             className="flex items-stretch gap-2"
           >
-            <input
+            <Input
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="https://gamebanana.com/collections/164637"
               disabled={loadingItems}
-              className="flex-1 px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
+              className="flex-1"
             />
             <Button type="submit" disabled={loadingItems || !input.trim()}>
               {loadingItems ? <Loader2 className="w-4 h-4 animate-spin" /> : t('importCollection.actions.fetch')}
             </Button>
           </form>
           {resolveError && (
-            <p className="mt-2 text-xs text-red-400 flex items-center gap-1.5">
+            <p className="mt-2 text-xs text-state-danger flex items-center gap-1.5">
               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
               {resolveError}
             </p>
@@ -1063,7 +1064,7 @@ export default function ImportCollectionModal({
                         <button
                           type="button"
                           onClick={() => cancelRow(row)}
-                          className="text-accent inline-flex items-center gap-1.5 justify-end hover:text-red-400 cursor-pointer"
+                          className="text-accent inline-flex items-center gap-1.5 justify-end hover:text-state-danger cursor-pointer"
                           title={t('downloadQueue.removeFromQueue')}
                         >
                           <Ban className="w-4 h-4" /> {t('importCollection.status.queued')}
@@ -1078,7 +1079,7 @@ export default function ImportCollectionModal({
                         </span>
                       ) : row.status === 'failed' ? (
                         <span
-                          className="text-red-400 inline-flex items-center gap-1.5 justify-end"
+                          className="text-state-danger inline-flex items-center gap-1.5 justify-end"
                           title={row.statusMessage}
                         >
                           <AlertTriangle className="w-4 h-4" /> {t('importCollection.status.failed')}
@@ -1097,7 +1098,7 @@ export default function ImportCollectionModal({
                         </div>
                       )}
                       {row.detailsError && (
-                        <div className="text-xs text-red-400 flex items-center gap-1.5">
+                        <div className="text-xs text-state-danger flex items-center gap-1.5">
                           <AlertTriangle className="w-3.5 h-3.5" />
                           {row.detailsError}
                         </div>
@@ -1214,7 +1215,7 @@ export default function ImportCollectionModal({
                 )}
                 {profileStatus.kind === 'failed' && (
                   <span
-                    className="text-red-400 inline-flex items-center gap-1.5 text-xs"
+                    className="text-state-danger inline-flex items-center gap-1.5 text-xs"
                     title={profileStatus.message}
                   >
                     <AlertTriangle className="w-3.5 h-3.5" />

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -236,7 +236,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
 
           {error && (
             <div className="flex items-start gap-2 text-sm text-red-200 bg-red-500/10 border border-red-500/30 rounded-lg p-2.5">
-              <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+              <AlertTriangle className="w-4 h-4 text-state-danger flex-shrink-0 mt-0.5" />
               <div>{error}</div>
             </div>
           )}

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -4,6 +4,7 @@ import { Layers, X, AlertTriangle, Info } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import ModThumbnail from './ModThumbnail';
 import { Button } from './common/ui';
+import { FormField, Input } from './common/forms';
 import { Modal } from './common/Modal';
 
 interface Props {
@@ -109,24 +110,21 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
               />
             </div>
             <div className="flex-1 min-w-0">
-              <label htmlFor="merge-name" className="block text-sm font-medium text-text-primary mb-1.5">
-                {t('mergeMods.mergedModName')} <span className="text-red-400">*</span>
-              </label>
-              <input
-                id="merge-name"
-                type="text"
-                value={liveName}
-                onChange={(e) => {
-                  setNameTouched(true);
-                  setName(e.target.value);
-                }}
-                placeholder={t('mergeMods.namePlaceholder')}
-                className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent"
-                autoFocus
-              />
-              <p className="mt-2 text-xs text-text-secondary">
-                {t('mergeMods.originalsStay')}
-              </p>
+              <FormField
+                label={t('mergeMods.mergedModName')}
+                required
+                hint={t('mergeMods.originalsStay')}
+              >
+                <Input
+                  value={liveName}
+                  onChange={(e) => {
+                    setNameTouched(true);
+                    setName(e.target.value);
+                  }}
+                  placeholder={t('mergeMods.namePlaceholder')}
+                  autoFocus
+                />
+              </FormField>
             </div>
           </div>
 

--- a/src/components/MergedContentsModal.tsx
+++ b/src/components/MergedContentsModal.tsx
@@ -188,7 +188,7 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
 
             {actionError && (
               <div className="flex items-start gap-2 text-sm text-red-200 bg-red-500/10 border border-red-500/30 rounded-lg p-2.5 mt-2">
-                <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                <AlertTriangle className="w-4 h-4 text-state-danger flex-shrink-0 mt-0.5" />
                 <div>{actionError}</div>
               </div>
             )}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1353,7 +1353,7 @@ function ModDetailsModal({
                         target="_blank"
                         rel="noopener noreferrer"
                         title={`Support ${submitter.name} on Ko-fi`}
-                        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5E5B]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary"
+                        className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-full bg-brand-kofi px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-brand-kofi-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-kofi/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-secondary"
                       >
                         <Coffee className="h-4 w-4" />
                         {t('modDetails.meta.koFi')}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -31,7 +31,7 @@ import { getModComments, getModUpdates } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
 import { Skeleton } from './common/Skeleton';
-import { ArchivedTag } from './common/ui';
+import { ArchivedTag, Button, IconButton } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
 
 type ModDetailsNavigationDirection = 'previous' | 'next';
@@ -531,38 +531,32 @@ function ModDetailsModal({
         </div>
         <div className="col-start-2 flex min-w-0 flex-wrap items-center justify-end gap-2 sm:col-start-3 sm:row-start-1">
           {showEnablePill && installedFileState && (
-            <button
+            <Button
               type="button"
+              variant="warning"
+              icon={Power}
               onClick={() => onEnableFile!(installedFileState.modId)}
               disabled={isBusyThis}
               title={t('modDetails.actions.enableThisModTitle')}
-              className="flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-yellow-500/40 bg-yellow-500/15 px-3 py-2 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-500/25 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
             >
-              <Power className="w-3.5 h-3.5" />
               {t('modDetails.actions.enable')}
-            </button>
+            </Button>
           )}
           {showDeleteButton && installedFileState && (
-            <button
-              type="button"
+            <IconButton
+              icon={Trash2}
+              label={`Delete ${file.fileName}`}
+              tone="danger"
               onClick={() => setDeleteCandidate({ modId: installedFileState.modId, fileName: file.fileName })}
               disabled={isBusyThis || deleteInProgress}
-              title={`Delete ${file.fileName}`}
-              aria-label={`Delete ${file.fileName}`}
-              className="flex h-9 w-9 items-center justify-center rounded-md border border-state-danger/35 bg-state-danger/10 text-state-danger transition-colors hover:border-state-danger/55 hover:bg-state-danger/20 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
-            >
-              <Trash2 className="w-4 h-4" />
-            </button>
+            />
           )}
-          <button
+          <Button
             type="button"
+            variant={isUpdate || !isInstalled ? 'primary' : 'secondary'}
             onClick={() => onDownload(file.id, file.fileName)}
             disabled={isBusyThis}
-            className={`flex min-w-[110px] max-w-full items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer ${
-              isUpdate || !isInstalled
-                ? 'border-accent/45 bg-accent/10 text-text-primary hover:border-accent/65 hover:bg-accent/20'
-                : 'border-border bg-bg-secondary text-text-primary hover:bg-bg-primary'
-            }`}
+            className="min-w-[110px] max-w-full"
           >
             {isDownloadingThis ? (
               <>
@@ -580,7 +574,7 @@ function ModDetailsModal({
                 {actionLabel(file.id, archived)}
               </>
             )}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -950,22 +944,17 @@ function ModDetailsModal({
             );
           })()}
           {onChangeView && (
-            <button
+            <IconButton
+              icon={isSidebar ? Maximize2 : PanelRight}
+              label={isSidebar ? 'Pop out to centered window' : 'Dock to side'}
               onClick={() => onChangeView(isSidebar ? 'modal' : 'sidebar')}
-              aria-label={isSidebar ? 'Pop out to centered window' : 'Dock to side'}
-              title={isSidebar ? 'Pop out to centered window' : 'Dock to side'}
-              className="flex-shrink-0 p-1.5 rounded-full text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
-            >
-              {isSidebar ? <Maximize2 className="w-[18px] h-[18px]" /> : <PanelRight className="w-5 h-5" />}
-            </button>
+            />
           )}
-          <button
+          <IconButton
+            icon={X}
+            label={t('common.actions.close')}
             onClick={onClose}
-            aria-label={t('common.actions.close')}
-            className="flex-shrink-0 p-1.5 rounded-full text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors cursor-pointer"
-          >
-            <X className="w-5 h-5" />
-          </button>
+          />
         </div>
 
         {deleteCandidate && (
@@ -994,16 +983,18 @@ function ModDetailsModal({
                 />
               </p>
               <div className="mt-5 flex justify-end gap-3">
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
                   onClick={() => setDeleteCandidate(null)}
                   disabled={deleteInProgress}
-                  className="rounded-md border border-border bg-bg-tertiary px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
                 >
                   {t('common.actions.cancel')}
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="danger"
+                  isLoading={deleteInProgress}
                   onClick={async () => {
                     if (!onDeleteFile || !deleteCandidate) return;
                     setDeleteInProgress(true);
@@ -1014,12 +1005,9 @@ function ModDetailsModal({
                       setDeleteInProgress(false);
                     }
                   }}
-                  disabled={deleteInProgress}
-                  className="inline-flex items-center gap-2 rounded-md border border-state-danger/35 bg-state-danger/10 px-4 py-2 text-sm font-medium text-state-danger transition-colors hover:border-state-danger/55 hover:bg-state-danger/20 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
                 >
-                  {deleteInProgress && <Loader2 className="w-4 h-4 animate-spin" />}
                   {t('common.actions.delete')}
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import { Input } from './common/forms';
 
 interface Props {
   modName: string;
@@ -142,9 +143,8 @@ export default function PriorityEditor({
           <span className="mb-2 block text-xs font-semibold text-text-primary">{t('installed.priorityEditor.loadOrder')}</span>
           <span className="inline-flex h-9 w-full items-center rounded-md border border-border bg-bg-tertiary px-2.5 text-sm text-text-primary transition-colors focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/30">
             <span className="mr-1 text-text-secondary">#</span>
-            <input
+            <Input
               ref={inputRef}
-              type="text"
               inputMode="numeric"
               value={draft}
               disabled={busy}
@@ -161,7 +161,7 @@ export default function PriorityEditor({
               onBlur={() => {
                 if (!busy) void commit();
               }}
-              className="min-w-0 flex-1 bg-transparent text-sm tabular-nums text-text-primary focus:outline-none"
+              className="min-w-0 flex-1 border-0 bg-transparent p-0 tabular-nums focus-visible:ring-0"
               aria-label={t('installed.priorityEditor.inputAriaLabel', { modName })}
               aria-invalid={!!error}
             />

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react';
 import type { Mod } from '../types/mod';
 import { ArchivedTag, Button, CheckboxMark, Tag } from './common/ui';
+import { Input } from './common/forms';
 import { Modal } from './common/Modal';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { formatBytes } from '../lib/formatBytes';
@@ -328,9 +329,9 @@ export default function VariantPickerModal({
                         <CheckboxMark checked={isActive} />
                         <div className="min-w-0 flex-1">
                             {isEditing ? (
-                                <input
+                                <Input
                                     ref={editInputRef}
-                                    type="text"
+                                    inputSize="sm"
                                     value={editing.draft}
                                     onChange={(e) => setEditing({ id: v.id, draft: e.target.value })}
                                     onClick={(e) => e.stopPropagation()}
@@ -346,7 +347,6 @@ export default function VariantPickerModal({
                                     }}
                                     placeholder={t('variantPicker.renamePlaceholder')}
                                     maxLength={80}
-                                    className="w-full bg-bg-secondary border border-accent/50 rounded px-2 py-1 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
                                 />
                             ) : (
                                 <div className="flex items-center gap-2 min-w-0">

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -477,7 +477,7 @@ export default function VariantPickerModal({
                             type="button"
                             onClick={() => handleDelete(v)}
                             disabled={overlay || !!pending}
-                            className="flex-shrink-0 p-1.5 text-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-50"
+                            className="flex-shrink-0 p-1.5 text-text-secondary hover:text-state-danger hover:bg-red-500/10 rounded transition-colors cursor-pointer disabled:cursor-default disabled:opacity-50"
                             title={`Delete ${primaryTitle}`}
                             aria-label={`Delete ${primaryTitle}`}
                         >

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -56,7 +56,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             return (
                 <div className="flex flex-col items-center justify-center h-full p-8 text-center">
                     <div className="p-4 bg-red-500/10 rounded-full mb-4">
-                        <AlertTriangle className="w-12 h-12 text-red-400" />
+                        <AlertTriangle className="w-12 h-12 text-state-danger" />
                     </div>
                     <h2 className="text-xl font-bold text-text-primary mb-2">
                         <Tx k="common.errorBoundary.title" fallback="Something went wrong" />
@@ -68,7 +68,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                         />
                     </p>
                     {this.state.error && (
-                        <pre className="text-xs text-red-400 bg-red-500/5 border border-red-500/20 rounded-lg p-3 mb-4 max-w-lg overflow-auto">
+                        <pre className="text-xs text-state-danger bg-red-500/5 border border-red-500/20 rounded-lg p-3 mb-4 max-w-lg overflow-auto">
                             {this.state.error.message}
                         </pre>
                     )}

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
-import { type LucideIcon } from 'lucide-react';
+import { Loader2, type LucideIcon } from 'lucide-react';
 import { Modal } from './Modal';
+import { Skeleton } from './Skeleton';
 import Tx from '../translation/Tx';
 
 // ============================================================================
@@ -124,6 +125,87 @@ export function EmptyState({ icon: Icon, title, description, action, variant = '
                 </div>
             )}
             {action && <div className="mt-4">{action}</div>}
+        </div>
+    );
+}
+
+// ============================================================================
+// PageLayout - the standard page root.
+//
+// The app shell (Layout.tsx) already wraps the router Outlet in a scrolling,
+// fade-in container, so pages must NOT add their own `h-full overflow-y-auto`
+// or `animate-fade-in` (several used to, double-wrapping). This collapses the
+// competing root-div patterns into one:
+//   - `flow` (default): vertical stack; the shell scrolls the whole page.
+//   - `fill`: page fills the height and owns its own internal scroll regions
+//             (e.g. split panes). Pages that save/restore their own scroll
+//             position via a ref keep their bespoke container instead.
+// `maxWidth` centers and constrains the content column.
+// ============================================================================
+
+type PageWidth = 'none' | 'lg' | 'xl' | '2xl' | '3xl' | '5xl' | '7xl';
+
+const PAGE_WIDTHS: Record<PageWidth, string> = {
+    none: '',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '5xl': 'max-w-5xl',
+    '7xl': 'max-w-7xl',
+};
+
+interface PageLayoutProps {
+    children: ReactNode;
+    maxWidth?: PageWidth;
+    variant?: 'flow' | 'fill';
+    className?: string;
+}
+
+export function PageLayout({ children, maxWidth = 'none', variant = 'flow', className = '' }: PageLayoutProps) {
+    const width = maxWidth === 'none' ? '' : `${PAGE_WIDTHS[maxWidth]} mx-auto w-full`;
+    const base = variant === 'fill' ? 'p-6 h-full flex flex-col min-h-0 overflow-hidden' : 'p-6 space-y-6';
+    return <div className={`${base} ${width} ${className}`}>{children}</div>;
+}
+
+// ============================================================================
+// LoadingState - consistent pending UI. `spinner` for a centered loader,
+// `cards` for a skeleton grid that stands in for card content. Carries
+// aria-busy/aria-live so every loading surface announces uniformly. Pages with
+// a bespoke content-shaped skeleton (e.g. Conflicts) keep theirs.
+// ============================================================================
+
+interface LoadingStateProps {
+    variant?: 'spinner' | 'cards';
+    /** Number of skeleton cards (cards variant). */
+    count?: number;
+    /** Visible + screen-reader label (spinner variant). */
+    label?: ReactNode;
+    className?: string;
+}
+
+export function LoadingState({ variant = 'spinner', count = 8, label, className = '' }: LoadingStateProps) {
+    if (variant === 'cards') {
+        return (
+            <div
+                className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 ${className}`}
+                aria-busy="true"
+                aria-live="polite"
+            >
+                {Array.from({ length: count }).map((_, i) => (
+                    <Skeleton key={i} rounded="md" className="h-32 w-full" />
+                ))}
+            </div>
+        );
+    }
+    return (
+        <div
+            className={`flex h-full min-h-40 flex-col items-center justify-center gap-3 text-text-secondary ${className}`}
+            aria-busy="true"
+            aria-live="polite"
+        >
+            <Loader2 className="w-6 h-6 animate-spin text-accent" aria-hidden />
+            {label && <p className="text-sm">{label}</p>}
         </div>
     );
 }

--- a/src/components/common/PageComponents.tsx
+++ b/src/components/common/PageComponents.tsx
@@ -111,15 +111,15 @@ interface EmptyStateProps {
 }
 
 export function EmptyState({ icon: Icon, title, description, action, variant = 'default', className = '' }: EmptyStateProps) {
-    const iconColor = variant === 'error' ? 'text-red-500' : 'text-text-secondary';
-    const titleColor = variant === 'error' ? 'text-red-400' : 'text-text-primary';
+    const iconColor = variant === 'error' ? 'text-state-danger' : 'text-text-secondary';
+    const titleColor = variant === 'error' ? 'text-state-danger' : 'text-text-primary';
 
     return (
         <div className={`flex flex-col items-center justify-center h-full text-text-secondary animate-fade-in ${className}`}>
             <Icon className={`w-16 h-16 mb-4 opacity-50 ${iconColor}`} />
             <h2 className={`text-xl font-semibold mb-2 ${titleColor}`}>{title}</h2>
             {description && (
-                <div className={`text-center max-w-md ${variant === 'error' ? 'text-red-400' : ''}`}>
+                <div className={`text-center max-w-md ${variant === 'error' ? 'text-state-danger' : ''}`}>
                     {description}
                 </div>
             )}
@@ -154,7 +154,7 @@ export function ConfirmModal({
     onCancel,
 }: ConfirmModalProps) {
     const confirmClass = variant === 'danger'
-        ? 'border border-red-500/40 bg-red-500/10 hover:bg-red-500/20 hover:border-red-500/60 text-red-400 focus-visible:ring-red-400'
+        ? 'border border-state-danger/40 bg-state-danger/10 hover:bg-state-danger/20 hover:border-state-danger/60 text-state-danger focus-visible:ring-state-danger'
         : 'border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary focus-visible:ring-accent';
 
     return (
@@ -165,7 +165,7 @@ export function ConfirmModal({
             size="sm"
             panelClassName="relative overflow-hidden p-6"
         >
-            <span aria-hidden className={`absolute left-0 top-0 bottom-0 w-[2px] ${variant === 'danger' ? 'bg-red-500/60' : 'bg-accent/60'}`} />
+            <span aria-hidden className={`absolute left-0 top-0 bottom-0 w-[2px] ${variant === 'danger' ? 'bg-state-danger/60' : 'bg-accent/60'}`} />
             <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
             <div className="text-text-secondary mb-4">{message}</div>
             <div className="flex justify-end gap-3">

--- a/src/components/common/forms.tsx
+++ b/src/components/common/forms.tsx
@@ -1,0 +1,162 @@
+import {
+    cloneElement,
+    isValidElement,
+    useId,
+    type InputHTMLAttributes,
+    type ReactElement,
+    type ReactNode,
+    type Ref,
+    type SelectHTMLAttributes,
+    type TextareaHTMLAttributes,
+} from 'react';
+import { ChevronDown, type LucideIcon } from 'lucide-react';
+
+// ============================================================================
+// Form primitives - the single styled surface for text inputs, textareas and
+// (native) selects, plus a FormField wrapper that wires a label + helper/error
+// text to its control for accessibility.
+//
+// Before this file, every page/modal hand-rolled `<input className="...">` and
+// the styles drifted (rounded-sm vs rounded-lg, different placeholder colors,
+// stray transitions). Reach for these instead of raw form elements. Domain
+// pickers (HeroSelect, DynamicSelect) intentionally stay separate.
+//
+// Canonical control surface (see docs/ui-conventions.md):
+//   bg-bg-tertiary border border-white/5 rounded-sm
+//   focus-visible:ring-2 focus-visible:ring-accent
+//   disabled:opacity-60 disabled:cursor-not-allowed
+// ============================================================================
+
+type ControlSize = 'sm' | 'md';
+
+const CONTROL_BASE =
+    'w-full bg-bg-tertiary border border-white/5 rounded-sm text-text-primary text-sm ' +
+    'placeholder:text-text-secondary/50 transition-colors ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ' +
+    'disabled:opacity-60 disabled:cursor-not-allowed';
+
+const CONTROL_SIZE: Record<ControlSize, string> = {
+    sm: 'px-3 py-1.5',
+    md: 'px-4 py-2.5',
+};
+
+// ----------------------------------------------------------------------------
+// Input
+// ----------------------------------------------------------------------------
+
+// `size` is a native (numeric) input attribute, so the UI size prop is named
+// `inputSize` to avoid clobbering it.
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+    inputSize?: ControlSize;
+    /** Optional leading icon rendered inside the field. */
+    icon?: LucideIcon;
+    ref?: Ref<HTMLInputElement>;
+}
+
+export function Input({ inputSize = 'md', icon: Icon, className = '', ref, ...props }: InputProps) {
+    const sizeCls = CONTROL_SIZE[inputSize];
+    const control = (
+        <input ref={ref} className={`${CONTROL_BASE} ${sizeCls} ${Icon ? 'pl-10' : ''} ${className}`} {...props} />
+    );
+    if (!Icon) return control;
+    return (
+        <div className="relative">
+            <Icon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" aria-hidden />
+            {control}
+        </div>
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Textarea
+// ----------------------------------------------------------------------------
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+    inputSize?: ControlSize;
+    ref?: Ref<HTMLTextAreaElement>;
+}
+
+export function Textarea({ inputSize = 'md', className = '', ref, ...props }: TextareaProps) {
+    return (
+        <textarea ref={ref} className={`${CONTROL_BASE} ${CONTROL_SIZE[inputSize]} resize-y ${className}`} {...props} />
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Select - generic native select styled to match. Pass <option>s as children.
+// Domain-specific dropdowns (HeroSelect) stay separate.
+// ----------------------------------------------------------------------------
+
+interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
+    inputSize?: ControlSize;
+    ref?: Ref<HTMLSelectElement>;
+}
+
+export function Select({ inputSize = 'md', className = '', children, ref, ...props }: SelectProps) {
+    return (
+        <div className="relative">
+            <select
+                ref={ref}
+                className={`${CONTROL_BASE} ${CONTROL_SIZE[inputSize]} cursor-pointer appearance-none pr-10 ${className}`}
+                {...props}
+            >
+                {children}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" aria-hidden />
+        </div>
+    );
+}
+
+// ----------------------------------------------------------------------------
+// FormField - label + control + optional hint/error, wired for a11y.
+//
+// Generates an id with useId() and injects it (plus aria-describedby /
+// aria-invalid) into the single control child via cloneElement, so callers
+// don't have to thread ids by hand:
+//
+//   <FormField label="Profile name" error={err}>
+//     <Input value={name} onChange={...} />
+//   </FormField>
+// ----------------------------------------------------------------------------
+
+interface FormFieldProps {
+    label?: ReactNode;
+    /** Sub-label helper text shown below the control. */
+    hint?: ReactNode;
+    /** Error message; when set it replaces the hint and flags the control invalid. */
+    error?: ReactNode;
+    required?: boolean;
+    className?: string;
+    children: ReactNode;
+}
+
+export function FormField({ label, hint, error, required, className = '', children }: FormFieldProps) {
+    const id = useId();
+    const describedById = `${id}-desc`;
+    const hasDesc = !!(error || hint);
+
+    const control = isValidElement(children)
+        ? cloneElement(children as ReactElement<Record<string, unknown>>, {
+              id,
+              'aria-invalid': error ? true : undefined,
+              'aria-describedby': hasDesc ? describedById : undefined,
+          })
+        : children;
+
+    return (
+        <div className={`flex flex-col gap-1.5 ${className}`}>
+            {label && (
+                <label htmlFor={id} className="text-sm font-medium text-text-secondary">
+                    {label}
+                    {required && <span className="ml-0.5 text-state-danger" aria-hidden>*</span>}
+                </label>
+            )}
+            {control}
+            {hasDesc && (
+                <p id={describedById} className={`text-xs ${error ? 'text-state-danger' : 'text-text-secondary'}`}>
+                    {error ?? hint}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -495,6 +495,13 @@ interface SegmentedControlProps<T extends string> {
     onChange: (value: T) => void;
     label?: string;
     className?: string;
+    /** Equal-width segments that stretch to fill the container, instead of the
+     *  default content-width chips. Use for full-width pickers (e.g. a settings
+     *  popover row) where the segments should split the available width. */
+    fill?: boolean;
+    /** Disable the whole control (no clicks, no roving focus). Dimming is left to
+     *  the caller so the control's label can dim alongside it. */
+    disabled?: boolean;
 }
 
 export function SegmentedControl<T extends string>({
@@ -503,17 +510,20 @@ export function SegmentedControl<T extends string>({
     onChange,
     label,
     className = '',
+    fill = false,
+    disabled = false,
 }: SegmentedControlProps<T>) {
     const refs = useRef<(HTMLButtonElement | null)[]>([]);
 
     const move = (from: number, dir: -1 | 1) => {
+        if (disabled) return;
         const next = (from + dir + options.length) % options.length;
         onChange(options[next].value);
         refs.current[next]?.focus();
     };
 
     return (
-        <div role="tablist" aria-label={label} className={`flex flex-wrap gap-1.5 ${className}`}>
+        <div role="tablist" aria-label={label} className={`flex gap-1.5 ${fill ? 'w-full' : 'flex-wrap'} ${className}`}>
             {options.map((opt, i) => {
                 const active = opt.value === value;
                 return (
@@ -524,7 +534,8 @@ export function SegmentedControl<T extends string>({
                         role="tab"
                         aria-selected={active}
                         tabIndex={active ? 0 : -1}
-                        onClick={() => onChange(opt.value)}
+                        disabled={disabled}
+                        onClick={() => !disabled && onChange(opt.value)}
                         onKeyDown={(e) => {
                             if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
                                 e.preventDefault();
@@ -534,7 +545,7 @@ export function SegmentedControl<T extends string>({
                                 move(i, -1);
                             }
                         }}
-                        className={`whitespace-nowrap rounded-md border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                        className={`inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md border px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-default ${fill ? 'flex-1' : ''} ${
                             active
                                 ? 'border-accent/70 bg-accent/15 text-text-primary'
                                 : 'border-border bg-bg-tertiary text-text-secondary hover:border-accent/40 hover:text-text-primary'

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -53,10 +53,10 @@ interface BadgeProps {
 
 export function Badge({ children, variant = 'neutral', className = '' }: BadgeProps) {
     const variants = {
-        success: 'bg-green-500/10 text-green-400 border-green-500/20',
-        warning: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-        error: 'bg-red-500/10 text-red-400 border-red-500/20',
-        info: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+        success: 'bg-state-success/10 text-state-success border-state-success/20',
+        warning: 'bg-state-warning/10 text-state-warning border-state-warning/20',
+        error: 'bg-state-danger/10 text-state-danger border-state-danger/20',
+        info: 'bg-state-info/10 text-state-info border-state-info/20',
         neutral: 'bg-white/5 text-text-secondary border-white/10',
     };
 

--- a/src/components/locker/CardCropper.tsx
+++ b/src/components/locker/CardCropper.tsx
@@ -164,7 +164,7 @@ export default function CardCropper({
         </div>
 
         {error ? (
-          <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-400">
+          <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-state-danger">
             <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span className="break-words">{error}</span>
           </div>

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -332,7 +332,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
                 className={`group relative block w-full overflow-hidden rounded-[10px] border text-left backdrop-blur-sm transition-[border-color,background-color,box-shadow] duration-200 disabled:cursor-not-allowed ${
                   isApplied
                     ? 'border-accent bg-accent/[0.08] shadow-[0_0_0_1px_var(--color-accent),0_0_18px_-6px_var(--color-accent)] hover:bg-accent/[0.12]'
-                    : 'border-white/[0.08] bg-[#141414]/55 hover:border-white/[0.16]'
+                    : 'border-white/[0.08] bg-bg-sunken/55 hover:border-white/[0.16]'
                 } ${busySource !== null && !isBusy ? 'opacity-60' : 'cursor-pointer'}`}
               >
                 <div className="flex items-center justify-between gap-2 border-b border-border/50 px-3 py-2">
@@ -386,7 +386,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
           className={`space-y-3 rounded-[10px] border p-3 backdrop-blur-sm transition-[border-color,box-shadow] duration-200 ${
             customApplied
               ? 'border-accent bg-accent/[0.08] shadow-[0_0_0_1px_var(--color-accent),0_0_18px_-6px_var(--color-accent)]'
-              : 'border-white/[0.08] bg-[#141414]/55'
+              : 'border-white/[0.08] bg-bg-sunken/55'
           }`}
         >
           <div className="flex items-center justify-between gap-2">

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -291,14 +291,14 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       )}
 
       {error && (
-        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
           <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
           <span className="break-words">{error}</span>
         </div>
       )}
 
       {actionError && (
-        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
           <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
           <span className="break-words">{actionError}</span>
         </div>

--- a/src/components/locker/HeroColorPicker.tsx
+++ b/src/components/locker/HeroColorPicker.tsx
@@ -479,7 +479,7 @@ export default function HeroColorPicker({ heroName, onAppliedChange }: HeroColor
 
   if (error) {
     return (
-      <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+      <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
         <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
         <span className="break-words">{error}</span>
       </div>
@@ -952,7 +952,7 @@ export default function HeroColorPicker({ heroName, onAppliedChange }: HeroColor
       )}
 
       {actionError && (
-        <div className="flex items-start gap-2 py-1 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-1 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{actionError}</span>
         </div>

--- a/src/components/locker/HeroEffectsPanel.tsx
+++ b/src/components/locker/HeroEffectsPanel.tsx
@@ -62,7 +62,7 @@ export default function HeroEffectsPanel({ heroName }: HeroEffectsPanelProps) {
       </div>
 
       {error && (
-        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{error}</span>
         </div>

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -361,7 +361,7 @@ function SkinGroupCard({
               groupActive ? 'opacity-55' : 'opacity-30 grayscale-[0.4]'
             }`}
           />
-          <div className="absolute inset-0 bg-gradient-to-b from-[#0f0f0f]/45 via-[#0f0f0f]/65 to-[#0f0f0f]/[0.88]" />
+          <div className="absolute inset-0 scrim-bottom" />
         </div>
       )}
 

--- a/src/components/locker/HeroSoundPicker.tsx
+++ b/src/components/locker/HeroSoundPicker.tsx
@@ -511,14 +511,14 @@ export default function HeroSoundPicker({ heroName, soundList, onSelect }: HeroS
       )}
 
       {error && (
-        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{error}</span>
         </div>
       )}
 
       {actionError && (
-        <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{actionError}</span>
         </div>

--- a/src/components/locker/LockerImageCropper.tsx
+++ b/src/components/locker/LockerImageCropper.tsx
@@ -343,7 +343,7 @@ export default function LockerImageCropper({
   return (
     <div className="flex flex-col gap-3">
       {error && (
-        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-400">
+        <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{error}</span>
         </div>

--- a/src/components/locker/LockerModImagePicker.tsx
+++ b/src/components/locker/LockerModImagePicker.tsx
@@ -470,7 +470,7 @@ export function LockerModImagePicker({
               {t('locker.modImage.loadingGallery')}
             </div>
           ) : error ? (
-            <div className="py-6 text-center text-sm text-red-400">{error}</div>
+            <div className="py-6 text-center text-sm text-state-danger">{error}</div>
           ) : choices.length > 0 ? (
             <>
               <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">

--- a/src/components/locker/SoulContainerImportModal.tsx
+++ b/src/components/locker/SoulContainerImportModal.tsx
@@ -739,7 +739,7 @@ export default function SoulContainerImportModal({
           )}
 
           {error && (
-            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg p-2">
+            <div className="text-sm text-state-danger bg-red-500/10 border border-red-500/30 rounded-lg p-2">
               {error}
             </div>
           )}

--- a/src/components/locker/SoulContainerImportModal.tsx
+++ b/src/components/locker/SoulContainerImportModal.tsx
@@ -25,6 +25,7 @@ import { loadGltfPreview, parseGltfPreview } from '../../lib/loadGltfPreview';
 import { computeSceneStats, deriveNameFromPath, norm360, TRIANGLE_WARN_THRESHOLD } from '../../lib/soulImport';
 import { useAppStore } from '../../stores/appStore';
 import type { Mod } from '../../types/mod';
+import { FormField, Input } from '../common/forms';
 import SoulImportPreview from './SoulImportPreview';
 import { SOUL_BACKDROP_COUNT } from './soulBackdrops';
 import { disposeScene } from './soulModel';
@@ -552,18 +553,13 @@ export default function SoulContainerImportModal({
 
           {/* Right: controls */}
           <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-text-primary mb-1.5">
-                {t('locker.soulImport.fields.name')} <span className="text-red-400">*</span>
-              </label>
-              <input
-                type="text"
+            <FormField label={t('locker.soulImport.fields.name')} required>
+              <Input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('locker.soulImport.fields.namePlaceholder')}
-                className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent"
               />
-            </div>
+            </FormField>
 
             {/* Orientation */}
             <div>
@@ -700,18 +696,20 @@ export default function SoulContainerImportModal({
               </div>
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-text-primary mb-1.5">
-                {t('locker.soulImport.fields.notes')} <span className="text-text-secondary font-normal">{t('locker.soulImport.fields.notesOptional')}</span>
-              </label>
-              <input
-                type="text"
+            <FormField
+              label={
+                <>
+                  {t('locker.soulImport.fields.notes')}{' '}
+                  <span className="text-text-secondary font-normal">{t('locker.soulImport.fields.notesOptional')}</span>
+                </>
+              }
+            >
+              <Input
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder={t('locker.soulImport.fields.notesPlaceholder')}
-                className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent"
               />
-            </div>
+            </FormField>
 
             <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer select-none">
               <input

--- a/src/components/locker/TrippySkinPanel.tsx
+++ b/src/components/locker/TrippySkinPanel.tsx
@@ -196,7 +196,7 @@ export default function TrippySkinPanel({
 
   if (error) {
     return (
-      <div className="flex items-start gap-2 py-2 text-xs text-red-400">
+      <div className="flex items-start gap-2 py-2 text-xs text-state-danger">
         <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
         <span className="break-words">{error}</span>
       </div>
@@ -306,7 +306,7 @@ export default function TrippySkinPanel({
       )}
 
       {actionError && (
-        <div className="flex items-start gap-2 py-1 text-xs text-red-400">
+        <div className="flex items-start gap-2 py-1 text-xs text-state-danger">
           <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="break-words">{actionError}</span>
         </div>

--- a/src/components/performance/PerformanceConfigCard.tsx
+++ b/src/components/performance/PerformanceConfigCard.tsx
@@ -162,7 +162,7 @@ export default function PerformanceConfigCard() {
               }}
             />
           </p>
-          {openError && <p className="text-xs text-red-400">{openError}</p>}
+          {openError && <p className="text-xs text-state-danger">{openError}</p>}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {canRestore && (

--- a/src/components/profiles/ExportProfileModal.tsx
+++ b/src/components/profiles/ExportProfileModal.tsx
@@ -92,7 +92,7 @@ export default function ExportProfileModal({ profileId, profileName, onClose }: 
           )}
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
               <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { Button, CheckboxMark } from '../common/ui';
+import { Input, Textarea } from '../common/forms';
 import { Modal } from '../common/Modal';
 import ModThumbnail from '../ModThumbnail';
 import SocialProfileHeader, { type SocialProfileSeed } from '../social/SocialProfileHeader';
@@ -752,12 +753,12 @@ export default function ImportProfileDialog({
 
         {showInputForm && (
           <div className="p-4 sm:p-6 border-b border-white/10 space-y-3">
-            <textarea
+            <Textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder={t('importProfile.pastePlaceholder')}
               rows={4}
-              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent font-mono"
+              className="font-mono"
             />
             <div className="flex items-center justify-between gap-3">
               <label className="text-xs text-text-secondary inline-flex items-center gap-2 cursor-pointer hover:text-text-primary">
@@ -778,7 +779,7 @@ export default function ImportProfileDialog({
               </Button>
             </div>
             {parseError && (
-              <div className="text-xs text-red-400 flex items-start gap-1.5">
+              <div className="text-xs text-state-danger flex items-start gap-1.5">
                 <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
                 <span>{parseError}</span>
               </div>
@@ -797,14 +798,15 @@ export default function ImportProfileDialog({
                   <span className="text-xs text-text-tertiary truncate min-w-0">{t('importProfile.originallyBy', { author: parsed.profile.author })}</span>
                 )}
               </div>
-              <input
+              <Input
+                inputSize="sm"
                 type="text"
                 value={profileName}
                 onChange={(e) => setProfileName(e.target.value)}
                 disabled={importing || !!importedProfileName}
                 placeholder={parsed.profile.name}
                 aria-label={t('profiles.create.profileName')}
-                className="w-full px-3 py-1.5 bg-bg-tertiary border border-white/10 rounded-md text-sm font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-60"
+                className="font-semibold"
               />
             </div>
 
@@ -1056,7 +1058,7 @@ export default function ImportProfileDialog({
                             </div>
                           )}
                           {mod.status === 'unresolvable' && (
-                            <div className="text-xs text-red-400 mt-1 inline-flex items-center gap-1">
+                            <div className="text-xs text-state-danger mt-1 inline-flex items-center gap-1">
                               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
                               <span className="truncate">{mod.reason ?? t('importProfile.notAvailableOnGameBanana')}</span>
                             </div>
@@ -1102,7 +1104,7 @@ export default function ImportProfileDialog({
                           )}
                           {r.status === 'failed' && (
                             <span
-                              className="text-red-400 inline-flex items-center gap-1.5 justify-end text-xs"
+                              className="text-state-danger inline-flex items-center gap-1.5 justify-end text-xs"
                               title={r.statusMessage ?? t('importProfile.status.failed')}
                             >
                               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
@@ -1124,7 +1126,7 @@ export default function ImportProfileDialog({
                             </div>
                           )}
                           {r.detailsError && (
-                            <div className="text-xs text-red-400 flex items-center gap-1.5">
+                            <div className="text-xs text-state-danger flex items-center gap-1.5">
                               <AlertTriangle className="w-3.5 h-3.5" />
                               {r.detailsError}
                             </div>
@@ -1213,7 +1215,7 @@ export default function ImportProfileDialog({
                   t('importProfile.selectedSummary', { selected: selectedCount, total: selectableCount })
                 )}
                 {finalizeError && (
-                  <div className="text-red-400 mt-1 inline-flex items-center gap-1">
+                  <div className="text-state-danger mt-1 inline-flex items-center gap-1">
                     <AlertTriangle className="w-3.5 h-3.5" />
                     {finalizeError}
                   </div>

--- a/src/components/settings/AppearanceArtSection.tsx
+++ b/src/components/settings/AppearanceArtSection.tsx
@@ -658,7 +658,7 @@ export default function AppearanceArtSection() {
                 </div>
               )}
 
-              {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+              {error && <p className="mt-3 text-xs text-state-danger">{error}</p>}
             </div>
 
             {/* Footer (pinned). Image kinds commit through the cropper's own button,

--- a/src/components/settings/LanguageSelector.tsx
+++ b/src/components/settings/LanguageSelector.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../i18n';
 import { downloadLocale, getLocaleManifest, listDownloadedLocales } from '../../lib/api';
 import type { LocaleManifest, LocaleManifestEntry } from '../../types/locales';
+import { Select } from '../common/forms';
 import Tx from '../translation/Tx';
 
 interface LanguageSelectorProps {
@@ -110,19 +111,20 @@ export default function LanguageSelector({ value, onChange }: LanguageSelectorPr
           fallback="Choose the app language, or follow your system preference. Percentages show how much of the app each community translation covers."
         />
       </p>
-      <select
-        value={value ?? ''}
-        onChange={(event) => void handleSelect(event.target.value)}
-        disabled={downloading !== null}
-        className="w-full max-w-xs rounded-md border border-border bg-bg-tertiary px-3 py-2 text-sm text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <option value="">{t('settings.language.systemDefault')}</option>
-        {languages.map((entry) => (
-          <option key={entry.code} value={entry.code}>
-            {optionLabel(entry)}
-          </option>
-        ))}
-      </select>
+      <div className="max-w-xs">
+        <Select
+          value={value ?? ''}
+          onChange={(event) => void handleSelect(event.target.value)}
+          disabled={downloading !== null}
+        >
+          <option value="">{t('settings.language.systemDefault')}</option>
+          {languages.map((entry) => (
+            <option key={entry.code} value={entry.code}>
+              {optionLabel(entry)}
+            </option>
+          ))}
+        </Select>
+      </div>
       {downloading && (
         <div className="mt-2 flex items-center gap-2 text-xs text-text-secondary">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/src/components/social/EditProfileDialog.tsx
+++ b/src/components/social/EditProfileDialog.tsx
@@ -126,7 +126,7 @@ export default function EditProfileDialog({
                   />
                 </FormField>
                 <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
-                  <span className={titleTooLong ? 'text-red-400' : ''}>
+                  <span className={titleTooLong ? 'text-state-danger' : ''}>
                     {trimmedTitle.length}/80
                   </span>
                 </div>
@@ -147,14 +147,14 @@ export default function EditProfileDialog({
                   />
                 </FormField>
                 <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
-                  <span className={descriptionTooLong ? 'text-red-400' : ''}>
+                  <span className={descriptionTooLong ? 'text-state-danger' : ''}>
                     {trimmedDescription.length}/1000
                   </span>
                 </div>
               </div>
 
               {submitError && (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
                   <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                   <span>{submitError}</span>
                 </div>

--- a/src/components/social/EditProfileDialog.tsx
+++ b/src/components/social/EditProfileDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, AlertTriangle, CheckCircle2, Pencil } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Input, Textarea, FormField } from '../common/forms';
 import { Modal } from '../common/Modal';
 import { socialUpdateProfile, type SocialUpdateProfileResponse } from '../../lib/api';
 
@@ -113,23 +114,18 @@ export default function EditProfileDialog({
           ) : (
             <>
               <div>
-                <label
-                  htmlFor="edit-profile-title-input"
-                  className="block text-xs font-medium text-text-secondary uppercase tracking-wider mb-1.5"
+                <FormField
+                  label={t('social.editProfile.title')}
+                  error={titleTooLong ? t('social.editProfile.max80Characters') : undefined}
                 >
-                  {t('social.editProfile.title')}
-                </label>
-                <input
-                  id="edit-profile-title-input"
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  maxLength={80}
-                  placeholder={t('social.editProfile.titlePlaceholder')}
-                  className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-                <div className="text-[11px] text-text-secondary mt-1 flex justify-between">
-                  <span>{titleTooLong ? t('social.editProfile.max80Characters') : ' '}</span>
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    maxLength={80}
+                    placeholder={t('social.editProfile.titlePlaceholder')}
+                  />
+                </FormField>
+                <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
                   <span className={titleTooLong ? 'text-red-400' : ''}>
                     {trimmedTitle.length}/80
                   </span>
@@ -137,23 +133,20 @@ export default function EditProfileDialog({
               </div>
 
               <div>
-                <label
-                  htmlFor="edit-profile-description"
-                  className="block text-xs font-medium text-text-secondary uppercase tracking-wider mb-1.5"
+                <FormField
+                  label={t('social.editProfile.descriptionOptional')}
+                  error={descriptionTooLong ? t('social.editProfile.max1000Characters') : undefined}
                 >
-                  {t('social.editProfile.descriptionOptional')}
-                </label>
-                <textarea
-                  id="edit-profile-description"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  maxLength={1000}
-                  rows={4}
-                  placeholder={t('social.editProfile.descriptionPlaceholder')}
-                  className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-none"
-                />
-                <div className="text-[11px] text-text-secondary mt-1 flex justify-between">
-                  <span>{descriptionTooLong ? t('social.editProfile.max1000Characters') : ' '}</span>
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    maxLength={1000}
+                    rows={4}
+                    placeholder={t('social.editProfile.descriptionPlaceholder')}
+                    className="resize-none"
+                  />
+                </FormField>
+                <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
                   <span className={descriptionTooLong ? 'text-red-400' : ''}>
                     {trimmedDescription.length}/1000
                   </span>

--- a/src/components/social/MyPublishedSection.tsx
+++ b/src/components/social/MyPublishedSection.tsx
@@ -135,7 +135,7 @@ export default function MyPublishedSection({
       )}
 
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-red-400 flex items-start gap-2">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-state-danger flex items-start gap-2">
           <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
           <span className="break-words">{error}</span>
           <button

--- a/src/components/social/PublishDialog.tsx
+++ b/src/components/social/PublishDialog.tsx
@@ -143,7 +143,7 @@ export default function PublishDialog({
           ) : (
             <>
               {exportError && (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
                   <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                   <span>{t('social.publish.couldNotBuildShareCode', { error: exportError })}</span>
                 </div>
@@ -174,7 +174,7 @@ export default function PublishDialog({
               )}
 
               {noShareableMods && (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
                   <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                   <span>{t('social.publish.noGamebananaMods')}</span>
                 </div>
@@ -193,7 +193,7 @@ export default function PublishDialog({
                   />
                 </FormField>
                 <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
-                  <span className={titleTooLong ? 'text-red-400' : ''}>{trimmedTitle.length}/80</span>
+                  <span className={titleTooLong ? 'text-state-danger' : ''}>{trimmedTitle.length}/80</span>
                 </div>
               </div>
 
@@ -212,7 +212,7 @@ export default function PublishDialog({
                   />
                 </FormField>
                 <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
-                  <span className={descriptionTooLong ? 'text-red-400' : ''}>{trimmedDescription.length}/1000</span>
+                  <span className={descriptionTooLong ? 'text-state-danger' : ''}>{trimmedDescription.length}/1000</span>
                 </div>
               </div>
 
@@ -238,7 +238,7 @@ export default function PublishDialog({
               )}
 
               {submitError && (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+                <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
                   <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                   <span>{submitError}</span>
                 </div>

--- a/src/components/social/PublishDialog.tsx
+++ b/src/components/social/PublishDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, AlertTriangle, Loader2, CheckCircle2, Globe } from 'lucide-react';
 import { Button } from '../common/ui';
+import { Input, Textarea, FormField } from '../common/forms';
 import { Modal } from '../common/Modal';
 import {
   exportPortableProfile,
@@ -180,39 +181,37 @@ export default function PublishDialog({
               )}
 
               <div>
-                <label htmlFor="publish-title" className="block text-xs font-medium text-text-secondary uppercase tracking-wider mb-1.5">
-                  {t('social.publish.title')}
-                </label>
-                <input
-                  id="publish-title"
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  maxLength={80}
-                  placeholder={t('social.publish.titlePlaceholder')}
-                  className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-                <div className="text-[11px] text-text-secondary mt-1 flex justify-between">
-                  <span>{titleTooLong ? t('social.publish.max80Characters') : ' '}</span>
+                <FormField
+                  label={t('social.publish.title')}
+                  error={titleTooLong ? t('social.publish.max80Characters') : undefined}
+                >
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    maxLength={80}
+                    placeholder={t('social.publish.titlePlaceholder')}
+                  />
+                </FormField>
+                <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
                   <span className={titleTooLong ? 'text-red-400' : ''}>{trimmedTitle.length}/80</span>
                 </div>
               </div>
 
               <div>
-                <label htmlFor="publish-description" className="block text-xs font-medium text-text-secondary uppercase tracking-wider mb-1.5">
-                  {t('social.publish.descriptionOptional')}
-                </label>
-                <textarea
-                  id="publish-description"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  maxLength={1000}
-                  rows={4}
-                  placeholder={t('social.publish.descriptionPlaceholder')}
-                  className="w-full px-3 py-2 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-none"
-                />
-                <div className="text-[11px] text-text-secondary mt-1 flex justify-between">
-                  <span>{descriptionTooLong ? t('social.publish.max1000Characters') : ' '}</span>
+                <FormField
+                  label={t('social.publish.descriptionOptional')}
+                  error={descriptionTooLong ? t('social.publish.max1000Characters') : undefined}
+                >
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    maxLength={1000}
+                    rows={4}
+                    placeholder={t('social.publish.descriptionPlaceholder')}
+                    className="resize-none"
+                  />
+                </FormField>
+                <div className="text-[11px] text-text-secondary mt-1 flex justify-end">
                   <span className={descriptionTooLong ? 'text-red-400' : ''}>{trimmedDescription.length}/1000</span>
                 </div>
               </div>

--- a/src/components/social/PublishPickerDialog.tsx
+++ b/src/components/social/PublishPickerDialog.tsx
@@ -75,7 +75,7 @@ export default function PublishPickerDialog({ onClose, onPick }: PublishPickerDi
           )}
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
               <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>

--- a/src/components/social/SocialAccountSection.tsx
+++ b/src/components/social/SocialAccountSection.tsx
@@ -57,7 +57,7 @@ export default function SocialAccountSection() {
       </p>
 
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start justify-between gap-2">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start justify-between gap-2">
           <div className="flex items-start gap-2 min-w-0">
             <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
             <span className="break-words">{error}</span>

--- a/src/components/social/SocialProfileHeader.tsx
+++ b/src/components/social/SocialProfileHeader.tsx
@@ -231,7 +231,7 @@ export default function SocialProfileHeader({
       {/* Body */}
       <div className="px-4 py-3 space-y-3 text-sm">
         {error && !view && (
-          <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-red-400 flex items-start gap-2">
+          <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-state-danger flex items-start gap-2">
             <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
             <span>{error}</span>
           </div>
@@ -305,7 +305,7 @@ export default function SocialProfileHeader({
             </div>
 
             {likeError && (
-              <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2 text-xs text-red-400 flex items-start gap-2">
+              <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2 text-xs text-state-danger flex items-start gap-2">
                 <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
                 <span>{likeError}</span>
               </div>
@@ -324,7 +324,7 @@ export default function SocialProfileHeader({
                   className="text-xs resize-none"
                 />
                 {reportError && (
-                  <div className="text-xs text-red-400 flex items-start gap-1.5">
+                  <div className="text-xs text-state-danger flex items-start gap-1.5">
                     <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
                     <span>{reportError}</span>
                   </div>

--- a/src/components/social/SocialProfileHeader.tsx
+++ b/src/components/social/SocialProfileHeader.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
 } from 'lucide-react';
 import { Button, Badge } from '../common/ui';
+import { Textarea } from '../common/forms';
 import {
   socialGetProfile,
   socialLike,
@@ -313,13 +314,14 @@ export default function SocialProfileHeader({
             {reportOpen && !reported && (
               <div className="bg-bg-secondary border border-white/10 rounded-md p-2.5 space-y-2">
                 <div className="text-xs font-medium text-text-primary">{t('social.header.reportThisProfile')}</div>
-                <textarea
+                <Textarea
+                  inputSize="sm"
                   value={reportReason}
                   onChange={(e) => setReportReason(e.target.value)}
                   maxLength={500}
                   rows={2}
                   placeholder={t('social.header.reportIssuePlaceholder')}
-                  className="w-full px-2.5 py-1.5 bg-bg-tertiary border border-white/10 rounded-md text-xs text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent resize-none"
+                  className="text-xs resize-none"
                 />
                 {reportError && (
                   <div className="text-xs text-red-400 flex items-start gap-1.5">

--- a/src/components/stats/MmrChart.tsx
+++ b/src/components/stats/MmrChart.tsx
@@ -310,7 +310,7 @@ export function MmrChart({ history, snapshots, height = 220 }: MmrChartProps) {
         <div>
             <div className="flex items-center justify-between gap-3 mb-2">
                 <div className="text-xs text-text-secondary">
-                    <span className={delta >= 0 ? 'text-green-400' : 'text-red-400'}>
+                    <span className={delta >= 0 ? 'text-green-400' : 'text-state-danger'}>
                         {delta >= 0 ? '+' : ''}
                         {delta.toFixed(1)}
                     </span>

--- a/src/components/stats/PlayerSelect.tsx
+++ b/src/components/stats/PlayerSelect.tsx
@@ -201,7 +201,7 @@ export function PlayerSelect() {
                                             title={t('stats.playerSelect.removePlayer')}
                                             className="opacity-0 group-hover:opacity-100 p-1 hover:bg-red-500/20 rounded transition-all cursor-pointer"
                                         >
-                                            <Trash2 className="w-4 h-4 text-red-400" />
+                                            <Trash2 className="w-4 h-4 text-state-danger" />
                                         </button>
                                     </div>
                                 )
@@ -226,7 +226,7 @@ export function PlayerSelect() {
                             </Button>
                         </div>
                         {searchError && (
-                            <p className="text-red-400 text-xs mt-2 flex items-center gap-1">
+                            <p className="text-state-danger text-xs mt-2 flex items-center gap-1">
                                 <AlertCircle className="w-3 h-3 shrink-0" />
                                 {searchError}
                             </p>

--- a/src/components/stats/primitives.tsx
+++ b/src/components/stats/primitives.tsx
@@ -110,8 +110,8 @@ export function AsyncSection<T>({
     if (state.status === 'error') {
         return (
             <div className="flex flex-col items-center gap-3 py-8 text-center">
-                <AlertCircle className="w-8 h-8 text-red-400" />
-                <p className="text-sm text-red-400 max-w-md">{state.error}</p>
+                <AlertCircle className="w-8 h-8 text-state-danger" />
+                <p className="text-sm text-state-danger max-w-md">{state.error}</p>
                 <Button variant="secondary" size="sm" icon={RefreshCw} onClick={onRetry}>
                     {t('common.actions.retry')}
                 </Button>
@@ -177,7 +177,7 @@ export function MatchRow({
             <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                     <span className="font-medium truncate">{heroName(heroId)}</span>
-                    <span className={`text-xs font-semibold ${won ? 'text-green-400' : 'text-red-400'}`}>
+                    <span className={`text-xs font-semibold ${won ? 'text-green-400' : 'text-state-danger'}`}>
                         {won ? t('stats.primitives.win') : t('stats.primitives.loss')}
                     </span>
                 </div>
@@ -192,7 +192,7 @@ export function MatchRow({
                 <div className="font-mono text-sm tabular-nums">
                     {kills}
                     <span className="text-text-secondary/60">/</span>
-                    <span className="text-red-400">{deaths}</span>
+                    <span className="text-state-danger">{deaths}</span>
                     <span className="text-text-secondary/60">/</span>
                     {assists}
                 </div>

--- a/src/components/stats/tabs/SocialTab.tsx
+++ b/src/components/stats/tabs/SocialTab.tsx
@@ -89,8 +89,8 @@ export function SocialTab({ accountId }: SocialTabProps) {
     if (social.status === 'error') {
         return (
             <div className="flex flex-col items-center gap-3 py-12 text-center">
-                <AlertCircle className="w-8 h-8 text-red-400" />
-                <p className="text-sm text-red-400 max-w-md">{social.error}</p>
+                <AlertCircle className="w-8 h-8 text-state-danger" />
+                <p className="text-sm text-state-danger max-w-md">{social.error}</p>
                 <Button variant="secondary" size="sm" icon={RefreshCw} onClick={() => loadSocialStats(accountId)}>
                     {t('common.actions.retry')}
                 </Button>
@@ -153,7 +153,7 @@ export function SocialTab({ accountId }: SocialTabProps) {
                                 name={enemy.persona_name}
                                 avatarUrl={enemy.avatar_url}
                                 fallbackIcon={UserX}
-                                fallbackTone="bg-red-500/20 text-red-400"
+                                fallbackTone="bg-red-500/20 text-state-danger"
                                 subtitle={t('stats.social.gamesAgainst', { count: enemy.matches_played })}
                                 winRate={enemy.win_rate || 0}
                                 wins={enemy.wins}

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,12 @@
   --color-bg-primary: #0f0f0f;
   --color-bg-secondary: #1a1a1a;
   --color-bg-tertiary: #242424;
+  /* Sunken/recessed surface, darker than the app bg. Sits behind cards and
+     backs inactive picker/segment chips. */
+  --color-bg-sunken: #141414;
+  /* Dark "glass" surface for floating popovers layered over imagery (e.g. the
+     Browse sound-card volume flyout). */
+  --color-bg-glass: #0a0c10;
   --color-accent: #f97316;
   --color-accent-hover: #ea580c;
   /* Foreground (text/icon) color for solid `bg-accent` surfaces. Flips between
@@ -95,6 +101,9 @@
   --color-text-secondary: #a1a1aa;
   --color-text-tertiary: #8a8a94;
   --color-border: #2d2d2d;
+  /* Warm off-white for the Browse "readable" card title, deliberately softer
+     than pure white. */
+  --color-mod-title: #eee8df;
 
   /* Semantic state tokens. Use these for card states, toasts, badges —
      anything that communicates status. The raw Tailwind colors

--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,7 @@
   /* Third-party brand colors (buttons/links that represent the brand itself). */
   --color-brand-discord: #5865F2;
   --color-brand-kofi: #FF5E5B;
+  --color-brand-kofi-hover: #ff4542;
 
   --font-radiance: 'Radiance', system-ui, sans-serif;
   --font-reaver: 'Reaver', serif;
@@ -118,6 +119,18 @@
      distinctly from l. To switch to a cleaner neutral look, change this one line
      to: Tahoma, Verdana, system-ui, sans-serif (OS fonts, nothing bundled). */
   --font-mod-title: 'Reaver', serif;
+}
+
+/* Bottom-up dark scrim for art/thumbnail overlays so foreground chrome stays
+   legible over any underlying image. Pairs with `absolute inset-0`. Replaces
+   the gradient that was copy-pasted across the Locker/Installed surfaces. */
+@utility scrim-bottom {
+  background-image: linear-gradient(
+    to bottom,
+    rgb(15 15 15 / 0.45),
+    rgb(15 15 15 / 0.65),
+    rgb(15 15 15 / 0.88)
+  );
 }
 
 /* Base styles */

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket } from 'lucide-react';
 import { getSettings, setSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
+import { Input } from '../components/common/forms';
 import { ConfirmModal } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import type { AppSettings } from '../types/mod';
@@ -235,14 +236,13 @@ export default function Autoexec() {
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
                 {/* Left Panel - Command Presets */}
                 <div className="w-full lg:w-1/2 flex flex-col gap-4 overflow-hidden order-2 lg:order-1">
-                    <div className="relative shrink-0">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary" />
-                        <input
+                    <div className="shrink-0">
+                        <Input
+                            icon={Search}
                             type="text"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
                             placeholder={t('autoexec.search.placeholder')}
-                            className="w-full pl-10 pr-4 py-2.5 bg-bg-secondary border border-white/5 rounded-xl text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-text-secondary/50"
                         />
                     </div>
 
@@ -250,12 +250,12 @@ export default function Autoexec() {
                         {/* Custom Command Input */}
                         <Card title={<Tx k="autoexec.customCommand.title" fallback="Custom Command" />}>
                             <div className="flex gap-2">
-                                <input
+                                <Input
                                     type="text"
                                     value={customCommand}
                                     onChange={(e) => setCustomCommand(e.target.value)}
                                     placeholder={t('autoexec.customCommand.placeholder')}
-                                    className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+                                    className="flex-1 font-mono"
                                     onKeyDown={(e) => e.key === 'Enter' && handleAddCustomCommand()}
                                 />
                                 <Button onClick={handleAddCustomCommand} disabled={!customCommand.trim()} icon={Plus} />
@@ -426,12 +426,12 @@ export default function Autoexec() {
                             </p>
 
                             <div className="flex gap-2">
-                                <input
+                                <Input
                                     type="text"
                                     value={launchOptionsDraft}
                                     onChange={(e) => setLaunchOptionsDraft(e.target.value)}
                                     placeholder="-high -nojoy"
-                                    className="flex-1 px-3 py-2 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+                                    className="flex-1 font-mono"
                                 />
                                 <Button
                                     onClick={handleSaveLaunchOptions}

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -365,7 +365,7 @@ export default function Autoexec() {
                                     </div>
                                 )}
                                 {saveMessage && (
-                                    <div className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${saveMessageTone === 'error' ? 'bg-red-500/10 border-red-500/20 text-red-400' : 'bg-green-500/10 border-green-500/20 text-green-400'}`}>
+                                    <div className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${saveMessageTone === 'error' ? 'bg-red-500/10 border-red-500/20 text-state-danger' : 'bg-green-500/10 border-green-500/20 text-green-400'}`}>
                                         {saveMessageTone === 'error' ? <AlertTriangle className="w-3 h-3" /> : <Check className="w-3 h-3" />}
                                         {saveMessage}
                                     </div>
@@ -391,7 +391,7 @@ export default function Autoexec() {
                                         </div>
                                         <button
                                             onClick={() => handleRemoveCommand(i)}
-                                            className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-text-secondary hover:text-red-400 rounded transition-all cursor-pointer"
+                                            className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-text-secondary hover:text-state-danger rounded transition-all cursor-pointer"
                                             title={t('common.actions.remove')}
                                         >
                                             <Trash2 className="w-4 h-4" />
@@ -449,7 +449,7 @@ export default function Autoexec() {
                                     aria-live="polite"
                                     className={`text-xs flex items-center gap-2 p-2 rounded-lg border ${
                                         launchMessageTone === 'error'
-                                            ? 'bg-red-500/10 border-red-500/20 text-red-400'
+                                            ? 'bg-red-500/10 border-red-500/20 text-state-danger'
                                             : 'bg-green-500/10 border-green-500/20 text-green-400'
                                     }`}
                                 >

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -2782,7 +2782,7 @@ export default function Browse() {
                   target="_blank"
                   rel="noopener noreferrer"
                   title={`Support ${submitter.name} on Ko-fi`}
-                  className="inline-flex items-center gap-1.5 rounded-full bg-[#FF5E5B] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[#ff4542]"
+                  className="inline-flex items-center gap-1.5 rounded-full bg-brand-kofi px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-brand-kofi-hover"
                 >
                   <KofiIcon className="h-4 w-4" />
                   {t('browse.artist.kofi')}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3659,7 +3659,7 @@ function ReadableBrowseModCard({
       tabIndex={0}
       aria-label={`Open details for ${mod.name}`}
       style={cardFrameStyle}
-      className={`browse-card-hover-surface browse-readable-card group flex w-full flex-col overflow-hidden rounded-md border bg-[#141414] text-left shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-[border-color,transform,box-shadow] duration-150 cursor-pointer focus-visible:border-accent focus-visible:outline-none [container-type:inline-size] ${
+      className={`browse-card-hover-surface browse-readable-card group flex w-full flex-col overflow-hidden rounded-md border bg-bg-sunken text-left shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-[border-color,transform,box-shadow] duration-150 cursor-pointer focus-visible:border-accent focus-visible:outline-none [container-type:inline-size] ${
         isPlaying
           ? 'border-state-danger/70 ring-2 ring-state-danger/35 shadow-lg shadow-state-danger/15'
           : downloading
@@ -3690,7 +3690,7 @@ function ReadableBrowseModCard({
           {/* font-semibold, not font-bold: Reaver ships only a 600 face, so
               bolder weights get synthetic (smeared, blurry) emboldening. */}
           <h3
-            className={`block truncate font-mod-title font-semibold text-[#eee8df] ${
+            className={`block truncate font-mod-title font-semibold text-mod-title ${
               isMicro
                 ? 'text-[13px] leading-4'
                 : 'text-[clamp(11px,5.3571cqw,17px)] leading-[1.28] pb-px'
@@ -3740,7 +3740,7 @@ function ReadableBrowseModCard({
                     )}
                   </button>
                   {showVolumeSlider && (
-                    <div className="absolute bottom-[calc(100%+8px)] right-0 flex items-center rounded-full border border-white/10 bg-[#0a0c10]/92 px-3 py-2 shadow-[0_8px_24px_rgba(0,0,0,0.45)] backdrop-blur-md">
+                    <div className="absolute bottom-[calc(100%+8px)] right-0 flex items-center rounded-full border border-white/10 bg-bg-glass/92 px-3 py-2 shadow-[0_8px_24px_rgba(0,0,0,0.45)] backdrop-blur-md">
                       <input
                         type="range"
                         min={0}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -86,7 +86,7 @@ import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
 import { HeroSelect } from '../components/common/HeroSelect';
-import { Button, IconButton, Tag } from '../components/common/ui';
+import { Button, IconButton, SegmentedControl, Tag } from '../components/common/ui';
 import { IconText } from '../components/common/IconText';
 import { EmptyState } from '../components/common/PageComponents';
 import ModDetailsModal from '../components/ModDetailsModal';
@@ -2934,32 +2934,16 @@ export default function Browse() {
                   <div className="space-y-4">
                     <div>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.layout')}</div>
-                      <div className="grid grid-cols-2 gap-2">
-                        <button
-                          type="button"
-                          onClick={() => setLayout('grid')}
-                          className={`flex h-9 items-center justify-center gap-2 rounded-md border text-sm transition-colors ${
-                            layout === 'grid'
-                              ? 'border-accent/50 bg-accent/10 text-accent'
-                              : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
-                          }`}
-                        >
-                          <LayoutGrid className="h-4 w-4" />
-                          {t('browse.viewOptions.grid')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setLayout('list')}
-                          className={`flex h-9 items-center justify-center gap-2 rounded-md border text-sm transition-colors ${
-                            layout === 'list'
-                              ? 'border-accent/50 bg-accent/10 text-accent'
-                              : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
-                          }`}
-                        >
-                          <List className="h-4 w-4" />
-                          {t('browse.viewOptions.list')}
-                        </button>
-                      </div>
+                      <SegmentedControl<BrowseLayout>
+                        fill
+                        label={t('browse.viewOptions.layout')}
+                        value={layout}
+                        onChange={setLayout}
+                        options={[
+                          { value: 'grid', label: <><LayoutGrid className="h-4 w-4" />{t('browse.viewOptions.grid')}</> },
+                          { value: 'list', label: <><List className="h-4 w-4" />{t('browse.viewOptions.list')}</> },
+                        ]}
+                      />
                     </div>
 
                     <div className={layout === 'list' ? 'opacity-45' : ''}>
@@ -2990,54 +2974,31 @@ export default function Browse() {
 
                     <div className={layout === 'list' ? 'opacity-45' : ''}>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.cardStyle')}</div>
-                      <div className="grid grid-cols-2 gap-2" role="tablist" aria-label={t('browse.viewOptions.cardDesign')}>
-                        {(['readable', 'classic'] as const).map((design) => {
-                          const active = browseCardDesign === design;
-                          return (
-                            <button
-                              key={design}
-                              type="button"
-                              role="tab"
-                              aria-selected={active}
-                              disabled={layout === 'list'}
-                              onClick={() => setBrowseCardDesign(design)}
-                              className={`h-9 rounded-md border text-xs font-semibold transition-colors disabled:cursor-default ${
-                                active
-                                  ? 'border-accent/50 bg-accent/10 text-accent'
-                                  : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
-                              }`}
-                            >
-                              {design === 'readable' ? t('browse.cardStyle.default') : t('browse.cardStyle.classic')}
-                            </button>
-                          );
-                        })}
-                      </div>
+                      <SegmentedControl<BrowseCardDesign>
+                        fill
+                        disabled={layout === 'list'}
+                        label={t('browse.viewOptions.cardDesign')}
+                        value={browseCardDesign}
+                        onChange={setBrowseCardDesign}
+                        options={[
+                          { value: 'readable', label: t('browse.cardStyle.default') },
+                          { value: 'classic', label: t('browse.cardStyle.classic') },
+                        ]}
+                      />
                     </div>
 
                     <div>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.detailsView')}</div>
-                      <div className="grid grid-cols-2 gap-2" role="tablist" aria-label={t('browse.viewOptions.modDetailsView')}>
-                        {(['modal', 'sidebar'] as const).map((view) => {
-                          const active = browseDetailsView === view;
-                          return (
-                            <button
-                              key={view}
-                              type="button"
-                              role="tab"
-                              aria-selected={active}
-                              onClick={() => setBrowseDetailsView(view)}
-                              className={`flex h-9 items-center justify-center gap-1.5 rounded-md border text-xs font-semibold transition-colors ${
-                                active
-                                  ? 'border-accent/50 bg-accent/10 text-accent'
-                                  : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
-                              }`}
-                            >
-                              {view === 'modal' ? <Maximize2 className="h-3.5 w-3.5" /> : <PanelRight className="h-3.5 w-3.5" />}
-                              {view === 'modal' ? t('browse.detailsView.window') : t('browse.detailsView.sidebar')}
-                            </button>
-                          );
-                        })}
-                      </div>
+                      <SegmentedControl<BrowseDetailsView>
+                        fill
+                        label={t('browse.viewOptions.modDetailsView')}
+                        value={browseDetailsView}
+                        onChange={setBrowseDetailsView}
+                        options={[
+                          { value: 'modal', label: <><Maximize2 className="h-3.5 w-3.5" />{t('browse.detailsView.window')}</> },
+                          { value: 'sidebar', label: <><PanelRight className="h-3.5 w-3.5" />{t('browse.detailsView.sidebar')}</> },
+                        ]}
+                      />
                     </div>
 
                   </div>

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -86,7 +86,7 @@ import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
 import { HeroSelect } from '../components/common/HeroSelect';
-import { Button, Tag } from '../components/common/ui';
+import { Button, IconButton, Tag } from '../components/common/ui';
 import { IconText } from '../components/common/IconText';
 import { EmptyState } from '../components/common/PageComponents';
 import ModDetailsModal from '../components/ModDetailsModal';
@@ -2709,15 +2709,12 @@ export default function Browse() {
       <div className="sticky top-0 z-40 p-4 border-b border-border bg-bg-primary">
         {artistMode && submitter ? (
           <div className="flex items-center gap-3">
-            <button
-              type="button"
+            <IconButton
+              icon={ArrowLeft}
+              label={t('browse.artist.backToBrowse')}
               onClick={clearArtist}
-              aria-label={t('browse.artist.backToBrowse')}
-              title={t('browse.artist.backToBrowse')}
-              className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-bg-secondary text-text-secondary transition-colors hover:border-accent/50 hover:text-text-primary cursor-pointer"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </button>
+              className="flex-shrink-0"
+            />
             {submitter.avatarUrl && !artistAvatarFailed ? (
               <img
                 src={submitter.avatarUrl}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -87,6 +87,7 @@ import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
 import { HeroSelect } from '../components/common/HeroSelect';
 import { Button, IconButton, SegmentedControl, Tag } from '../components/common/ui';
+import { Select } from '../components/common/forms';
 import { IconText } from '../components/common/IconText';
 import { EmptyState } from '../components/common/PageComponents';
 import ModDetailsModal from '../components/ModDetailsModal';
@@ -3133,18 +3134,17 @@ export default function Browse() {
                         {categoryOptions.length > 0 && (
                           <div className="block">
                             <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.category')}</span>
-                            <select
+                            <Select
                               aria-label={t('browse.filters.filterByCategory')}
                               value={String(categoryId)}
                               onChange={(e) => setCategoryId(e.target.value === 'all' ? 'all' : Number(e.target.value))}
                               disabled={heroCategoryId !== 'all'}
-                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                               <option value="all">{t('browse.filters.allCategories')}</option>
                               {categoryOptions.map((cat) => (
                                 <option key={cat.id} value={String(cat.id)}>{cat.label}</option>
                               ))}
-                            </select>
+                            </Select>
                             {heroCategoryId !== 'all' && (
                               <span className="block text-[11px] text-text-tertiary mt-1">{t('browse.filters.heroOverridesCategories')}</span>
                             )}
@@ -3156,34 +3156,32 @@ export default function Browse() {
                         {hasLocalCache && (
                           <div className="block">
                             <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.content')}</span>
-                            <select
+                            <Select
                               aria-label={t('browse.filters.filterByContentRating')}
                               value={nsfw}
                               onChange={(e) => setNsfw(e.target.value as BrowseNsfwFilter)}
-                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
                             >
                               <option value="all">{t('browse.filters.contentAll')}</option>
                               <option value="sfw">{t('browse.filters.sfwOnly')}</option>
                               <option value="nsfw">{t('browse.filters.nsfwOnly')}</option>
-                            </select>
+                            </Select>
                           </div>
                         )}
 
                         {hasLocalCache && (
                           <div className="block">
                             <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.added')}</span>
-                            <select
+                            <Select
                               aria-label={t('browse.filters.filterByDateAdded')}
                               value={addedWithin}
                               onChange={(e) => setAddedWithin(e.target.value as BrowseTimeRange)}
-                              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-md text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
                             >
                               <option value="all">{t('browse.filters.anyTime')}</option>
                               <option value="today">{t('browse.filters.today')}</option>
                               <option value="week">{t('browse.filters.thisWeek')}</option>
                               <option value="month">{t('browse.filters.thisMonth')}</option>
                               <option value="custom">{t('browse.filters.customRange')}</option>
-                            </select>
+                            </Select>
                             {addedWithin === 'custom' && (
                               <div className="mt-2 grid grid-cols-2 gap-2">
                                 <label className="block">

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -15,7 +15,7 @@ import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
 import { Button } from '../components/common/ui';
-import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, type ViewMode } from '../components/common/PageComponents';
+import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, PageLayout, type ViewMode } from '../components/common/PageComponents';
 import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
 import Tx from '../components/translation/Tx';
 
@@ -418,7 +418,7 @@ export default function Conflicts() {
   }
 
   return (
-    <div className="p-6 max-w-5xl mx-auto animate-fade-in">
+    <PageLayout maxWidth="5xl">
       <PageHeader
         title={
           <Tx
@@ -889,6 +889,6 @@ export default function Conflicts() {
           )
         }
       />
-    </div>
+    </PageLayout>
   );
 }

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -6,6 +6,7 @@ import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import { renderCrosshairThumbnail } from '../components/crosshair/drawCrosshair';
 import { getSettings } from '../lib/api';
 import { Card, Slider, Toggle, Button } from '../components/common/ui';
+import { Input, Select } from '../components/common/forms';
 import Tx from '../components/translation/Tx';
 
 // The in-game crosshair is authored in 1080p-reference px and scaled by
@@ -369,12 +370,13 @@ export default function Crosshair() {
                             <div className="flex items-center gap-2 h-full">
                                 {showSaveInput ? (
                                     <>
-                                        <input
+                                        <Input
+                                            inputSize="sm"
                                             type="text"
                                             value={presetName}
                                             onChange={(e) => setPresetName(e.target.value)}
                                             placeholder={t('crosshair.presetNamePlaceholder')}
-                                            className="flex-1 px-3 py-1.5 bg-bg-tertiary border border-white/10 rounded-lg text-text-primary text-sm focus:outline-none focus:ring-1 focus:ring-accent min-w-0"
+                                            className="flex-1 min-w-0"
                                             onKeyDown={(e) => e.key === 'Enter' && handleSavePreset()}
                                             autoFocus
                                         />
@@ -408,16 +410,17 @@ export default function Crosshair() {
                     {/* Preview Area */}
                     <Card className="relative w-full" contentClassName="p-0">
                         <div className="absolute top-4 right-4 z-10 flex items-center gap-3 bg-black/40 backdrop-blur-md rounded-full px-3 py-1.5 border border-white/5">
-                            <select
+                            <Select
+                                inputSize="sm"
                                 value={resolution}
                                 onChange={(e) => setResolution(parseInt(e.target.value, 10))}
                                 title={t('crosshair.preview.resolutionTitle')}
-                                className="bg-transparent text-xs text-text-secondary focus:outline-none cursor-pointer [&>option]:bg-bg-tertiary"
+                                className="text-xs"
                             >
                                 {RESOLUTIONS.map((r) => (
                                     <option key={r.height} value={r.height}>{r.label}</option>
                                 ))}
-                            </select>
+                            </Select>
                             <span className="text-xs text-text-secondary">
                                 <Tx k="crosshair.preview.zoom" fallback="Zoom:" />
                             </span>

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -522,7 +522,7 @@ export default function Crosshair() {
                                                 </button>
                                                 <button
                                                     onClick={(e) => { e.stopPropagation(); handleDeletePreset(preset.id); }}
-                                                    className="p-1.5 bg-red-500/20 hover:bg-red-500/40 text-red-400 rounded-md cursor-pointer"
+                                                    className="p-1.5 bg-red-500/20 hover:bg-red-500/40 text-state-danger rounded-md cursor-pointer"
                                                     title={t('common.actions.delete')}
                                                 >
                                                     <Trash2 className="w-3 h-3" />

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -25,7 +25,7 @@ import {
 import { useAppStore } from '../stores/appStore';
 import { useSocialStore } from '../stores/socialStore';
 import { Card, Button } from '../components/common/ui';
-import { EmptyState, PageHeader } from '../components/common/PageComponents';
+import { EmptyState, PageHeader, PageLayout } from '../components/common/PageComponents';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import MyPublishedSection from '../components/social/MyPublishedSection';
 import PublishPickerDialog from '../components/social/PublishPickerDialog';
@@ -300,8 +300,8 @@ export default function Discover() {
   );
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-6 space-y-6 max-w-7xl mx-auto">
+    <>
+      <PageLayout maxWidth="7xl">
       <div>
         <PageHeader
           title={t('nav.discover')}
@@ -626,7 +626,7 @@ export default function Discover() {
         </div>
       )}
 
-      </div>
+      </PageLayout>
       {showPicker && (
         <PublishPickerDialog
           onClose={() => setShowPicker(false)}
@@ -668,6 +668,6 @@ export default function Discover() {
           }}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -360,7 +360,7 @@ export default function Discover() {
         </div>
       )}
       {!signedIn && signInError && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-red-400 flex items-start justify-between gap-2">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-state-danger flex items-start justify-between gap-2">
           <div className="flex items-start gap-2 min-w-0">
             <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
             <span className="break-words">{signInError}</span>
@@ -588,8 +588,8 @@ export default function Discover() {
                         className={`flex-shrink-0 inline-flex items-center gap-1 text-xs px-2 py-1 -mr-1 rounded-md transition-colors ${
                           signedIn
                             ? liked
-                              ? 'text-red-400 hover:bg-red-500/10 cursor-pointer'
-                              : 'text-text-secondary hover:text-red-400 hover:bg-white/5 cursor-pointer'
+                              ? 'text-state-danger hover:bg-red-500/10 cursor-pointer'
+                              : 'text-text-secondary hover:text-state-danger hover:bg-white/5 cursor-pointer'
                             : 'text-text-tertiary cursor-help hover:bg-white/5'
                         } disabled:opacity-50`}
                         title={signedIn ? (liked ? 'Unlike' : 'Like') : 'Sign in to like'}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -87,7 +87,7 @@ import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
-import { Button, Tag } from '../components/common/ui';
+import { Button, IconButton, Tag } from '../components/common/ui';
 import { LockerOverridesModal } from '../components/LockerOverridesModal';
 import { ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
 
@@ -3431,17 +3431,19 @@ export default function Installed() {
               ? t('installed.empty.noSearchMatch', { query: search })
               : t('installed.empty.noFilterMatch')}
           </p>
-          <button
+          <Button
+            variant="primary"
+            size="sm"
+            className="mt-1"
             onClick={() => {
               setSearch('');
               setSourceSel(['gamebanana', 'local']);
               setStatusSel(['enabled', 'disabled']);
               setTypeFilter([]);
             }}
-            className="mt-1 px-3 py-1.5 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer text-sm"
           >
             {searchNeedle ? t('installed.filters.clearSearch') : t('installed.filters.clearFilters')}
-          </button>
+          </Button>
         </div>
       )}
 
@@ -3705,7 +3707,7 @@ export default function Installed() {
             className="bg-bg-secondary border border-border rounded-xl p-6 max-w-md"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-lg font-semibold text-red-400 mb-2">{t('installed.details.loadFailed')}</h3>
+            <h3 className="text-lg font-semibold text-state-danger mb-2">{t('installed.details.loadFailed')}</h3>
             <p className="text-sm text-text-secondary mb-4">{detailsError}</p>
             <div className="flex justify-end">
               <Button onClick={closeModDetails}>{t('common.actions.close')}</Button>
@@ -3934,21 +3936,13 @@ export default function Installed() {
                   : t('installed.select.countSelected', { count: selectedMods.length })}
               </span>
               <span className="h-5 w-px bg-border" />
-              <button
-                type="button"
-                onClick={selectAllVisible}
-                className="text-sm text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-tertiary cursor-pointer"
-              >
+              <Button variant="ghost" size="sm" onClick={selectAllVisible}>
                 {t('installed.select.selectAll')}
-              </button>
+              </Button>
               {selectedMods.length > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setSelectedIds(new Set())}
-                  className="text-sm text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-tertiary cursor-pointer"
-                >
+                <Button variant="ghost" size="sm" onClick={() => setSelectedIds(new Set())}>
                   {t('common.actions.clear')}
-                </button>
+                </Button>
               )}
               <span className="h-5 w-px bg-border" />
               <Button
@@ -4057,15 +4051,12 @@ export default function Installed() {
                 {t('common.actions.delete')}{selectedMods.length > 0 ? ` (${selectedMods.length})` : ''}
               </Button>
               <span className="h-5 w-px bg-border" />
-              <button
-                type="button"
+              <IconButton
+                icon={X}
+                label={t('installed.actions.exitSelectionMode')}
+                size="sm"
                 onClick={exitSelectMode}
-                className="p-1.5 text-text-secondary hover:text-text-primary rounded hover:bg-bg-tertiary cursor-pointer"
-                aria-label={t('installed.actions.exitSelectionMode')}
-                title={t('installed.actions.exitSelectionMode')}
-              >
-                <X className="w-4 h-4" />
-              </button>
+              />
             </>
           )}
         </div>
@@ -4189,14 +4180,11 @@ function UnknownFilterGuessModal({
               {mod.fileName}
             </p>
           </div>
-          <button
-            type="button"
+          <IconButton
+            icon={X}
+            label={t('common.actions.close')}
             onClick={onClose}
-            className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
-            aria-label={t('common.actions.close')}
-          >
-            <X className="w-5 h-5" />
-          </button>
+          />
         </div>
 
         <UnknownMatchPanel
@@ -4320,14 +4308,11 @@ function BulkUnknownFixModal({
                 </Button>
               </>
             )}
-            <button
-              type="button"
+            <IconButton
+              icon={X}
+              label={t('common.actions.close')}
               onClick={onClose}
-              className="p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer text-text-secondary hover:text-text-primary flex-shrink-0"
-              aria-label={t('common.actions.close')}
-            >
-              <X className="w-5 h-5" />
-            </button>
+            />
           </div>
         </div>
 
@@ -4503,7 +4488,7 @@ function UnknownMatchPanel({
       />
 
       {applyError && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
           <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
           <span>{applyError}</span>
         </div>
@@ -4556,7 +4541,7 @@ function UnknownMatchPanel({
           )}
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-red-400 flex items-start gap-2">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-3 text-sm text-state-danger flex items-start gap-2">
               <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>
@@ -4866,7 +4851,7 @@ function UnknownManualSearch({
       </div>
 
       {searchError && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-red-400 flex items-start gap-2">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-state-danger flex items-start gap-2">
           <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
           <span>{searchError}</span>
         </div>
@@ -5166,7 +5151,7 @@ function UnknownFileList({
             </div>
           )}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-red-400 flex items-start gap-2">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-md p-2.5 text-xs text-state-danger flex items-start gap-2">
               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>
@@ -7066,19 +7051,17 @@ function ImportCustomModModal({
             <FilePlus className="w-5 h-5" />
             {title}
           </h3>
-          <button
+          <IconButton
+            icon={X}
+            label={t('common.actions.close')}
             onClick={onClose}
-            className="p-1 text-text-secondary hover:text-text-primary rounded cursor-pointer"
-            aria-label={t('common.actions.close')}
-          >
-            <X className="w-5 h-5" />
-          </button>
+          />
         </div>
 
         <div className="p-5 space-y-4">
           <div>
             <label className="block text-sm font-medium text-text-primary mb-1.5">
-              {t('installed.import.vpkFile')} <span className="text-red-400">*</span>
+              {t('installed.import.vpkFile')} <span className="text-state-danger">*</span>
             </label>
             <div
               role="button"
@@ -7127,7 +7110,7 @@ function ImportCustomModModal({
 
           <div>
             <label className="block text-sm font-medium text-text-primary mb-1.5">
-              {t('installed.import.modName')} <span className="text-red-400">*</span>
+              {t('installed.import.modName')} <span className="text-state-danger">*</span>
             </label>
             <input
               type="text"
@@ -7195,28 +7178,28 @@ function ImportCustomModModal({
           </label>
 
           {error && (
-            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg p-2">
+            <div className="text-sm text-state-danger bg-red-500/10 border border-red-500/30 rounded-lg p-2">
               {error}
             </div>
           )}
         </div>
 
         <div className="flex justify-end gap-3 p-5 border-t border-border">
-          <button
+          <Button
+            variant="secondary"
             onClick={onClose}
             disabled={submitting}
-            className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer disabled:opacity-50"
           >
             {t('common.actions.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className="px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            isLoading={submitting}
           >
-            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
             {submitLabel}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -88,6 +88,7 @@ import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
 import { Button, IconButton, Tag } from '../components/common/ui';
+import { FormField, Input, Select } from '../components/common/forms';
 import { LockerOverridesModal } from '../components/LockerOverridesModal';
 import { ViewModeToggle, EmptyState, ConfirmModal, SectionHeader, type ViewMode } from '../components/common/PageComponents';
 
@@ -4919,18 +4920,20 @@ function UnknownManualSearch({
                     {files && files.length > 0 && (
                       <label className="block text-xs text-text-secondary">
                         {t('installed.unknown.pinExactFile')}
-                        <select
-                          value={fileId ?? ''}
-                          onChange={(e) => setFileId(e.target.value ? Number(e.target.value) : undefined)}
-                          className="mt-1 w-full bg-bg-primary border border-white/10 rounded-md px-2 py-1.5 text-sm text-text-primary focus:outline-none focus:border-accent/50"
-                        >
-                          <option value="">{t('installed.unknown.dontPinFile')}</option>
-                          {files.map((f) => (
-                            <option key={f.id} value={f.id}>
-                              {f.fileName}
-                            </option>
-                          ))}
-                        </select>
+                        <div className="mt-1">
+                          <Select
+                            inputSize="sm"
+                            value={fileId ?? ''}
+                            onChange={(e) => setFileId(e.target.value ? Number(e.target.value) : undefined)}
+                          >
+                            <option value="">{t('installed.unknown.dontPinFile')}</option>
+                            {files.map((f) => (
+                              <option key={f.id} value={f.id}>
+                                {f.fileName}
+                              </option>
+                            ))}
+                          </Select>
+                        </div>
                       </label>
                     )}
                     <div className="flex justify-end">
@@ -6784,21 +6787,18 @@ function EditLocalModModal({ mod, onClose, onSave }: EditLocalModModalProps) {
           </div>
         </div>
 
-        <label className="mt-5 block text-sm font-medium text-text-primary" htmlFor="local-mod-name">
-          {t('locker.soulImport.fields.name')}
-        </label>
-        <input
-          id="local-mod-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') void submit();
-            if (e.key === 'Escape') onClose();
-          }}
-          autoFocus
-          className="mt-2 w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-secondary/60 focus:border-accent focus:ring-2 focus:ring-accent/25"
-          placeholder={t('installed.edit.modNamePlaceholder')}
-        />
+        <FormField className="mt-5" label={t('locker.soulImport.fields.name')}>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void submit();
+              if (e.key === 'Escape') onClose();
+            }}
+            autoFocus
+            placeholder={t('installed.edit.modNamePlaceholder')}
+          />
+        </FormField>
         <p className="mt-2 truncate text-xs text-text-secondary" title={mod.fileName}>
           {t('installed.edit.fileLabel', { fileName: mod.fileName })}
         </p>
@@ -7108,18 +7108,13 @@ function ImportCustomModModal({
             </p>
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-text-primary mb-1.5">
-              {t('installed.import.modName')} <span className="text-state-danger">*</span>
-            </label>
-            <input
-              type="text"
+          <FormField label={t('installed.import.modName')} required>
+            <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('installed.import.modNamePlaceholder')}
-              className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-accent"
             />
-          </div>
+          </FormField>
 
           <div>
             <label className="block text-sm font-medium text-text-primary mb-1.5">

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -6534,7 +6534,7 @@ function ModCard({
                 mod.enabled ? 'opacity-55' : 'opacity-30 grayscale-[0.4]'
               }`}
             />
-            <div className="absolute inset-0 bg-gradient-to-b from-[#0f0f0f]/45 via-[#0f0f0f]/65 to-[#0f0f0f]/[0.88]" />
+            <div className="absolute inset-0 scrim-bottom" />
           </div>
         )}
         {(() => {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -6066,8 +6066,8 @@ function ModCard({
   const stateClasses = hasConflicts
     ? 'bg-state-warning/5 border-state-warning/45'
     : mod.enabled
-      ? 'bg-[#242424] border-white/[0.08] hover:border-white/[0.14] hover:bg-bg-secondary'
-      : 'bg-[#242424]/85 border-white/[0.08] text-text-primary/80 hover:border-white/[0.14] hover:bg-bg-secondary hover:text-text-primary';
+      ? 'bg-bg-tertiary border-white/[0.08] hover:border-white/[0.14] hover:bg-bg-secondary'
+      : 'bg-bg-tertiary/85 border-white/[0.08] text-text-primary/80 hover:border-white/[0.14] hover:bg-bg-secondary hover:text-text-primary';
 
   // Glass surface for grid/compact cards: a translucent base over which a
   // blurred copy of the cover art (see glassBackdropUrl) bleeds, so the card
@@ -6075,8 +6075,8 @@ function ModCard({
   const glassStateClasses = hasConflicts
     ? 'border-state-warning/45 bg-state-warning/[0.07]'
     : mod.enabled
-      ? 'border-white/[0.12] bg-[#141414]/65 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)] hover:border-white/[0.2]'
-      : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary';
+      ? 'border-white/[0.12] bg-bg-sunken/65 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)] hover:border-white/[0.2]'
+      : 'border-white/[0.08] bg-bg-sunken/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary';
 
   // Merged mods get a "stacked card" silhouette via two offset box-shadows
   // that read as cards-behind-the-card. Uses only neutral surface/border

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1313,7 +1313,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                               mod.enabled ? 'opacity-55' : 'opacity-30 grayscale-[0.4]'
                             }`}
                           />
-                          <div className="absolute inset-0 bg-gradient-to-b from-[#0f0f0f]/45 via-[#0f0f0f]/65 to-[#0f0f0f]/[0.88]" />
+                          <div className="absolute inset-0 scrim-bottom" />
                         </div>
                       )}
 

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1295,7 +1295,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                       className={`group/card relative flex flex-col rounded-[10px] border p-2.5 transition-[border-color,background-color,box-shadow] duration-200 ${
                         mod.enabled
                           ? 'border-accent bg-accent/[0.06] shadow-[0_0_0_1px_var(--color-accent)] hover:bg-accent/[0.10]'
-                          : 'border-white/[0.08] bg-[#141414]/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
+                          : 'border-white/[0.08] bg-bg-sunken/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
                       }`}
                     >
                       {/* Glass backdrop: a blurred copy of the cover art bleeds

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Layers, Plus, Trash2, Play, Save, RefreshCw, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X, Upload, Share2, Globe, History, RotateCcw, Camera } from 'lucide-react';
+import { Layers, Plus, Trash2, Play, Save, AlertTriangle, User, ChevronDown, ChevronUp, Terminal, Check, Pencil, X, Upload, Share2, Globe, History, RotateCcw, Camera } from 'lucide-react';
 import {
   getProfiles,
   createProfile,
@@ -23,7 +23,7 @@ import { useCrosshairStore } from '../stores/crosshairStore';
 import { useSocialStore } from '../stores/socialStore';
 import { Card, Badge, Button, CheckboxMark } from '../components/common/ui';
 import { Input } from '../components/common/forms';
-import { ConfirmModal, EmptyState } from '../components/common/PageComponents';
+import { ConfirmModal, EmptyState, PageLayout, LoadingState } from '../components/common/PageComponents';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import ExportProfileModal from '../components/profiles/ExportProfileModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
@@ -379,22 +379,15 @@ export default function Profiles() {
   };
 
   if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full text-text-secondary">
-        <RefreshCw className="w-8 h-8 animate-spin mb-4 text-accent" />
-        <p>
-          <Tx k="profiles.loading" fallback="Loading profiles..." />
-        </p>
-      </div>
-    );
+    return <LoadingState label={<Tx k="profiles.loading" fallback="Loading profiles..." />} />;
   }
 
   return (
-    <div className="p-6 h-full max-w-5xl mx-auto w-full flex flex-col overflow-hidden animate-fade-in">
+    <PageLayout variant="fill" maxWidth="5xl">
       <div className="flex flex-col gap-6 flex-1 overflow-auto px-1">
         <div className="space-y-6 pr-1">
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-2 text-red-400">
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-2 text-state-danger">
               <AlertTriangle className="w-5 h-5" />
               <p>{error}</p>
             </div>
@@ -546,7 +539,7 @@ export default function Profiles() {
                           variant="ghost"
                           icon={Trash2}
                           onClick={() => setBulkDeleteSnapshotsOpen(true)}
-                          className="ml-auto text-red-400 hover:text-red-300"
+                          className="ml-auto text-state-danger hover:text-red-300"
                           title={t('profiles.snapshots.deleteSelectedTitle', { count: selectedSnapshotIds.size })}
                         >
                           <Tx
@@ -1079,6 +1072,6 @@ export default function Profiles() {
         }
         variant="danger"
       />
-    </div>
+    </PageLayout>
   );
 }

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -22,6 +22,7 @@ import { useAppStore } from '../stores/appStore';
 import { useCrosshairStore } from '../stores/crosshairStore';
 import { useSocialStore } from '../stores/socialStore';
 import { Card, Badge, Button, CheckboxMark } from '../components/common/ui';
+import { Input } from '../components/common/forms';
 import { ConfirmModal, EmptyState } from '../components/common/PageComponents';
 import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import ExportProfileModal from '../components/profiles/ExportProfileModal';
@@ -402,14 +403,14 @@ export default function Profiles() {
           {/* Create New Profile */}
           <Card title={<Tx k="profiles.create.title" fallback="Create New Profile" />} icon={Plus}>
             <div className="flex flex-wrap gap-3">
-              <input
+              <Input
                 type="text"
                 value={newProfileName}
                 onChange={(e) => setNewProfileName(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && handleCreateProfile()}
                 placeholder={t('profiles.create.placeholder')}
                 aria-label={t('profiles.create.profileName')}
-                className="flex-1 px-4 py-2.5 bg-bg-tertiary border border-white/5 rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent transition-all"
+                className="flex-1"
               />
               <Button
                 onClick={handleCreateProfile}

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, Badge } from '../components/common/ui';
-import { EmptyState, PageHeader } from '../components/common/PageComponents';
+import { EmptyState, PageHeader, PageLayout } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import { useAppStore } from '../stores/appStore';
 import {
@@ -108,7 +108,7 @@ export default function Servers() {
   }, [servers, query, region, mapFilter, hideFull]);
 
   return (
-    <div className="space-y-5 p-6">
+    <PageLayout>
       <PageHeader
         title={<Tx k="nav.servers" fallback="Servers" />}
         description={
@@ -349,6 +349,6 @@ export default function Servers() {
       {connectTarget && (
         <ConnectServerDialog server={connectTarget} onClose={() => setConnectTarget(null)} />
       )}
-    </div>
+    </PageLayout>
   );
 }

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -33,7 +33,7 @@ function pingTone(ms: number): { color: string } {
   if (ms < 0) return { color: 'text-text-secondary/50' };
   if (ms < 60) return { color: 'text-green-400' };
   if (ms < 120) return { color: 'text-yellow-400' };
-  return { color: 'text-red-400' };
+  return { color: 'text-state-danger' };
 }
 
 export default function Servers() {

--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -11,10 +11,10 @@ import {
   Play,
   AlertTriangle,
   CloudOff,
-  Globe2,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, Badge } from '../components/common/ui';
+import { Input, Select } from '../components/common/forms';
 import { EmptyState, PageHeader, PageLayout } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import { useAppStore } from '../stores/appStore';
@@ -158,47 +158,44 @@ export default function Servers() {
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">
-        <div className="relative min-w-[220px] flex-1">
-          <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
-          <input
+        <div className="min-w-[220px] flex-1">
+          <Input
+            icon={Search}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={t('servers.filters.searchPlaceholder')}
-            className="w-full rounded-sm border border-border bg-bg-tertiary py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-secondary/60 focus:border-accent/50 focus:outline-none"
           />
         </div>
 
         {regions.length > 1 && (
-          <div className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-tertiary px-2 py-1.5">
-            <Globe2 size={14} className="text-text-secondary" />
-            <select
+          <div className="w-40">
+            <Select
+              inputSize="sm"
               value={region}
               onChange={(e) => setRegion(e.target.value)}
-              className="bg-transparent text-sm text-text-primary focus:outline-none"
             >
               {regions.map((r) => (
-                <option key={r} value={r} className="bg-bg-secondary">
+                <option key={r} value={r}>
                   {r === 'all' ? t('servers.filters.allRegions') : r}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
         )}
 
         {maps.length > 1 && (
-          <div className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-tertiary px-2 py-1.5">
-            <MapPin size={14} className="text-text-secondary" />
-            <select
+          <div className="w-40">
+            <Select
+              inputSize="sm"
               value={mapFilter}
               onChange={(e) => setMapFilter(e.target.value)}
-              className="bg-transparent text-sm text-text-primary focus:outline-none"
             >
               {maps.map((m) => (
-                <option key={m} value={m} className="bg-bg-secondary">
+                <option key={m} value={m}>
                   {m === 'all' ? t('servers.filters.allMaps') : m}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
         )}
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,7 +19,7 @@ import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { Input, Textarea } from '../components/common/forms';
-import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
+import { PageHeader, ConfirmModal, PageLayout } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import LanguageSelector from '../components/settings/LanguageSelector';
 import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
@@ -609,7 +609,7 @@ export default function Settings() {
   }
 
   return (
-    <div className="p-8 max-w-5xl mx-auto space-y-8 animate-fade-in">
+    <PageLayout maxWidth="5xl">
       <PageHeader
         title={<Tx k="nav.settings" fallback="Settings" />}
         description={<Tx k="settings.header.description" fallback="Game paths, preferences, and maintenance" />}
@@ -1649,7 +1649,7 @@ export default function Settings() {
         confirmLabel={<Tx k="common.actions.reset" fallback="Reset" />}
         variant="primary"
       />
-    </div>
+    </PageLayout>
   );
 }
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
+import { Input, Textarea } from '../components/common/forms';
 import { PageHeader, ConfirmModal } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import LanguageSelector from '../components/settings/LanguageSelector';
@@ -656,13 +657,13 @@ export default function Settings() {
 
               <div className="flex gap-2">
                 <div className="relative flex-1">
-                  <input
+                  <Input
                     type="text"
                     value={displayPath}
                     onChange={(e) => handlePathChange(e.target.value)}
                     placeholder={t('settings.gamePath.pathPlaceholder')}
                     disabled={isDevMode}
-                    className="w-full bg-bg-tertiary border border-white/5 rounded-sm px-4 py-2.5 text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-60 disabled:cursor-not-allowed font-mono text-sm"
+                    className="font-mono"
                   />
                 </div>
                 <Button
@@ -1283,12 +1284,11 @@ export default function Settings() {
                 </p>
               </div>
 
-              <textarea
+              <Textarea
                 value={bugDescription}
                 onChange={(e) => setBugDescription(e.target.value)}
                 placeholder={t('settings.support.bugPlaceholder')}
                 rows={3}
-                className="w-full px-3 py-2 text-sm bg-bg-tertiary border border-white/5 rounded-sm text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-accent resize-y"
               />
 
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
@@ -1320,7 +1320,7 @@ export default function Settings() {
               </div>
 
               {bugReportError && (
-                <p className="text-xs text-red-400 break-all">{bugReportError}</p>
+                <p className="text-xs text-state-danger break-all">{bugReportError}</p>
               )}
 
               {bugReportText && (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,7 +19,7 @@ import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { Input, Textarea } from '../components/common/forms';
-import { PageHeader, ConfirmModal, PageLayout } from '../components/common/PageComponents';
+import { PageHeader, ConfirmModal, PageLayout, LoadingState } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 import LanguageSelector from '../components/settings/LanguageSelector';
 import { ACCENT_PRESETS, DEFAULT_ACCENT_COLOR, applyAccentColor } from '../lib/accentColor';
@@ -601,11 +601,7 @@ export default function Settings() {
     : 0;
 
   if (settingsLoading && !settings) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <Loader2 className="w-8 h-8 animate-spin text-accent" />
-      </div>
-    );
+    return <LoadingState />;
   }
 
   return (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -630,7 +630,7 @@ export default function Settings() {
                       </span>
                     )}
                     {isValidPath === false && (
-                      <span className="text-red-400 flex items-center gap-1">
+                      <span className="text-state-danger flex items-center gap-1">
                         <X className="w-3 h-3" />
                         <Tx k="common.status.invalid" fallback="Invalid" />
                       </span>
@@ -784,7 +784,7 @@ export default function Settings() {
                   </span>
                 )}
                 {updateStatus?.error && (
-                  <span className="text-xs text-red-400 basis-full">{updateStatus.error}</span>
+                  <span className="text-xs text-state-danger basis-full">{updateStatus.error}</span>
                 )}
               </div>
               <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## What

Pays down UI "slop" in the renderer by **adopting the existing design system** (primitives in `src/components/common/`, tokens in `index.css` `@theme`) instead of rewriting anything. This is the cheap, additive track of the UI-uniformity initiative; no behavior changes.

A house rulebook lands alongside it: `docs/ui-conventions.md` (tokens-not-hex, components-not-markup, `rounded-sm` default, `focus-visible:ring-accent`, canonical form-control surface).

## Changes by phase

**Phase 0/1 - primitives + token cleanups**
- New `forms.tsx` primitives: `Input` / `Textarea` / `Select` / `FormField` (React 19 ref-as-prop, `useId` a11y wiring).
- Token cleanups: `Badge`/`ConfirmModal`/`EmptyState` raw palette -> `state-*`; Ko-fi brand color -> `brand-kofi`; duplicated dark gradient -> `@utility scrim-bottom`.

**Phase 2 - page shells**
- `PageLayout` + `LoadingState` added; migrated Servers, Settings, Discover, Conflicts, Profiles. (Locker/Autoexec/Crosshair/Stats/god-pages intentionally kept their bespoke layouts.)

**Phase 3 - button sweep**
- Raw `<button>` -> `Button` / `IconButton` where they map cleanly: ModDetailsModal (file-row actions, header, delete-confirm), Browse artist back-arrow, Installed (import modal, unknown-match closes, selection toolbar, empty-state CTA). Bespoke buttons (card-overlay actions, menus, toggles, segmented controls, in-input affordances) left as-is.

**Phase 3b - segmented controls, form controls, tokens**
- `SegmentedControl` gained `fill` (equal-width) + `disabled` props; adopted for the Browse view-options popover (layout / card style / details view).
- `forms.tsx` adoption across ~13 dialogs/components + Browse filter selects + Installed name/select fields (the contained files were swept by parallel agents; god pages done by hand). Documented exceptions left raw: checkbox/radio/file/color/range/number/date, domain pickers, search inputs with trailing affordances, in-place rename editors.
- Raw hex -> new `@theme` tokens (`--color-bg-sunken`, `--color-bg-glass`, `--color-mod-title`); `bg-[#242424]` -> `bg-bg-tertiary`.
- `text-red-400` -> `text-state-danger` repo-wide (identical `#f87171`, danger semantics).

## Out of scope (follow-ups)
- `PageToolbar` primitive (deferred until Installed/Browse top-bar work needs it).
- Pill section-toggles (Browse toolbar+artist pair, Locker skins/sounds + LockerHeroView twin) - need a deliberate pill-vs-chip decision before migrating each matched pair together.
- Track B architecture debt: `appStore.ts` split, `enrichMod`/classification extraction, routing stray `window.electronAPI` through `src/lib/api.ts`.

## Verification
`pnpm typecheck` + `pnpm lint` green after every commit. No tests exist in this repo (TS strict + ESLint only); changes are token/markup swaps with behavior preserved.