### PR TITLE
i18n: act on French/Arabic translator feedback

### DIFF
--- a/src/components/LockerOverridesModal.tsx
+++ b/src/components/LockerOverridesModal.tsx
@@ -153,7 +153,7 @@ function ParamSliders({
             </div>
             <div className="flex items-center justify-between">
                 <span className="text-[9px] text-text-secondary/70">
-                    {saving ? t('lockerOverrides.saving') : t('lockerOverrides.appliesOnRelease')}
+                    {saving ? t('lockerOverrides.saving') : ''}
                 </span>
                 {dirty && !disabled && (
                     <button

--- a/src/components/SyncIndicator.tsx
+++ b/src/components/SyncIndicator.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { RefreshCw } from 'lucide-react';
 import type { SyncProgressData } from '../types/electron';
 
@@ -6,7 +8,15 @@ interface SyncIndicatorProps {
     className?: string;
 }
 
+// The section names ('Mod', 'Sound', 'Gui', 'Model', 'Wip') arrive from the
+// main process as raw English identifiers; map them to localized labels, falling
+// back to the raw value for anything unmapped.
+function localizedSection(section: string, t: TFunction): string {
+    return t(`sync.sections.${section}`, { defaultValue: section });
+}
+
 export default function SyncIndicator({ className = '' }: SyncIndicatorProps) {
+    const { t } = useTranslation();
     const [syncProgress, setSyncProgress] = useState<SyncProgressData | null>(null);
 
     useEffect(() => {
@@ -32,8 +42,8 @@ export default function SyncIndicator({ className = '' }: SyncIndicatorProps) {
             <RefreshCw className="w-4 h-4 animate-spin text-accent" />
             <span className="text-text-secondary">
                 {syncProgress.phase === 'error'
-                    ? `Sync error: ${syncProgress.section}`
-                    : `Syncing ${syncProgress.section}: ${percent}%`}
+                    ? t('sync.error', { section: localizedSection(syncProgress.section, t) })
+                    : t('sync.syncing', { section: localizedSection(syncProgress.section, t), percent })}
             </span>
         </div>
     );

--- a/src/components/locker/HeroSoundPicker.tsx
+++ b/src/components/locker/HeroSoundPicker.tsx
@@ -121,7 +121,7 @@ function ParamSliders({
       </div>
       <div className="flex items-center justify-between">
         <span className="text-[9px] text-text-secondary/70">
-          {saving ? t('locker.sounds.saving') : t('locker.sounds.appliesOnRelease')}
+          {saving ? t('locker.sounds.saving') : ''}
         </span>
         {dirty && !disabled && (
           <button

--- a/src/components/performance/PerformanceConfigCard.tsx
+++ b/src/components/performance/PerformanceConfigCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useNavigate } from 'react-router-dom';
 import { Gauge, ExternalLink, RefreshCw, RotateCcw, Settings2, SquarePen } from 'lucide-react';
 import { Card, Badge, Button } from '../common/ui';
@@ -27,6 +28,43 @@ const SQOOKY_ARTIST: BrowseArtistRef = {
   profileUrl: 'https://gamebanana.com/members/3826762',
   kofiUrl: SQOOKY_KOFI_URL,
 };
+
+/**
+ * Localized status sentence built from the structured status fields, so the
+ * line follows the UI language instead of the English prose the main process
+ * composes. Mirrors the message logic in performanceConfig.ts; falls back to
+ * the backend message for the error state (which carries a raw error detail).
+ */
+function performanceStatusMessage(status: PerformanceConfigStatus, t: TFunction): string {
+  const overrideCount = status.overrideCount ?? 0;
+  switch (status.state) {
+    case 'applied': {
+      const base =
+        status.appliedVersion === status.bundledVersion
+          ? t('performance.status.applied', { version: status.appliedVersion })
+          : t('performance.status.appliedOutdated', {
+              version: status.appliedVersion,
+              latest: status.bundledVersion,
+            });
+      const overrideNote = overrideCount
+        ? t('performance.status.overrideNote', { count: overrideCount })
+        : '';
+      const handEditedNote = status.handEdited ? t('performance.status.handEditedNote') : '';
+      return `${base}${overrideNote}${handEditedNote}`;
+    }
+    case 'wiped':
+      if (status.canRestoreBackup === true) return t('performance.status.wipedRestorable');
+      return (
+        t('performance.status.wiped') +
+        (overrideCount ? t('performance.status.wipedRestoreNote', { count: overrideCount }) : '')
+      );
+    case 'not-applied':
+      return t('performance.status.notApplied');
+    default:
+      // error: keep the backend message (carries the raw error detail).
+      return status.message;
+  }
+}
 
 // Settings card for the OptimizationLock performance preset (experimental).
 // Applies Sqooky's community fps config onto gameinfo.gi in place, shows
@@ -130,7 +168,7 @@ export default function PerformanceConfigCard() {
     >
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div className="min-w-0 space-y-1">
-          <p className="text-sm text-text-secondary">{status?.message ?? t('performance.checkingGameinfo')}</p>
+          <p className="text-sm text-text-secondary">{status ? performanceStatusMessage(status, t) : t('performance.checkingGameinfo')}</p>
           <p className="text-xs text-text-secondary">
             <Trans
               i18nKey="performance.credit"

--- a/src/components/stats/MmrChart.tsx
+++ b/src/components/stats/MmrChart.tsx
@@ -52,8 +52,10 @@ function divisionForScore(v: number): { division: number; tier: number } {
     return { division, tier }
 }
 
-function formatDay(ms: number, withYear = false): string {
-    return new Date(ms).toLocaleDateString(undefined, {
+function formatDay(ms: number, locale: string, withYear = false): string {
+    // Format with the active UI language so axis/tooltip dates match the user's
+    // locale instead of the OS default.
+    return new Date(ms).toLocaleDateString(locale || undefined, {
         month: 'short',
         day: 'numeric',
         ...(withYear ? { year: '2-digit' as const } : {}),
@@ -109,7 +111,8 @@ function smoothPath(pts: { x: number; y: number }[]): string {
 }
 
 export function MmrChart({ history, snapshots, height = 220 }: MmrChartProps) {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
+    const locale = i18n.language
     const svgRef = useRef<SVGSVGElement>(null)
     const [hovered, setHovered] = useState<number | null>(null)
     const ranks = useHeroStore((s) => s.ranks)
@@ -236,10 +239,10 @@ export function MmrChart({ history, snapshots, height = 220 }: MmrChartProps) {
         const withYear = tSpan > 320 * 86_400_000
         const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => ({
             f,
-            label: formatDay(t0 + f * tSpan, withYear),
+            label: formatDay(t0 + f * tSpan, locale, withYear),
         }))
         return { xy, line, area, vMin, vMax, t0, tSpan, boundaries, ticks }
-    }, [points, height])
+    }, [points, height, locale])
 
     const rangeButtons = (
         <div className="flex gap-1">
@@ -315,7 +318,7 @@ export function MmrChart({ history, snapshots, height = 220 }: MmrChartProps) {
                         {delta.toFixed(1)}
                     </span>
                     <span className="ml-1.5">
-                        {formatDay(first.t)} to {formatDay(last.t)}
+                        {formatDay(first.t, locale)} to {formatDay(last.t, locale)}
                         {fromSnapshots ? ` ${t('stats.mmrChart.localDailySnapshots')}` : ''}
                     </span>
                 </div>
@@ -447,7 +450,7 @@ export function MmrChart({ history, snapshots, height = 220 }: MmrChartProps) {
                                     </span>
                                 </div>
                                 <div className="text-xs text-text-secondary leading-tight">
-                                    {formatDay(hoveredPoint.t)}
+                                    {formatDay(hoveredPoint.t, locale)}
                                 </div>
                             </div>
                         </div>

--- a/src/components/stats/tabs/MatchesTab.tsx
+++ b/src/components/stats/tabs/MatchesTab.tsx
@@ -8,30 +8,32 @@ import type { StoredMatch } from '../../../types/deadlock-stats'
 import { MatchRow } from '../primitives'
 import { winRateClass } from '../format'
 
-function dayLabel(unixSeconds: number, t: TFunction): string {
+function dayLabel(unixSeconds: number, t: TFunction, locale: string): string {
     const d = new Date(unixSeconds * 1000)
     const today = new Date()
     const yesterday = new Date(today)
     yesterday.setDate(today.getDate() - 1)
     if (d.toDateString() === today.toDateString()) return t('stats.matches.today')
     if (d.toDateString() === yesterday.toDateString()) return t('stats.matches.yesterday')
-    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+    // Format weekday/month with the active UI language so the header matches the
+    // user's locale instead of falling back to the OS default.
+    return d.toLocaleDateString(locale || undefined, { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
 export function MatchesTab() {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const localMatchHistory = usePlayerStore((s) => s.playerData.data.localMatchHistory)
 
     const groups = useMemo(() => {
         const byDay: { label: string; matches: StoredMatch[] }[] = []
         for (const match of localMatchHistory) {
-            const label = dayLabel(match.start_time, t)
+            const label = dayLabel(match.start_time, t, i18n.language)
             const last = byDay[byDay.length - 1]
             if (last && last.label === label) last.matches.push(match)
             else byDay.push({ label, matches: [match] })
         }
         return byDay
-    }, [localMatchHistory, t])
+    }, [localMatchHistory, t, i18n.language])
 
     const wins = localMatchHistory.filter((m) => m.match_outcome === 'Win').length
     const rate = localMatchHistory.length > 0 ? (wins / localMatchHistory.length) * 100 : 0

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,31 +1,40 @@
+import i18n from '../i18n';
+
 /**
  * Compact "time since" label for installed-mod timestamps. Granularity tops out
  * at years so the strings stay short enough for the meta row on cards and
  * variant rows (size, slot, filename, date). Pair with formatAbsoluteDate for
  * the hover tooltip so users can still see the exact install time.
+ *
+ * Strings come from the active i18n catalog (common.relativeTime.*), so the
+ * label follows the user's selected language. Components that render this also
+ * consume `t`, so they re-render (and re-call this) when the language switches.
  */
 export function formatRelativeDate(iso: string): string {
     const then = new Date(iso).getTime();
     if (!Number.isFinite(then)) return '';
     const diffMs = Date.now() - then;
+    const t = i18n.t.bind(i18n);
 
-    if (diffMs < 60_000) return 'just now';
+    if (diffMs < 60_000) return t('common.relativeTime.justNow');
     const minutes = Math.floor(diffMs / 60_000);
-    if (minutes < 60) return `${minutes}m ago`;
+    if (minutes < 60) return t('common.relativeTime.minutesAgo', { count: minutes });
     const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
+    if (hours < 24) return t('common.relativeTime.hoursAgo', { count: hours });
     const days = Math.floor(hours / 24);
-    if (days < 7) return `${days}d ago`;
+    if (days < 7) return t('common.relativeTime.daysAgo', { count: days });
     const weeks = Math.floor(days / 7);
-    if (days < 30) return `${weeks}w ago`;
+    if (days < 30) return t('common.relativeTime.weeksAgo', { count: weeks });
     const months = Math.floor(days / 30);
-    if (days < 365) return `${months} mo ago`;
+    if (days < 365) return t('common.relativeTime.monthsAgo', { count: months });
     const years = Math.floor(days / 365);
-    return `${years} yr ago`;
+    return t('common.relativeTime.yearsAgo', { count: years });
 }
 
 export function formatAbsoluteDate(iso: string): string {
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) return '';
-    return d.toLocaleString();
+    // Format with the active UI language so the tooltip's month/day order and
+    // separators match the user's locale, not the OS default.
+    return d.toLocaleString(i18n.language || undefined);
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -37,10 +37,30 @@
       "missing": "Missing",
       "valid": "Valid"
     },
+    "relativeTime": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago",
+      "weeksAgo": "{{count}}w ago",
+      "monthsAgo": "{{count}} mo ago",
+      "yearsAgo": "{{count}} yr ago"
+    },
     "emptyValue": "(empty)",
     "none": "None",
     "versus": "VS",
     "versusLower": "vs"
+  },
+  "sync": {
+    "syncing": "Syncing {{section}}: {{percent}}%",
+    "error": "Sync error: {{section}}",
+    "sections": {
+      "Mod": "Mods",
+      "Sound": "Sounds",
+      "Gui": "GUI",
+      "Model": "Models",
+      "Wip": "WiPs"
+    }
   },
   "nav": {
     "installed": "Installed",
@@ -548,7 +568,11 @@
       "issuesFound": "Issues Found",
       "verifySteam": "In Steam: right-click Deadlock > Properties > Installed Files > Verify integrity of game files.",
       "foundNearby": "Found nearby: {{candidates}}. Rename one to gameinfo.gi to restore.",
-      "fixConfiguration": "Fix Configuration"
+      "fixConfiguration": "Fix Configuration",
+      "openFile": "Open gameinfo.gi",
+      "openConfirmTitle": "Open gameinfo.gi?",
+      "openConfirmMessage": "This opens Deadlock's gameinfo.gi in your text editor. It controls how the game loads mods. Editing it by hand can break mod loading or stop the game from launching. If something goes wrong, use Fix Configuration to repair it. Only proceed if you know what you're changing.",
+      "openFailed": "Could not open gameinfo.gi: {{error}}"
     },
     "updates": {
       "releaseNotesTitle": "View release notes for {{version}}",
@@ -819,6 +843,12 @@
       "status": "Status",
       "enabled": "Enabled",
       "modType": "Mod type"
+    },
+    "sections": {
+      "enabled_one": "Enabled",
+      "enabled_other": "Enabled",
+      "disabled_one": "Disabled",
+      "disabled_other": "Disabled"
     },
     "view": {
       "viewOptions": "View options",
@@ -1277,7 +1307,6 @@
       "pitch": "Pitch",
       "db": "dB",
       "saving": "Saving...",
-      "appliesOnRelease": "Applies on release",
       "alsoAbilities": "also {{slots}}",
       "applied": "Applied",
       "use": "Use",
@@ -2087,6 +2116,8 @@
       "previewHidden": "NSFW preview hidden"
     },
     "viewOnGamebanana": "View on GameBanana",
+    "copyLink": "Copy link",
+    "linkCopied": "Link copied",
     "outdatedWarning": "This mod was last updated on {{date}} and may not be compatible with the current Deadlock version.",
     "deleteFile": {
       "title": "Delete installed file?",
@@ -2229,6 +2260,18 @@
       "error": "Error",
       "notApplied": "Not applied"
     },
+    "status": {
+      "applied": "Performance config v{{version}} is applied.",
+      "appliedOutdated": "Performance config v{{version}} is applied; v{{latest}} is available (reapply to update).",
+      "overrideNote_one": " Keeping {{count}} of your override.",
+      "overrideNote_other": " Keeping {{count}} of your overrides.",
+      "handEditedNote": " The file has manual edits: Reapply folds them into your overrides.",
+      "wipedRestorable": "gameinfo.gi is empty or corrupt. Restore the Grimoire backup (or verify game files in Steam), then reapply.",
+      "wiped": "A game update reset gameinfo.gi and removed the performance config. Reapply to restore it.",
+      "wipedRestoreNote_one": " Your {{count}} saved override will be restored too.",
+      "wipedRestoreNote_other": " Your {{count}} saved overrides will be restored too.",
+      "notApplied": "Performance config is not applied."
+    },
     "credit": "Map looks dark? Set in-game shadows to Medium or Low. Game updates wipe the config; Grimoire spots that here so you can reapply. By <sqooky>Sqooky</sqooky> and <contributors>contributors<extlink></extlink></contributors>. If it helps, <kofi>buy them a coffee</kofi>.",
     "restoreBackup": "Restore Backup",
     "reapply": "Reapply",
@@ -2250,7 +2293,6 @@
     "pitch": "Pitch",
     "db": "{{value}} dB",
     "saving": "Saving...",
-    "appliesOnRelease": "Applies on release",
     "title": "Locker Overrides",
     "subtitle": "Always-on cosmetics, separate from your mod load order and the 99-slot cap.",
     "tabs": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1734,
+  "totalKeys": 1766,
   "languages": [
     {
       "code": "bg",
       "name": "български",
-      "translatedKeys": 1610,
-      "pct": 93
+      "translatedKeys": 1608,
+      "pct": 91
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1734,
+      "translatedKeys": 1766,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
-      "translatedKeys": 1668,
-      "pct": 96
+      "translatedKeys": 1666,
+      "pct": 94
     },
     {
       "code": "ru",

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -3451,7 +3451,7 @@ export default function Installed() {
       {visibleEnabled.length > 0 && (
         <div className="mb-6">
           <div className="flex items-baseline justify-between mb-[14px]">
-            <SectionHeader count={visibleEnabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">{t('installed.filters.enabled')}</SectionHeader>
+            <SectionHeader count={visibleEnabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">{t('installed.sections.enabled', { count: visibleEnabled.length })}</SectionHeader>
           </div>
           {renderSortableSection('enabled')}
         </div>
@@ -3460,7 +3460,7 @@ export default function Installed() {
       {visibleDisabled.length > 0 && (
         <div>
           <div className="flex items-baseline justify-between mb-[14px]">
-            <SectionHeader count={visibleDisabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">{t('locker.global.disabledBadge')}</SectionHeader>
+            <SectionHeader count={visibleDisabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">{t('installed.sections.disabled', { count: visibleDisabled.length })}</SectionHeader>
           </div>
           {renderSortableSection('disabled')}
         </div>


### PR DESCRIPTION
Acts on the translation feedback from **BXZ1** (French/Arabic translator) in Discord. Five fixes, all English-catalog only; the FR/AR translations for new keys flow back through Weblate as usual.

## Changes

1. **Drop the misleading "Applies on release" hint.** It actually means "on cast", and the translator flagged it as confusing/redundant. Removed from the Locker sound picker (`HeroSoundPicker`) and overrides modal (`LockerOverridesModal`); the "Saving..." indicator stays and the layout is preserved. Deleted `locker.sounds.appliesOnRelease` + `lockerOverrides.appliesOnRelease`.

2. **Wire the sync-progress badge.** `SyncIndicator` ("Syncing Sound: 25%") was hardcoded English. Now uses `sync.*` keys, including a `sync.sections.*` map so the section names (Mod/Sound/Gui/Model/Wip) localize too, with a raw-value fallback.

3. **Localize the Performance Config status line.** It was English prose built in the main process. The renderer now composes the localized sentence from the structured status fields already returned (`state`, `appliedVersion`, `bundledVersion`, `handEdited`, `overrideCount`, `canRestoreBackup`) via new `performance.status.*` keys. The error variant keeps the backend message (it carries the raw error detail).

4. **Localize dates.** Relative "time ago" labels now come from `common.relativeTime.*`, and absolute dates format with the active language (`lib/dates.ts`). The Stats match-history day headers (`MatchesTab`) and the MMR chart axis/tooltip dates (`MmrChart`) now use the active locale instead of the OS default.

5. **Plural-aware Installed section titles.** The Enabled/Disabled section headers shared the filter-chip strings. Added dedicated `installed.sections.enabled_one/_other` + `disabled_one/_other` keyed on count, so e.g. French can render Activé/Activés. Filter-chip labels unchanged.

## Notes
- `src/locales/manifest.json` regenerated (`pnpm i18n:manifest`).
- Gates: `pnpm i18n:check`, manifest `--check`, `pnpm typecheck`, and ESLint on touched files all pass.