### PR TITLE
feat(browse): WiP mod support, file-picker scroll fix, copy-link + open gameinfo.gi

### DIFF
--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -4,7 +4,7 @@ import { upsertMods, getSyncState, updateSyncState, getModCount, type CachedMod 
 import type { GameBananaMod } from '../../../src/types/gamebanana';
 
 const SYNC_PER_PAGE = 50;
-const SECTIONS = ['Mod', 'Sound', 'Gui', 'Model'] as const;
+const SECTIONS = ['Mod', 'Sound', 'Gui', 'Model', 'Wip'] as const;
 type SectionType = typeof SECTIONS[number];
 
 export interface SyncProgress {

--- a/src/components/BrowseFileQuickPicker.tsx
+++ b/src/components/BrowseFileQuickPicker.tsx
@@ -90,14 +90,22 @@ export default function BrowseFileQuickPicker({
     return () => anchor.focus();
   }, [anchor]);
 
-  // Dismiss on any scroll/resize so the popover never drifts from its anchor.
-  // Outside clicks are caught by the backdrop; Escape/arrow keys live on the
-  // menu element itself (roving focus).
+  // Dismiss when the background page scrolls or the window resizes so the
+  // popover never drifts from its anchor. The scroll listener is in the capture
+  // phase (scroll events don't bubble), so it also sees scrolls from the
+  // popover's own file list: skip those, or scrolling the list would instantly
+  // close the picker (issue: file picker scroll does nothing). Outside clicks
+  // are caught by the backdrop; Escape/arrow keys live on the menu element.
   useEffect(() => {
-    window.addEventListener('scroll', onClose, true);
+    const onScroll = (e: Event) => {
+      const target = e.target as Node | null;
+      if (popoverRef.current && target && popoverRef.current.contains(target)) return;
+      onClose();
+    };
+    window.addEventListener('scroll', onScroll, true);
     window.addEventListener('resize', onClose);
     return () => {
-      window.removeEventListener('scroll', onClose, true);
+      window.removeEventListener('scroll', onScroll, true);
       window.removeEventListener('resize', onClose);
     };
   }, [onClose]);

--- a/src/components/ImportCollectionModal.tsx
+++ b/src/components/ImportCollectionModal.tsx
@@ -40,7 +40,7 @@ import {
 const DEADLOCK_GAME_ID = 20948;
 
 // Item types Grimoire can install. Matches Browse.tsx SECTION_WHITELIST.
-const SUPPORTED_MODEL_NAMES = new Set(['Mod', 'Sound']);
+const SUPPORTED_MODEL_NAMES = new Set(['Mod', 'Sound', 'Wip']);
 
 interface ImportCollectionModalProps {
   hideNsfwPreviews: boolean;

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import {
@@ -23,6 +23,7 @@ import {
   Bell,
   Trash2,
   Coffee,
+  Link2,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate } from '../types/gamebanana';
@@ -33,6 +34,8 @@ import AudioPreviewPlayer from './AudioPreviewPlayer';
 import { Skeleton } from './common/Skeleton';
 import { ArchivedTag, Button, IconButton } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
+import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from './common/menu';
+import { showToast } from '../stores/toastStore';
 
 type ModDetailsNavigationDirection = 'previous' | 'next';
 
@@ -126,6 +129,33 @@ function ModDetailsModal({
   onViewArtist,
 }: ModDetailsModalProps) {
   const { t } = useTranslation();
+  // Canonical GameBanana page for this submission. WiPs live under /wips, Sounds
+  // under /sounds, etc., which section.toLowerCase()+'s' already yields.
+  const gbUrl = `https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`;
+  const copyGbLink = async () => {
+    try {
+      await navigator.clipboard.writeText(gbUrl);
+      showToast(t('modDetails.linkCopied'), { tone: 'success' });
+    } catch (err) {
+      console.error('[ModDetails] Failed to copy GameBanana link:', err);
+    }
+  };
+  // Wrap a GameBanana link in a right-click menu (Open / Copy link). A render
+  // helper, not a component, so the trigger keeps its element identity across
+  // re-renders (an inline component type would remount and close an open menu).
+  const withGbLinkMenu = (trigger: ReactNode) => (
+    <MenuRoot>
+      <MenuTrigger asChild>{trigger}</MenuTrigger>
+      <MenuContent>
+        <MenuItem icon={ExternalLink} onSelect={() => window.open(gbUrl, '_blank', 'noopener,noreferrer')}>
+          {t('modDetails.viewOnGamebanana')}
+        </MenuItem>
+        <MenuItem icon={Link2} onSelect={copyGbLink}>
+          {t('modDetails.copyLink')}
+        </MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  );
   const isSidebar = variant === 'sidebar';
   const images = mod.previewMedia?.images ?? [];
   const audioPreviewUrl = mod.previewMedia?.metadata?.audioUrl;
@@ -888,16 +918,18 @@ function ModDetailsModal({
                   <span className="sr-only">{t('modDetails.aria.loadingNamed', { label: navigationLabel ?? t('modDetails.meta.modDetails') })}</span>
                 </span>
               ) : (
-                <a
-                  href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title={`View ${mod.name} on GameBanana`}
-                  className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
-                >
-                  <span className="min-w-0 truncate">{mod.name}</span>
-                  <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
-                </a>
+                withGbLinkMenu(
+                  <a
+                    href={gbUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`View ${mod.name} on GameBanana`}
+                    className="group inline-flex max-w-full min-w-0 items-center gap-1.5 text-text-primary transition-colors hover:text-accent"
+                  >
+                    <span className="min-w-0 truncate">{mod.name}</span>
+                    <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+                  </a>
+                )
               )}
             </h2>
           )}
@@ -1246,16 +1278,18 @@ function ModDetailsModal({
                   {isNavigating ? (
                     <Skeleton className="h-6 w-3/4" />
                   ) : (
-                    <a
-                      href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title={`View ${mod.name} on GameBanana`}
-                      className="group inline-flex max-w-full items-start gap-1.5 text-xl font-bold leading-tight text-text-primary transition-colors hover:text-accent"
-                    >
-                      <span className="min-w-0">{mod.name}</span>
-                      <ExternalLink className="mt-1 h-4 w-4 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
-                    </a>
+                    withGbLinkMenu(
+                      <a
+                        href={gbUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`View ${mod.name} on GameBanana`}
+                        className="group inline-flex max-w-full items-start gap-1.5 text-xl font-bold leading-tight text-text-primary transition-colors hover:text-accent"
+                      >
+                        <span className="min-w-0">{mod.name}</span>
+                        <ExternalLink className="mt-1 h-4 w-4 flex-shrink-0 text-text-tertiary transition-colors group-hover:text-accent" />
+                      </a>
+                    )
                   )}
                   {(() => {
                     const addedStr = dateAdded && dateAdded > 0 ? formatDate(dateAdded) : null;
@@ -1564,15 +1598,17 @@ function ModDetailsModal({
                 )}
               </section>
 
-              <a
-                href={`https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
-              >
-                <ExternalLink className="w-4 h-4" />
-                {t('modDetails.viewOnGamebanana')}
-              </a>
+              {withGbLinkMenu(
+                <a
+                  href={gbUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-accent hover:text-accent-hover transition-colors text-sm"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  {t('modDetails.viewOnGamebanana')}
+                </a>
+              )}
             </div>
           </div>
           {isNavigating && navigationSkeleton}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1974,6 +1974,7 @@
     },
     "section": {
       "sounds": "Sounds",
+      "wips": "WiPs",
       "label": "Section"
     },
     "search": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1766,
+  "totalKeys": 1767,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1766,
+      "translatedKeys": 1767,
       "pct": 100
     },
     {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -19,6 +19,7 @@ import {
   Clock,
   Package,
   Music,
+  Construction,
   SlidersHorizontal,
   Power,
   Library,
@@ -107,7 +108,11 @@ type BrowseCardDesign = 'classic' | 'readable';
 // like the other Browse view preferences (card design/size).
 type BrowseDetailsView = 'modal' | 'sidebar';
 type ModDetailsNavigationDirection = 'previous' | 'next';
-const SECTION_WHITELIST = new Set(['Mod', 'Sound']);
+// WiPs (Work in Progress) are real installable uploads on GameBanana (53 for
+// Deadlock at time of writing) served by the same /Wip/Index + /Wip/{id} API
+// shape as Mods, so they browse and install through the existing parameterized
+// section path. The section list is otherwise data-driven from CategoryTree.
+const SECTION_WHITELIST = new Set(['Mod', 'Sound', 'Wip']);
 const BROWSE_CARD_DESIGN_STORAGE_KEY = 'browseCardDesign';
 const BROWSE_DETAILS_VIEW_STORAGE_KEY = 'browseDetailsView';
 // Below this window width the docked sidebar would crush the grid, so we force
@@ -2851,7 +2856,7 @@ export default function Browse() {
               )}
             </div>
             <div className="hidden flex-shrink-0 items-center gap-1 rounded-lg border border-border bg-bg-secondary p-0.5 sm:flex">
-              {(['Mod', 'Sound'] as const).map((s) => (
+              {(['Mod', 'Sound', 'Wip'] as const).map((s) => (
                 <button
                   key={s}
                   type="button"
@@ -2860,7 +2865,11 @@ export default function Browse() {
                     section === s ? 'bg-accent/15 text-accent' : 'text-text-secondary hover:text-text-primary'
                   }`}
                 >
-                  {s === 'Mod' ? t('profiles.mods.label') : t('browse.section.sounds')}
+                  {s === 'Mod'
+                    ? t('profiles.mods.label')
+                    : s === 'Sound'
+                      ? t('browse.section.sounds')
+                      : t('browse.section.wips')}
                 </button>
               ))}
             </div>
@@ -3074,7 +3083,12 @@ export default function Browse() {
             {sections.length > 1 && (
               <div className="flex items-center h-10 rounded-lg border border-border bg-bg-secondary p-1" role="tablist" aria-label={t('browse.section.label')}>
                 {sections.map((entry) => {
-                  const Icon = entry.modelName === 'Sound' ? Music : Package;
+                  const Icon =
+                    entry.modelName === 'Sound'
+                      ? Music
+                      : entry.modelName === 'Wip'
+                        ? Construction
+                        : Package;
                   const active = section === entry.modelName;
                   return (
                     <button

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,7 +14,9 @@ import {
   openGameFolder,
   validateDeadlockPath,
   showOpenDialog,
+  openPerformanceConfigFile,
 } from '../lib/api';
+import { showToast } from '../stores/toastStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
@@ -76,6 +78,7 @@ export default function Settings() {
   const [gameinfoMissing, setGameinfoMissing] = useState(false);
   const [gameinfoCandidates, setGameinfoCandidates] = useState<string[]>([]);
   const [isFixingGameinfo, setIsFixingGameinfo] = useState(false);
+  const [openGameinfoConfirm, setOpenGameinfoConfirm] = useState(false);
   const [syncStatus, setSyncStatus] = useState<Record<string, { lastSync: number; count: number } | null> | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncProgress, setSyncProgress] = useState<{ section: string; modsProcessed: number; totalMods: number } | null>(null);
@@ -402,6 +405,23 @@ export default function Settings() {
       setGameinfoConfigured(false);
     } finally {
       setIsFixingGameinfo(false);
+    }
+  };
+
+  const handleOpenGameinfo = async () => {
+    setOpenGameinfoConfirm(false);
+    try {
+      // Reuses the performance-config opener: same gameinfo.gi, opened in the
+      // user's chosen editor (path read in the main process, never passed here).
+      await openPerformanceConfigFile();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      showToast(
+        t('settings.gameinfo.openFailed', {
+          error: detail.replace(/^Error invoking remote method '[^']+': (Error: )?/, ''),
+        }),
+        { tone: 'error' }
+      );
     }
   };
 
@@ -740,15 +760,25 @@ export default function Settings() {
                   <Tx k="settings.gamePath.openGameFolder" fallback="Open Game Folder" />
                 </Button>
               ) : (
-                <Button
-                  onClick={handleFixGameinfo}
-                  disabled={isFixingGameinfo || !activeDeadlockPath}
-                  isLoading={isFixingGameinfo}
-                  variant={gameinfoConfigured ? 'secondary' : 'primary'}
-                  icon={Wrench}
-                >
-                  <Tx k="settings.gameinfo.fixConfiguration" fallback="Fix Configuration" />
-                </Button>
+                <div className="flex flex-shrink-0 gap-2">
+                  <Button
+                    onClick={() => setOpenGameinfoConfirm(true)}
+                    disabled={!activeDeadlockPath}
+                    variant="secondary"
+                    icon={FileText}
+                  >
+                    <Tx k="settings.gameinfo.openFile" fallback="Open gameinfo.gi" />
+                  </Button>
+                  <Button
+                    onClick={handleFixGameinfo}
+                    disabled={isFixingGameinfo || !activeDeadlockPath}
+                    isLoading={isFixingGameinfo}
+                    variant={gameinfoConfigured ? 'secondary' : 'primary'}
+                    icon={Wrench}
+                  >
+                    <Tx k="settings.gameinfo.fixConfiguration" fallback="Fix Configuration" />
+                  </Button>
+                </div>
               )}
             </div>
           </div>
@@ -1651,6 +1681,21 @@ export default function Settings() {
           />
         }
         confirmLabel={<Tx k="common.actions.reset" fallback="Reset" />}
+        variant="primary"
+      />
+
+      <ConfirmModal
+        isOpen={openGameinfoConfirm}
+        onCancel={() => setOpenGameinfoConfirm(false)}
+        onConfirm={handleOpenGameinfo}
+        title={<Tx k="settings.gameinfo.openConfirmTitle" fallback="Open gameinfo.gi?" />}
+        message={
+          <Tx
+            k="settings.gameinfo.openConfirmMessage"
+            fallback="This opens Deadlock's gameinfo.gi in your text editor. It controls how the game loads mods. Editing it by hand can break mod loading or stop the game from launching. If something goes wrong, use Fix Configuration to repair it. Only proceed if you know what you're changing."
+          />
+        }
+        confirmLabel={<Tx k="settings.gameinfo.openFile" fallback="Open gameinfo.gi" />}
         variant="primary"
       />
     </PageLayout>


### PR DESCRIPTION
Four related quality-of-life changes around Browse, mod details, and Settings.

## 1. WiP (Work in Progress) mod support
GameBanana's `Wip` itemtype is real installable content: the live API returns **53 WiPs** for Deadlock (the docs' count of 1 was stale), served by the same `/Wip/Index` + `/Wip/{id}` shape as Mods, all with downloadable files.

- `Browse.tsx`: `Wip` added to `SECTION_WHITELIST`. The section toggle is data-driven from GameBanana's `CategoryTree` (which already returns a `Wip` section), so a **WiPs** tab now appears automatically with its own item counts, category tree, and hero filter. New `Construction` icon; the submitter/artist-view toggle covers WiPs too.
- `syncService.ts`: WiPs included in the offline catalog sync + FTS search.
- `ImportCollectionModal.tsx`: WiPs in an imported collection now install instead of being skipped as "unsupported-type."
- Download / details / one-click paths were already section-parameterized, so install works end to end.

## 2. Browse file-picker scroll fix
The quick install picker registered a **capture-phase** `scroll` listener that called `onClose` on any scroll. Since scroll events don't bubble, capture phase also saw scrolls from the picker's own `overflow-y-auto` file list, so the first scroll tick instantly dismissed it. Now it ignores scrolls originating inside the popover and only dismisses on background-page scroll.

## 3. Copy link on GameBanana links (mod details)
Right-click any GameBanana link in the details modal (the two mod-name title links and the "View on GameBanana" button) for an **Open / Copy link** menu. Shared via a small render helper so the trigger keeps element identity (no remount).

## 4. Open gameinfo.gi button (Settings)
New **Open gameinfo.gi** button in the gameinfo.gi Status row, behind a be-careful confirmation dialog. Reuses the existing editor-open path (editor path resolved in the main process, never passed from the renderer).

## Validation
`pnpm typecheck`, `pnpm lint`, and `pnpm i18n:check` all pass; locale manifest regenerated. Verified `/Wip/Index` returns 53 items with files against the live API.