### PR TITLE
fix(stats): correct inverted win/loss and keep recent-matches tabs in sync

### DIFF
--- a/electron/main/ipc/stats.ts
+++ b/electron/main/ipc/stats.ts
@@ -12,6 +12,7 @@ import type {
     TrackedPlayer,
     MMRSnapshot,
     StoredMatch,
+    PlayerMatch,
     HeroStatsSnapshot,
     AggregatedStats,
 } from '../../../src/types/deadlock-stats'
@@ -165,6 +166,15 @@ ipcMain.handle(
 
 ipcMain.handle('stats:getLocalMatchCount', (_, accountId: number): number => {
     return statsDb.getMatchCount(accountId)
+})
+
+// Persist already-fetched live matches into the local recorded history. Called
+// on player load so the recorded Match History tab stays in lockstep with the
+// live recent-matches feed (otherwise the newest game shows in Overview but not
+// in the Matches tab until a manual Refresh).
+ipcMain.handle('stats:recordMatches', (_, accountId: number, matches: PlayerMatch[]): void => {
+    if (!Array.isArray(matches) || matches.length === 0) return
+    statsDb.saveMatches(accountId, matches)
 })
 
 ipcMain.handle(

--- a/electron/main/services/stats.ts
+++ b/electron/main/services/stats.ts
@@ -326,7 +326,11 @@ export async function getPlayerMatchHistory(
     const matches = (rawMatches || []).map(match => ({
         ...match,
         hero_name: HERO_NAMES[match.hero_id] || `Hero ${match.hero_id}`,
-        match_outcome: (match.match_result === 1 ? 'Win' : 'Loss') as 'Win' | 'Loss',
+        // match_result is the WINNING TEAM id (0 or 1), not the player's result.
+        // The player won iff their team matches the winning team. (Treating
+        // match_result === 1 as a win inverted every team-0 game, roughly half
+        // of all matches.)
+        match_outcome: (match.match_result === match.player_team ? 'Win' : 'Loss') as 'Win' | 'Loss',
         duration_s: match.match_duration_s,
         kills: match.player_kills,
         deaths: match.player_deaths,

--- a/electron/main/services/statsDatabase.ts
+++ b/electron/main/services/statsDatabase.ts
@@ -149,8 +149,63 @@ export function initDatabase(): Database.Database {
         CREATE INDEX IF NOT EXISTS idx_hero_stats_account ON hero_stats_snapshots(account_id, snapshot_date DESC);
     `)
 
+    // One-time correction for the inverted win/loss bug: match rows synced
+    // before the fix stored match_outcome from `match_result === 1`, which
+    // inverted every team-0 game. Flip those once and recompute aggregates.
+    correctInvertedMatchOutcomes(db)
+
     console.log('[StatsDatabase] Database initialized successfully')
     return db
+}
+
+/**
+ * Historical fix for the win/loss inversion (see stats.ts getPlayerMatchHistory):
+ * earlier syncs labelled outcomes with `match_result === 1`, treating the
+ * winning-team id as the player's result. That inverted the outcome for every
+ * game the player was on team 0. Those rows are deterministically wrong, so flip
+ * the outcome for all team-0 rows once, then recompute aggregated stats. Guarded
+ * by a settings flag so it runs exactly once.
+ */
+const WINLOSS_FIX_FLAG = 'winloss_team0_outcome_fix_v1'
+function correctInvertedMatchOutcomes(database: Database.Database): void {
+    const done = database
+        .prepare('SELECT value FROM stats_settings WHERE key = ?')
+        .get(WINLOSS_FIX_FLAG) as { value: string } | undefined
+    if (done) return
+
+    const apply = database.transaction(() => {
+        const result = database
+            .prepare(
+                `UPDATE match_history
+                 SET match_outcome = CASE
+                     WHEN match_outcome = 'Win' THEN 'Loss'
+                     WHEN match_outcome = 'Loss' THEN 'Win'
+                     ELSE match_outcome
+                 END
+                 WHERE CAST(player_team AS INTEGER) = 0`
+            )
+            .run()
+
+        // Recompute aggregated stats for every account that has stored matches
+        // so totals/streaks/win-rate reflect the corrected outcomes.
+        const accounts = database
+            .prepare('SELECT DISTINCT account_id FROM match_history')
+            .all() as Array<{ account_id: number }>
+        for (const { account_id } of accounts) {
+            updateAggregatedStats(account_id)
+        }
+
+        database
+            .prepare('INSERT INTO stats_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+            .run(WINLOSS_FIX_FLAG, new Date().toISOString())
+
+        return result.changes
+    })
+
+    const changed = apply()
+    if (changed > 0) {
+        console.log(`[StatsDatabase] Corrected ${changed} inverted match outcome(s) (team-0 win/loss fix)`)
+    }
 }
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -572,6 +572,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             ipcRenderer.invoke('stats:getLocalMatchHistory', accountId, limit, offset),
         getLocalMatchCount: (accountId: number) =>
             ipcRenderer.invoke('stats:getLocalMatchCount', accountId),
+        recordMatches: (accountId: number, matches: unknown[]) =>
+            ipcRenderer.invoke('stats:recordMatches', accountId, matches),
         getLocalHeroStats: (accountId: number, heroId?: number) =>
             ipcRenderer.invoke('stats:getLocalHeroStats', accountId, heroId),
         getAggregatedStats: (accountId: number) =>

--- a/src/components/stats/tabs/OverviewTab.tsx
+++ b/src/components/stats/tabs/OverviewTab.tsx
@@ -113,7 +113,7 @@ export function OverviewTab() {
                                     key={match.match_id}
                                     matchId={match.match_id}
                                     heroId={match.hero_id}
-                                    outcome={match.match_outcome ?? (match.match_result === 1 ? 'Win' : 'Loss')}
+                                    outcome={match.match_outcome ?? (match.match_result === match.player_team ? 'Win' : 'Loss')}
                                     kills={match.kills ?? match.player_kills}
                                     deaths={match.deaths ?? match.player_deaths}
                                     assists={match.assists ?? match.player_assists}

--- a/src/stores/stats/playerStore.ts
+++ b/src/stores/stats/playerStore.ts
@@ -53,21 +53,30 @@ interface PlayerState {
 }
 
 async function fetchBundle(accountId: number): Promise<PlayerDataBundle> {
-    const [mmrData, mmrHistory, heroStats, matchHistory, aggregated, localMMR, localMatches] =
-        await Promise.all([
-            window.electronAPI.stats.getPlayerMMR([accountId]) as Promise<PlayerMMR[]>,
-            // Full per-match score history drives the trajectory chart; if the
-            // endpoint hiccups the chart falls back to local daily snapshots,
-            // so don't let it sink the whole bundle.
-            (window.electronAPI.stats.getPlayerMMRHistory(accountId) as Promise<
-                PlayerMMRHistoryEntry[]
-            >).catch(() => [] as PlayerMMRHistoryEntry[]),
-            window.electronAPI.stats.getPlayerHeroStats(accountId) as Promise<PlayerHeroStats>,
-            window.electronAPI.stats.getPlayerMatchHistory(accountId, 20) as Promise<PlayerMatchHistory>,
-            window.electronAPI.stats.getAggregatedStats(accountId) as Promise<AggregatedStats | null>,
-            window.electronAPI.stats.getLocalMMRHistory(accountId, 60) as Promise<MMRSnapshot[]>,
-            window.electronAPI.stats.getLocalMatchHistory(accountId, 100) as Promise<StoredMatch[]>,
-        ])
+    const [mmrData, mmrHistory, heroStats, matchHistory, localMMR] = await Promise.all([
+        window.electronAPI.stats.getPlayerMMR([accountId]) as Promise<PlayerMMR[]>,
+        // Full per-match score history drives the trajectory chart; if the
+        // endpoint hiccups the chart falls back to local daily snapshots,
+        // so don't let it sink the whole bundle.
+        (window.electronAPI.stats.getPlayerMMRHistory(accountId) as Promise<
+            PlayerMMRHistoryEntry[]
+        >).catch(() => [] as PlayerMMRHistoryEntry[]),
+        window.electronAPI.stats.getPlayerHeroStats(accountId) as Promise<PlayerHeroStats>,
+        window.electronAPI.stats.getPlayerMatchHistory(accountId, 20) as Promise<PlayerMatchHistory>,
+        window.electronAPI.stats.getLocalMMRHistory(accountId, 60) as Promise<MMRSnapshot[]>,
+    ])
+
+    // Persist the freshly fetched live matches into the local recorded history
+    // before reading it back, so the Matches tab (and the aggregated totals
+    // derived from those rows) include the newest games and stay in lockstep
+    // with the Overview recent-matches feed. Best-effort: a failed persist just
+    // leaves the Matches tab one sync behind, it doesn't break the page.
+    await window.electronAPI.stats.recordMatches(accountId, matchHistory.matches).catch(() => {})
+
+    const [aggregated, localMatches] = await Promise.all([
+        window.electronAPI.stats.getAggregatedStats(accountId) as Promise<AggregatedStats | null>,
+        window.electronAPI.stats.getLocalMatchHistory(accountId, 100) as Promise<StoredMatch[]>,
+    ])
     return {
         mmr: mmrData[0] || null,
         mmrHistory,

--- a/src/types/deadlock-stats.ts
+++ b/src/types/deadlock-stats.ts
@@ -102,7 +102,7 @@ export interface PlayerMatch {
   team_abandoned: boolean
   abandoned_time_s: number | null
   match_duration_s: number
-  match_result: number  // 0 = loss, 1 = win
+  match_result: number  // WINNING TEAM id (0 or 1); player won iff match_result === player_team
   objectives_mask_team0: number
   objectives_mask_team1: number
   username: string

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -898,6 +898,7 @@ export interface ElectronAPI {
         getLocalMMRHistory: (accountId: number, limit?: number) => Promise<unknown[]>;
         getLocalMatchHistory: (accountId: number, limit?: number, offset?: number) => Promise<unknown[]>;
         getLocalMatchCount: (accountId: number) => Promise<number>;
+        recordMatches: (accountId: number, matches: unknown[]) => Promise<void>;
         getLocalHeroStats: (accountId: number, heroId?: number) => Promise<unknown[]>;
         getAggregatedStats: (accountId: number) => Promise<unknown | null>;
 


### PR DESCRIPTION
## Summary

Fixes a set of Stats-page bugs reported by carcass in the Discord stats thread. The headline issue: **win/loss was inverted for ~half of all matches.**

The deadlock-api `/v1/players/{id}/match-history` field `match_result` is the **winning team id (0 or 1)**, not whether the player won. `getPlayerMatchHistory` mapped `match_result === 1 ? 'Win' : 'Loss'`, which inverted the outcome for every game the player was on team 0. This flipped win/loss badges, the overall win rate, and streaks (the local `stats.db` `match_history` stores the label and `updateAggregatedStats` SUMs it).

Verified against authoritative `/v1/matches/{id}/metadata` `winning_team`:
- match 89659924 (team 1, match_result 0, winning_team 0) -> player Lost
- match 89633796 (team 1, match_result 1, winning_team 1) -> player Won

On a sample account this rendered a true 53.9% winrate as 49.6%.

A second report (Overview "Last 8" and the Matches tab showing different newest games) was a live-vs-local freshness gap: Overview reads the live API feed, the Matches tab reads the local DB which only updated on a manual Refresh.

## Changes

- Derive outcome from `match_result === player_team` (service mapping + `OverviewTab` fallback).
- One-time DB correction: flip `match_outcome` for all stored team-0 rows and recompute aggregated stats, guarded by the `winloss_team0_outcome_fix_v1` settings flag so it runs exactly once.
- New `stats.recordMatches` IPC: persist live matches on player load so the recorded Match History tab stays in lockstep with the live Overview feed (also makes it auto-populate instead of needing a manual Refresh).

## Not addressed here (upstream / separate)

- Game count vs statlocker differs because deadlock-api stopped auto-ingesting ~1.5y ago (partial per-account history). Needs the planned match-loader ingestion, not a render fix. Hero win% is server-computed and was never affected by the inversion.
- carcass's request to match rank badge colors closer to in-game (separate UI tweak).

## Test plan

- `pnpm typecheck` clean
- `pnpm lint` clean on touched files
- Win/loss formula verified against live API + authoritative match metadata (both win and loss cases)
- DB correction is deterministic: every stored team-0 row was written by the buggy mapping and is therefore inverted; flipping them once is exact. Idempotent via the settings flag.

Reported by carcass in the Discord stats thread.