### PR TITLE
Honest download counts in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 
   [![Website](https://img.shields.io/badge/grimoiremods.com-f97316)](https://grimoiremods.com)
   [![Release](https://img.shields.io/github/v/release/Slush97/grimoire?label=release)](../../releases/latest)
-  [![Downloads](https://img.shields.io/github/downloads/Slush97/grimoire/total?label=downloads)](../../releases)
+  [![GitHub downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgrimoiremods.com%2Fapi%2Fdownloads-badge.json)](../../releases)
+  [![GameBanana downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgrimoiremods.com%2Fapi%2Fgamebanana-badge.json)](https://gamebanana.com/tools/22583)
+  [![apt installs](https://img.shields.io/endpoint?url=https%3A%2F%2Fgrimoiremods.com%2Fapi%2Fapt-badge.json)](https://apt.grimoiremods.com)
   [![AUR](https://img.shields.io/aur/version/grimoire-bin?label=aur)](https://aur.archlinux.org/packages/grimoire-bin)
   [![CI](https://img.shields.io/github/actions/workflow/status/Slush97/grimoire/ci.yml?branch=main&label=ci)](../../actions/workflows/ci.yml)
-  [![Translation status](https://translate.grimoiremods.com/widget/grimoire/svg-badge.svg)](https://translate.grimoiremods.com/engage/grimoire/)
   [![GameBanana](https://img.shields.io/badge/GameBanana-FCDC2A)](https://gamebanana.com/tools/22583)
   [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/KgYGHEMq2P)
   [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)

--- a/docs/apt-repo.md
+++ b/docs/apt-repo.md
@@ -12,9 +12,13 @@ manager channel that message refers to.
 
 ## How it works
 
-- Hosting: a Cloudflare **R2** bucket (`grimoire-apt`) exposed publicly through
-  the custom domain `apt.grimoiremods.com`. R2 has zero egress fees, so serving
-  large Electron debs costs effectively nothing.
+- Hosting: a Cloudflare **R2** bucket (`grimoire-apt`) served at
+  `apt.grimoiremods.com` by the `grimoire-apt` Worker (in the workspace root).
+  The Worker streams objects straight from the bucket (R2 has zero egress fees,
+  so serving large Electron debs costs effectively nothing) and additionally
+  tallies real `.deb` downloads in KV, which powers the apt install-count badge
+  in the README. It was originally a direct R2 custom domain with no counter;
+  see `../../grimoire-apt/README.md` for that Worker and its one-time cutover.
 - Publishing: the `apt-publish` job in `.github/workflows/release.yml` runs on
   each tagged release. It rebuilds a fresh, GPG-signed, **latest-only** repo
   from that release's `.deb` with `reprepro`, then syncs it to R2.


### PR DESCRIPTION
Replaces the inflated GitHub `downloads/total` badge (counted electron-updater `latest.yml` polls + `.blockmap` diffs, ~96k, ~85% non-installs) with an endpoint badge that counts real installer assets only (~13k). Adds GameBanana and apt install-count badges. Endpoints live in grimoire-site (`/api/*-badge.json`); apt count comes from the new grimoire-apt worker. Docs updated in `docs/apt-repo.md"`.