### PR TITLE
feat(locker): Spirit Urn global tab + GLB import

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -31,10 +31,11 @@ import {
 import { downloadMod } from '../services/download';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
 import { buildSoulContainerVpk, cleanupSoulContainerBuild, previewSoulContainerGlb } from '../services/soulContainerImport';
+import { buildSpiritUrnVpk, cleanupSpiritUrnBuild, previewSpiritUrnGlb } from '../services/spiritUrnImport';
 import { resolveModVpk, clearSoulModelCache } from '../services/soulContainerModels';
 import { getMainWindow } from '../index';
-import type { ImportCustomModArgs, ImportSoulContainerGlbArgs, PreviewSoulContainerGlbArgs, SoulContainerPreview } from '../../../src/types/electron';
-import type { AbilitySoundClassification, ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, AssociateUnknownModArgs, EditLocalModArgs, GlobalModType, LockerHeroSource, MergeModsArgs, Mod as WireMod, SoulContainerImportInfo, UnmergeModResult, ExtractMergeSourceResult, UnknownModFileList } from '../../../src/types/mod';
+import type { ImportCustomModArgs, ImportSoulContainerGlbArgs, PreviewSoulContainerGlbArgs, SoulContainerPreview, ImportSpiritUrnGlbArgs, PreviewSpiritUrnGlbArgs, SpiritUrnPreview } from '../../../src/types/electron';
+import type { AbilitySoundClassification, ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, AssociateUnknownModArgs, EditLocalModArgs, GlobalModType, LockerHeroSource, MergeModsArgs, Mod as WireMod, SoulContainerImportInfo, UrnImportInfo, UnmergeModResult, ExtractMergeSourceResult, UnknownModFileList } from '../../../src/types/mod';
 
 const unknownDetectionControllers = new Map<string, AbortController>();
 
@@ -204,6 +205,7 @@ function enrichMod(mod: Mod): WireMod {
             lockerSounds: metadata.lockerSounds,
             abilitySounds: abilitySounds ?? undefined,
             soulImport: metadata.soulImport,
+            urnImport: metadata.urnImport,
             ignoreUpdates: metadata.ignoreUpdates,
         };
     }
@@ -1026,6 +1028,125 @@ ipcMain.handle(
             // 4. Always remove the temp staging dir (the installed copy is
             //    byte-identical, so nothing is lost).
             await cleanupSoulContainerBuild(built.vpkPath);
+        }
+    }
+);
+
+// preview-spirit-urn-glb
+// Build the urn override VPK for the current orientation/span and export its
+// model back to a GLB so the import modal renders EXACTLY what loads in-game.
+// Mirrors preview-soul-container-glb.
+ipcMain.handle(
+    'preview-spirit-urn-glb',
+    async (_, args: PreviewSpiritUrnGlbArgs): Promise<SpiritUrnPreview> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const preview = await previewSpiritUrnGlb(deadlockPath, {
+            glbPath: args.glbPath,
+            name: 'preview',
+            orient: args.orient,
+            rotate: args.rotate,
+            ground: args.ground,
+            span: args.span,
+        });
+        return {
+            glbBase64: preview.glbBase64,
+            orient: preview.orient,
+            fitScale: preview.report.fitScale,
+            sourceSpan: preview.report.sourceSpan,
+            targetSpan: preview.report.targetSpan,
+        };
+    }
+);
+
+// import-spirit-urn-glb
+// Build a Spirit Urn override VPK from a user GLB (bundled `vpkmerge
+// soul-container import-urn`) and install it as a tracked local mod, mirroring
+// import-soul-container-glb. Urn imports all override the same model path
+// (idol_urn.vmdl_c), so two enabled at once would fight: when `replaceMetaKey`
+// is given we reuse that slot in place instead of allocating a new one.
+ipcMain.handle(
+    'import-spirit-urn-glb',
+    async (_, args: ImportSpiritUrnGlbArgs): Promise<Mod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const { glbPath, name, orient, rotate, ground, span, status, notes, nsfw, thumbnailDataUrl, replaceMetaKey } = args;
+        if (!name?.trim()) {
+            throw new Error('A name is required');
+        }
+
+        // 1. Build the override VPK to a temp staging path.
+        const built = await buildSpiritUrnVpk(deadlockPath, {
+            glbPath,
+            name: name.trim(),
+            orient,
+            rotate,
+            ground,
+            span,
+        });
+
+        try {
+            // 2. Resolve the destination slot: reuse the previous import's slot
+            //    when replacing (never stack two urns), else allocate the next
+            //    free ENABLED slot the same way import-soul-container-glb does.
+            let destPath: string | null = null;
+            let destMetaKey: string | null = null;
+            if (replaceMetaKey) {
+                destPath = await resolveModVpk(deadlockPath, replaceMetaKey);
+                if (destPath) destMetaKey = replaceMetaKey;
+            }
+            if (!destPath) {
+                destPath = await allocateEnabledVpkPath(deadlockPath);
+                destMetaKey = metaKeyFor(destPath);
+            }
+
+            await fs.copyFile(built.vpkPath, destPath);
+            // A reused slot may have a stale exported-GLB cache; drop it so the
+            // Locker tile re-exports the new model.
+            await clearSoulModelCache(destMetaKey!);
+
+            const urnImport: UrnImportInfo = {
+                glbFileName: basename(glbPath),
+                orient,
+                ...(rotate && (rotate[0] || rotate[1] || rotate[2]) ? { rotate } : {}),
+                ...(ground ? { ground } : {}),
+                span,
+                vpkmergeVersion: built.report.version,
+                fitScale: built.report.fitScale,
+                sourceSpan: built.report.sourceSpan,
+                targetSpan: built.report.targetSpan,
+                status: status ?? 'untested',
+            };
+
+            // 3. Scrub orphan metadata, then write the local-import entry. We set
+            //    globalType explicitly (always 'spirit-urn') so it lands in the
+            //    Locker's Global spirit-urn group immediately.
+            removeModMetadata(destMetaKey!);
+            await setModMetadataWithHash(
+                destMetaKey!,
+                {
+                    modName: name.trim(),
+                    thumbnailUrl: thumbnailDataUrl,
+                    nsfw: !!nsfw,
+                    sourceSection: 'SpiritUrnImport',
+                    globalType: 'spirit-urn',
+                    globalTypeClassifierVersion: GLOBAL_CLASSIFIER_VERSION,
+                    urnImport,
+                    ...(notes?.trim() ? { variantLabel: notes.trim() } : {}),
+                },
+                destPath
+            );
+
+            const mods = await scanMods(deadlockPath);
+            return mods.map(enrichMod);
+        } finally {
+            // 4. Always remove the temp staging dir (the installed copy is
+            //    byte-identical, so nothing is lost).
+            await cleanupSpiritUrnBuild(built.vpkPath);
         }
     }
 );

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -113,10 +113,10 @@ ipcMain.handle(
 
 ipcMain.handle(
     'export-soul-model',
-    async (_, metaKey: string, cacheKey: string): Promise<SoulModelInfo> => {
+    async (_, metaKey: string, cacheKey: string, entry?: string): Promise<SoulModelInfo> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) throw new Error('No Deadlock path configured');
-        return exportSoulModel(deadlockPath, metaKey, cacheKey);
+        return exportSoulModel(deadlockPath, metaKey, cacheKey, entry);
     }
 );
 

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -78,6 +78,10 @@ export interface ModMetadata {
      *  import. The orientation/glow transform + tracking status; presence marks
      *  the slot for idempotent re-import (replace the previous build). */
     soulImport?: import('../../../src/types/mod').SoulContainerImportInfo;
+    /** Set when this VPK was built from a user GLB via the Spirit Urn import.
+     *  The orientation/span transform + tracking status; presence marks the slot
+     *  for idempotent re-import (replace the previous build). */
+    urnImport?: import('../../../src/types/mod').UrnImportInfo;
     /** Load-order slot this mod last held while enabled. Disabled mods now
      *  get free-form filenames (no pakNN), so the priority is no longer encoded
      *  in the name; we stash it here on disable and try to restore it on enable

--- a/electron/main/services/soulContainerModels.ts
+++ b/electron/main/services/soulContainerModels.ts
@@ -43,6 +43,13 @@ const SOUL_CACHE_VERSION = '2';
  */
 export const SOUL_CONTAINER_ENTRY = 'models/props_gameplay/soul_container/soul_container.vmdl_c';
 
+/**
+ * Canonical Idol/urn model entry. A Spirit Urn import overrides this slot (its
+ * VPK packs the cloned model here), so the Locker tile exports THIS entry for an
+ * urn mod instead of the soul-container entry. See exportSoulModel's `entry` arg.
+ */
+export const URN_CONTAINER_ENTRY = 'models/props_gameplay/idol_urn/idol_urn.vmdl_c';
+
 function sanitize(value: string): string {
     return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }
@@ -195,11 +202,12 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
 export async function exportSoulModel(
     deadlockPath: string,
     metaKey: string,
-    cacheKey: string
+    cacheKey: string,
+    entry: string = SOUL_CONTAINER_ENTRY
 ): Promise<SoulModelInfo> {
     const vpk = await resolveModVpk(deadlockPath, metaKey);
     if (!vpk) {
-        throw new Error(`Soul-container VPK not found: ${metaKey}`);
+        throw new Error(`Prop-container VPK not found: ${metaKey}`);
     }
     const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
 
@@ -213,7 +221,7 @@ export async function exportSoulModel(
         '--vpk',
         vpk,
         '--entry',
-        SOUL_CONTAINER_ENTRY,
+        entry,
         '--base',
         pak01,
         '--out',

--- a/electron/main/services/spiritUrnImport.ts
+++ b/electron/main/services/spiritUrnImport.ts
@@ -1,0 +1,192 @@
+import { promises as fs, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { getCitadelPath } from './deadlock';
+import { runVpkmerge, runVpkmergeStdout, verifyVpkOutput } from './modMerger';
+import { stripGlbSkins, URN_CONTAINER_ENTRY } from './soulContainerModels';
+
+/**
+ * Build a Spirit Urn override VPK from a user GLB by spawning the bundled
+ * `vpkmerge soul-container import-urn`, writing it to a temp staging path. The
+ * IPC handler then installs the staged VPK as a tracked local mod and deletes
+ * the staging dir. Mirrors soulContainerImport.ts: the urn reuses the same clone
+ * pipeline retargeted at the carryable Idol/urn objective (`idol_urn.vmdl_c`),
+ * so it ships no soul-glow particles, has no spinning-orb yaw/upright recipe, and
+ * is sized by an explicit `span` instead of fitting the soul orb's bounds.
+ */
+
+export type UrnOrient = 'y-up' | 'z-up' | 'flip-y' | 'auto';
+
+export interface BuildSpiritUrnArgs {
+    glbPath: string;
+    /** Display name; sanitized to a safe VPK-internal material basename. */
+    name: string;
+    orient: UrnOrient;
+    /** Extra Euler degrees [X, Y, Z] applied after orient. */
+    rotate?: [number, number, number];
+    /** Lift the mesh so its base sits at the origin instead of being centered. */
+    ground?: boolean;
+    /** Largest-axis size in Source units to fit the import to. */
+    span: number;
+}
+
+/** Machine-readable report the CLI prints as a single JSON line on stdout. */
+export interface UrnImportCliReport {
+    orient?: string;
+    version?: string;
+    fitScale?: number;
+    sourceSpan?: number;
+    targetSpan?: number;
+    entryCount?: number;
+}
+
+export interface BuiltSpiritUrn {
+    /** Path of the built `pak01_dir.vpk` in its temp staging dir. */
+    vpkPath: string;
+    report: UrnImportCliReport;
+}
+
+/** A non-empty `[X, Y, Z]` rotation, or null when it's an effective no-op. */
+function nonZeroRotate(rotate?: [number, number, number]): [number, number, number] | null {
+    if (!rotate) return null;
+    return rotate[0] || rotate[1] || rotate[2] ? rotate : null;
+}
+
+/** A display name -> a safe lowercase `[a-z0-9_]` basename for VPK-internal paths. */
+function sanitizeName(name: string): string {
+    const cleaned = name
+        .toLowerCase()
+        .replace(/[^a-z0-9_]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .slice(0, 40);
+    return cleaned || 'custom_urn';
+}
+
+export async function buildSpiritUrnVpk(
+    deadlockPath: string,
+    args: BuildSpiritUrnArgs
+): Promise<BuiltSpiritUrn> {
+    if (!args.glbPath || !existsSync(args.glbPath)) {
+        throw new Error('GLB file not found');
+    }
+    if (!args.glbPath.toLowerCase().endsWith('.glb')) {
+        throw new Error('Selected file is not a .glb');
+    }
+    const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+    if (!existsSync(pak01)) {
+        throw new Error(
+            `Base game pak not found: ${pak01}. The urn import reads the stock envelope model and textures from it.`
+        );
+    }
+
+    // Staging dir: unique per build; the file must end in `_dir.vpk` for the
+    // engine's chunk-directory naming. We copy it into the addons slot and then
+    // delete this dir, so the import is byte-identical to the built VPK.
+    const stageDir = await fs.mkdtemp(join(tmpdir(), 'grimoire-urn-'));
+    const out = join(stageDir, 'pak01_dir.vpk');
+
+    const cliArgs = [
+        'soul-container',
+        'import-urn',
+        '--glb',
+        args.glbPath,
+        '--pak',
+        pak01,
+        '--out',
+        out,
+        '--name',
+        sanitizeName(args.name),
+        '--orient',
+        args.orient,
+        '--span',
+        `${args.span}`,
+    ];
+    const rotate = nonZeroRotate(args.rotate);
+    if (rotate) {
+        cliArgs.push('--rotate', `${rotate[0]},${rotate[1]},${rotate[2]}`);
+    }
+    if (args.ground) {
+        cliArgs.push('--ground');
+    }
+
+    let stdout = '';
+    try {
+        stdout = await runVpkmergeStdout(cliArgs);
+        await verifyVpkOutput(out);
+    } catch (err) {
+        await cleanupSpiritUrnBuild(out);
+        throw err;
+    }
+
+    // The CLI prints a one-line JSON report on stdout (human progress goes to
+    // stderr). Parse the last non-empty line; treat a parse miss as "no report"
+    // rather than failing a successful build.
+    let report: UrnImportCliReport = {};
+    try {
+        const line = stdout.trim().split('\n').filter(Boolean).pop() ?? '{}';
+        report = JSON.parse(line) as UrnImportCliReport;
+    } catch {
+        /* report is best-effort */
+    }
+
+    return { vpkPath: out, report };
+}
+
+/** Remove a staged build's temp directory. Safe to call on a partial build. */
+export async function cleanupSpiritUrnBuild(vpkPath: string): Promise<void> {
+    try {
+        await fs.rm(dirname(vpkPath), { recursive: true, force: true });
+    } catch {
+        /* best-effort cleanup */
+    }
+}
+
+export interface UrnPreview {
+    /** The built model exported back to a `.glb`, as base64. Renders in three.js
+     *  showing EXACTLY the in-game orientation (model export converts the packed
+     *  Source-space mesh back to glTF), so the preview can't drift from the build. */
+    glbBase64: string;
+    /** Resolved orientation label from the build (e.g. `y-up`, `auto:z-up`). */
+    orient: string;
+    report: UrnImportCliReport;
+}
+
+/**
+ * Build the urn VPK for the given args, export its model back to a GLB, and
+ * return the GLB bytes. The import preview renders this instead of a client-side
+ * transform so what the user orients is exactly what the build produces (and
+ * loads in-game). Both temp artifacts are cleaned up.
+ */
+export async function previewSpiritUrnGlb(
+    deadlockPath: string,
+    args: BuildSpiritUrnArgs
+): Promise<UrnPreview> {
+    const built = await buildSpiritUrnVpk(deadlockPath, args);
+    const glbOut = join(dirname(built.vpkPath), 'preview.glb');
+    try {
+        const pak01 = join(getCitadelPath(deadlockPath), 'pak01_dir.vpk');
+        await runVpkmerge([
+            'model',
+            'export',
+            '--vpk',
+            built.vpkPath,
+            '--entry',
+            URN_CONTAINER_ENTRY,
+            '--base',
+            pak01,
+            '--out',
+            glbOut,
+        ]);
+        // Drop the degenerate skin the static prop carries so three.js loads it as
+        // a plain mesh (same patch the soul-container export applies).
+        const raw = await fs.readFile(glbOut);
+        const patched = stripGlbSkins(raw);
+        return {
+            glbBase64: patched.toString('base64'),
+            orient: built.report.orient ?? args.orient,
+            report: built.report,
+        };
+    } finally {
+        await cleanupSpiritUrnBuild(built.vpkPath);
+    }
+}

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -466,6 +466,10 @@ const HERO_PAYLOAD_PATTERNS: RegExp[] = [
  * panorama/images/heroes/ folder holds both global packs and single-hero art.
  */
 const SOUL_CONTAINER_PATTERN = /(?:^|\/)models\/props_gameplay\/soul_container\//i;
+const URN_CONTAINER_PATTERN = /(?:^|\/)models\/props_gameplay\/idol_urn\//i;
+// Compiled model file. Used to break a soul-container/urn tie by which prop's
+// MODEL (not just incidental materials) the mod actually overrides.
+const VMDL_PATTERN = /\.vmdl_c?$/i;
 const HIDEOUT_PATTERN = /(?:^|\/)models\/hideout\//i;
 const HUD_PATTERN = /(?:^|\/)panorama\/(?:layout|styles|images\/hud)\//i;
 const HERO_IMAGE_PREFIX = /(?:^|\/)panorama\/images\/heroes\//i;
@@ -516,7 +520,7 @@ function heroImageCodenames(paths: string[]): Set<string> {
  * an older version, so pattern improvements (e.g. new HUD paths) reach
  * already-installed mods without a manual retag or a metadata migration.
  */
-export const GLOBAL_CLASSIFIER_VERSION = 1;
+export const GLOBAL_CLASSIFIER_VERSION = 3;
 
 export function classifyGlobalModType(paths: string[]): GlobalModType | null {
     if (paths.length === 0) return null;
@@ -524,7 +528,22 @@ export function classifyGlobalModType(paths: string[]): GlobalModType | null {
     if (paths.some((p) => HERO_PAYLOAD_PATTERNS.some((re) => re.test(p)))) {
         return null;
     }
-    if (paths.some((p) => SOUL_CONTAINER_PATTERN.test(p))) return 'soul-container';
+    // Soul containers and spirit urns are sibling props under props_gameplay.
+    // A single VPK can touch BOTH folders (e.g. a urn reskin that ships a stray
+    // soul_container material, or vice versa), so a plain soul-before-urn order
+    // would mis-file it. When both match, break the tie by which prop's actual
+    // MODEL (.vmdl_c) is overridden: that's the prop the mod really reskins.
+    // Texture-only packs (a model in neither folder) keep the soul-first
+    // precedence, preserving the existing texture-only soul-container behavior.
+    const hasSoul = paths.some((p) => SOUL_CONTAINER_PATTERN.test(p));
+    const hasUrn = paths.some((p) => URN_CONTAINER_PATTERN.test(p));
+    if (hasSoul && hasUrn) {
+        const soulModel = paths.some((p) => SOUL_CONTAINER_PATTERN.test(p) && VMDL_PATTERN.test(p));
+        const urnModel = paths.some((p) => URN_CONTAINER_PATTERN.test(p) && VMDL_PATTERN.test(p));
+        return urnModel && !soulModel ? 'spirit-urn' : 'soul-container';
+    }
+    if (hasSoul) return 'soul-container';
+    if (hasUrn) return 'spirit-urn';
     if (paths.some((p) => HIDEOUT_PATTERN.test(p))) return 'hideout';
 
     const heroImages = heroImageCodenames(paths);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -38,6 +38,8 @@ import type {
     ImportCustomModArgs,
     ImportSoulContainerGlbArgs,
     PreviewSoulContainerGlbArgs,
+    ImportSpiritUrnGlbArgs,
+    PreviewSpiritUrnGlbArgs,
     SearchLocalModsOptions,
     CrosshairSettings,
     VanillaRestoreResult,
@@ -142,8 +144,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('get-applied-custom-card', heroName),
     getSoulModelInfo: (key: string) =>
         ipcRenderer.invoke('get-soul-model-info', key),
-    exportSoulModel: (metaKey: string, cacheKey: string) =>
-        ipcRenderer.invoke('export-soul-model', metaKey, cacheKey),
+    exportSoulModel: (metaKey: string, cacheKey: string, entry?: string) =>
+        ipcRenderer.invoke('export-soul-model', metaKey, cacheKey, entry),
     getHeroPoseInfo: (heroName: string, skinSources?: unknown[]) =>
         ipcRenderer.invoke('get-hero-pose-info', heroName, skinSources),
     exportHeroPose: (heroName: string, skinSources?: unknown[], fallbackSkinMetaKey?: string) =>
@@ -225,6 +227,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('import-soul-container-glb', args),
     previewSoulContainerGlb: (args: PreviewSoulContainerGlbArgs) =>
         ipcRenderer.invoke('preview-soul-container-glb', args),
+    importSpiritUrnGlb: (args: ImportSpiritUrnGlbArgs) =>
+        ipcRenderer.invoke('import-spirit-urn-glb', args),
+    previewSpiritUrnGlb: (args: PreviewSpiritUrnGlbArgs) =>
+        ipcRenderer.invoke('preview-spirit-urn-glb', args),
     readGlbFile: (glbPath: string) =>
         ipcRenderer.invoke('read-glb-file', glbPath),
     readImageDataUrl: (imagePath: string) =>

--- a/src/components/locker/SoulContainerTile.tsx
+++ b/src/components/locker/SoulContainerTile.tsx
@@ -29,6 +29,7 @@ import { useSoulRegistry } from './soulRegistry';
 export default function SoulContainerTile({
   tileId,
   modKey,
+  entry,
 }: {
   /** Content-stable id (sha256) used as the registry key, so the model survives
    *  the metaKey change that a toggle causes. */
@@ -37,6 +38,9 @@ export default function SoulContainerTile({
    *  Changes when the mod is enabled/disabled (the VPK is renamed); the export
    *  CACHE is keyed by the content-stable tileId instead, not this. */
   modKey: string;
+  /** Model entry to export. Defaults to the soul-container model; a spirit urn
+   *  passes its own entry (`idol_urn.vmdl_c`) so the tile shows the urn model. */
+  entry?: string;
 }) {
   const registry = useSoulRegistry();
   const trackRef = useRef<HTMLDivElement>(null);
@@ -66,7 +70,7 @@ export default function SoulContainerTile({
           // Spinner only when there's nothing to show yet; on a reload (toggle)
           // the existing model keeps rendering instead.
           if (!rootRef.current) setGenerating(true);
-          info = await exportSoulModel(modKey, tileId);
+          info = await exportSoulModel(modKey, tileId, entry);
           if (cancelled) return;
           setGenerating(false);
         }
@@ -100,7 +104,7 @@ export default function SoulContainerTile({
     return () => {
       cancelled = true;
     };
-  }, [tileId, modKey, registry]);
+  }, [tileId, modKey, entry, registry]);
 
   // Unregister and free the model only on true unmount (tileId is stable, so
   // this does not run on a toggle).

--- a/src/components/locker/SpiritUrnImportModal.tsx
+++ b/src/components/locker/SpiritUrnImportModal.tsx
@@ -1,0 +1,652 @@
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import * as THREE from 'three';
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Box,
+  Loader2,
+  Pause,
+  Play,
+  RefreshCw,
+  RotateCcw,
+  RotateCw,
+  Shuffle,
+  UploadCloud,
+  X,
+} from 'lucide-react';
+import { importSpiritUrnGlb, previewSpiritUrnGlb, showOpenDialog } from '../../lib/api';
+import { parseGltfPreview } from '../../lib/loadGltfPreview';
+import { computeSceneStats, deriveNameFromPath, TRIANGLE_WARN_THRESHOLD } from '../../lib/soulImport';
+import { useAppStore } from '../../stores/appStore';
+import type { Mod } from '../../types/mod';
+import { FormField, Input } from '../common/forms';
+import SoulImportPreview from './SoulImportPreview';
+import { SOUL_BACKDROP_COUNT } from './soulBackdrops';
+import { disposeScene } from './soulModel';
+
+type UrnOrientMode = 'y-up' | 'z-up' | 'flip-y' | 'auto';
+
+interface SpiritUrnImportModalProps {
+  onClose: () => void;
+  onImported: (mods: Mod[]) => void;
+  /** Enabled urn imports already installed (conflict handling). */
+  existingUrnImports: Mod[];
+  /** Optional pre-resolved GLB path (e.g. from a drop onto the page). */
+  initialGlbPath?: string;
+}
+
+const ORIENT_OPTIONS: { value: UrnOrientMode; labelKey: string }[] = [
+  { value: 'y-up', labelKey: 'locker.soulImport.orient.yUp' },
+  { value: 'z-up', labelKey: 'locker.soulImport.orient.zUp' },
+  { value: 'flip-y', labelKey: 'locker.soulImport.orient.flipY' },
+  { value: 'auto', labelKey: 'locker.soulImport.orient.auto' },
+];
+
+// Default urn size in Source units (matches the CLI's `--span` default). The
+// real urn is bigger than a soul orb, so this is the size yardstick.
+const DEFAULT_SPAN = 28;
+
+function describeScene(
+  scene: THREE.Object3D,
+  t: TFunction
+): { meshCount: number; triangleCount: number; label: string } {
+  const stats = computeSceneStats(scene);
+  if (!stats.meshCount || !stats.hasBounds) {
+    return {
+      meshCount: stats.meshCount,
+      triangleCount: stats.triangleCount,
+      label: t('locker.soulImport.preview.noMeshGeometry'),
+    };
+  }
+  return {
+    meshCount: stats.meshCount,
+    triangleCount: stats.triangleCount,
+    label: t('locker.soulImport.preview.statsLabel', {
+      count: stats.meshCount,
+      verts: stats.vertexCount.toLocaleString(),
+      span: stats.span.toFixed(2),
+    }),
+  };
+}
+
+export default function SpiritUrnImportModal({
+  onClose,
+  onImported,
+  existingUrnImports,
+  initialGlbPath = '',
+}: SpiritUrnImportModalProps) {
+  const { t } = useTranslation();
+  const toggleMod = useAppStore((s) => s.toggleMod);
+  const [glbPath, setGlbPath] = useState<string>(initialGlbPath);
+  const [name, setName] = useState<string>(initialGlbPath ? deriveNameFromPath(initialGlbPath) : '');
+  const [scene, setScene] = useState<THREE.Object3D | null>(null);
+  const [orientMode, setOrientMode] = useState<UrnOrientMode>('auto');
+  const [rotate, setRotate] = useState<[number, number, number]>([0, 0, 0]);
+  const [span, setSpan] = useState<number>(DEFAULT_SPAN);
+  const [ground, setGround] = useState<boolean>(false);
+  const [resolvedOrient, setResolvedOrient] = useState<string | null>(null);
+  const [spinning, setSpinning] = useState(true);
+  const [nsfw, setNsfw] = useState(false);
+  const [notes, setNotes] = useState('');
+  // When another urn is already enabled, default to disabling it (single in-game
+  // slot) rather than overwriting it: the old one stays in the library, just off.
+  const [disableExisting, setDisableExisting] = useState(true);
+  const [backdropIndex, setBackdropIndex] = useState(() =>
+    Math.floor(Math.random() * SOUL_BACKDROP_COUNT)
+  );
+  const [building, setBuilding] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const [previewStats, setPreviewStats] = useState<string | null>(null);
+  const [triangleCount, setTriangleCount] = useState(0);
+
+  const captureRef = useRef<(() => string | null) | null>(null);
+  // Track the live scene so we can dispose its GPU resources on swap/unmount.
+  const sceneRef = useRef<THREE.Object3D | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (sceneRef.current) disposeScene(sceneRef.current);
+    };
+  }, []);
+
+  const hasRotation = rotate[0] !== 0 || rotate[1] !== 0 || rotate[2] !== 0;
+
+  // Preview the actual built artifact: vpkmerge imports the source GLB into an
+  // urn override VPK, then exports that model back to GLB for three.js.
+  useEffect(() => {
+    if (!glbPath) return;
+    let cancelled = false;
+    setBuilding(true);
+    setError(null);
+    setResolvedOrient(null);
+    setPreviewStats(null);
+    setTriangleCount(0);
+
+    const handle = window.setTimeout(() => {
+      (async () => {
+        try {
+          const preview = await previewSpiritUrnGlb({
+            glbPath,
+            orient: orientMode,
+            rotate: hasRotation ? rotate : undefined,
+            ground,
+            span,
+          });
+          const gltf = await parseGltfPreview(preview.glb);
+          if (cancelled) {
+            disposeScene(gltf.scene);
+            return;
+          }
+          if (sceneRef.current) disposeScene(sceneRef.current);
+          sceneRef.current = gltf.scene;
+          setScene(gltf.scene);
+          setResolvedOrient(preview.orient);
+          const stats = describeScene(gltf.scene, t);
+          setPreviewStats(stats.label);
+          setTriangleCount(stats.triangleCount);
+          if (stats.meshCount === 0) setError(t('locker.soulImport.errors.noMeshGeometry'));
+        } catch (err) {
+          if (!cancelled) {
+            if (sceneRef.current) disposeScene(sceneRef.current);
+            sceneRef.current = null;
+            setScene(null);
+            setPreviewStats(null);
+            setTriangleCount(0);
+            setError(t('locker.urnImport.errors.previewFailed', { error: String(err) }));
+          }
+        } finally {
+          if (!cancelled) setBuilding(false);
+        }
+      })();
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [glbPath, orientMode, rotate, span, ground, hasRotation, t]);
+
+  const acceptGlbPath = (picked: string) => {
+    setError(null);
+    setGlbPath(picked);
+    if (!name.trim()) setName(deriveNameFromPath(picked));
+  };
+
+  const pickGlb = async () => {
+    const picked = await showOpenDialog({
+      title: t('locker.soulImport.dialog.title'),
+      filters: [{ name: t('locker.soulImport.dialog.filterName'), extensions: ['glb'] }],
+    });
+    if (picked) acceptGlbPath(picked);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    if (!/\.glb$/i.test(file.name)) {
+      setError(t('locker.soulImport.errors.expectedGlb', { name: file.name }));
+      return;
+    }
+    const path = window.electronAPI.getDroppedFilePath(file);
+    if (!path) {
+      setError(t('locker.soulImport.errors.dropPathUnresolved'));
+      return;
+    }
+    acceptGlbPath(path);
+  };
+
+  const bumpAxis = (axis: 0 | 1 | 2, delta: number) => {
+    setRotate((r) => {
+      const next: [number, number, number] = [...r];
+      next[axis] = ((next[axis] + delta) % 360 + 360) % 360;
+      return next;
+    });
+  };
+
+  const setAxis = (axis: 0 | 1 | 2, value: number) => {
+    setRotate((r) => {
+      const next: [number, number, number] = [...r];
+      next[axis] = Number.isFinite(value) ? value : 0;
+      return next;
+    });
+  };
+
+  const rerollBackdrop = () => {
+    setBackdropIndex((current) => {
+      if (SOUL_BACKDROP_COUNT <= 1) return current;
+      let next = current;
+      while (next === current) next = Math.floor(Math.random() * SOUL_BACKDROP_COUNT);
+      return next;
+    });
+  };
+
+  const modeLabel = hasRotation
+    ? resolvedOrient
+      ? t('locker.soulImport.orient.customRotationResolved', { orient: resolvedOrient })
+      : t('locker.soulImport.orient.customRotation')
+    : (resolvedOrient ?? orientMode);
+
+  const canSubmit = !!glbPath && !!scene && !!name.trim() && span > 0 && !submitting && !building;
+  const highPoly = triangleCount > TRIANGLE_WARN_THRESHOLD;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const thumbnailDataUrl = captureRef.current?.() ?? undefined;
+      const mods = await importSpiritUrnGlb({
+        glbPath,
+        name: name.trim(),
+        orient: orientMode,
+        rotate: hasRotation ? rotate : undefined,
+        ground,
+        span,
+        status: 'untested',
+        notes: notes.trim() || undefined,
+        nsfw,
+        thumbnailDataUrl,
+      });
+      // The new import lands enabled. When the user chose to disable the old one
+      // (single in-game slot), turn off the previously enabled urns; they stay in
+      // the library, just off. "Keep both" skips this.
+      if (disableExisting) {
+        for (const existing of existingUrnImports) {
+          if (existing.enabled) await toggleMod(existing.id);
+        }
+      }
+      onImported(mods);
+      onClose();
+    } catch (err) {
+      setError(String(err));
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-bg-secondary border border-border rounded-xl w-full max-w-3xl max-h-[92vh] flex flex-col">
+        <div className="flex items-center justify-between p-5 border-b border-border">
+          <h3 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+            <Box className="w-5 h-5" />
+            {t('locker.urnImport.title')}
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-text-primary rounded cursor-pointer"
+            aria-label={t('common.actions.close')}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 overflow-y-auto grid grid-cols-1 md:grid-cols-2 gap-5">
+          {/* Left: source picker + live preview */}
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1.5">
+                {t('locker.soulImport.fields.source')}
+              </label>
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label={glbPath ? t('locker.soulImport.dropzone.ariaSelected', { path: glbPath }) : t('locker.soulImport.dropzone.ariaBrowse')}
+                onClick={pickGlb}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void pickGlb();
+                  }
+                }}
+                onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
+                onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setDragActive(true); }}
+                onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
+                onDrop={handleDrop}
+                className={`flex flex-col items-center justify-center gap-1 px-4 py-3 rounded-lg border border-dashed text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                  dragActive
+                    ? 'border-accent bg-accent/10'
+                    : glbPath
+                      ? 'border-accent/40 bg-bg-tertiary/60 cursor-pointer hover:bg-bg-tertiary'
+                      : 'border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-white/20'
+                }`}
+              >
+                <UploadCloud className="w-5 h-5 text-text-secondary" aria-hidden />
+                {glbPath ? (
+                  <span className="text-sm text-text-primary font-medium truncate max-w-full">
+                    {glbPath.split(/[\\/]/).pop()}
+                  </span>
+                ) : (
+                  <span className="text-sm text-text-primary font-medium">
+                    {t('locker.soulImport.dropzone.prompt')}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Preview surface: kept square so the urn reads consistently and the
+                canvas never stretches. */}
+            <div className="relative w-full aspect-square rounded-lg border border-border bg-bg-tertiary/40 overflow-hidden">
+              {scene ? (
+                <Suspense fallback={null}>
+                  <SoulImportPreview
+                    scene={scene}
+                    orientMode="y-up"
+                    rotate={[0, 0, 0]}
+                    showVanilla={false}
+                    spinning={spinning}
+                    backdropIndex={backdropIndex}
+                    captureRef={captureRef}
+                  />
+                </Suspense>
+              ) : (
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-xs text-text-secondary">
+                  {!glbPath && (
+                    <>
+                      <Box className="w-8 h-8 text-text-secondary/40" aria-hidden />
+                      <span>{t('locker.urnImport.dropzone.previewEmpty')}</span>
+                    </>
+                  )}
+                </div>
+              )}
+              {building && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+                  <Loader2 className="w-6 h-6 animate-spin text-white/80" />
+                </div>
+              )}
+              {scene && (
+                <>
+                  {previewStats && (
+                    <span
+                      className="absolute top-2 left-2 z-10 max-w-[60%] truncate px-2 py-0.5 rounded bg-black/50 text-[11px] text-text-secondary"
+                      title={previewStats}
+                    >
+                      {previewStats}
+                    </span>
+                  )}
+
+                  <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 text-[11px]">
+                    <button
+                      type="button"
+                      onClick={() => setSpinning((s) => !s)}
+                      className="p-1 rounded bg-black/50 text-text-secondary hover:text-text-primary cursor-pointer"
+                      title={spinning ? t('locker.soulImport.preview.pause') : t('locker.soulImport.preview.play')}
+                      aria-label={spinning ? t('locker.soulImport.preview.pause') : t('locker.soulImport.preview.play')}
+                    >
+                      {spinning ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={rerollBackdrop}
+                      className="p-1 rounded bg-black/50 text-text-secondary hover:text-text-primary cursor-pointer"
+                      title={t('locker.soulImport.preview.shuffleBackdrop')}
+                      aria-label={t('locker.soulImport.preview.shuffleBackdrop')}
+                    >
+                      <Shuffle className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+
+                  {/* Up/down quarter-turn the pre-swizzle pitch (rotate X) to
+                      upright the mesh. */}
+                  <button
+                    type="button"
+                    onClick={() => bumpAxis(0, 90)}
+                    className="absolute top-1.5 left-1/2 -translate-x-1/2 z-10 p-1 rounded-full bg-black/45 text-white/80 hover:bg-black/70 hover:text-white cursor-pointer"
+                    aria-label={t('locker.soulImport.orient.tiltUp')}
+                  >
+                    <ArrowUp className="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => bumpAxis(0, -90)}
+                    className="absolute bottom-9 left-1/2 -translate-x-1/2 z-10 p-1 rounded-full bg-black/45 text-white/80 hover:bg-black/70 hover:text-white cursor-pointer"
+                    aria-label={t('locker.soulImport.orient.tiltDown')}
+                  >
+                    <ArrowDown className="w-4 h-4" />
+                  </button>
+
+                  <div className="absolute bottom-2 left-2 right-2 z-10 flex items-center justify-between gap-2 text-[11px]">
+                    <span className="px-2 py-0.5 rounded bg-black/50 text-text-secondary truncate">
+                      {t('locker.soulImport.preview.orientationLabel')} <span className="text-text-primary">{modeLabel}</span>
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Right: controls */}
+          <div className="space-y-4">
+            <FormField label={t('locker.soulImport.fields.name')} required>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t('locker.urnImport.fields.namePlaceholder')}
+              />
+            </FormField>
+
+            {/* Orientation */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1.5">{t('locker.soulImport.orient.label')}</label>
+              <div className="grid grid-cols-4 gap-1.5 mb-2">
+                {ORIENT_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setOrientMode(opt.value)}
+                    className={`px-2 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+                      orientMode === opt.value
+                        ? 'border-accent/60 bg-accent/15 text-text-primary'
+                        : 'border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary'
+                    }`}
+                  >
+                    {t(opt.labelKey)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Rotation nudges */}
+              <div className="space-y-1.5">
+                {(['X', 'Y', 'Z'] as const).map((axisLabel, axis) => (
+                  <div key={axisLabel} className="flex items-center gap-1.5">
+                    <span className="w-4 text-xs font-mono text-text-secondary">{axisLabel}</span>
+                    <button
+                      onClick={() => bumpAxis(axis as 0 | 1 | 2, -90)}
+                      className="p-1.5 rounded border border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary cursor-pointer"
+                      aria-label={t('locker.soulImport.orient.rotateMinus', { axis: axisLabel })}
+                    >
+                      <RotateCcw className="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      onClick={() => bumpAxis(axis as 0 | 1 | 2, 90)}
+                      className="p-1.5 rounded border border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary cursor-pointer"
+                      aria-label={t('locker.soulImport.orient.rotatePlus', { axis: axisLabel })}
+                    >
+                      <RotateCw className="w-3.5 h-3.5" />
+                    </button>
+                    <input
+                      type="number"
+                      value={rotate[axis]}
+                      onChange={(e) => setAxis(axis as 0 | 1 | 2, parseFloat(e.target.value))}
+                      step={15}
+                      className="w-16 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs text-text-primary focus:outline-none focus:border-accent"
+                      aria-label={t('locker.soulImport.orient.axisDegrees', { axis: axisLabel })}
+                    />
+                    <span className="text-[11px] text-text-secondary">{t('locker.soulImport.orient.deg')}</span>
+                  </div>
+                ))}
+                <div className="flex gap-1.5 pt-0.5">
+                  <button
+                    onClick={() => bumpAxis(0, 180)}
+                    className="flex-1 px-2 py-1 rounded border border-border bg-bg-tertiary/60 text-xs text-text-secondary hover:bg-bg-tertiary cursor-pointer"
+                  >
+                    {t('locker.soulImport.orient.flipVertical')}
+                  </button>
+                  <button
+                    onClick={() => setRotate([0, 0, 0])}
+                    className="flex-1 px-2 py-1 rounded border border-border bg-bg-tertiary/60 text-xs text-text-secondary hover:bg-bg-tertiary cursor-pointer flex items-center justify-center gap-1"
+                  >
+                    <RefreshCw className="w-3 h-3" /> {t('common.actions.reset')}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Size: largest-axis span in Source units + ground toggle */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-1.5">
+                {t('locker.urnImport.size.label')}
+              </label>
+              <div className="flex items-center gap-2 mb-2">
+                <input
+                  type="range"
+                  min={6}
+                  max={64}
+                  step={1}
+                  value={span}
+                  onChange={(e) => setSpan(parseFloat(e.target.value) || DEFAULT_SPAN)}
+                  className="flex-1 accent-accent cursor-pointer"
+                  aria-label={t('locker.urnImport.size.label')}
+                />
+                <input
+                  type="number"
+                  value={span}
+                  min={1}
+                  step={1}
+                  onChange={(e) => setSpan(parseFloat(e.target.value) || 0)}
+                  className="w-16 px-2 py-1 bg-bg-tertiary border border-border rounded text-xs text-text-primary focus:outline-none focus:border-accent"
+                  aria-label={t('locker.urnImport.size.label')}
+                />
+                <span className="text-[11px] text-text-secondary">{t('locker.urnImport.size.units')}</span>
+                <button
+                  type="button"
+                  onClick={() => setSpan(DEFAULT_SPAN)}
+                  disabled={span === DEFAULT_SPAN}
+                  className="p-1.5 rounded border border-border bg-bg-tertiary/60 text-text-secondary hover:bg-bg-tertiary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  aria-label={t('common.actions.reset')}
+                >
+                  <RefreshCw className="w-3 h-3" />
+                </button>
+              </div>
+              <p className="text-[11px] text-text-secondary mb-2">{t('locker.urnImport.size.hint')}</p>
+              <label className="flex items-center gap-2 text-xs text-text-secondary cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={ground}
+                  onChange={(e) => setGround(e.target.checked)}
+                  className="accent-accent cursor-pointer"
+                />
+                <span>{t('locker.urnImport.ground.label')}</span>
+              </label>
+            </div>
+
+            <FormField
+              label={
+                <>
+                  {t('locker.soulImport.fields.notes')}{' '}
+                  <span className="text-text-secondary font-normal">{t('locker.soulImport.fields.notesOptional')}</span>
+                </>
+              }
+            >
+              <Input
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder={t('locker.soulImport.fields.notesPlaceholder')}
+              />
+            </FormField>
+
+            <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={nsfw}
+                onChange={(e) => setNsfw(e.target.checked)}
+                className="w-4 h-4 accent-accent cursor-pointer"
+              />
+              {t('locker.soulImport.fields.nsfw')}
+            </label>
+          </div>
+        </div>
+
+        {/* High-poly + error notices, full width above the footer. */}
+        <div className="px-5 space-y-3">
+          {highPoly && (
+            <div className="flex items-start gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3">
+              <AlertTriangle className="w-4 h-4 shrink-0 mt-px" />
+              <span>
+                {t('locker.urnImport.highPolyWarning', {
+                  count: triangleCount.toLocaleString(),
+                  threshold: TRIANGLE_WARN_THRESHOLD.toLocaleString(),
+                })}
+              </span>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-sm text-state-danger bg-red-500/10 border border-red-500/30 rounded-lg p-2">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 p-5 border-t border-border mt-3">
+          {existingUrnImports.length > 0 && (
+            <div
+              className="flex min-w-0 items-center gap-2 text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2"
+              title={t('locker.urnImport.conflict.body', { name: existingUrnImports[0].name })}
+            >
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate text-amber-200/90">{t('locker.urnImport.conflict.heading')}</span>
+              <div className="flex shrink-0 overflow-hidden rounded-md border border-amber-500/40">
+                <button
+                  onClick={() => setDisableExisting(true)}
+                  className={`px-2.5 py-1 text-[11px] cursor-pointer transition-colors ${
+                    disableExisting
+                      ? 'bg-accent/25 text-text-primary'
+                      : 'text-amber-200/70 hover:bg-amber-500/10'
+                  }`}
+                >
+                  {t('locker.soulImport.conflict.disableCurrent')}
+                </button>
+                <button
+                  onClick={() => setDisableExisting(false)}
+                  className={`px-2.5 py-1 text-[11px] cursor-pointer border-l border-amber-500/40 transition-colors ${
+                    !disableExisting
+                      ? 'bg-accent/25 text-text-primary'
+                      : 'text-amber-200/70 hover:bg-amber-500/10'
+                  }`}
+                >
+                  {t('locker.soulImport.conflict.keepBoth')}
+                </button>
+              </div>
+            </div>
+          )}
+          <div className="flex justify-end gap-3 ml-auto shrink-0">
+            <button
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 bg-bg-tertiary border border-border rounded-lg hover:bg-bg-secondary transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {t('common.actions.cancel')}
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-4 py-2 border border-accent/40 bg-accent/10 hover:bg-accent/20 hover:border-accent/60 text-text-primary rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+              {t('locker.soulImport.submit')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -191,8 +191,8 @@ export async function getSoulModelInfo(key: string): Promise<SoulModelInfo> {
  *  SOURCE VPK is located by `metaKey` (folder-qualified for overflow mods); the
  *  cache is keyed by `cacheKey` (the mod's content-stable sha256) so an
  *  enable/disable rename can't serve a different soul's stale export. */
-export async function exportSoulModel(metaKey: string, cacheKey: string): Promise<SoulModelInfo> {
-  return window.electronAPI.exportSoulModel(metaKey, cacheKey);
+export async function exportSoulModel(metaKey: string, cacheKey: string, entry?: string): Promise<SoulModelInfo> {
+  return window.electronAPI.exportSoulModel(metaKey, cacheKey, entry);
 }
 
 /** Whether a hero's posed 3D still exists for the given active skin stack (+ mtime, key). */
@@ -407,6 +407,27 @@ export async function previewSoulContainerGlb(
   args: import('../types/electron').PreviewSoulContainerGlbArgs
 ): Promise<{ glb: ArrayBuffer; orient: string; fitScale?: number; sourceSpan?: number; targetSpan?: number }> {
   const res = await window.electronAPI.previewSoulContainerGlb(args);
+  const binary = atob(res.glbBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return { glb: bytes.buffer, orient: res.orient, fitScale: res.fitScale, sourceSpan: res.sourceSpan, targetSpan: res.targetSpan };
+}
+
+/** Build a Spirit Urn override VPK from a user GLB and install it as a tracked
+ *  local mod. Returns the full enriched mod list after install. */
+export async function importSpiritUrnGlb(
+  args: import('../types/electron').ImportSpiritUrnGlbArgs
+): Promise<Mod[]> {
+  return window.electronAPI.importSpiritUrnGlb(args);
+}
+
+/** Build the urn for the given orientation/span and export its model to a GLB
+ *  for the import preview. Returns the GLB as an ArrayBuffer + the resolved
+ *  orientation label and fitted bounds. */
+export async function previewSpiritUrnGlb(
+  args: import('../types/electron').PreviewSpiritUrnGlbArgs
+): Promise<{ glb: ArrayBuffer; orient: string; fitScale?: number; sourceSpan?: number; targetSpan?: number }> {
+  const res = await window.electronAPI.previewSpiritUrnGlb(args);
   const binary = atob(res.glbBase64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -444,6 +444,7 @@ export function countLockerSkins(mods: Mod[]): number {
  */
 export const GLOBAL_MOD_TYPE_LABELS: Record<GlobalModType, string> = {
   'soul-container': 'Soul Containers',
+  'spirit-urn': 'Spirit Urns',
   hideout: 'Hideout',
   icons: 'Icon Packs',
   hud: 'HUD',
@@ -454,12 +455,28 @@ export const GLOBAL_MOD_TYPE_LABELS: Record<GlobalModType, string> = {
 /** Carousel/section order for the global types. */
 export const GLOBAL_MOD_TYPE_ORDER: readonly GlobalModType[] = [
   'soul-container',
+  'spirit-urn',
   'hideout',
   'icons',
   'hud',
   'announcer',
   'killstreak-music',
 ];
+
+/**
+ * Global types that are a single imported static prop shown with a live 3D
+ * preview and treated as single-select (one in-game slot, so enabling one
+ * disables the others of the same type). Soul containers and spirit urns both
+ * override one prop model and share the GLB-import + 3D-tile treatment. Centralized
+ * so the Locker UI branches (single-select toggle, 3D tile, content-stable key,
+ * frosted glass, active badge) stay in sync across both types.
+ */
+export const PROP_CONTAINER_GLOBAL_TYPES: readonly GlobalModType[] = ['soul-container', 'spirit-urn'];
+
+/** Whether a global type is an imported-prop container (soul container or urn). */
+export function isPropContainerType(type: GlobalModType | undefined | null): boolean {
+  return type === 'soul-container' || type === 'spirit-urn';
+}
 
 export type GlobalModGroups = Record<GlobalModType, Mod[]>;
 
@@ -476,6 +493,7 @@ export type GlobalModGroups = Record<GlobalModType, Mod[]>;
 export function groupGlobalMods(mods: Mod[]): GlobalModGroups {
   const groups: GlobalModGroups = {
     'soul-container': [],
+    'spirit-urn': [],
     hideout: [],
     icons: [],
     hud: [],
@@ -489,7 +507,7 @@ export function groupGlobalMods(mods: Mod[]): GlobalModGroups {
     }
   }
   for (const type of GLOBAL_MOD_TYPE_ORDER) {
-    if (type === 'soul-container') {
+    if (isPropContainerType(type)) {
       groups[type].sort((a, b) => a.name.localeCompare(b.name) || a.priority - b.priority);
     } else {
       groups[type].sort((a, b) => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -998,7 +998,8 @@
       "activeBadgeTitle": "This soul container is active and loaded in-game",
       "disabledBadge": "Disabled",
       "disabledBadgeTitle": "This mod is disabled and not loaded in-game",
-      "deleteMod": "Delete {{name}}"
+      "deleteMod": "Delete {{name}}",
+      "propEmpty": "No {{type}} installed yet. Import one from a 3D model (.glb) to get started."
     },
     "soulImport": {
       "trigger": {
@@ -1083,6 +1084,36 @@
       "dialog": {
         "title": "Select a GLB model",
         "filterName": "glTF binary"
+      }
+    },
+    "urnImport": {
+      "trigger": {
+        "label": "Import Spirit Urn (GLB)",
+        "ariaLabel": "Import spirit urn from GLB",
+        "title": "Import a Spirit Urn from a 3D model (.glb): orient it, size it, preview it, and build a tracked local mod that replaces the carryable Idol/urn"
+      },
+      "title": "Import Spirit Urn (GLB)",
+      "dropzone": {
+        "previewEmpty": "Drop a GLB to preview it fitted to the spirit urn."
+      },
+      "fields": {
+        "namePlaceholder": "My spirit urn"
+      },
+      "size": {
+        "label": "Size",
+        "units": "units",
+        "hint": "Largest-axis size in Source units. The urn is bigger than a soul orb; the default (28) is a good starting point. Confirm the real size in-game."
+      },
+      "ground": {
+        "label": "Sit base on the ground (instead of centering)"
+      },
+      "highPolyWarning": "This model has {{count}} triangles, well above the {{threshold}} an urn usually needs. It will still build, but a very heavy model can hurt in-game performance.",
+      "conflict": {
+        "heading": "A spirit urn is already enabled",
+        "body": "Only one spirit urn loads in-game at a time (they override the same model). Choose what to do with “{{name}}”:"
+      },
+      "errors": {
+        "previewFailed": "Spirit urn preview failed: {{error}}"
       }
     },
     "colors": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1669,
+  "totalKeys": 1684,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1669,
+      "translatedKeys": 1684,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1668,
-      "pct": 100
+      "pct": 99
     },
     {
       "code": "ru",

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
+import { ArrowLeft, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
@@ -22,6 +22,11 @@ const SoulContainerCanvas = lazy(() => import('../components/locker/SoulContaine
 // Heavy (three.js): only pulled in when the user opens the soul-container GLB
 // import from the global Locker tab, mirroring the Installed-page trigger.
 const SoulContainerImportModal = lazy(() => import('../components/locker/SoulContainerImportModal'));
+const SpiritUrnImportModal = lazy(() => import('../components/locker/SpiritUrnImportModal'));
+// Idol/urn model entry a Spirit Urn mod overrides; the 3D tile exports this entry
+// for an urn (vs the soul-container entry, the tile's default). Mirrors
+// URN_CONTAINER_ENTRY in the main-process soulContainerModels service.
+const URN_MODEL_ENTRY = 'models/props_gameplay/idol_urn/idol_urn.vmdl_c';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { GlobalModType, Mod } from '../types/mod';
@@ -48,6 +53,7 @@ import {
   groupModsByCategory,
   isLockerManagedMod,
   isLockerManagedSound,
+  isPropContainerType,
   modLoadOrder,
   readStoredFavorites,
   type GlobalModGroups,
@@ -154,10 +160,18 @@ export default function Locker() {
   // Soul-container GLB import (lazy three.js modal), openable from the global
   // Locker tab. Mirrors the Installed-page trigger.
   const [soulImportOpen, setSoulImportOpen] = useState(false);
+  // Spirit Urn GLB import (lazy three.js modal), openable from the global Locker
+  // tab. Mirrors the soul-container trigger.
+  const [urnImportOpen, setUrnImportOpen] = useState(false);
   // Enabled soul-container imports (they override the same model), so the modal
   // can warn + offer to replace rather than silently stack two.
   const existingSoulImports = useMemo(
     () => mods.filter((m) => m.enabled && m.globalType === 'soul-container'),
+    [mods]
+  );
+  // Enabled spirit-urn imports (single in-game slot), same warn-or-replace flow.
+  const existingUrnImports = useMemo(
+    () => mods.filter((m) => m.enabled && m.globalType === 'spirit-urn'),
     [mods]
   );
   // List-view accordion state. The Settings preference decides the initial
@@ -590,14 +604,16 @@ export default function Locker() {
     }
   };
 
-  // Soul containers are single-select: there's one soul-container slot, so
-  // enabling one disables any other active soul container, and clicking the
-  // already-active card turns it back off (vanilla). Other global types keep
-  // normal multi-toggle (they don't all collapse to a single slot).
+  // Prop containers (soul containers + spirit urns) are single-select: each kind
+  // has one in-game slot, so enabling one disables any other active mod of the
+  // SAME kind, and clicking the already-active card turns it back off (vanilla).
+  // A soul container and an urn can both be enabled (different slots). Other
+  // global types keep normal multi-toggle.
   const selectGlobalMod = async (modId: string) => {
     const target = mods.find((m) => m.id === modId);
     if (!target) return;
-    if (getEffectiveGlobalType(target) !== 'soul-container') {
+    const targetType = getEffectiveGlobalType(target);
+    if (!isPropContainerType(targetType)) {
       await toggleMod(modId);
       return;
     }
@@ -607,7 +623,7 @@ export default function Locker() {
     }
     const active = mods.filter(
       (m) =>
-        m.id !== modId && m.enabled && getEffectiveGlobalType(m) === 'soul-container'
+        m.id !== modId && m.enabled && getEffectiveGlobalType(m) === targetType
     );
     for (const m of active) await toggleMod(m.id);
     await toggleMod(modId);
@@ -976,6 +992,7 @@ export default function Locker() {
             onSetGlobalType={tagModGlobalType}
             onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
             onImportSoul={() => setSoulImportOpen(true)}
+            onImportUrn={() => setUrnImportOpen(true)}
           />
         </div>
       )}
@@ -985,6 +1002,18 @@ export default function Locker() {
           <SoulContainerImportModal
             onClose={() => setSoulImportOpen(false)}
             existingSoulImports={existingSoulImports}
+            onImported={() => {
+              void loadMods();
+            }}
+          />
+        </Suspense>
+      )}
+
+      {urnImportOpen && (
+        <Suspense fallback={null}>
+          <SpiritUrnImportModal
+            onClose={() => setUrnImportOpen(false)}
+            existingUrnImports={existingUrnImports}
             onImported={() => {
               void loadMods();
             }}
@@ -1098,6 +1127,8 @@ interface LockerGlobalViewProps {
   onRequestDelete: (modIds: string[], name: string) => void;
   /** Open the soul-container GLB import modal (shown on the soul-container tab). */
   onImportSoul: () => void;
+  /** Open the Spirit Urn GLB import modal (shown on the spirit-urn tab). */
+  onImportUrn: () => void;
 }
 
 /**
@@ -1105,10 +1136,17 @@ interface LockerGlobalViewProps {
  * frosted-glass carousel of cosmetic types (echoing the LockerHeroView shell's
  * art + blur language). Selecting a tile reveals that type's toggleable mods.
  */
-function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onRequestDelete, onImportSoul }: LockerGlobalViewProps) {
+function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onRequestDelete, onImportSoul, onImportUrn }: LockerGlobalViewProps) {
   const { t } = useTranslation();
   const soundVolume = useAppStore((s) => s.soundVolume);
-  const available = GLOBAL_MOD_TYPE_ORDER.filter((type) => groups[type].length > 0);
+  // Prop-container types (soul container, spirit urn) are always selectable even
+  // when empty: their tab is the only entry point to the GLB importer, so
+  // disabling an empty one would make it impossible to import the first of its
+  // kind (the chicken-and-egg that blocked testing the urn import path). Every
+  // other type only appears once it has at least one mod.
+  const available = GLOBAL_MOD_TYPE_ORDER.filter(
+    (type) => groups[type].length > 0 || isPropContainerType(type)
+  );
   const [selectedType, setSelectedType] = useState<GlobalModType>(
     () => available[0] ?? 'soul-container'
   );
@@ -1133,9 +1171,16 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
     };
   }, [retagMenu]);
   // Guard against the selected type emptying out (e.g. last mod deleted) by
-  // falling back to the first non-empty type at render time.
-  const activeType = groups[selectedType]?.length ? selectedType : available[0];
+  // falling back to the first available type at render time. Prop-container
+  // types stay selected even while empty so the importer remains reachable.
+  const activeType =
+    groups[selectedType]?.length || isPropContainerType(selectedType)
+      ? selectedType
+      : available[0];
   const activeMods = activeType ? groups[activeType] : [];
+  // Soul containers and spirit urns share the single-select + live-3D-tile
+  // treatment (frosted glass, content-stable key, active badge, import button).
+  const isPropContainer = isPropContainerType(activeType);
   const total = GLOBAL_MOD_TYPE_ORDER.reduce((sum, type) => sum + groups[type].length, 0);
   // The scrollable card pane: the shared soul-container canvas clamps each
   // card's render rect to this element so models never bleed past the pane.
@@ -1229,18 +1274,21 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             const items = groups[type];
             const isActive = type === activeType;
             const isEmpty = items.length === 0;
+            // An empty prop-container tab is still clickable (it opens the
+            // importer); only non-importable types are disabled when empty.
+            const isDisabled = isEmpty && !isPropContainerType(type);
             return (
               <button
                 key={type}
                 type="button"
-                disabled={isEmpty}
+                disabled={isDisabled}
                 onClick={() => setSelectedType(type)}
                 className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
-                  isEmpty
+                  isDisabled
                     ? 'cursor-default border-transparent opacity-40'
                     : isActive
                       ? 'border-accent/60 bg-accent/15'
-                      : 'border-transparent hover:bg-white/10'
+                      : 'cursor-pointer border-transparent hover:bg-white/10'
                 }`}
               >
                 <span className="flex-1 truncate text-sm font-medium text-white">
@@ -1265,18 +1313,40 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                 <span className="text-xs text-white/60">
                   {t('locker.page.modCount', { count: activeMods.length })}
                 </span>
-                {activeType === 'soul-container' && (
+                {isPropContainer && (
                   <button
                     type="button"
-                    onClick={onImportSoul}
+                    onClick={activeType === 'spirit-urn' ? onImportUrn : onImportSoul}
                     className="ml-auto inline-flex items-center gap-1.5 self-center rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:border-accent/60 hover:bg-accent/20"
-                    title={t('locker.soulImport.trigger.title')}
+                    title={activeType === 'spirit-urn' ? t('locker.urnImport.trigger.title') : t('locker.soulImport.trigger.title')}
                   >
-                    <Ghost className="h-3.5 w-3.5" />
-                    {t('locker.soulImport.trigger.label')}
+                    {activeType === 'spirit-urn' ? <Box className="h-3.5 w-3.5" /> : <Ghost className="h-3.5 w-3.5" />}
+                    {activeType === 'spirit-urn' ? t('locker.urnImport.trigger.label') : t('locker.soulImport.trigger.label')}
                   </button>
                 )}
               </div>
+              {activeMods.length === 0 && isPropContainer ? (
+                <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/15 bg-bg-sunken/30 px-6 py-12 text-center">
+                  {activeType === 'spirit-urn' ? (
+                    <Box className="h-8 w-8 text-white/40" />
+                  ) : (
+                    <Ghost className="h-8 w-8 text-white/40" />
+                  )}
+                  <p className="max-w-sm text-sm text-white/70">
+                    {t('locker.global.propEmpty', {
+                      type: GLOBAL_MOD_TYPE_LABELS[activeType],
+                    })}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={activeType === 'spirit-urn' ? onImportUrn : onImportSoul}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:border-accent/60 hover:bg-accent/20"
+                  >
+                    {activeType === 'spirit-urn' ? <Box className="h-3.5 w-3.5" /> : <Ghost className="h-3.5 w-3.5" />}
+                    {activeType === 'spirit-urn' ? t('locker.urnImport.trigger.label') : t('locker.soulImport.trigger.label')}
+                  </button>
+                </div>
+              ) : (
               <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 2xl:grid-cols-4">
                 {activeMods.map((mod) => {
                   // Skipped when NSFW previews are hidden so we never bleed
@@ -1285,12 +1355,12 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                     mod.thumbnailUrl && !(mod.nsfw && hideNsfw) ? mod.thumbnailUrl : null;
                   return (
                     <div
-                      // Soul containers key on the content-stable sha256: their
+                      // Prop containers key on the content-stable sha256: their
                       // id/metaKey change when toggled, which would otherwise
                       // remount the card and reload its 3D model on every select.
                       // Other types keep the plain id key (original behavior).
                       key={
-                        activeType === 'soul-container' ? mod.sha256 ?? mod.id : mod.id
+                        isPropContainer ? mod.sha256 ?? mod.id : mod.id
                       }
                       className={`group/card relative flex flex-col rounded-[10px] border p-2.5 transition-[border-color,background-color,box-shadow] duration-200 ${
                         mod.enabled
@@ -1302,7 +1372,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                           behind the card so it's tinted by its own thumbnail,
                           matching the Installed grid cards. Soul containers show
                           a 3D model on a clear window, so they skip it. */}
-                      {glassBackdropUrl && activeType !== 'soul-container' && (
+                      {glassBackdropUrl && !isPropContainer && (
                         <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[10px]">
                           <img
                             src={glassBackdropUrl}
@@ -1322,7 +1392,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                           background shows through; other types keep a solid bg. */}
                       <div
                         className={`relative mb-2 aspect-video w-full overflow-hidden rounded-lg border border-white/[0.08] ${
-                          activeType === 'soul-container' ? '' : 'bg-bg-tertiary'
+                          isPropContainer ? '' : 'bg-bg-tertiary'
                         }`}
                       >
                         {/* Frosted-glass panel for soul containers, kept as a
@@ -1331,17 +1401,19 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                             stacking context, which would sink this subtree (and
                             the retag kebab below) under the z-10 full-card toggle
                             and swallow the kebab's clicks. */}
-                        {activeType === 'soul-container' && (
+                        {isPropContainer && (
                           <div className="pointer-events-none absolute inset-0 bg-white/[0.04] backdrop-blur-md" />
                         )}
-                        {/* Soul containers show a live 3D model on a clear window
+                        {/* Prop containers show a live 3D model on a clear window
                             (no 2D thumbnail behind it); other types show their
-                            GameBanana thumbnail. */}
-                        {activeType === 'soul-container' ? (
+                            GameBanana thumbnail. The urn exports its own model
+                            entry; the soul container is the tile's default. */}
+                        {isPropContainer ? (
                           <Suspense fallback={null}>
                             <SoulContainerTile
                               tileId={mod.sha256 ?? mod.id}
                               modKey={mod.metaKey}
+                              entry={activeType === 'spirit-urn' ? URN_MODEL_ENTRY : undefined}
                             />
                           </Suspense>
                         ) : (
@@ -1366,13 +1438,13 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                           </div>
                         )}
                         <div className="pointer-events-none absolute inset-0 bg-bg-primary/0 transition-colors duration-200 group-hover/card:bg-bg-primary/20" />
-                        {/* Soul containers are single-select, so mark the one
+                        {/* Prop containers are single-select, so mark the one
                             active pick with a positive "Active" badge (a disabled
                             card is simply unmarked) and fade it in so selecting
                             animates rather than snapping. Other global types
                             allow multiple enabled, so they keep tagging the
                             disabled ones. */}
-                        {activeType === 'soul-container'
+                        {isPropContainer
                           ? mod.enabled && (
                               <div className="pointer-events-none absolute left-2 top-2 z-10 flex h-5 items-start animate-fade-in">
                                 <Tag
@@ -1488,19 +1560,21 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                   );
                 })}
               </div>
+              )}
             </>
           ) : (
             <p className="text-sm text-white/70">{t('locker.page.noGlobalNonHeroCosmeticsInstalledYet')}</p>
           )}
         </div>
 
-        {/* Shared 3D canvas for the Global soul-container grid: one WebGL context
-            renders every card (scissored into its on-screen rect), so the grid
-            can't exhaust the browser's live-context cap. Mounted INSIDE the pane
-            (not at the view root) so its z-[5] sits below each card's tags/kebab
-            but above the card background, keeping chrome on top of the model.
-            Only mounted while that type is selected. */}
-        {activeType === 'soul-container' && (
+        {/* Shared 3D canvas for the Global prop-container grid (soul containers
+            and spirit urns): one WebGL context renders every card (scissored into
+            its on-screen rect), so the grid can't exhaust the browser's
+            live-context cap. Mounted INSIDE the pane (not at the view root) so its
+            z-[5] sits below each card's tags/kebab but above the card background,
+            keeping chrome on top of the model. Only mounted while a prop-container
+            type is selected. */}
+        {isPropContainer && (
           <Suspense fallback={null}>
             <SoulContainerCanvas paneRef={paneRef} />
           </Suspense>

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -201,6 +201,50 @@ export interface SoulContainerPreview {
     targetSpan?: number;
 }
 
+export interface ImportSpiritUrnGlbArgs {
+    /** Path to the source `.glb` on disk. */
+    glbPath: string;
+    name: string;
+    orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
+    /** Extra Euler degrees [X, Y, Z] applied after orient. */
+    rotate?: [number, number, number];
+    /** Lift the mesh so its base sits at the origin instead of being centered. */
+    ground?: boolean;
+    /** Largest-axis size in Source units to fit the import to. */
+    span: number;
+    /** User-tracked test status; defaults to 'untested'. */
+    status?: SoulImportStatus;
+    /** Free-text label shown as the variant sublabel in Installed. */
+    notes?: string;
+    nsfw?: boolean;
+    /** Captured 3D preview as a data URL, used as the Installed thumbnail. */
+    thumbnailDataUrl?: string;
+    /** metaKey of an existing urn import to REPLACE in place (reuse its slot)
+     *  instead of allocating a new one. Avoids stacking two enabled urns. */
+    replaceMetaKey?: string;
+}
+
+export interface PreviewSpiritUrnGlbArgs {
+    glbPath: string;
+    orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
+    rotate?: [number, number, number];
+    ground?: boolean;
+    span: number;
+}
+
+export interface SpiritUrnPreview {
+    /** The built model exported back to a GLB, base64-encoded. */
+    glbBase64: string;
+    /** Resolved orientation label from the build (e.g. `y-up`, `auto:z-up`). */
+    orient: string;
+    /** Uniform fit scale applied to match the requested span. */
+    fitScale?: number;
+    /** Import's largest-axis span before fitting (Source units). */
+    sourceSpan?: number;
+    /** Span the mesh was fit to (equals the requested span). */
+    targetSpan?: number;
+}
+
 export interface VanillaStashStatus {
     active: boolean;
     startedAt?: string;
@@ -510,7 +554,9 @@ export interface ElectronAPI {
         heroName: string
     ) => Promise<{ variant: string; dataUrl: string }[]>;
     getSoulModelInfo: (key: string) => Promise<SoulModelInfo>;
-    exportSoulModel: (metaKey: string, cacheKey: string) => Promise<SoulModelInfo>;
+    /** `entry` selects which model entry to export (soul container vs urn);
+     *  defaults to the soul-container model when omitted. */
+    exportSoulModel: (metaKey: string, cacheKey: string, entry?: string) => Promise<SoulModelInfo>;
     getHeroPoseInfo: (
         heroName: string,
         skinSources?: HeroPoseSkinSource[]
@@ -588,6 +634,8 @@ export interface ElectronAPI {
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     importSoulContainerGlb: (args: ImportSoulContainerGlbArgs) => Promise<Mod[]>;
     previewSoulContainerGlb: (args: PreviewSoulContainerGlbArgs) => Promise<SoulContainerPreview>;
+    importSpiritUrnGlb: (args: ImportSpiritUrnGlbArgs) => Promise<Mod[]>;
+    previewSpiritUrnGlb: (args: PreviewSpiritUrnGlbArgs) => Promise<SpiritUrnPreview>;
     readGlbFile: (glbPath: string) => Promise<string>;
     readImageDataUrl: (imagePath: string) => Promise<string>;
     /** Read a bundled renderer asset (built-in art, hero render) as a data URL.

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -442,7 +442,7 @@ export interface ApplyTrippySkinResult {
  * here so the classifier (main) and the Locker grouping/UI (renderer) agree on
  * the union.
  */
-export type GlobalModType = 'soul-container' | 'hideout' | 'icons' | 'hud' | 'announcer' | 'killstreak-music';
+export type GlobalModType = 'soul-container' | 'spirit-urn' | 'hideout' | 'icons' | 'hud' | 'announcer' | 'killstreak-music';
 export type LockerHeroSource = 'manual' | 'title' | 'vpk' | 'download-title' | 'download-vpk';
 
 /** Deadlock ability slot. 1-3 are the signature abilities; 4 is the ultimate. */
@@ -536,6 +536,38 @@ export interface SoulContainerImportInfo {
   status: SoulImportStatus;
 }
 
+/**
+ * Set on a mod imported via the Spirit Urn GLB importer (the carryable Idol/urn
+ * objective, overriding `idol_urn.vmdl_c`). Mirrors SoulContainerImportInfo: it
+ * labels the mod as a local urn import and lets the user reproduce/rebuild the
+ * exact orientation later. Presence also identifies the slot for idempotent
+ * re-import. Distinct from SoulContainerImportInfo because the urn has no
+ * soul-glow particles (no `glow`), is not the spinning orb (no `yaw`/`upright`),
+ * and is sized by an explicit `span` instead of fitting the orb's bounds.
+ */
+export interface UrnImportInfo {
+  /** Original GLB filename (basename), for display. */
+  glbFileName: string;
+  /** Orientation mode chosen in the import UI. */
+  orient: 'y-up' | 'z-up' | 'flip-y' | 'auto';
+  /** Extra Euler rotation in degrees [X, Y, Z] applied after orient, if any. */
+  rotate?: [number, number, number];
+  /** Lift the mesh so its base sits at the origin instead of being centered. */
+  ground?: boolean;
+  /** Largest-axis size in Source units the mesh was fit to. */
+  span: number;
+  /** vpkmerge version that built the VPK. */
+  vpkmergeVersion?: string;
+  /** Uniform fit scale applied to match `span`. */
+  fitScale?: number;
+  /** Import's largest-axis span before fitting (Source units). */
+  sourceSpan?: number;
+  /** Target span the mesh was fit to (equals the requested `span`). */
+  targetSpan?: number;
+  /** User-tracked test status. */
+  status: SoulImportStatus;
+}
+
 export interface Mod {
   id: string;
   name: string;
@@ -596,6 +628,10 @@ export interface Mod {
    *  Carries the orientation/glow transform so the build is reproducible and the
    *  UI can label it as a local soul-container import. */
   soulImport?: SoulContainerImportInfo;
+  /** Set when this VPK was built from a user GLB via the Spirit Urn import.
+   *  Carries the orientation/span transform so the build is reproducible and the
+   *  UI can label it as a local urn import. */
+  urnImport?: UrnImportInfo;
   /** User opted out of the "update available" flag for this mod. Persisted
    *  in metadata; toggled from the mod details modal. */
   ignoreUpdates?: boolean;


### PR DESCRIPTION
## What

Adds the **Spirit Urn** global cosmetic type end to end: classify, sort, render a live 3D tile, and import a custom urn from a `.glb` that overrides the carryable Idol/urn model (`idol_urn.vmdl_c`). Mirrors the existing Soul Container import flow.

## Changes

- **types/mod**: add `'spirit-urn'` to `GlobalModType`, new `UrnImportInfo`; metadata carries `urnImport` for idempotent re-import (reuse the previous slot instead of stacking two urns).
- **vpk classifier**: detect `idol_urn`. When a VPK touches **both** `soul_container/` and `idol_urn/`, break the tie by which prop's actual `.vmdl_c` **model** is overridden (that's the prop the mod really reskins); texture-only soul packs keep the soul-first precedence so they don't regress. Bump `GLOBAL_CLASSIFIER_VERSION` 1→3 so already-scanned mods with a stale `null` re-sort on the next scan (no manual retag).
- **spiritUrnImport** service + IPC (`import-spirit-urn-glb`, `preview-spirit-urn-glb`): reuses the soul-container clone pipeline retargeted at `idol_urn`, sized by an explicit `span` (no soul-glow particles / spin recipe).
- **SoulContainerTile / exportSoulModel**: take an optional `entry` so the urn tile exports its own model.
- **Locker Global view**: spirit-urn tab, single-select toggle, 3D tile, import button + modal. Prop-container tabs (soul container, spirit urn) stay clickable **even when empty**, with an import empty-state, so the first of a kind can be imported (fixes the empty-tab chicken-and-egg that blocked testing).
- **i18n**: `locker.urnImport.*` + `locker.global.propEmpty`; manifest regenerated.

## Two bugs this fixes (reported)

1. **Urns not sorting into the Spirit Urns tab** — stale classifications + soul-before-urn order mis-filed urn reskins that ship a stray `soul_container` file (e.g. `sprite_can_urn_csdk`). Verified all installed urn VPKs now classify as `spirit-urn`.
2. **Couldn't open an empty prop-container tab** — the importer was the only entry point, so an empty Spirit Urns tab could never be opened to import the first urn.

## Testing

- `pnpm typecheck`, `pnpm i18n:check`, eslint, and the pre-push i18n/manifest gate all pass.
- Classifier verified against the real installed urn VPKs (pepsi / steamhappy / sprite_can_urn / sprite_can_urn_csdk).

Note: reclassification fires on the next `loadMods` scan (opening the Locker), so existing urns move into the tab on reload.