### PR TITLE
feat(preview): always-on Source 2 draw-state renderer + unified material path

### DIFF
--- a/electron/main/services/heroPoseModels.ts
+++ b/electron/main/services/heroPoseModels.ts
@@ -87,6 +87,7 @@ const MODEL_ENTRY_OVERRIDES: Readonly<Record<string, string>> = {
     'Lady Geist': 'models/heroes_wip/geist/geist.vmdl_c',
     Rem: 'models/heroes_wip/familiar/familiar_wip.vmdl_c',
     Viscous: 'models/heroes_staging/viscous/viscous.vmdl_c',
+    Wraith: 'models/heroes_wip/wraith/wraith.vmdl_c'
 };
 
 /** Model codenames to try for a hero, most-specific first: any divergent
@@ -520,9 +521,9 @@ async function resolveSkinVpk(deadlockPath: string, metaKey: string): Promise<st
     const candidates = metaKey.includes('/')
         ? [join(getCitadelPath(deadlockPath), metaKey)] // enabled overflow folder
         : [
-              join(getAddonsPath(deadlockPath), metaKey), // enabled base addons
-              join(getDisabledPath(deadlockPath), metaKey), // disabled parking lot
-          ];
+            join(getAddonsPath(deadlockPath), metaKey), // enabled base addons
+            join(getDisabledPath(deadlockPath), metaKey), // disabled parking lot
+        ];
     for (const candidate of candidates) {
         try {
             await fs.access(candidate);
@@ -1058,7 +1059,7 @@ export function registerHeroPoseProtocol(): void {
             // must keep meaning "export time". Both glbs share the dir, so
             // touching the one sidecar protects the whole entry.
             const now = new Date();
-            void fs.utimes(versionFile(key), now, now).catch(() => {});
+            void fs.utimes(versionFile(key), now, now).catch(() => { });
             return net.fetch(pathToFileURL(file).toString());
         } catch {
             return new Response(null, { status: 404 });

--- a/src/components/locker/HeroPoseViewer.test.ts
+++ b/src/components/locker/HeroPoseViewer.test.ts
@@ -20,9 +20,6 @@ beforeAll(() => {
 
 function baseFlags() {
   return {
-    npr: false,
-    nprOutline: false,
-    source2: false,
     unified: false,
     celV2: false,
     cloth: false,
@@ -121,15 +118,12 @@ describe('resolveHeroPoseRenderFeatures', () => {
     expect(features.unifiedEnabled).toBe(true);
   });
 
-  it('lets trippy paint own material state while keeping Source 2 hints available', () => {
-    const features = resolveHeroPoseRenderFeatures(
-      { ...baseFlags(), npr: true, unified: true, source2: true },
-      true
-    );
+  it('keeps unified NPR materials mounted while trippy paint owns the material maps', () => {
+    const features = resolveHeroPoseRenderFeatures({ ...baseFlags(), unified: true }, true);
 
     expect(features.source2ShaderHintsEnabled).toBe(true);
     expect(features.source2SkipNpr).toBe(false);
-    expect(features.nprMaterialsEnabled).toBe(false);
+    expect(features.nprMaterialsEnabled).toBe(true);
   });
 
   it('enables cloth and the rigged preview when the dev flag is set', () => {

--- a/src/components/locker/HeroPoseViewer.tsx
+++ b/src/components/locker/HeroPoseViewer.tsx
@@ -37,7 +37,6 @@ import {
   isNprMaterial,
   isSelfIllumMaterial,
   wrapMaterialWithNpr,
-  buildOutlineShell,
   unwrapNprBase,
   summarizeNprScene,
   applySource2MaterialHints,
@@ -48,6 +47,7 @@ import {
   type MorphicDynamicExpr,
 } from '../../lib/source2NprMaterial';
 import { buildDeadlockMaterial, type DeadlockMaterialResult } from '../../lib/deadlockMaterial';
+import { compileSource2DrawState, summarizeSource2Scene } from '../../lib/source2Preview';
 import { resolveHeroPoseRenderFeatures } from './heroPoseRenderFeatures';
 import type { HeroPoseSkinSource } from '../../types/portrait';
 import type { TrippySpriteResult } from '../../types/mod';
@@ -85,16 +85,6 @@ const IBL_FACES = [
 
 const USE_CLOTH: boolean = false;
 
-// Source 2 NPR cel/rim/tint restyle layered on top of the PMREM IBL + ACES
-// tonemap output (not a replacement pass). Gated per-material on userData.morphic
-// + F_USE_NPR_LIGHTING, so heroes/materials without that data keep their base path.
-const USE_NPR_PREVIEW: boolean = false;
-
-// Inverted-hull solid-color outline (Source 2's method; vpkmerge strips the
-// engine shells from the export, so we regenerate them). Honors per-material
-// outline data.
-const USE_NPR_OUTLINE: boolean = false;
-
 // Bloom postprocessing gives self-illum glows their bright-core + colored-halo look.
 const USE_BLOOM: boolean = true;
 // UnrealBloomPass starting params. Threshold is in LINEAR space, so it mainly catches
@@ -104,12 +94,10 @@ const BLOOM_INTENSITY = 1;
 const BLOOM_RADIUS = 0.5;
 const BLOOM_THRESHOLD = 0.85;
 
-// Broader Source 2 material approximations for shader-heavy heroes.
-const USE_SOURCE2_SHADER_HINTS: boolean = false;
-
-// Unified single build pass (deadlockMaterial.buildDeadlockMaterial): collapses
-// the Source2 hints + NPR CSM two-pass into one pass on an owned clone of each
-// material, so the GLTF base is never mutated.
+// Unified single build pass (deadlockMaterial.buildDeadlockMaterial): the one
+// material-styling path. Collapses the Source 2 hints + NPR cel/rim/tint into one
+// pass on an owned clone of each material, so the GLTF base is never mutated. Off
+// shows the raw GLB.
 const USE_UNIFIED_MATERIAL: boolean = true;
 
 // Phase 5 shader experiment: quantize accumulated direct diffuse at
@@ -120,9 +108,6 @@ const USE_CEL_V2: boolean = true;
 const USE_EFFECT_PREVIEW: boolean = false;
 
 const RELEASE_RENDER_FLAGS = {
-  npr: USE_NPR_PREVIEW,
-  nprOutline: USE_NPR_OUTLINE,
-  source2: USE_SOURCE2_SHADER_HINTS,
   unified: USE_UNIFIED_MATERIAL,
   celV2: USE_CEL_V2,
   cloth: USE_CLOTH,
@@ -143,8 +128,8 @@ type BloomParams = {
 
 const COMPACT_LEVA_THEME = {
   sizes: {
-    rootWidth: '248px',
-    controlWidth: '104px',
+    rootWidth: '300px',
+    controlWidth: '150px',
     rowHeight: '22px',
     folderTitleHeight: '22px',
     checkboxSize: '14px',
@@ -648,7 +633,6 @@ function TrippyPaint({
 function NprMaterials({
   scene,
   enabled,
-  outline,
   tint,
   unified,
   source2Active,
@@ -656,7 +640,6 @@ function NprMaterials({
 }: {
   scene: THREE.Object3D;
   enabled: boolean;
-  outline: boolean;
   tint: THREE.Color | null;
   /** When true, build each material via the unified single pass
    *  (buildDeadlockMaterial) instead of the old applySource2MaterialHints +
@@ -675,7 +658,7 @@ function NprMaterials({
       {
         material: THREE.Material;
         uniforms: Record<string, THREE.IUniform>;
-        selfIllumScaleFn?: ((t: number) => number) | null;
+        selfIllumPulseFn?: ((t: number) => number) | null;
       }
     >
   >(new Map());
@@ -687,7 +670,7 @@ function NprMaterials({
       {
         material: THREE.Material;
         uniforms: Record<string, THREE.IUniform>;
-        selfIllumScaleFn?: ((t: number) => number) | null;
+        selfIllumPulseFn?: ((t: number) => number) | null;
       }
     >();
     // Per-build teardown (dispose the owned CSM/clone/masks). On the unified path
@@ -720,7 +703,7 @@ function NprMaterials({
             b = {
               material: built.material,
               uniforms: built.uniforms,
-              selfIllumScaleFn: built.selfIllumScaleFn,
+              selfIllumPulseFn: built.selfIllumPulseFn,
             };
             builds.set(mat, b);
             disposers.push(built.dispose);
@@ -754,11 +737,6 @@ function NprMaterials({
           });
         }
       });
-
-      if (outline) {
-        const dispose = buildOutlineShell(mesh);
-        if (dispose) restore.push(dispose);
-      }
     });
 
     buildsRef.current = builds;
@@ -775,7 +753,7 @@ function NprMaterials({
     // `tint` is intentionally excluded: the separate effect below applies it by
     // mutating uniforms, so a recolor never tears down and rebuilds the builds.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scene, enabled, outline, unified, source2Active]);
+  }, [scene, enabled, unified, source2Active]);
 
   // Drive uTime for the self-illum UV scroll (viscous_head's liquid glow).
   useFrame((state) => {
@@ -783,13 +761,13 @@ function NprMaterials({
     const t = state.clock.elapsedTime;
     buildsRef.current.forEach((b) => {
       if (b.uniforms.uTime) b.uniforms.uTime.value = t;
-      // Drive a dynamic self-illum scale (inferno body's 0.5*sin(3*time())+0.5);
-      // static scales have no fn and keep their build-time uniform value.
-      if (b.selfIllumScaleFn && b.uniforms.uSelfIllumScale) {
-        const s = b.selfIllumScaleFn(t);
+      // Drive a dynamic self-illum envelope (inferno body's 0.5*sin(3*time())+0.5).
+      // Static scales have no fn and keep uSelfIllumPulse at 1.
+      if (b.selfIllumPulseFn && b.uniforms.uSelfIllumPulse) {
+        const s = b.selfIllumPulseFn(t);
         // Guard: a future divergent expr could go NaN/Inf mid-stream; one bad
         // uniform write blows out the whole material.
-        if (Number.isFinite(s)) b.uniforms.uSelfIllumScale.value = s;
+        if (Number.isFinite(s)) b.uniforms.uSelfIllumPulse.value = s;
       }
     });
   });
@@ -810,6 +788,30 @@ function NprMaterials({
       if (b.uniforms.uCelV2) b.uniforms.uCelV2.value = celV2 ? 1.0 : 0.0;
     });
   }, [celV2, enabled]);
+
+  return null;
+}
+
+/**
+ * Always-on Source 2 draw state. Applies additive / translucent blend, backface
+ * culling, and overlay render-order to EVERY material carrying morphic extras,
+ * independent of the NPR / unified / source2 / bloom dev flags. This is the one
+ * pass that runs on the default preview path, so additive self-illum glow
+ * overlays (kept by the vpkmerge exporter) composite as `AdditiveBlending` rather
+ * than rendering an opaque white hull. Mesh-level `renderOrder` is the piece the
+ * material builders cannot set and persists across the flag-gated material swaps.
+ */
+function Source2DrawState({ scene, debug }: { scene: THREE.Object3D; debug: boolean }) {
+  useEffect(() => {
+    const compiled = compileSource2DrawState(scene);
+    if (debug) {
+      // Phase 3 round-trip inspection: blend-mode + renderOrder distribution and
+      // the overlay mesh names, so a maintainer can confirm kept glow overlays
+      // composite additively. Logging only; the compile itself is always-on.
+      console.info('[source2drawstate]', compiled.stats, summarizeSource2Scene(scene));
+    }
+    return () => compiled.restore();
+  }, [scene, debug]);
 
   return null;
 }
@@ -869,9 +871,6 @@ export default function HeroPoseViewer({
   const sourceKey = skinSources.map((source) => `${source.priority}:${source.metaKey}`).join('|');
   const [devFlags, setDevFlags] = useState<DevPreviewFlags>(() => ({
     ...RELEASE_RENDER_FLAGS,
-    npr: previewFlag('grimoire.preview.npr', USE_NPR_PREVIEW),
-    nprOutline: previewFlag('grimoire.preview.nprOutline', USE_NPR_OUTLINE),
-    source2: previewFlag('grimoire.preview.source2Shaders', USE_SOURCE2_SHADER_HINTS),
     unified: previewFlag('grimoire.preview.unifiedMaterial', USE_UNIFIED_MATERIAL),
     celV2: previewFlag('grimoire.preview.celV2', USE_CEL_V2),
     cloth: previewFlag('grimoire.preview.cloth', USE_CLOTH),
@@ -1120,6 +1119,7 @@ export default function HeroPoseViewer({
         ) : (
           <PosedModel scene={scene} interaction={interaction} effect={effect} />
         )}
+        {scene && <Source2DrawState scene={scene} debug={features.nprDebugEnabled} />}
         {features.source2ShaderHintsEnabled && scene && (
           <Source2MaterialHints
             scene={scene}
@@ -1132,7 +1132,6 @@ export default function HeroPoseViewer({
           <NprMaterials
             scene={scene}
             enabled={features.nprMaterialsEnabled}
-            outline={features.nprOutlineEnabled}
             tint={null /* wire to a recolor color once the Locker recolor surface exists */}
             unified={features.unifiedEnabled}
             source2Active={features.source2ShaderHintsEnabled}
@@ -1187,20 +1186,6 @@ function DevViewerControls({
   useControls(
     'Preview',
     () => ({
-      S2: {
-        value: devFlags.source2,
-        onChange: (value: boolean) =>
-          setDevFlag('source2', 'grimoire.preview.source2Shaders', value),
-      },
-      NPR: {
-        value: devFlags.npr,
-        onChange: (value: boolean) => setDevFlag('npr', 'grimoire.preview.npr', value),
-      },
-      Outline: {
-        value: devFlags.nprOutline,
-        onChange: (value: boolean) =>
-          setDevFlag('nprOutline', 'grimoire.preview.nprOutline', value),
-      },
       Unified: {
         value: devFlags.unified,
         onChange: (value: boolean) =>
@@ -1274,7 +1259,6 @@ function DevViewerControls({
     <Leva
       collapsed={false}
       hideCopyButton
-      oneLineLabels
       theme={COMPACT_LEVA_THEME}
       titleBar={{ title: 'Preview', drag: true, filter: false }}
     />

--- a/src/components/locker/heroPoseRenderFeatures.ts
+++ b/src/components/locker/heroPoseRenderFeatures.ts
@@ -4,9 +4,6 @@
 const USE_RIGGED_PREVIEW: boolean = false;
 
 export interface HeroPoseDevFlags {
-  npr: boolean;
-  nprOutline: boolean;
-  source2: boolean;
   unified: boolean;
   celV2: boolean;
   cloth: boolean;
@@ -16,8 +13,6 @@ export interface HeroPoseDevFlags {
 }
 
 export interface HeroPoseRenderFeatures {
-  nprPreviewEnabled: boolean;
-  nprOutlineEnabled: boolean;
   unifiedEnabled: boolean;
   celV2Enabled: boolean;
   clothPreviewEnabled: boolean;
@@ -29,25 +24,28 @@ export interface HeroPoseRenderFeatures {
   nprMaterialsEnabled: boolean;
 }
 
+// `unified` is the single material-styling driver: it builds each material via
+// buildDeadlockMaterial (Source 2 hints + NPR cel/rim/tint collapsed into one
+// pass). The standalone Source 2 / NPR toggles were removed; both renderers now
+// mount iff unified is on. Turn unified off to compare against the raw GLB.
 export function resolveHeroPoseRenderFeatures(
   flags: HeroPoseDevFlags,
   trippySpriteActive: boolean
 ): HeroPoseRenderFeatures {
   const clothPreviewEnabled = flags.cloth;
   const unifiedEnabled = flags.unified;
-  const source2ShaderHintsEnabled = flags.source2 || unifiedEnabled;
 
   return {
-    nprPreviewEnabled: flags.npr,
-    nprOutlineEnabled: flags.nprOutline,
     unifiedEnabled,
     celV2Enabled: flags.celV2,
     clothPreviewEnabled,
     bloomEnabled: flags.bloom,
     riggedPreviewEnabled: USE_RIGGED_PREVIEW || clothPreviewEnabled,
-    source2ShaderHintsEnabled,
+    source2ShaderHintsEnabled: unifiedEnabled,
     nprDebugEnabled: flags.nprDebug,
     source2SkipNpr: unifiedEnabled && !trippySpriteActive,
-    nprMaterialsEnabled: (flags.npr || unifiedEnabled) && !trippySpriteActive,
+    // Trippy/tattoo paint replaces the material maps, but unified still owns the
+    // Source 2 shader path: self-illum masks, CelV2, and pulse uniforms live there.
+    nprMaterialsEnabled: unifiedEnabled,
   };
 }

--- a/src/lib/deadlockMaterial.test.ts
+++ b/src/lib/deadlockMaterial.test.ts
@@ -652,6 +652,108 @@ describe('buildDeadlockMaterial self-illum placeholder gate (Yamato shogun_body 
     expect(head.uniforms.uHasSelfIllum.value).toBe(1);
     head.dispose();
   });
+
+  it('glows an additive placeholder-mask self-illum at authored scale 1 (vindicta_glow)', () => {
+    const glow = buildDeadlockMaterial(
+      materialWithMorphic({
+        shader: 'pbr.vfx',
+        blend_mode: 'additive',
+        ints: {
+          F_ADDITIVE_BLEND: 1,
+          F_SELF_ILLUM: 1,
+          F_TRANSLUCENT: 1,
+          F_USE_NPR_LIGHTING: 1,
+        },
+        floats: {
+          g_flOpacityScale1: 0.066,
+          g_flSelfIllumAlbedoFactor1: 0,
+          g_flSelfIllumScale1: 1,
+        },
+        vectors: {
+          g_vSelfIllumScrollSpeed1: [0.1, 0.1, 0, 0],
+          g_vSelfIllumTint1: [0.011765, 0.564706, 0.607843, 0],
+        },
+        resolvedTextures: { g_tSelfIllumMask: texture(4) },
+        self_illum_valid: false,
+      })
+    );
+
+    expect(glow.uniforms.uHasSelfIllum.value).toBe(1);
+    expect(glow.uniforms.uSelfIllumScale.value).toBe(1);
+    expect(glow.uniforms.uSelfIllumAlbedoFactor.value).toBe(0);
+    expect(glow.uniforms.uSelfIllumScroll.value).toMatchObject({ x: 0.1, y: 0.1 });
+    expect(glow.uniforms.uSelfIllumTint.value).toMatchObject({
+      r: 0.011765,
+      g: 0.564706,
+      b: 0.607843,
+    });
+    glow.dispose();
+  });
+
+  it('boosts and shapes a real dynamic self-illum mask (inferno_body tattoos)', () => {
+    const body = buildDeadlockMaterial(
+      materialWithMorphic({
+        shader: 'pbr.vfx',
+        ints: { F_USE_NPR_LIGHTING: 1, F_SELF_ILLUM: 1 },
+        floats: {
+          g_flSelfIllumScale1: 10,
+          g_flSelfIllumAlbedoFactor1: 0.739,
+        },
+        dynamic_params: {
+          g_flSelfIllumScale1: dynamicExpr('20 * sin(10 * time()) + 22'),
+        },
+        resolvedTextures: { g_tSelfIllumMask: texture(64) },
+        self_illum_valid: true,
+      })
+    );
+
+    expect(body.uniforms.uHasSelfIllum.value).toBe(1);
+    expect(body.uniforms.uSelfIllumScale.value).toBeCloseTo(10);
+    expect(body.uniforms.uSelfIllumPulse.value).toBeCloseTo(22 / 42);
+    expect(body.selfIllumPulseFn?.(Math.PI / 20)).toBeCloseTo(1);
+    expect(body.uniforms.uSelfIllumCap.value).toBe(DEFAULT_NPR_TUNING.selfIllumCap);
+    expect(body.uniforms.uSelfIllumMaskShaping.value).toBe(1);
+    expect(body.uniforms.uSelfIllumMaskLow.value).toBe(DEFAULT_NPR_TUNING.selfIllumMaskLow);
+    expect(body.uniforms.uSelfIllumMaskHigh.value).toBe(DEFAULT_NPR_TUNING.selfIllumMaskHigh);
+    body.dispose();
+  });
+});
+
+describe('buildDeadlockMaterial jitter uniforms (vindicta_glow breathing)', () => {
+  it('drives F_JITTER_VERTICES from VMAT speeds and amplitudes without requiring a real mask', () => {
+    const glow = buildDeadlockMaterial(
+      materialWithMorphic({
+        shader: 'pbr.vfx',
+        blend_mode: 'additive',
+        ints: { F_JITTER_VERTICES: 1, F_USE_NPR_LIGHTING: 1 },
+        floats: {
+          g_flJitterSpeedA1: 0.5,
+          g_flJitterSpeedB1: 0.25,
+        },
+        vectors: {
+          g_vJitterFrequenciesA1: [0.02, 0.02, 0, 0],
+          g_vJitterFrequenciesB1: [0.03, 0.04, 0.17, 0],
+          g_vJitterAmplitudesXA1: [0, 0, 0, 0],
+          g_vJitterAmplitudesXB1: [0, 0, 0.711, 0],
+          g_vJitterAmplitudesYA1: [1, 0, 0, 0],
+          g_vJitterAmplitudesYB1: [1, 0, 1, 0],
+          g_vJitterAmplitudesZA1: [1, 0, 0, 0],
+          g_vJitterAmplitudesZB1: [1, 0, 0, 0],
+        },
+        resolvedTextures: { g_tJitterMask: texture(4) },
+      })
+    );
+
+    expect(glow.uniforms.uHasJitter.value).toBe(1);
+    expect(glow.uniforms.uHasJitterMask.value).toBe(0);
+    expect(glow.uniforms.uJitterSpeedA.value).toBeCloseTo(0.5);
+    expect(glow.uniforms.uJitterSpeedB.value).toBeCloseTo(0.25);
+    expect(glow.uniforms.uJitterStrength.value).toBe(DEFAULT_NPR_TUNING.jitterStrength);
+    expect(glow.uniforms.uJitterFreqB.value).toMatchObject({ x: 0.03, y: 0.04, z: 0.17 });
+    expect(glow.uniforms.uJitterAmpXB.value).toMatchObject({ x: 0, y: 0, z: 0.711 });
+    expect(glow.uniforms.uJitterAmpYB.value).toMatchObject({ x: 1, y: 0, z: 1 });
+    glow.dispose();
+  });
 });
 
 describe('buildDeadlockMaterial vertex-color albedo gate (Celeste dress regression)', () => {

--- a/src/lib/deadlockMaterial.ts
+++ b/src/lib/deadlockMaterial.ts
@@ -11,6 +11,7 @@ import {
   flag,
   firstNumber,
   vectorColor,
+  vector3,
   transmissiveTint,
   isMeaningfulMask,
   isTrueGlassMaterial,
@@ -25,8 +26,8 @@ import {
   highlightLayer,
 } from './source2NprMaterial';
 import { compileScalarExpr, peakScalar } from './dynamicScalar';
-
-type Source2BlendMode = NonNullable<MorphicExtras['blend_mode']>;
+// Shared blend-mode resolver (the cycle-free leaf of the source2Preview core).
+import { resolveBlendMode } from './source2Preview/blendMode';
 
 /**
  * Unified Deadlock NPR material builder (the Phase 0/1 single build pass).
@@ -90,9 +91,9 @@ export interface DeadlockMaterialResult {
   /**
    * When self-illum scale is a Tier-1 dynamic expression (e.g. inferno body's
    * 0.5*sin(3*time())+0.5), the compiled per-frame fn the ticker calls each frame
-   * to drive uSelfIllumScale. Null for a static scale.
+   * to drive uSelfIllumPulse. Null for a static scale.
    */
-  selfIllumScaleFn: ((t: number) => number) | null;
+  selfIllumPulseFn: ((t: number) => number) | null;
 }
 
 /**
@@ -109,14 +110,6 @@ function needsPhysical(morphic: MorphicExtras, base: THREE.Material): boolean {
     return true;
   }
   return false;
-}
-
-function fallbackBlendMode(morphic: MorphicExtras): Source2BlendMode {
-  if (flag(morphic, 'F_ADDITIVE_BLEND')) return 'additive';
-  if (flag(morphic, 'F_TRANSLUCENT') || flag(morphic, 'F_ADVANCED_TRANSLUCENCY')) {
-    return 'blend_zwrite';
-  }
-  return 'opaque';
 }
 
 // Above this a self-illum scale counts as "on" for a material with a REAL
@@ -150,19 +143,17 @@ const F6_HIGHLIGHT_ENABLED = false;
 /**
  * Resolve a material's self-illum scale into { value at t=0, peak, fn }.
  *
- * A dynamic g_flSelfIllumScale1 (inferno body pulses 0.5*sin(3*time())+0.5) is the
- * literal in-game scale, but at that magnitude (peaks ~1) the additive glow is too
- * dim to READ in the no-bloom preview: inferno's tattoos vanished under the unified
- * path while the legacy path - which just used the static fallback (10) - showed them
- * clearly. So anchor the glow BRIGHTNESS to the static fallback (legacy-matching) and
- * use the pulse only as a 0..1 animation envelope; the selfIllumCap then tames the
- * static "full blast" both paths share. An un-parseable / attribute-driven expr falls
- * back to the static value (NOT 0) so the glow still shows rather than gating off.
+ * A dynamic g_flSelfIllumScale1 (inferno body uses 20*sin(10*time())+22) is the
+ * authored animation envelope. The no-bloom preview keeps the static fallback as
+ * brightness and uses the dynamic value only as a normalized pulse; driving the
+ * full peak through a post-light additive pass washes the skin instead of matching
+ * the localized in-game tattoo glow.
  */
 function selfIllumScale(morphic: MorphicExtras): {
   value: number;
   peak: number;
-  fn: ((t: number) => number) | null;
+  pulseValue: number;
+  pulseFn: ((t: number) => number) | null;
 } {
   const staticScale = firstNumber(morphic, ['g_flSelfIllumScale1', 'g_flSelfIllumScale'], 0);
   const dyn = morphic.dynamic_params?.g_flSelfIllumScale1;
@@ -171,15 +162,14 @@ function selfIllumScale(morphic: MorphicExtras): {
       const pulse = compileScalarExpr(dyn.source);
       if (pulse) {
         const pk = peakScalar(pulse) || 1;
-        const base = staticScale > 0 ? staticScale : pk;
-        // pulse(t)/pk is a 0..1 envelope; `base` sets the legacy-matching brightness.
-        const fn = (t: number) => (base * pulse(t)) / pk;
-        return { value: fn(0), peak: base, fn };
+        const value = staticScale > 0 ? staticScale : pk;
+        const pulseFn = (t: number) => Math.max(0, pulse(t)) / pk;
+        return { value, peak: value, pulseValue: pulseFn(0), pulseFn };
       }
     }
-    return { value: staticScale, peak: staticScale, fn: null };
+    return { value: staticScale, peak: staticScale, pulseValue: 1, pulseFn: null };
   }
-  return { value: staticScale, peak: staticScale, fn: null };
+  return { value: staticScale, peak: staticScale, pulseValue: 1, pulseFn: null };
 }
 
 /**
@@ -263,7 +253,7 @@ export function buildDeadlockMaterial(
 
   // --- Material-state flags (ported from applySource2MaterialHints). --------
   const glass = isTrueGlassMaterial(morphic, base);
-  const blendMode = morphic.blend_mode ?? fallbackBlendMode(morphic);
+  const blendMode = resolveBlendMode(morphic);
   const alphaBlend = !glass && (blendMode === 'blend_zwrite' || blendMode === 'blend' || blendMode === 'additive');
   const additive = blendMode === 'additive';
   const unlit = flag(morphic, 'F_UNLIT');
@@ -345,7 +335,8 @@ export function buildDeadlockMaterial(
   // self_illum_valid is the exporter's ">4x4 real mask" call (mirrors the legacy
   // hints path, which the unified builder previously forgot to honor).
   const hasRealSelfIllumMask = morphic.self_illum_valid ?? isMeaningfulMask(selfIllumMap);
-  const hasSelfIllum = si.peak > (hasRealSelfIllumMask ? SI_SCALE_EPS : PLACEHOLDER_SI_SCALE);
+  const placeholderSelfIllumThreshold = additive ? SI_SCALE_EPS : PLACEHOLDER_SI_SCALE;
+  const hasSelfIllum = si.peak > (hasRealSelfIllumMask ? SI_SCALE_EPS : placeholderSelfIllumThreshold);
   if (unlit && clone.emissive) {
     clone.emissive.copy(clone.color ?? new THREE.Color(1, 1, 1));
     clone.emissiveIntensity = Math.max(clone.emissiveIntensity ?? 1, 1.2);
@@ -408,18 +399,22 @@ export function buildDeadlockMaterial(
     transmissiveMap.needsUpdate = true;
   }
 
-  // A meaningful mask localizes + scrolls the glow; a placeholder (4x4) mask means
-  // "illuminate everywhere", so leave illumMap null and let the uniform fall back
-  // to solid white (full coverage) - the fix for familiar eyes / inferno body
-  // whose glow is not mask-localized.
+  // A real self-illum mask localizes + scrolls the glow; a genuine placeholder
+  // (4x4) mask means "illuminate everywhere", so leave illumMap null and let the
+  // uniform fall back to solid white (full coverage), e.g. familiar eyes. Bind the
+  // mask whenever the exporter flagged it real (self_illum_valid, folded into
+  // hasRealSelfIllumMask) and it resolved, NOT only when isMeaningfulMask passes:
+  // Infernus's body mask IS the tattoo pattern, so it must localize to the tattoos
+  // rather than glow the whole skin (incl. the face).
   let illumMap: THREE.Texture | null = null;
-  if (hasSelfIllum && isMeaningfulMask(selfIllumMap)) {
+  if (hasSelfIllum && selfIllumMap && hasRealSelfIllumMask) {
     // Scroll wraps via fract(), so the sampler must repeat or the seam smears.
     illumMap = ownClone(selfIllumMap);
     illumMap.wrapS = THREE.RepeatWrapping;
     illumMap.wrapT = THREE.RepeatWrapping;
     illumMap.needsUpdate = true;
   }
+  const shapeSelfIllumMask = !!illumMap && !!si.pulseFn;
   const siScroll =
     morphic.vectors?.g_vSelfIllumScrollSpeed1 ?? morphic.vectors?.g_vSelfIllumScrollSpeed;
   // Default tint WHITE: a scale-driven glow with albedoFactor 0 and no authored
@@ -432,7 +427,17 @@ export function buildDeadlockMaterial(
   );
   // Blend tint<->albedo per g_flSelfIllumAlbedoFactor1 (0 = tint, 1 = surface
   // albedo). The albedo side is sampled GPU-side from diffuseColor.
-  const siAlbedoFactor = firstNumber(morphic, ['g_flSelfIllumAlbedoFactor1'], 0);
+  //
+  // Additive self-illum overlays (e.g. inferno_armglow / inferno_headglow) carry
+  // their glow in the BASE COLOR (inferno_glow, a gradient on black) and bind only
+  // a flat 4x4 placeholder self-illum mask. With the default factor 0 the glow is a
+  // solid white tint gated by a white mask, so the whole overlay mesh floods - it
+  // buries the crisp tattoos the opaque body draws from its own real emissive mask.
+  // Default these to albedo: the gradient's black regions then add nothing under
+  // additive blend, so the overlay only brightens where its texture is lit, matching
+  // the in-game additive pass. An explicitly authored factor still wins.
+  const siAlbedoFactorDefault = additive && !hasRealSelfIllumMask ? 1 : 0;
+  const siAlbedoFactor = firstNumber(morphic, ['g_flSelfIllumAlbedoFactor1'], siAlbedoFactorDefault);
   const csb = albedoCsb(morphic);
   const detail = detailLayer(morphic);
   const highlight = F6_HIGHLIGHT_ENABLED && isNpr ? highlightLayer(morphic) : null;
@@ -443,6 +448,13 @@ export function buildDeadlockMaterial(
     detailMap.wrapT = THREE.RepeatWrapping;
     detailMap.needsUpdate = true;
   }
+  const jitterMap = jitterMask && isMeaningfulMask(jitterMask) ? ownClone(jitterMask) : null;
+  if (jitterMap) {
+    jitterMap.wrapS = THREE.RepeatWrapping;
+    jitterMap.wrapT = THREE.RepeatWrapping;
+    jitterMap.needsUpdate = true;
+  }
+  const hasJitter = flag(morphic, 'F_JITTER_VERTICES');
 
   const uniforms: Record<string, THREE.IUniform> = {
     uKeyDir: { value: tuning.keyDir.clone() },
@@ -467,9 +479,13 @@ export function buildDeadlockMaterial(
     uSelfIllumScroll: { value: new THREE.Vector2(siScroll?.[0] ?? 0, siScroll?.[1] ?? 0) },
     uSelfIllumTint: { value: siTint },
     uSelfIllumScale: { value: si.value },
+    uSelfIllumPulse: { value: si.pulseValue },
     uSelfIllumAlbedoFactor: { value: siAlbedoFactor },
     uSelfIllumCap: { value: tuning.selfIllumCap },
     uSelfIllumSat: { value: tuning.selfIllumSat },
+    uSelfIllumMaskShaping: { value: shapeSelfIllumMask ? 1.0 : 0.0 },
+    uSelfIllumMaskLow: { value: tuning.selfIllumMaskLow },
+    uSelfIllumMaskHigh: { value: tuning.selfIllumMaskHigh },
     uAlbedoCSB: { value: csb.vec },
     uHasAlbedoCSB: { value: csb.has },
     uNprTransmissiveColor: { value: transmissiveMap ?? whiteFallback() },
@@ -486,6 +502,20 @@ export function buildDeadlockMaterial(
     uDetailUvScale: { value: detail.uvScale },
     uDetailUvRotation: { value: detail.uvRotation },
     uDetailUvChannel: { value: detail.uvChannel },
+    uHasJitter: { value: hasJitter ? 1.0 : 0.0 },
+    uJitterMap: { value: jitterMap ?? whiteFallback() },
+    uHasJitterMask: { value: jitterMap ? 1.0 : 0.0 },
+    uJitterSpeedA: { value: firstNumber(morphic, ['g_flJitterSpeedA1', 'g_flJitterSpeedA'], 0) },
+    uJitterSpeedB: { value: firstNumber(morphic, ['g_flJitterSpeedB1', 'g_flJitterSpeedB'], 0) },
+    uJitterStrength: { value: tuning.jitterStrength },
+    uJitterFreqA: { value: vector3(morphic.vectors?.g_vJitterFrequenciesA1 ?? morphic.vectors?.g_vJitterFrequenciesA) },
+    uJitterFreqB: { value: vector3(morphic.vectors?.g_vJitterFrequenciesB1 ?? morphic.vectors?.g_vJitterFrequenciesB) },
+    uJitterAmpXA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesXA1 ?? morphic.vectors?.g_vJitterAmplitudesXA) },
+    uJitterAmpXB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesXB1 ?? morphic.vectors?.g_vJitterAmplitudesXB) },
+    uJitterAmpYA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesYA1 ?? morphic.vectors?.g_vJitterAmplitudesYA) },
+    uJitterAmpYB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesYB1 ?? morphic.vectors?.g_vJitterAmplitudesYB) },
+    uJitterAmpZA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesZA1 ?? morphic.vectors?.g_vJitterAmplitudesZA) },
+    uJitterAmpZB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesZB1 ?? morphic.vectors?.g_vJitterAmplitudesZB) },
     uHasHighlight: { value: highlight?.has ?? 0.0 },
     uHighlightTint: { value: highlight?.tint ?? new THREE.Color(0, 0, 0) },
     uHighlightCoverage: { value: highlight?.coverage ?? 0.0 },
@@ -519,6 +549,6 @@ export function buildDeadlockMaterial(
     uniforms,
     ownedTextures,
     dispose,
-    selfIllumScaleFn: si.fn,
+    selfIllumPulseFn: si.pulseFn,
   };
 }

--- a/src/lib/source2BlendAudit.test.ts
+++ b/src/lib/source2BlendAudit.test.ts
@@ -1,0 +1,196 @@
+/**
+ * ============================================================================
+ * BLEND-AUDIT-TEMP  --  TEMPORARY diagnostic harness, safe to delete.
+ * ============================================================================
+ * Companion to tools/blend-testbed.html. The .html shows the *visual* blend-math
+ * soft spots (alpha-weighted additive, no intra-mesh sort, per-mesh renderOrder).
+ * This file proves the two *code-path* claims that a visual mock cannot honestly
+ * demonstrate, by running the REAL modules:
+ *
+ *   1. "What draw-state ignores"  (skips non-morphic / opaque / glass; never
+ *      touches polygonOffset, depthTest, or material appearance).
+ *   2. "The gotcha": with `unified` on (default), the rendered material is the
+ *      buildDeadlockMaterial CLONE; the always-on draw-state pass is RESTORED on
+ *      the base, and only the mesh-level renderOrder survives. The two files
+ *      stay in sync only because both read the shared resolveBlendMode.
+ *
+ * This file ONLY IMPORTS the preview modules; it does not modify them.
+ * To remove the whole harness:  rm src/lib/source2BlendAudit.test.ts
+ *                               rm tools/blend-testbed.html
+ * (grep token: BLEND-AUDIT-TEMP)
+ * ============================================================================
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+
+import {
+  resolveSource2DrawState,
+  applySource2DrawState,
+} from './source2Preview/drawState';
+import { compileSource2DrawState } from './source2Preview/compileScene';
+import { resolveBlendMode } from './source2Preview/blendMode';
+import {
+  ADDITIVE_OVERLAY_RENDER_ORDER,
+  TRANSLUCENT_OVERLAY_RENDER_ORDER,
+} from './source2Preview/types';
+import { buildDeadlockMaterial } from './deadlockMaterial';
+import type { MorphicExtras } from './source2NprMaterial';
+
+function baseWith(morphic: MorphicExtras): THREE.MeshStandardMaterial {
+  const m = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  m.userData = { morphic };
+  return m;
+}
+function meshWith(mat: THREE.Material): THREE.Mesh {
+  return new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat);
+}
+
+const OPAQUE: MorphicExtras = { shader: 'pbr.vfx', ints: { F_USE_NPR_LIGHTING: 1 } };
+const ADDITIVE: MorphicExtras = {
+  shader: 'pbr.vfx',
+  blend_mode: 'additive',
+  ints: { F_USE_NPR_LIGHTING: 1, F_ADDITIVE_BLEND: 1, F_SELF_ILLUM: 1 },
+  floats: { g_flSelfIllumScale1: 5 },
+};
+const TRANSLUCENT: MorphicExtras = {
+  shader: 'pbr.vfx',
+  blend_mode: 'blend_zwrite',
+  ints: { F_USE_NPR_LIGHTING: 1, F_TRANSLUCENT: 1 },
+};
+const GLASS: MorphicExtras = { shader: 'pbr.vfx', ints: { F_USE_NPR_LIGHTING: 1, F_GLASS: 1 } };
+
+// ---------------------------------------------------------------------------
+describe('BLEND-AUDIT-TEMP: what draw-state ignores', () => {
+  it('skips materials with no morphic extras (returns null)', () => {
+    const mat = new THREE.MeshStandardMaterial();
+    const app = applySource2DrawState(meshWith(mat), mat);
+    expect(app).toBeNull();
+  });
+
+  it('no-ops on plain opaque morphic materials (restore is null, material untouched)', () => {
+    const mat = baseWith(OPAQUE);
+    const before = { blending: mat.blending, transparent: mat.transparent };
+    const app = applySource2DrawState(meshWith(mat), mat, OPAQUE);
+    expect(app).not.toBeNull();
+    expect(app!.restore).toBeNull(); // <- the "no-op" signal
+    expect(mat.blending).toBe(before.blending);
+    expect(mat.transparent).toBe(before.transparent);
+  });
+
+  it('excludes glass from the blend rules (routed to transmission instead)', () => {
+    const plan = resolveSource2DrawState(GLASS, baseWith(GLASS));
+    expect(plan.glass).toBe(true);
+    expect(plan.additive).toBe(false);
+    expect(plan.translucent).toBe(false);
+    expect(plan.isOverlay).toBe(false);
+  });
+
+  it('never enables polygonOffset, and only ever sets depthTest=true (both dead/no-op)', () => {
+    for (const m of [OPAQUE, ADDITIVE, TRANSLUCENT, GLASS]) {
+      const plan = resolveSource2DrawState(m);
+      expect(plan.polygonOffset).toBe(false); // drawState.ts:89 hardcoded false
+      expect(plan.depthTest).toBe(true); // only ever true == GLTFLoader default
+    }
+  });
+
+  it('never touches material appearance (no emissive/opacity/sheen in the plan or on apply)', () => {
+    const plan = resolveSource2DrawState(ADDITIVE);
+    expect('emissive' in plan).toBe(false);
+    expect('opacity' in plan).toBe(false);
+    expect('sheen' in plan).toBe(false);
+    expect('map' in plan).toBe(false);
+
+    const mat = baseWith(ADDITIVE);
+    mat.emissive = new THREE.Color(0x123456);
+    mat.opacity = 0.7;
+    applySource2DrawState(meshWith(mat), mat, ADDITIVE);
+    expect(mat.emissive.getHex()).toBe(0x123456); // unchanged
+    expect(mat.opacity).toBe(0.7); // unchanged (opacity scaling lives in the builders)
+  });
+
+  it('compile pass counts only morphic meshes; non-morphic geometry is skipped', () => {
+    const scene = new THREE.Group();
+    scene.add(meshWith(new THREE.MeshStandardMaterial())); // no morphic -> skipped
+    scene.add(meshWith(baseWith(ADDITIVE))); // morphic additive -> counted
+    const { stats, restore } = compileSource2DrawState(scene);
+    expect(stats.meshes).toBe(1);
+    expect(stats.morphicMaterials).toBe(1);
+    expect(stats.additive).toBe(1);
+    restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('BLEND-AUDIT-TEMP: unified clone supersedes the draw-state pass', () => {
+  // CORRECTED by this harness: what survives is the MATERIAL SWAP, not restore().
+  // restore() is symmetric and reverts mesh.renderOrder too (drawState.ts:165).
+  it('renderOrder survives the unified material SWAP; the base mutation stops rendering', () => {
+    const base = baseWith(ADDITIVE);
+    const mesh = meshWith(base);
+    const scene = new THREE.Group();
+    scene.add(mesh);
+
+    // 1) Always-on pass mutates the GLTF base material in place + sets mesh order.
+    compileSource2DrawState(scene);
+    expect(base.blending).toBe(THREE.AdditiveBlending);
+    expect(base.transparent).toBe(true);
+    expect(base.depthWrite).toBe(false);
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+
+    // 2) Unified builder clones the base and swaps the clone onto the mesh.
+    //    This is the LIVE runtime flow (no restore() while the model is shown).
+    const built = buildDeadlockMaterial(base);
+    mesh.material = built.material;
+
+    // mesh.renderOrder is untouched by the swap -> it orders the CLONE. (Survives.)
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+    // The clone is what renders; the draw-state mutation on `base` no longer
+    // contributes anything (base is detached from the mesh).
+    expect(mesh.material).not.toBe(base);
+    expect((mesh.material as THREE.Material).blending).toBe(THREE.AdditiveBlending);
+
+    built.dispose();
+  });
+
+  it('the clone decides blending ITSELF (not inherited from the base)', () => {
+    // Build from a FRESH base that never went through draw-state (NormalBlending).
+    // An AdditiveBlending clone therefore proves deadlockMaterial.ts:327 set it,
+    // not a copied-from-base value.
+    const fresh = baseWith(ADDITIVE);
+    expect(fresh.blending).toBe(THREE.NormalBlending);
+    const built = buildDeadlockMaterial(fresh);
+    expect((built.material as THREE.Material).blending).toBe(THREE.AdditiveBlending);
+    built.dispose();
+  });
+
+  it('restore() is a COMPLETE teardown: it reverts the base AND renderOrder', () => {
+    const base = baseWith(ADDITIVE);
+    const mesh = meshWith(base);
+    const scene = new THREE.Group();
+    scene.add(mesh);
+
+    const compiled = compileSource2DrawState(scene);
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+
+    compiled.restore();
+    expect(base.blending).toBe(THREE.NormalBlending); // reverted
+    expect(base.transparent).toBe(false); // reverted
+    expect(base.depthWrite).toBe(true); // reverted
+    expect(mesh.renderOrder).toBe(0); // ALSO reverted -- does NOT survive restore()
+  });
+
+  it('the two files agree ONLY via the shared resolveBlendMode', () => {
+    // drawState.ts:46 and deadlockMaterial.ts:264 both call resolveBlendMode(morphic).
+    // Nothing else couples them: change one mapping and they silently drift.
+    for (const [m, expected] of [
+      [ADDITIVE, 'additive'],
+      [TRANSLUCENT, 'blend_zwrite'],
+      [OPAQUE, 'opaque'],
+    ] as const) {
+      expect(resolveBlendMode(m)).toBe(expected);
+      expect(resolveSource2DrawState(m).blendMode).toBe(resolveBlendMode(m));
+    }
+    // translucent draw-state order constant, asserted so the harness pins both orders.
+    expect(resolveSource2DrawState(TRANSLUCENT).renderOrder).toBe(TRANSLUCENT_OVERLAY_RENDER_ORDER);
+  });
+});

--- a/src/lib/source2NprMaterial.test.ts
+++ b/src/lib/source2NprMaterial.test.ts
@@ -3,17 +3,13 @@ import * as THREE from 'three';
 import {
   NPR_FRAGMENT,
   NPR_PATCH_MAP,
-  OUTLINE_DEFAULT_THICKNESS,
-  OUTLINE_MAX_THICKNESS,
-  OUTLINE_MIN_THICKNESS,
+  NPR_VERTEX,
   applySource2MaterialHints,
-  buildOutlineShell,
   detailLayer,
   glassTransmissionTexture,
   hasDynamicAlphaOverride,
   highlightLayer,
   isTrueGlassMaterial,
-  outlineParams,
   translucentAlphaTexture,
   wrapMaterialWithNpr,
 } from './source2NprMaterial';
@@ -244,6 +240,9 @@ describe('highlightLayer', () => {
     expect(typeof patch === 'object' ? patch.value : '').toContain('#include <displacementmap_vertex>');
     expect(typeof patch === 'object' ? patch.value : '').toContain('vNprSourcePosition = transformed;');
     expect(typeof patch === 'object' ? patch.value : '').not.toContain('modelMatrix');
+    expect(NPR_VERTEX).toContain('uniform float uHasJitter;');
+    expect(NPR_VERTEX).toContain('uniform sampler2D uJitterMap;');
+    expect(NPR_VERTEX).toContain('uniform float uJitterStrength;');
     expect(NPR_FRAGMENT).toContain('uniform float uHasHighlight;');
     expect(NPR_FRAGMENT).toContain('uniform vec3  uHighlightPositionSource;');
     expect(NPR_FRAGMENT).toContain('varying vec3 vNprSourcePosition;');
@@ -522,111 +521,6 @@ describe('applySource2MaterialHints glass and cloak state', () => {
   });
 });
 
-describe('outlineParams (F8)', () => {
-  function morphic(overrides: Partial<MorphicExtras> = {}): MorphicExtras {
-    return { shader: 'pbr.vfx', ...overrides };
-  }
-
-  it('disables when no g_vSolidOutlineTint is authored', () => {
-    const p = outlineParams(morphic());
-    expect(p.enabled).toBe(false);
-    expect(p.reason).toBe('no-outline-tint');
-  });
-
-  it('disables when F_DISABLE_NPR_OUTLINE is set, keeping the authored tint readable', () => {
-    const p = outlineParams(
-      morphic({
-        vectors: { g_vSolidOutlineTint: [0.1, 0.2, 0.3, 1] },
-        ints: { F_DISABLE_NPR_OUTLINE: 1 },
-      })
-    );
-    expect(p.enabled).toBe(false);
-    expect(p.reason).toBe('disabled-flag');
-    expect(p.tint.r).toBeCloseTo(0.1);
-  });
-
-  it('combines outline tint + additive when enabled', () => {
-    const p = outlineParams(
-      morphic({
-        vectors: {
-          g_vSolidOutlineTint: [0.1, 0.2, 0.3, 1],
-          g_vSolidOutlineAdditive: [0.05, 0, 0.1, 0],
-        },
-      })
-    );
-    expect(p.enabled).toBe(true);
-    expect(p.reason).toBe('');
-    expect(p.tint.r).toBeCloseTo(0.15);
-    expect(p.tint.b).toBeCloseTo(0.4);
-  });
-
-  it('defaults thickness when unauthored', () => {
-    const p = outlineParams(morphic({ vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] } }));
-    expect(p.thickness).toBe(OUTLINE_DEFAULT_THICKNESS);
-  });
-
-  it('clamps a pathological large thickness to the safe max (no detached shell)', () => {
-    const p = outlineParams(
-      morphic({
-        vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] },
-        floats: { g_flOverrideNprOutlineThickness: 5 },
-      })
-    );
-    expect(p.thickness).toBe(OUTLINE_MAX_THICKNESS);
-  });
-
-  it('clamps a sub-pixel thickness up to the safe min', () => {
-    const p = outlineParams(
-      morphic({
-        vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] },
-        floats: { g_flOverrideNprOutlineThickness: 0.00001 },
-      })
-    );
-    expect(p.thickness).toBe(OUTLINE_MIN_THICKNESS);
-  });
-});
-
-describe('buildOutlineShell (F8)', () => {
-  function outlineMesh(morphic: MorphicExtras): THREE.Mesh {
-    const mat = new THREE.MeshStandardMaterial();
-    mat.userData = { morphic };
-    return new THREE.Mesh(new THREE.BoxGeometry(), mat);
-  }
-
-  it('returns null when the material is not outline-eligible', () => {
-    expect(buildOutlineShell(outlineMesh({ shader: 'pbr.vfx' }))).toBeNull();
-  });
-
-  it('returns null when F_DISABLE_NPR_OUTLINE opts out', () => {
-    const mesh = outlineMesh({
-      shader: 'pbr.vfx',
-      vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] },
-      ints: { F_DISABLE_NPR_OUTLINE: 1 },
-    });
-    expect(buildOutlineShell(mesh)).toBeNull();
-  });
-
-  it('adds a shell child for an eligible mesh and removes it on teardown', () => {
-    const mesh = outlineMesh({ shader: 'pbr.vfx', vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] } });
-    expect(mesh.children).toHaveLength(0);
-
-    const dispose = buildOutlineShell(mesh);
-    expect(dispose).toBeTypeOf('function');
-    expect(mesh.children).toHaveLength(1);
-
-    dispose!();
-    expect(mesh.children).toHaveLength(0);
-  });
-
-  it('shares the mesh geometry with the shell (disposes only its own material)', () => {
-    const mesh = outlineMesh({ shader: 'pbr.vfx', vectors: { g_vSolidOutlineTint: [1, 1, 1, 1] } });
-    const dispose = buildOutlineShell(mesh)!;
-    const shell = mesh.children[0] as THREE.Mesh;
-    expect(shell.geometry).toBe(mesh.geometry);
-    dispose();
-  });
-});
-
 describe('NPR rim mask (F8)', () => {
   it('drives the rim strength from the tint/rim mask GREEN channel', () => {
     const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
@@ -638,12 +532,41 @@ describe('NPR rim mask (F8)', () => {
 describe('NPR self-illum hue-preserving cap', () => {
   it('caps the self-illum additive by its peak channel so a bright tint keeps its hue', () => {
     const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
+
     expect(patch).toContain('float siPeak = max(max(siAdd.r, siAdd.g), siAdd.b);');
     expect(patch).toContain('siAdd *= uSelfIllumCap / siPeak;');
   });
 
+  it('applies the dynamic self-illum pulse after the cap so the cap does not flatten it', () => {
+    const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
+
+    expect(NPR_FRAGMENT).toContain('uniform float uSelfIllumPulse;');
+    expect(patch.indexOf('siAdd *= uSelfIllumCap / siPeak;')).toBeLessThan(
+      patch.indexOf('siAdd *= uSelfIllumPulse;')
+    );
+  });
+
   it('boosts self-illum tint chroma so a pale tint does not read white', () => {
     const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
+
     expect(patch).toContain('mix(vec3(siLuma), siColor, uSelfIllumSat)');
+  });
+
+  it('routes self-illum through the post-opaque NPR output so it affects visible color', () => {
+    const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
+
+    expect(NPR_FRAGMENT).not.toContain('csm_Emissive += siAdd;');
+    expect(patch).toContain('uHasSelfIllum');
+    expect(patch).toContain('nprOut += siAdd');
+  });
+
+  it('gates shaped self-illum to chromatic warm tattoo pixels, not the whole body mask', () => {
+    const patch = NPR_PATCH_MAP['*']['#include <opaque_fragment>'] as string;
+
+    expect(patch).toContain('float baseChroma = baseMax - baseMin;');
+    expect(patch).toContain('float baseWarmth = csm_DiffuseColor.r - max');
+    expect(patch).toContain('float detailGate = smoothstep');
+    expect(patch).toContain('float headRegion = smoothstep(70.0, 78.0, vNprSourcePosition.z)');
+    expect(patch).toContain('rawSiMask * rawSiMask * 8192.0 * inkGate');
   });
 });

--- a/src/lib/source2NprMaterial.ts
+++ b/src/lib/source2NprMaterial.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import CustomShaderMaterial, { type CSMPatchMap } from 'three-custom-shader-material/vanilla';
 import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+// Shared blend-mode resolver (the cycle-free leaf of the source2Preview core).
+import { resolveBlendMode } from './source2Preview/blendMode';
 
 /**
  * Source 2 NPR (cel / rim / tint) restyle for the Locker hero preview.
@@ -137,6 +139,12 @@ export interface NprTuning {
    * Calibration knob: 1.0 = authored chroma, higher = punchier color.
    */
   selfIllumSat: number;
+  /** Lower edge for optional self-illum mask shaping on noisy real masks. */
+  selfIllumMaskLow: number;
+  /** Upper edge for optional self-illum mask shaping on noisy real masks. */
+  selfIllumMaskHigh: number;
+  /** Source 2 authored jitter amplitudes are normalized controls, not Three model units. */
+  jitterStrength: number;
   keyDir: THREE.Vector3;
 }
 
@@ -275,6 +283,9 @@ export const DEFAULT_NPR_TUNING: NprTuning = {
   transPower: 2.0,
   selfIllumCap: 1.5,
   selfIllumSat: 1.6,
+  selfIllumMaskLow: 0.005,
+  selfIllumMaskHigh: 0.08,
+  jitterStrength: 0.3,
   keyDir: new THREE.Vector3(3, 5, 4).normalize(),
 };
 
@@ -315,12 +326,17 @@ export function vectorColor(v: number[] | undefined, fallback: THREE.Color): THR
   return new THREE.Color(v[0] ?? fallback.r, v[1] ?? fallback.g, v[2] ?? fallback.b);
 }
 
+export function vector3(v: number[] | undefined, fallback = new THREE.Vector3(0, 0, 0)): THREE.Vector3 {
+  if (!v) return fallback.clone();
+  return new THREE.Vector3(v[0] ?? fallback.x, v[1] ?? fallback.y, v[2] ?? fallback.z);
+}
+
 export function transmissiveTint(morphic: MorphicExtras): THREE.Color {
   return vectorColor(
     morphic.vectors?.TextureNprTramsissiveColor1 ??
-      morphic.vectors?.TextureNprTransmissiveColor1 ??
-      morphic.vectors?.g_vNprTransmissiveColor1 ??
-      morphic.vectors?.g_vNprTransmissiveColor,
+    morphic.vectors?.TextureNprTransmissiveColor1 ??
+    morphic.vectors?.g_vNprTransmissiveColor1 ??
+    morphic.vectors?.g_vNprTransmissiveColor,
     new THREE.Color(1, 1, 1)
   );
 }
@@ -700,6 +716,15 @@ export function summarizeNprScene(scene: THREE.Object3D): NprSceneSummary {
  * Cheap Source 2 material hints for shader families GLTFLoader cannot represent
  * fully. This deliberately mutates only standard/physical material properties
  * and returns a restore handle so it can be gated independently from the NPR CSM.
+ *
+ * This is the FLAG-GATED richer-material pass (glass transmission, opacity
+ * scaling, alpha masks, self-illum emissive, sheen, jitter). It also sets a
+ * draw-state subset (side / transparent / blending / depthWrite) that is
+ * intertwined with that work. The authoritative ALWAYS-ON owner of the same
+ * draw-state subset -- plus the mesh-level renderOrder this cannot set -- is
+ * `src/lib/source2Preview/` (`resolveSource2DrawState`); the two produce the
+ * same values and compose (this pass and the always-on pass each operate on the
+ * GLTF base material and restore it). Keep them in sync if either changes.
  */
 export function applySource2MaterialHints(
   scene: THREE.Object3D,
@@ -770,12 +795,7 @@ export function applySource2MaterialHints(
       };
 
       const glass = isTrueGlassMaterial(morphic, mat);
-      const fallbackBlendMode = flag(morphic, 'F_ADDITIVE_BLEND')
-        ? 'additive'
-        : flag(morphic, 'F_TRANSLUCENT') || flag(morphic, 'F_ADVANCED_TRANSLUCENCY')
-          ? 'blend_zwrite'
-          : 'opaque';
-      const blendMode = morphic.blend_mode ?? fallbackBlendMode;
+      const blendMode = resolveBlendMode(morphic);
       const translucent = blendMode === 'blend_zwrite' || blendMode === 'blend';
       const additive = blendMode === 'additive';
       const alphaBlend = !glass && (translucent || additive);
@@ -956,6 +976,21 @@ export function applySource2MaterialHints(
 // to <skinning_vertex> / <morphtarget_vertex>, risking the rigged spine. Keep this
 // to varying passthrough only.
 export const NPR_VERTEX = /* glsl */ `
+uniform float uTime;
+uniform float uHasJitter;
+uniform sampler2D uJitterMap;
+uniform float uHasJitterMask;
+uniform float uJitterSpeedA;
+uniform float uJitterSpeedB;
+uniform float uJitterStrength;
+uniform vec3  uJitterFreqA;
+uniform vec3  uJitterFreqB;
+uniform vec3  uJitterAmpXA;
+uniform vec3  uJitterAmpXB;
+uniform vec3  uJitterAmpYA;
+uniform vec3  uJitterAmpYB;
+uniform vec3  uJitterAmpZA;
+uniform vec3  uJitterAmpZB;
 varying vec2 vNprUv;
 varying vec2 vNprUv2;
 varying vec3 vNprSourcePosition;
@@ -1001,9 +1036,13 @@ uniform float uHasSelfIllum;
 uniform vec2  uSelfIllumScroll;
 uniform vec3  uSelfIllumTint;
 uniform float uSelfIllumScale;
+uniform float uSelfIllumPulse;
 uniform float uSelfIllumAlbedoFactor;
 uniform float uSelfIllumCap;
 uniform float uSelfIllumSat;
+uniform float uSelfIllumMaskShaping;
+uniform float uSelfIllumMaskLow;
+uniform float uSelfIllumMaskHigh;
 uniform vec3  uAlbedoCSB;
 uniform float uHasAlbedoCSB;
 uniform sampler2D uNprTransmissiveColor;
@@ -1020,6 +1059,20 @@ uniform vec2  uDetailUvOffset;
 uniform vec2  uDetailUvScale;
 uniform float uDetailUvRotation;
 uniform float uDetailUvChannel;
+uniform float uHasJitter;
+uniform sampler2D uJitterMap;
+uniform float uHasJitterMask;
+uniform float uJitterSpeedA;
+uniform float uJitterSpeedB;
+uniform float uJitterStrength;
+uniform vec3  uJitterFreqA;
+uniform vec3  uJitterFreqB;
+uniform vec3  uJitterAmpXA;
+uniform vec3  uJitterAmpXB;
+uniform vec3  uJitterAmpYA;
+uniform vec3  uJitterAmpYB;
+uniform vec3  uJitterAmpZA;
+uniform vec3  uJitterAmpZB;
 uniform float uHasHighlight;
 uniform vec3  uHighlightTint;
 uniform float uHighlightCoverage;
@@ -1140,6 +1193,17 @@ export const NPR_PATCH_MAP: CSMPatchMap = {
       type: 'vs',
       value: /* glsl */ `
       #include <displacementmap_vertex>
+      if (uHasJitter > 0.5) {
+        float jitterMask = uHasJitterMask > 0.5 ? texture2D(uJitterMap, vNprUv).r : 1.0;
+        vec3 jitterWaveA = sin(transformed * uJitterFreqA + vec3(uTime * uJitterSpeedA * 6.2831853));
+        vec3 jitterWaveB = sin(transformed * uJitterFreqB + vec3(uTime * uJitterSpeedB * 6.2831853));
+        vec3 jitterOffset = vec3(
+          dot(jitterWaveA, uJitterAmpXA) + dot(jitterWaveB, uJitterAmpXB),
+          dot(jitterWaveA, uJitterAmpYA) + dot(jitterWaveB, uJitterAmpYB),
+          dot(jitterWaveA, uJitterAmpZA) + dot(jitterWaveB, uJitterAmpZB)
+        );
+        transformed += jitterOffset * jitterMask * uJitterStrength;
+      }
       vNprSourcePosition = transformed;
     `,
     },
@@ -1201,37 +1265,38 @@ export const NPR_PATCH_MAP: CSMPatchMap = {
           nprOut = mix(nprOut, nprOut + clamp(uHighlightTint, vec3(0.0), vec3(4.0)), highlightAmount);
         }
 
-        // Self-illum (NPR plan D5/F2): scale-first, additive glow. Color is the
-        // tint<->albedo blend per g_flSelfIllumAlbedoFactor1 (familiar eyes glow
-        // their cyan tint at factor 0; viscous_head glows its green albedo at
-        // factor 1; inferno body mixes fire albedo + tint). diffuseColor.rgb holds
-        // the per-texel BASE albedo (unlit) here - correct for emission, which is
-        // view/shadow-independent. uHasSelfIllum is now scale-driven;
-        // a placeholder mask resolves to solid white (full coverage) on the CPU
-        // side. The GLB-baked base emissive is zeroed so this is the sole glow owner.
+        // Self-illum has to be added here, after Three has built gl_FragColor.
+        // CSM's emissive hook initializes totalEmissiveRadiance before the custom
+        // fragment body runs, so mutating csm_Emissive there compiles but is too
+        // late to affect outgoingLight in MeshStandard/Physical.
         if (uHasSelfIllum > 0.5) {
           vec2 siUv = fract(vNprUv + uSelfIllumScroll * uTime);
-          float siMask = texture2D(uSelfIllumMap, siUv).r;
-          vec3 siColor = mix(uSelfIllumTint, diffuseColor.rgb, uSelfIllumAlbedoFactor);
-          // Chroma boost: a pale authored tint (familiar eyes cyan [0.27,0.88,1] is
-          // luma-heavy) ACES-washes to white even when capped, because its red channel
-          // stays high. Push saturation about the luma axis so the off-hue channel drops
-          // and it reads as its color; a neutral/white tint (luma == channels) is left as
-          // is. Clamp >= 0 since over-saturation can drive a channel negative.
+          float rawSiMask = texture2D(uSelfIllumMap, siUv).r;
+          float siMask = rawSiMask;
+          if (uSelfIllumMaskShaping > 0.5) {
+            float baseMax = max(max(csm_DiffuseColor.r, csm_DiffuseColor.g), csm_DiffuseColor.b);
+            float baseMin = min(min(csm_DiffuseColor.r, csm_DiffuseColor.g), csm_DiffuseColor.b);
+            float baseChroma = baseMax - baseMin;
+            float baseWarmth = csm_DiffuseColor.r - max(csm_DiffuseColor.g, csm_DiffuseColor.b);
+            float baseLuma = dot(csm_DiffuseColor.rgb, vec3(0.2126, 0.7152, 0.0722));
+            float warmLine = smoothstep(0.0002, 0.003, baseWarmth);
+            float brightLine = smoothstep(0.006, 0.028, baseLuma) * smoothstep(0.0008, 0.006, baseChroma);
+            float detailGate = smoothstep(0.0008, 0.01, length(fwidth(csm_DiffuseColor.rgb)));
+            float headRegion = smoothstep(70.0, 78.0, vNprSourcePosition.z) *
+              (1.0 - smoothstep(8.0, 16.0, abs(vNprSourcePosition.x)));
+            float inkGate = max(warmLine, brightLine) * detailGate * (1.0 - headRegion);
+            siMask = clamp(rawSiMask * rawSiMask * 8192.0 * inkGate, 0.0, 1.0);
+          }
+          vec3 siColor = mix(uSelfIllumTint, csm_DiffuseColor.rgb, uSelfIllumAlbedoFactor);
           float siLuma = dot(siColor, vec3(0.2126, 0.7152, 0.0722));
           siColor = max(mix(vec3(siLuma), siColor, uSelfIllumSat), 0.0);
           vec3 siAdd = siColor * (siMask * uSelfIllumScale);
           if (uHasDetail > 0.5 && uDetailBlendMode > 0.5 && uDetailBlendMode < 1.5) {
             siAdd += nprDetail * (uDetailBlendFactor * siMask * uSelfIllumScale);
           }
-          // Hue-preserving cap: a high authored self-illum scale (familiar eyes cyan
-          // at 2.6, inferno at 10) pushes a saturated tint into HDR where the
-          // downstream ACES tonemap desaturates it to white (the in-game glow leans on
-          // HDR + bloom the preview lacks). Scale the whole additive down by its peak
-          // channel so the tint HUE survives the tonemap - trades unreachable HDR
-          // brightness for a readable color. Subtler glows (peak <= cap) are untouched.
           float siPeak = max(max(siAdd.r, siAdd.g), siAdd.b);
           if (siPeak > uSelfIllumCap) siAdd *= uSelfIllumCap / siPeak;
+          siAdd *= uSelfIllumPulse;
           nprOut += siAdd;
         }
 
@@ -1297,6 +1362,14 @@ export function wrapMaterialWithNpr(
     detailMap.wrapT = THREE.RepeatWrapping;
     detailMap.needsUpdate = true;
   }
+  const legacyJitterMask = morphic.resolvedTextures?.g_tJitterMask;
+  const jitterMap = isMeaningfulMask(legacyJitterMask) ? legacyJitterMask.clone() : null;
+  if (jitterMap) {
+    jitterMap.wrapS = THREE.RepeatWrapping;
+    jitterMap.wrapT = THREE.RepeatWrapping;
+    jitterMap.needsUpdate = true;
+  }
+  const hasJitter = flag(morphic, 'F_JITTER_VERTICES');
 
   // The GLB exporter bakes viscous_head's emissive (texture + green factor) into the
   // base; the lit pass would emit it before our patch runs -> double-green. When the
@@ -1332,11 +1405,15 @@ export function wrapMaterialWithNpr(
     uSelfIllumScroll: { value: new THREE.Vector2(siScroll?.[0] ?? 0, siScroll?.[1] ?? 0) },
     uSelfIllumTint: { value: siTint },
     uSelfIllumScale: { value: siScale },
+    uSelfIllumPulse: { value: 1.0 },
     // Parity with the unified path: the shared GLSL references these uniforms, so
     // the legacy wrap must declare them too or the material fails to compile.
     uSelfIllumAlbedoFactor: { value: firstNumber(morphic, ['g_flSelfIllumAlbedoFactor1'], 0) },
     uSelfIllumCap: { value: tuning.selfIllumCap },
     uSelfIllumSat: { value: tuning.selfIllumSat },
+    uSelfIllumMaskShaping: { value: 0.0 },
+    uSelfIllumMaskLow: { value: tuning.selfIllumMaskLow },
+    uSelfIllumMaskHigh: { value: tuning.selfIllumMaskHigh },
     uAlbedoCSB: { value: albedoCsb(morphic).vec },
     uHasAlbedoCSB: { value: albedoCsb(morphic).has },
     uNprTransmissiveColor: { value: transmissiveMap ?? whiteFallback() },
@@ -1353,6 +1430,20 @@ export function wrapMaterialWithNpr(
     uDetailUvScale: { value: detail.uvScale },
     uDetailUvRotation: { value: detail.uvRotation },
     uDetailUvChannel: { value: detail.uvChannel },
+    uHasJitter: { value: hasJitter ? 1.0 : 0.0 },
+    uJitterMap: { value: jitterMap ?? whiteFallback() },
+    uHasJitterMask: { value: jitterMap ? 1.0 : 0.0 },
+    uJitterSpeedA: { value: firstNumber(morphic, ['g_flJitterSpeedA1', 'g_flJitterSpeedA'], 0) },
+    uJitterSpeedB: { value: firstNumber(morphic, ['g_flJitterSpeedB1', 'g_flJitterSpeedB'], 0) },
+    uJitterStrength: { value: tuning.jitterStrength },
+    uJitterFreqA: { value: vector3(morphic.vectors?.g_vJitterFrequenciesA1 ?? morphic.vectors?.g_vJitterFrequenciesA) },
+    uJitterFreqB: { value: vector3(morphic.vectors?.g_vJitterFrequenciesB1 ?? morphic.vectors?.g_vJitterFrequenciesB) },
+    uJitterAmpXA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesXA1 ?? morphic.vectors?.g_vJitterAmplitudesXA) },
+    uJitterAmpXB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesXB1 ?? morphic.vectors?.g_vJitterAmplitudesXB) },
+    uJitterAmpYA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesYA1 ?? morphic.vectors?.g_vJitterAmplitudesYA) },
+    uJitterAmpYB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesYB1 ?? morphic.vectors?.g_vJitterAmplitudesYB) },
+    uJitterAmpZA: { value: vector3(morphic.vectors?.g_vJitterAmplitudesZA1 ?? morphic.vectors?.g_vJitterAmplitudesZA) },
+    uJitterAmpZB: { value: vector3(morphic.vectors?.g_vJitterAmplitudesZB1 ?? morphic.vectors?.g_vJitterAmplitudesZB) },
     uHasHighlight: { value: 0.0 },
     uHighlightTint: { value: new THREE.Color(0, 0, 0) },
     uHighlightCoverage: { value: 0.0 },
@@ -1377,6 +1468,7 @@ export function wrapMaterialWithNpr(
   const ownedTextures = tintMask ? [tintMask] : [];
   if (transmissiveMap) ownedTextures.push(transmissiveMap);
   if (detailMap) ownedTextures.push(detailMap);
+  if (jitterMap) ownedTextures.push(jitterMap);
   return { material: csm as unknown as THREE.Material, uniforms, ownedTextures };
 }
 
@@ -1399,122 +1491,10 @@ export function unwrapNprBase(mat: THREE.Material): void {
     delete m.__nprPrevEmissiveIntensity;
   }
   if (!m.__csm) return;
-  mat.onBeforeCompile = m.__csm.prevOnBeforeCompile ?? (() => {});
+  mat.onBeforeCompile = m.__csm.prevOnBeforeCompile ?? (() => { });
   delete m.__csm;
   // CSM set customProgramCacheKey as an own property; drop it to fall back to the
   // prototype default (it is non-optional on Material, hence the record cast).
   delete (mat as unknown as Record<string, unknown>).customProgramCacheKey;
   mat.needsUpdate = true;
-}
-
-export interface NprOutlineParams {
-  /** True when the mesh is outline-eligible (real outline tint present, not disabled). */
-  enabled: boolean;
-  /** Why disabled: '' when enabled, else the gate that closed it. */
-  reason: '' | 'no-outline-tint' | 'disabled-flag';
-  /** Shell color: g_vSolidOutlineTint + g_vSolidOutlineAdditive. */
-  tint: THREE.Color;
-  /** Inverted-hull push distance in object space, clamped to OUTLINE_*_THICKNESS. */
-  thickness: number;
-}
-
-// Inverted-hull thickness bounds (object space). The default matches the small
-// shell the in-game outline reads as; the max keeps a pathological authored value
-// (e.g. one in engine units) from inflating into a giant shell that detaches from
-// the body. We deliberately do NOT convert engine units (that would be guessing a
-// Source 2 constant); we only bound the value to a visually safe range.
-export const OUTLINE_DEFAULT_THICKNESS = 0.02;
-export const OUTLINE_MIN_THICKNESS = 0.002;
-export const OUTLINE_MAX_THICKNESS = 0.05;
-
-/**
- * Pure outline eligibility + parameters from a material's morphic extras (F8).
- * Split out of buildOutlineShell so eligibility / tint / thickness are testable
- * without constructing a real mesh + skeleton. Eligibility keys on the PRESENCE of
- * g_vSolidOutlineTint (the real outline data confirmed in vpkmerge fixtures);
- * F_DISABLE_NPR_OUTLINE opts out. Thickness is clamped (see OUTLINE_*_THICKNESS).
- */
-export function outlineParams(morphic: MorphicExtras): NprOutlineParams {
-  const tintVec = morphic.vectors?.g_vSolidOutlineTint;
-  if (!tintVec) {
-    return {
-      enabled: false,
-      reason: 'no-outline-tint',
-      tint: new THREE.Color(0, 0, 0),
-      thickness: OUTLINE_DEFAULT_THICKNESS,
-    };
-  }
-  const addVec = morphic.vectors?.g_vSolidOutlineAdditive;
-  const tint = new THREE.Color(
-    (tintVec[0] ?? 0) + (addVec?.[0] ?? 0),
-    (tintVec[1] ?? 0) + (addVec?.[1] ?? 0),
-    (tintVec[2] ?? 0) + (addVec?.[2] ?? 0)
-  );
-  if (scalar(morphic.ints?.F_DISABLE_NPR_OUTLINE, 0) === 1) {
-    return { enabled: false, reason: 'disabled-flag', tint, thickness: OUTLINE_DEFAULT_THICKNESS };
-  }
-  const raw =
-    scalar(morphic.floats?.g_flOverrideNprOutlineThickness, OUTLINE_DEFAULT_THICKNESS) ||
-    OUTLINE_DEFAULT_THICKNESS;
-  const thickness = Math.min(Math.max(raw, OUTLINE_MIN_THICKNESS), OUTLINE_MAX_THICKNESS);
-  return { enabled: true, reason: '', tint, thickness };
-}
-
-/**
- * Build the inverted-hull solid-color outline shell for a mesh, or null when the
- * mesh is not outline-eligible. Faithful to Source 2's method (vpkmerge strips
- * the engine shells from the export, so they are regenerated here). The shell is
- * added as a child of `mesh` so it inherits the mesh transform; for a SkinnedMesh
- * it binds the SAME skeleton + bindMatrix so it deforms with the body. Returns a
- * teardown that removes the shell and disposes ONLY the outline material
- * (geometry + skeleton are shared with the real mesh).
- *
- * Gated behind USE_NPR_OUTLINE in the viewer (default off): the skinned-shell
- * binding is the highest-risk piece, so it ships independently of ramp/rim/tint.
- * Eligibility keys on the PRESENCE of g_vSolidOutlineTint (the real outline data
- * confirmed in vpkmerge fixtures); F_DISABLE_NPR_OUTLINE, when present, opts out.
- */
-export function buildOutlineShell(mesh: THREE.Mesh): (() => void) | null {
-  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-  const base = mats[0];
-  const morphic = base ? getMorphic(base) : undefined;
-  if (!morphic) return null;
-  const params = outlineParams(morphic);
-  if (!params.enabled) return null;
-
-  const outlineMat = new CustomShaderMaterial({
-    baseMaterial: new THREE.MeshBasicMaterial({ side: THREE.BackSide }),
-    vertexShader: /* glsl */ `
-      uniform float uThickness;
-      void main() { csm_Position = position + normal * uThickness; }
-    `,
-    fragmentShader: /* glsl */ `
-      uniform vec3 uOutlineTint;
-      void main() { csm_FragColor = vec4(uOutlineTint, 1.0); }
-    `,
-    uniforms: {
-      uThickness: { value: params.thickness },
-      uOutlineTint: { value: params.tint },
-    },
-  });
-
-  const skinned = mesh as THREE.SkinnedMesh;
-  let shell: THREE.Mesh;
-  if (skinned.isSkinnedMesh) {
-    const s = new THREE.SkinnedMesh(mesh.geometry, outlineMat as unknown as THREE.Material);
-    // Same skeleton + bindMatrix so the shell deforms with the body. The hull is
-    // expanded in object space before skinning, so it follows the bones.
-    s.bind(skinned.skeleton, skinned.bindMatrix);
-    shell = s;
-  } else {
-    shell = new THREE.Mesh(mesh.geometry, outlineMat as unknown as THREE.Material);
-  }
-  shell.frustumCulled = false;
-  mesh.add(shell);
-
-  return () => {
-    mesh.remove(shell);
-    // Geometry + skeleton are SHARED with the real mesh; dispose only the material.
-    outlineMat.dispose();
-  };
 }

--- a/src/lib/source2Preview/blendMode.ts
+++ b/src/lib/source2Preview/blendMode.ts
@@ -1,0 +1,28 @@
+/**
+ * The single source of truth for resolving a Source 2 blend mode from morphic
+ * extras. Prefers the explicit `blend_mode` extras field and falls back to the
+ * shader flags, so v1 GLBs (no `blend_mode`) still resolve and producer/consumer
+ * cannot drift.
+ *
+ * This is a dependency-free leaf: it imports only the `MorphicExtras` *type*
+ * (erased at compile time), so the richer modules that own draw state
+ * (`source2NprMaterial.ts`, `deadlockMaterial.ts`) can import it without creating
+ * an import cycle back through `drawState.ts`.
+ */
+import type { MorphicExtras } from '../source2NprMaterial';
+import type { Source2BlendMode } from './types';
+
+function intFlag(morphic: MorphicExtras, name: string): boolean {
+  const v = morphic.ints?.[name];
+  const n = Array.isArray(v) ? (v[0] ?? 0) : (v ?? 0);
+  return n !== 0;
+}
+
+export function resolveBlendMode(morphic: MorphicExtras): Source2BlendMode {
+  if (morphic.blend_mode) return morphic.blend_mode;
+  if (intFlag(morphic, 'F_ADDITIVE_BLEND')) return 'additive';
+  if (intFlag(morphic, 'F_TRANSLUCENT') || intFlag(morphic, 'F_ADVANCED_TRANSLUCENCY')) {
+    return 'blend_zwrite';
+  }
+  return 'opaque';
+}

--- a/src/lib/source2Preview/compileScene.test.ts
+++ b/src/lib/source2Preview/compileScene.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import type { MorphicExtras } from '../source2NprMaterial';
+import { compileSource2DrawState } from './compileScene';
+import { ADDITIVE_OVERLAY_RENDER_ORDER, TRANSLUCENT_OVERLAY_RENDER_ORDER } from './types';
+
+function meshNamed(name: string, morphic: MorphicExtras | null): THREE.Mesh {
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  if (morphic) material.userData = { morphic };
+  const mesh = new THREE.Mesh(new THREE.BufferGeometry(), material);
+  mesh.name = name;
+  return mesh;
+}
+
+function sampleScene(): THREE.Scene {
+  const scene = new THREE.Scene();
+  scene.add(meshNamed('body', { shader: 'pbr.vfx', blend_mode: 'opaque' }));
+  scene.add(meshNamed('inferno_armglow', { shader: 'pbr.vfx', blend_mode: 'additive' }));
+  scene.add(meshNamed('ghost_glow', { shader: 'pbr.vfx', ints: { F_ADDITIVE_BLEND: 1 } }));
+  scene.add(meshNamed('goo', { shader: 'pbr.vfx', blend_mode: 'blend_zwrite' }));
+  scene.add(meshNamed('cape', { shader: 'pbr.vfx', ints: { F_RENDER_BACKFACES: 1 } }));
+  scene.add(meshNamed('plain', null)); // a non-morphic mesh is ignored
+  return scene;
+}
+
+describe('compileSource2DrawState', () => {
+  it('applies draw state across the scene and tallies stats', () => {
+    const scene = sampleScene();
+    const { stats } = compileSource2DrawState(scene);
+    expect(stats.morphicMaterials).toBe(5);
+    expect(stats.additive).toBe(2); // inferno_armglow + ghost_glow
+    expect(stats.translucent).toBe(1); // goo
+    expect(stats.backfaces).toBe(1); // cape
+  });
+
+  it('pushes additive overlays to a late renderOrder, leaves the body opaque', () => {
+    const scene = sampleScene();
+    compileSource2DrawState(scene);
+    const byName = (n: string) => scene.children.find((c) => c.name === n) as THREE.Mesh;
+    expect(byName('inferno_armglow').renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+    expect(byName('ghost_glow').renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+    expect(byName('goo').renderOrder).toBe(TRANSLUCENT_OVERLAY_RENDER_ORDER);
+    expect(byName('body').renderOrder).toBe(0);
+
+    const glow = byName('inferno_armglow').material as THREE.MeshStandardMaterial;
+    expect(glow.blending).toBe(THREE.AdditiveBlending);
+    expect(glow.depthWrite).toBe(false);
+    expect(glow.transparent).toBe(true);
+
+    const body = byName('body').material as THREE.MeshStandardMaterial;
+    expect(body.transparent).toBe(false);
+    expect(body.blending).toBe(THREE.NormalBlending);
+  });
+
+  it('restore reverts the whole scene to its original draw state', () => {
+    const scene = sampleScene();
+    const { restore } = compileSource2DrawState(scene);
+    restore();
+    for (const child of scene.children) {
+      const mesh = child as THREE.Mesh;
+      expect(mesh.renderOrder).toBe(0);
+      const mat = mesh.material as THREE.MeshStandardMaterial | undefined;
+      if (mat) {
+        expect(mat.blending).toBe(THREE.NormalBlending);
+        expect(mat.transparent).toBe(false);
+        expect(mat.depthWrite).toBe(true);
+      }
+    }
+  });
+
+  it('is a no-op on a scene with no morphic materials', () => {
+    const scene = new THREE.Scene();
+    scene.add(meshNamed('plain', null));
+    const { stats } = compileSource2DrawState(scene);
+    expect(stats.morphicMaterials).toBe(0);
+    expect(stats.meshes).toBe(0);
+  });
+});

--- a/src/lib/source2Preview/compileScene.ts
+++ b/src/lib/source2Preview/compileScene.ts
@@ -1,0 +1,76 @@
+/**
+ * Always-on Source 2 draw-state compilation over a loaded GLTF scene.
+ *
+ * Traverses the scene once and applies `applySource2DrawState` to every material
+ * carrying morphic extras, regardless of dev flags. This is the pass that makes
+ * additive self-illum glow overlays (kept by the vpkmerge exporter) composite
+ * correctly on the default preview path, where the scene would otherwise render
+ * untouched GLTFLoader materials (an opaque white hull for an additive overlay).
+ *
+ * Returns a `restore` handle so the host component can revert the mutations on
+ * scene change / unmount, exactly like `applySource2MaterialHints`. The mutations
+ * are restricted to the draw-state subset (blend/depth/cull/render-order), so
+ * this composes cleanly with the flag-gated NPR/unified passes: those operate on
+ * owned clones (the GLTF base is restored here) and re-decide material state on
+ * the clone, while the mesh-level `renderOrder` set here persists across a
+ * material swap.
+ */
+import type * as THREE from 'three';
+import { getMorphic } from '../source2NprMaterial';
+import { applySource2DrawState } from './drawState';
+import type { Source2CompileResult, Source2CompileStats } from './types';
+
+export function compileSource2DrawState(scene: THREE.Object3D): Source2CompileResult {
+  const restores: Array<() => void> = [];
+  const seen = new Set<THREE.Material>();
+  const stats: Source2CompileStats = {
+    meshes: 0,
+    morphicMaterials: 0,
+    additive: 0,
+    translucent: 0,
+    backfaces: 0,
+    unlit: 0,
+    glass: 0,
+  };
+
+  scene.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.material) return;
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    let meshCounted = false;
+    mats.forEach((mat) => {
+      if (!mat) return;
+      const morphic = getMorphic(mat);
+      if (!morphic) return;
+
+      const application = applySource2DrawState(mesh, mat, morphic);
+      if (!application) return;
+
+      // Count each unique material once (a material may be shared across meshes).
+      if (!seen.has(mat)) {
+        seen.add(mat);
+        stats.morphicMaterials += 1;
+        const { plan } = application;
+        if (plan.additive) stats.additive += 1;
+        if (plan.translucent) stats.translucent += 1;
+        if (plan.backfaces) stats.backfaces += 1;
+        if (plan.unlit) stats.unlit += 1;
+        if (plan.glass) stats.glass += 1;
+      }
+      if (!meshCounted) {
+        meshCounted = true;
+        stats.meshes += 1;
+      }
+      if (application.restore) restores.push(application.restore);
+    });
+  });
+
+  return {
+    // Restore in reverse application order so multi-material meshes (whose
+    // renderOrder is per-mesh) wind back to their original draw order.
+    restore: () => {
+      for (let i = restores.length - 1; i >= 0; i -= 1) restores[i]();
+    },
+    stats,
+  };
+}

--- a/src/lib/source2Preview/debugSummary.test.ts
+++ b/src/lib/source2Preview/debugSummary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import type { MorphicExtras } from '../source2NprMaterial';
+import { compileSource2DrawState } from './compileScene';
+import { summarizeSource2Scene } from './debugSummary';
+
+function meshNamed(name: string, morphic: MorphicExtras | null): THREE.Mesh {
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  if (morphic) material.userData = { morphic };
+  const mesh = new THREE.Mesh(new THREE.BufferGeometry(), material);
+  mesh.name = name;
+  return mesh;
+}
+
+function scene(): THREE.Scene {
+  const s = new THREE.Scene();
+  s.add(meshNamed('body', { shader: 'pbr.vfx', blend_mode: 'opaque' }));
+  s.add(
+    meshNamed('arm_glow', {
+      shader: 'pbr.vfx',
+      blend_mode: 'additive',
+      ints: { F_SELF_ILLUM: 1 },
+      floats: { g_flSelfIllumScale1: 1.5 },
+    })
+  );
+  s.add(meshNamed('goo', { shader: 'pbr.vfx', blend_mode: 'blend' }));
+  s.add(meshNamed('plain', null));
+  return s;
+}
+
+describe('summarizeSource2Scene', () => {
+  it('counts materials, morphic materials, and blend-mode distribution', () => {
+    const summary = summarizeSource2Scene(scene());
+    expect(summary.materialCount).toBe(4);
+    expect(summary.morphicMaterialCount).toBe(3);
+    expect(summary.additiveMaterialCount).toBe(1);
+    expect(summary.translucentMaterialCount).toBe(1);
+    expect(summary.selfIllumMaterialCount).toBe(1);
+    expect(summary.blendModeDistribution.additive).toBe(1);
+    expect(summary.blendModeDistribution.blend).toBe(1);
+    expect(summary.blendModeDistribution.opaque).toBe(1);
+  });
+
+  it('reports overlay mesh names and the applied renderOrder distribution', () => {
+    const s = scene();
+    compileSource2DrawState(s); // apply draw state first, then inspect orders
+    const summary = summarizeSource2Scene(s);
+    expect(summary.overlayMeshNames).toContain('arm_glow');
+    expect(summary.overlayMeshNames).toContain('goo');
+    expect(summary.overlayMeshNames).not.toContain('body');
+    // body + plain stay at 0; the two overlays move to 8 / 10.
+    expect(summary.renderOrderDistribution[0]).toBe(2);
+    expect(summary.renderOrderDistribution[10]).toBe(1);
+    expect(summary.renderOrderDistribution[8]).toBe(1);
+  });
+});

--- a/src/lib/source2Preview/debugSummary.ts
+++ b/src/lib/source2Preview/debugSummary.ts
@@ -1,0 +1,91 @@
+/**
+ * Read-only census of a loaded Source 2 preview scene, for the dev debug panel
+ * and the Phase 3 additive-overlay round-trip check. Reports the distributions
+ * the plan asks for: material / morphic / additive / self-illum counts, blend
+ * mode distribution, render-order distribution, and overlay mesh names.
+ *
+ * Pure read: it never mutates the scene. Run it AFTER `compileSource2DrawState`
+ * to see the applied render orders.
+ */
+import type * as THREE from 'three';
+import { getMorphic, isSelfIllumMaterial } from '../source2NprMaterial';
+import { resolveSource2DrawState } from './drawState';
+import type { Source2BlendMode } from './types';
+
+export interface Source2SceneSummary {
+  /** Every material on every mesh (morphic or not). */
+  materialCount: number;
+  morphicMaterialCount: number;
+  additiveMaterialCount: number;
+  translucentMaterialCount: number;
+  selfIllumMaterialCount: number;
+  unlitMaterialCount: number;
+  backfaceMaterialCount: number;
+  glassMaterialCount: number;
+  /** Count of morphic materials per resolved blend mode. */
+  blendModeDistribution: Record<Source2BlendMode, number>;
+  /** Count of meshes per current `mesh.renderOrder` value. */
+  renderOrderDistribution: Record<number, number>;
+  /** Names of meshes carrying an additive or translucent overlay material. */
+  overlayMeshNames: string[];
+}
+
+export function summarizeSource2Scene(scene: THREE.Object3D): Source2SceneSummary {
+  const seen = new Set<THREE.Material>();
+  const blendModeDistribution: Record<Source2BlendMode, number> = {
+    opaque: 0,
+    blend: 0,
+    blend_zwrite: 0,
+    additive: 0,
+  };
+  const renderOrderDistribution: Record<number, number> = {};
+  const overlayMeshNames: string[] = [];
+
+  const summary: Source2SceneSummary = {
+    materialCount: 0,
+    morphicMaterialCount: 0,
+    additiveMaterialCount: 0,
+    translucentMaterialCount: 0,
+    selfIllumMaterialCount: 0,
+    unlitMaterialCount: 0,
+    backfaceMaterialCount: 0,
+    glassMaterialCount: 0,
+    blendModeDistribution,
+    renderOrderDistribution,
+    overlayMeshNames,
+  };
+
+  scene.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.material) return;
+
+    const order = mesh.renderOrder ?? 0;
+    renderOrderDistribution[order] = (renderOrderDistribution[order] ?? 0) + 1;
+
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    let meshIsOverlay = false;
+    mats.forEach((mat) => {
+      if (!mat || seen.has(mat)) return;
+      seen.add(mat);
+      summary.materialCount += 1;
+
+      const morphic = getMorphic(mat);
+      if (!morphic) return;
+      summary.morphicMaterialCount += 1;
+      if (isSelfIllumMaterial(mat)) summary.selfIllumMaterialCount += 1;
+
+      const plan = resolveSource2DrawState(morphic, mat);
+      blendModeDistribution[plan.blendMode] += 1;
+      if (plan.additive) summary.additiveMaterialCount += 1;
+      if (plan.translucent) summary.translucentMaterialCount += 1;
+      if (plan.unlit) summary.unlitMaterialCount += 1;
+      if (plan.backfaces) summary.backfaceMaterialCount += 1;
+      if (plan.glass) summary.glassMaterialCount += 1;
+      if (plan.isOverlay) meshIsOverlay = true;
+    });
+
+    if (meshIsOverlay) overlayMeshNames.push(mesh.name || '(unnamed)');
+  });
+
+  return summary;
+}

--- a/src/lib/source2Preview/drawState.test.ts
+++ b/src/lib/source2Preview/drawState.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import type { MorphicExtras } from '../source2NprMaterial';
+import { applySource2DrawState, resolveBlendMode, resolveSource2DrawState } from './drawState';
+import { ADDITIVE_OVERLAY_RENDER_ORDER, TRANSLUCENT_OVERLAY_RENDER_ORDER } from './types';
+
+function morphic(overrides: Partial<MorphicExtras> = {}): MorphicExtras {
+  return { shader: 'pbr.vfx', ...overrides };
+}
+
+function meshWith(morphicExtras: MorphicExtras): {
+  mesh: THREE.Mesh;
+  material: THREE.MeshStandardMaterial;
+} {
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  material.userData = { morphic: morphicExtras };
+  const mesh = new THREE.Mesh(new THREE.BufferGeometry(), material);
+  return { mesh, material };
+}
+
+describe('resolveBlendMode', () => {
+  it('prefers the explicit blend_mode extras field', () => {
+    expect(resolveBlendMode(morphic({ blend_mode: 'additive' }))).toBe('additive');
+    expect(resolveBlendMode(morphic({ blend_mode: 'blend' }))).toBe('blend');
+    expect(resolveBlendMode(morphic({ blend_mode: 'blend_zwrite' }))).toBe('blend_zwrite');
+    expect(resolveBlendMode(morphic({ blend_mode: 'opaque' }))).toBe('opaque');
+  });
+
+  it('falls back to flags when blend_mode is absent (v1 GLBs)', () => {
+    expect(resolveBlendMode(morphic({ ints: { F_ADDITIVE_BLEND: 1 } }))).toBe('additive');
+    expect(resolveBlendMode(morphic({ ints: { F_TRANSLUCENT: 1 } }))).toBe('blend_zwrite');
+    expect(resolveBlendMode(morphic({ ints: { F_ADVANCED_TRANSLUCENCY: 1 } }))).toBe('blend_zwrite');
+    expect(resolveBlendMode(morphic())).toBe('opaque');
+  });
+});
+
+describe('resolveSource2DrawState', () => {
+  it('additive overlay: AdditiveBlending, depthTest on, depthWrite off, late renderOrder', () => {
+    const plan = resolveSource2DrawState(morphic({ blend_mode: 'additive' }));
+    expect(plan.isOverlay).toBe(true);
+    expect(plan.additive).toBe(true);
+    expect(plan.transparent).toBe(true);
+    expect(plan.blending).toBe(THREE.AdditiveBlending);
+    expect(plan.depthTest).toBe(true);
+    expect(plan.depthWrite).toBe(false);
+    expect(plan.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+  });
+
+  it('translucent blend_zwrite keeps depthWrite on; plain blend turns it off', () => {
+    const zwrite = resolveSource2DrawState(morphic({ blend_mode: 'blend_zwrite' }));
+    expect(zwrite.translucent).toBe(true);
+    expect(zwrite.transparent).toBe(true);
+    expect(zwrite.depthWrite).toBe(true);
+    expect(zwrite.renderOrder).toBe(TRANSLUCENT_OVERLAY_RENDER_ORDER);
+
+    const blend = resolveSource2DrawState(morphic({ blend_mode: 'blend' }));
+    expect(blend.translucent).toBe(true);
+    expect(blend.depthWrite).toBe(false);
+    expect(blend.renderOrder).toBe(TRANSLUCENT_OVERLAY_RENDER_ORDER);
+  });
+
+  it('opaque material is not an overlay and keeps default render state', () => {
+    const plan = resolveSource2DrawState(morphic({ blend_mode: 'opaque' }));
+    expect(plan.isOverlay).toBe(false);
+    expect(plan.transparent).toBe(false);
+    expect(plan.blending).toBe(THREE.NormalBlending);
+    expect(plan.renderOrder).toBe(0);
+    expect(plan.side).toBeNull();
+    expect(plan.toneMapped).toBeNull();
+  });
+
+  it('F_RENDER_BACKFACES forces DoubleSide', () => {
+    const plan = resolveSource2DrawState(morphic({ ints: { F_RENDER_BACKFACES: 1 } }));
+    expect(plan.backfaces).toBe(true);
+    expect(plan.side).toBe(THREE.DoubleSide);
+  });
+
+  it('F_UNLIT disables tone mapping', () => {
+    const plan = resolveSource2DrawState(morphic({ ints: { F_UNLIT: 1 } }));
+    expect(plan.unlit).toBe(true);
+    expect(plan.toneMapped).toBe(false);
+  });
+
+  it('glass renders through transmission, never as an additive/translucent overlay', () => {
+    const plan = resolveSource2DrawState(morphic({ ints: { F_GLASS: 1 } }));
+    expect(plan.glass).toBe(true);
+    expect(plan.additive).toBe(false);
+    expect(plan.translucent).toBe(false);
+    expect(plan.isOverlay).toBe(false);
+  });
+
+  it('explicit additive blend_mode wins over a glass flag', () => {
+    const plan = resolveSource2DrawState(morphic({ ints: { F_GLASS: 1 }, blend_mode: 'additive' }));
+    expect(plan.glass).toBe(false);
+    expect(plan.additive).toBe(true);
+  });
+});
+
+describe('applySource2DrawState', () => {
+  it('applies the additive rule to mesh + material and reports the plan', () => {
+    const { mesh, material } = meshWith(morphic({ blend_mode: 'additive' }));
+    const app = applySource2DrawState(mesh, material);
+    expect(app).not.toBeNull();
+    expect(app!.plan.additive).toBe(true);
+    expect(material.transparent).toBe(true);
+    expect(material.blending).toBe(THREE.AdditiveBlending);
+    expect(material.depthTest).toBe(true);
+    expect(material.depthWrite).toBe(false);
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+  });
+
+  it('restore reverts every mutation to the original GLTFLoader state', () => {
+    const { mesh, material } = meshWith(morphic({ blend_mode: 'additive', ints: { F_RENDER_BACKFACES: 1 } }));
+    const before = {
+      transparent: material.transparent,
+      blending: material.blending,
+      depthWrite: material.depthWrite,
+      side: material.side,
+      renderOrder: mesh.renderOrder,
+    };
+    const app = applySource2DrawState(mesh, material);
+    expect(material.side).toBe(THREE.DoubleSide);
+    app!.restore!();
+    expect(material.transparent).toBe(before.transparent);
+    expect(material.blending).toBe(before.blending);
+    expect(material.depthWrite).toBe(before.depthWrite);
+    expect(material.side).toBe(before.side);
+    expect(mesh.renderOrder).toBe(before.renderOrder);
+  });
+
+  it('leaves a plain opaque material untouched (no restore needed)', () => {
+    const { mesh, material } = meshWith(morphic({ blend_mode: 'opaque' }));
+    material.transparent = false;
+    const app = applySource2DrawState(mesh, material);
+    expect(app).not.toBeNull();
+    expect(app!.restore).toBeNull();
+    expect(material.transparent).toBe(false);
+    expect(material.blending).toBe(THREE.NormalBlending);
+    expect(mesh.renderOrder).toBe(0);
+  });
+
+  it('returns null when the material has no morphic extras', () => {
+    const material = new THREE.MeshStandardMaterial();
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry(), material);
+    expect(applySource2DrawState(mesh, material)).toBeNull();
+  });
+
+  it('infers additive from F_ADDITIVE_BLEND on a v1 GLB (no blend_mode)', () => {
+    const { mesh, material } = meshWith(morphic({ ints: { F_ADDITIVE_BLEND: 1 } }));
+    applySource2DrawState(mesh, material);
+    expect(material.blending).toBe(THREE.AdditiveBlending);
+    expect(material.depthWrite).toBe(false);
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+  });
+});
+
+describe('real Deadlock overlay materials (vpkmerge round-trip fixtures)', () => {
+  // Captured from a local vpkmerge export against the shipped pak01 (the glow
+  // overlays the exporter now keeps). The notable nuance: these carry
+  // self_illum_valid=false (a placeholder self-illum mask) but blend_mode
+  // 'additive', so the additive rule must key on the blend mode, NOT on a valid
+  // self-illum mask, or the overlays would render opaque.
+  it.each([
+    ['inferno_armglow.vmat', { shader: 'pbr.vfx', blend_mode: 'additive', self_illum_valid: false, ints: { F_ADDITIVE_BLEND: 1, F_SELF_ILLUM: 1 } }],
+    ['inferno_headglow.vmat', { shader: 'pbr.vfx', blend_mode: 'additive', self_illum_valid: false, ints: { F_ADDITIVE_BLEND: 1, F_SELF_ILLUM: 1 } }],
+    ['vindicta_glow.vmat (hornet ghost_glow)', { shader: 'pbr.vfx', blend_mode: 'additive', self_illum_valid: false, ints: { F_ADDITIVE_BLEND: 1, F_SELF_ILLUM: 1 } }],
+  ] as const)('%s composites additively despite self_illum_valid=false', (_name, extras) => {
+    const { mesh, material } = meshWith(extras as MorphicExtras);
+    const app = applySource2DrawState(mesh, material);
+    expect(app!.plan.additive).toBe(true);
+    expect(material.transparent).toBe(true);
+    expect(material.blending).toBe(THREE.AdditiveBlending);
+    expect(material.depthTest).toBe(true);
+    expect(material.depthWrite).toBe(false);
+    expect(mesh.renderOrder).toBe(ADDITIVE_OVERLAY_RENDER_ORDER);
+  });
+});

--- a/src/lib/source2Preview/drawState.ts
+++ b/src/lib/source2Preview/drawState.ts
@@ -1,0 +1,170 @@
+/**
+ * Source 2 draw-state mapping: morphic extras -> Three.js render state.
+ *
+ * `resolveSource2DrawState` is pure (no material mutation), so the rules are
+ * unit-testable without a GL context. `applySource2DrawState` writes the
+ * resolved state onto a mesh+material and returns a restore closure.
+ *
+ * This is the single source of truth for the additive / translucent / backface
+ * draw-state subset. It deliberately does NOT touch opacity scaling, alpha masks,
+ * emissive/self-illum color, glass transmission, sheen, or jitter displacement:
+ * those are richer material decisions owned by the NPR/unified material builders
+ * (`source2NprMaterial.ts` / `deadlockMaterial.ts`). Here we only set blend,
+ * depth, cull, tone-mapping-for-unlit, and the mesh-level render order.
+ */
+import * as THREE from 'three';
+import {
+  type MorphicExtras,
+  flag,
+  getMorphic,
+  isTrueGlassMaterial,
+} from '../source2NprMaterial';
+import {
+  ADDITIVE_OVERLAY_RENDER_ORDER,
+  TRANSLUCENT_OVERLAY_RENDER_ORDER,
+  type Source2DrawStateApplication,
+  type Source2DrawStatePlan,
+} from './types';
+import { resolveBlendMode } from './blendMode';
+
+// Re-export so consumers and tests can keep importing it from the draw-state
+// module; the implementation lives in the cycle-free leaf `./blendMode`.
+export { resolveBlendMode };
+
+/**
+ * Pure mapping from morphic extras to the target Three.js draw state. `base` lets
+ * the glass discriminator inspect an existing physical material (glass renders
+ * through transmission, never alpha blending, so it is excluded from the overlay
+ * rules). Opaque, non-backface, non-unlit materials map to `isOverlay: false`
+ * with render state left at the GLTFLoader defaults.
+ */
+export function resolveSource2DrawState(
+  morphic: MorphicExtras,
+  base?: THREE.Material
+): Source2DrawStatePlan {
+  const glass = isTrueGlassMaterial(morphic, base);
+  const blendMode = resolveBlendMode(morphic);
+  const additive = !glass && blendMode === 'additive';
+  const translucent = !glass && (blendMode === 'blend' || blendMode === 'blend_zwrite');
+  const backfaces = flag(morphic, 'F_RENDER_BACKFACES');
+  const unlit = flag(morphic, 'F_UNLIT');
+
+  // Opaque-body defaults: leave the material exactly as GLTFLoader produced it.
+  let transparent = false;
+  let blending: THREE.Blending = THREE.NormalBlending;
+  let depthTest = true;
+  let depthWrite = true;
+  let renderOrder = 0;
+
+  if (additive) {
+    // Additive self-illum overlay: composite over the opaque body, never occlude.
+    transparent = true;
+    blending = THREE.AdditiveBlending;
+    depthTest = true; // depth-tested against the body...
+    depthWrite = false; // ...but never writes depth (no self-occlusion / z-fight).
+    renderOrder = ADDITIVE_OVERLAY_RENDER_ORDER;
+  } else if (translucent) {
+    transparent = true;
+    // blend_zwrite keeps depthWrite ON (the goo occludes its own interior gear);
+    // plain blend turns it off (standard back-to-front transparency).
+    depthWrite = blendMode === 'blend_zwrite';
+    renderOrder = TRANSLUCENT_OVERLAY_RENDER_ORDER;
+  }
+
+  return {
+    blendMode,
+    glass,
+    additive,
+    translucent,
+    backfaces,
+    unlit,
+    isOverlay: additive || translucent,
+    transparent,
+    blending,
+    depthTest,
+    depthWrite,
+    side: backfaces ? THREE.DoubleSide : null,
+    toneMapped: unlit ? false : null,
+    renderOrder,
+    polygonOffset: false,
+    polygonOffsetFactor: 0,
+    polygonOffsetUnits: 0,
+  };
+}
+
+/**
+ * Apply the resolved Source 2 draw state to one mesh+material, returning a
+ * restore closure (or null when the material is plain opaque and nothing was
+ * touched). Returns the plan it used so callers can tally stats. `renderOrder` is
+ * raised at the mesh level (a Material cannot set draw order); the strongest
+ * overlay order among a multi-material mesh wins. Returns `null` (no application)
+ * only when the material carries no morphic extras at all.
+ */
+export function applySource2DrawState(
+  mesh: THREE.Mesh,
+  material: THREE.Material,
+  morphic?: MorphicExtras
+): Source2DrawStateApplication | null {
+  const extras = morphic ?? getMorphic(material);
+  if (!extras) return null;
+  const plan = resolveSource2DrawState(extras, material);
+
+  // Plain opaque material with no backface/unlit override: leave it untouched.
+  if (!plan.isOverlay && !plan.backfaces && plan.toneMapped === null) {
+    return { plan, restore: null };
+  }
+
+  const before = {
+    transparent: material.transparent,
+    blending: material.blending,
+    depthTest: material.depthTest,
+    depthWrite: material.depthWrite,
+    side: material.side,
+    toneMapped: material.toneMapped,
+    polygonOffset: material.polygonOffset,
+    polygonOffsetFactor: material.polygonOffsetFactor,
+    polygonOffsetUnits: material.polygonOffsetUnits,
+    renderOrder: mesh.renderOrder,
+  };
+
+  if (plan.side !== null) material.side = plan.side;
+  if (plan.toneMapped !== null) material.toneMapped = plan.toneMapped;
+
+  if (plan.additive) {
+    material.transparent = true;
+    material.blending = plan.blending;
+    material.depthTest = plan.depthTest;
+    material.depthWrite = plan.depthWrite;
+  } else if (plan.translucent) {
+    material.transparent = true;
+    material.depthWrite = plan.depthWrite;
+  }
+
+  if (plan.polygonOffset) {
+    material.polygonOffset = true;
+    material.polygonOffsetFactor = plan.polygonOffsetFactor;
+    material.polygonOffsetUnits = plan.polygonOffsetUnits;
+  }
+
+  if (plan.renderOrder > mesh.renderOrder) {
+    mesh.renderOrder = plan.renderOrder;
+  }
+
+  material.needsUpdate = true;
+
+  const restore = () => {
+    material.transparent = before.transparent;
+    material.blending = before.blending;
+    material.depthTest = before.depthTest;
+    material.depthWrite = before.depthWrite;
+    material.side = before.side;
+    material.toneMapped = before.toneMapped;
+    material.polygonOffset = before.polygonOffset;
+    material.polygonOffsetFactor = before.polygonOffsetFactor;
+    material.polygonOffsetUnits = before.polygonOffsetUnits;
+    mesh.renderOrder = before.renderOrder;
+    material.needsUpdate = true;
+  };
+
+  return { plan, restore };
+}

--- a/src/lib/source2Preview/index.ts
+++ b/src/lib/source2Preview/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Source 2 preview renderer core: the always-on draw-state pass.
+ *
+ * Barrel for the small renderer core extracted from `HeroPoseViewer.tsx`. The
+ * host mounts `compileSource2DrawState` unconditionally so any morphic material
+ * gets correct Source 2 blend / depth / cull / render-order, independent of the
+ * NPR / unified / bloom dev flags.
+ */
+export {
+  resolveBlendMode,
+  resolveSource2DrawState,
+  applySource2DrawState,
+} from './drawState';
+export { compileSource2DrawState } from './compileScene';
+export { summarizeSource2Scene, type Source2SceneSummary } from './debugSummary';
+export {
+  ADDITIVE_OVERLAY_RENDER_ORDER,
+  TRANSLUCENT_OVERLAY_RENDER_ORDER,
+  type Source2BlendMode,
+  type Source2DrawStatePlan,
+  type Source2DrawStateApplication,
+  type Source2CompileStats,
+  type Source2CompileResult,
+} from './types';

--- a/src/lib/source2Preview/types.ts
+++ b/src/lib/source2Preview/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared types + constants for the Source 2 preview renderer core
+ * (`src/lib/source2Preview/`).
+ *
+ * This module is the always-on counterpart to the flag-gated NPR/unified
+ * material passes in `source2NprMaterial.ts` / `deadlockMaterial.ts`. It owns the
+ * Source 2 *draw state* (blend / depth / cull / render-order) so that any
+ * material carrying `userData.morphic` composites correctly even when every dev
+ * flag (NPR, unified, source2 hints, bloom) is off. See
+ * `docs/3d-preview-fidelity-plan.md` and the vpkmerge VRF renderer gap report.
+ */
+import type * as THREE from 'three';
+import type { MorphicExtras } from '../source2NprMaterial';
+
+/** The Source 2 blend-mode union, mirrored from the morphic extras wire shape. */
+export type Source2BlendMode = NonNullable<MorphicExtras['blend_mode']>;
+
+/**
+ * Mesh `renderOrder` for additive self-illum overlays (Inferno arm/head glow,
+ * Hornet/Vindicta `ghost_glow`): drawn last, after the opaque body AND after
+ * translucent overlays, so additive color always composites on top. Additive is
+ * order-independent in color, but a stable late order keeps it visually behind
+ * nothing and avoids surprises when several overlays stack.
+ */
+export const ADDITIVE_OVERLAY_RENDER_ORDER = 10;
+
+/**
+ * Mesh `renderOrder` for translucent (`blend` / `blend_zwrite`) overlays: after
+ * the opaque pass, before additive overlays.
+ */
+export const TRANSLUCENT_OVERLAY_RENDER_ORDER = 8;
+
+/**
+ * The target Three.js draw state resolved from a material's morphic extras. Pure
+ * data: `resolveSource2DrawState` produces it without touching any material, so
+ * it is trivially unit-testable. `side` / `toneMapped` are `null` when the rule
+ * does not dictate them (leave whatever GLTFLoader produced).
+ */
+export interface Source2DrawStatePlan {
+  blendMode: Source2BlendMode;
+  glass: boolean;
+  additive: boolean;
+  translucent: boolean;
+  backfaces: boolean;
+  unlit: boolean;
+  /** Whether this material is an overlay that must be applied (vs. left opaque). */
+  isOverlay: boolean;
+  transparent: boolean;
+  blending: THREE.Blending;
+  depthTest: boolean;
+  depthWrite: boolean;
+  /** `THREE.Side` to force, or null to leave the existing side. */
+  side: THREE.Side | null;
+  /** `false` to disable tone mapping (unlit), or null to leave it. */
+  toneMapped: boolean | null;
+  /** Mesh-level draw order; 0 for opaque (the piece a Material cannot set). */
+  renderOrder: number;
+  polygonOffset: boolean;
+  polygonOffsetFactor: number;
+  polygonOffsetUnits: number;
+}
+
+/** Result of applying draw state to one mesh+material: the plan used and an
+ * optional restore (null when the material was opaque and left untouched). */
+export interface Source2DrawStateApplication {
+  plan: Source2DrawStatePlan;
+  restore: (() => void) | null;
+}
+
+/** Per-scene compilation counts (a smoke summary, surfaced to the debug panel). */
+export interface Source2CompileStats {
+  meshes: number;
+  morphicMaterials: number;
+  additive: number;
+  translucent: number;
+  backfaces: number;
+  unlit: number;
+  glass: number;
+}
+
+/** Handle returned by `compileSource2DrawState`: restore reverts every mutation. */
+export interface Source2CompileResult {
+  restore: () => void;
+  stats: Source2CompileStats;
+}


### PR DESCRIPTION
Builds on the in-app 3D hero preview (#235) with the Source 2 preview fidelity work.

## Changes
- Adds a Source 2 preview draw-state core (blend-mode resolver, scene compile, draw-state apply, debug summary) that runs on the default preview path, so additive self-illum glow overlays composite as additive blending instead of rendering as opaque hulls.
- Collapses the Source 2 hint pass and the NPR cel/rim/tint pass into a single unified material build on an owned clone (the base GLTF is never mutated).
- Removes the standalone S2/NPR/outline dev toggles and the inverted-hull outline path, now superseded by the unified path.
- Adds Vitest coverage for the draw-state, blend-mode resolver, debug summary, and blend audit, and updates the existing material suites.

## Notes
- No dependency or lockfile changes (the R3F stack already landed with #235).
- Verified locally: `tsc -b`, `vitest run` (239 passing), `eslint .`, and the i18n + locale-manifest checks all pass.