### PR TITLE
fix(profiles): atomic, fault-tolerant profile apply + dedupe duplicate VPKs

### DIFF
--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -24,6 +24,31 @@ export const ENABLE_LIMIT_MESSAGE =
 
 type CollisionMetadataOwner = 'enabled' | 'disabled';
 
+/**
+ * `fs.rename` that retries on transient Windows file locks. A VPK in `addons/`
+ * can be briefly held open by the running game, an antivirus scan, or one of
+ * grimoire's own readers (the 3D pose export and the conflict scanner both read
+ * VPK bytes), and the OS reports that as EBUSY / EPERM / EACCES on the rename.
+ * Left unretried, a single transient lock aborts a whole profile apply and
+ * leaves the file enabled on disk while the UI believes it moved (#bugs:
+ * "addons folder does not reflect what is shown"; "disabled in the Locker but
+ * the vpk stayed"). A short backoff clears the common case; a genuinely locked
+ * file (game actually running on it) still throws after the last attempt.
+ */
+async function renameWithRetry(from: string, to: string, attempts = 5): Promise<void> {
+    for (let i = 0; ; i++) {
+        try {
+            await fs.rename(from, to);
+            return;
+        } catch (err) {
+            const code = (err as NodeJS.ErrnoException)?.code;
+            const transient = code === 'EBUSY' || code === 'EPERM' || code === 'EACCES';
+            if (!transient || i >= attempts - 1) throw err;
+            await new Promise((resolve) => setTimeout(resolve, 80 * (i + 1)));
+        }
+    }
+}
+
 /** Filesystem-level mod record produced by scanMods. NOT the renderer-facing
  *  Mod from src/types/mod.ts: that wire type is a superset that the ipc
  *  layer's enrichMod builds from this plus the metadata sidecar (globalType,
@@ -421,7 +446,7 @@ async function moveModToFolderAs(
 
     await fs.mkdir(destinationFolder, { recursive: true });
     const destinationPath = join(destinationFolder, destinationFileName);
-    await fs.rename(targetMod.path, destinationPath);
+    await renameWithRetry(targetMod.path, destinationPath);
     const destMetaKey = metaKeyFor(destinationPath);
 
     if (destMetaKey !== targetMod.metaKey) {
@@ -546,6 +571,39 @@ function withModMutationLock<T>(fn: () => Promise<T>): Promise<T> {
  */
 export function enableMod(deadlockPath: string, modId: string): Promise<Mod> {
     return withModMutationLock(() => enableModImpl(deadlockPath, modId));
+}
+
+/**
+ * Run `fn` as ONE exclusive mod-folder mutation: it holds the mutation queue for
+ * its whole duration, so a multi-step batch (notably applyProfile's disable ->
+ * enable -> reorder sequence) executes atomically and cannot interleave with a
+ * Locker toggle that would rename files mid-batch and invalidate the batch's
+ * scan ids. Before this, applyProfile took the lock per sub-call, so a toggle
+ * landing in a gap left it operating on stale ids -> "Mod not found" aborted the
+ * apply partway and dropped every mod after it (#bugs: profile apply "dropped
+ * like 5 mods", "reapplying bugged it again").
+ *
+ * `fn` MUST call the *Unlocked variants below, never the exported locked
+ * enableMod/disableMod/reorderMods: those would re-enter the queue this batch
+ * already holds and deadlock.
+ */
+export function runExclusiveModMutation<T>(fn: () => Promise<T>): Promise<T> {
+    return withModMutationLock(fn);
+}
+
+/** Unlocked enable, for use only inside a runExclusiveModMutation batch. */
+export function enableModUnlocked(deadlockPath: string, modId: string): Promise<Mod> {
+    return enableModImpl(deadlockPath, modId);
+}
+
+/** Unlocked disable, for use only inside a runExclusiveModMutation batch. */
+export function disableModUnlocked(deadlockPath: string, modId: string): Promise<Mod> {
+    return disableModImpl(deadlockPath, modId);
+}
+
+/** Unlocked reorder, for use only inside a runExclusiveModMutation batch. */
+export function reorderModsUnlocked(deadlockPath: string, orderedIds: string[]): Promise<void> {
+    return reorderModsImpl(deadlockPath, orderedIds);
 }
 
 async function enableModImpl(deadlockPath: string, modId: string): Promise<Mod> {
@@ -823,7 +881,7 @@ async function reorderModsImpl(deadlockPath: string, orderedIds: string[]): Prom
     const phase1Done: RenameStep[] = [];
     try {
         for (const step of steps) {
-            await fs.rename(step.fromPath, step.tmpPath);
+            await renameWithRetry(step.fromPath, step.tmpPath);
             phase1Done.push(step);
         }
     } catch (err) {
@@ -838,7 +896,7 @@ async function reorderModsImpl(deadlockPath: string, orderedIds: string[]): Prom
     const phase2Done: RenameStep[] = [];
     try {
         for (const step of steps) {
-            await fs.rename(step.tmpPath, step.finalPath);
+            await renameWithRetry(step.tmpPath, step.finalPath);
             phase2Done.push(step);
         }
     } catch (err) {

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -1,7 +1,13 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getUserDataPath } from '../utils/paths';
-import { scanMods, enableMod, disableMod, reorderMods } from './mods';
+import {
+    scanMods,
+    runExclusiveModMutation,
+    enableModUnlocked,
+    disableModUnlocked,
+    reorderModsUnlocked,
+} from './mods';
 import { getModMetadata } from './metadata';
 import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
@@ -82,6 +88,54 @@ function saveProfiles(profiles: Profile[]): void {
 }
 
 /**
+ * Drop duplicate physical VPKs that resolve to the SAME GameBanana file before
+ * they're written into a profile. A toggle/apply race can leave two copies of
+ * one mod enabled in different pakNN slots; without this dedup, createProfile /
+ * updateProfile would record both (same gameBananaId:fileId, different fileName/
+ * priority) and the saved profile carries a phantom entry forever - exactly the
+ * corrupt "Bunnydicta at priority 21 AND 31" a reporter's exported profile
+ * showed (#bugs: profile/mods desync, leftover/duplicate vpk). We keep the
+ * lower-priority-number copy (loads first / wins conflicts). Mods without a
+ * GameBanana file id are left untouched: those are genuinely distinct locals.
+ */
+function dedupeEnabledForProfile<T extends { metaKey: string; fileName: string; priority: number }>(
+    mods: T[]
+): T[] {
+    const byGbFile = new Map<string, T>();
+    const out: T[] = [];
+    for (const mod of mods) {
+        const meta = getModMetadata(mod.metaKey);
+        const gbId = meta?.gameBananaId;
+        const fileId = meta?.gameBananaFileId;
+        if (typeof gbId !== 'number' || typeof fileId !== 'number') {
+            out.push(mod);
+            continue;
+        }
+        const key = `${gbId}:${fileId}`;
+        const existing = byGbFile.get(key);
+        if (!existing) {
+            byGbFile.set(key, mod);
+            out.push(mod);
+        } else if (mod.priority < existing.priority) {
+            // Prefer the higher-load-order copy; swap it in place.
+            const idx = out.indexOf(existing);
+            if (idx !== -1) out[idx] = mod;
+            byGbFile.set(key, mod);
+            console.warn(
+                `[profiles] dedupe: dropping duplicate VPK ${existing.fileName} ` +
+                `(same GameBanana file ${key} as ${mod.fileName})`
+            );
+        } else {
+            console.warn(
+                `[profiles] dedupe: dropping duplicate VPK ${mod.fileName} ` +
+                `(same GameBanana file ${key} as ${existing.fileName})`
+            );
+        }
+    }
+    return out;
+}
+
+/**
  * Create a new profile from current mod state and provided crosshair settings
  */
 export async function createProfile(deadlockPath: string, name: string, crosshairSettings?: ProfileCrosshairSettings): Promise<Profile> {
@@ -89,7 +143,9 @@ export async function createProfile(deadlockPath: string, name: string, crosshai
     // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
     // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
     // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
-    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey));
+    const enabledMods = dedupeEnabledForProfile(
+        mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey))
+    );
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -195,7 +251,9 @@ export async function updateProfile(deadlockPath: string, profileId: string, cro
     // Only save enabled mods, and never the Locker-managed VPKs (cards/sounds):
     // they're owned by the Locker, hidden, and auto-pinned, so they don't belong
     // in a profile's mod list (and have no gameBananaId to re-resolve anyway).
-    const enabledMods = mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey));
+    const enabledMods = dedupeEnabledForProfile(
+        mods.filter(mod => mod.enabled && !isLockerManaged(mod.metaKey))
+    );
 
     // Read current autoexec commands
     const autoexecData = readAutoexec(deadlockPath);
@@ -347,142 +405,174 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
         `${profile.mods.length} entries, ${profileStableCount} with stable ids`
     );
 
-    // 1. Apply Mods (enable/disable state).
+    // 1. Apply Mods (enable/disable state) as ONE atomic batch.
     //
-    // Resolve each profile mod against the current scan by stable id
-    // (gameBananaId + gameBananaFileId) first, then by fileName ONLY when
-    // both sides are stable-id-less (custom mods + truly-local current
-    // mods). See buildProfileModResolver for the cross-match refusal that
-    // landed in response to "Profile apply misrecognizing mods to turn on".
-    const currentMods = await scanMods(deadlockPath);
-    const resolveProfileMod = buildProfileModResolver(currentMods);
-
-    // currentMod.id → ProfileMod, when matched. Drives the enable/disable
-    // loop and the reorder pass below.
-    const profileModByCurrentId = new Map<string, ProfileMod>();
+    // The whole disable -> enable -> reorder sequence runs inside a single
+    // runExclusiveModMutation, so it holds the mod-mutation queue for its full
+    // duration. A Locker toggle (or a second apply) can no longer slip between
+    // sub-steps, rename files, and invalidate the scan ids this apply is driving
+    // off of - the interleave that used to throw "Mod not found" partway and drop
+    // every remaining mod (#bugs: profile apply "dropped like 5 mods").
+    //
+    // Per-mod enable/disable failures are caught and counted, not rethrown: a
+    // single locked VPK (game running, antivirus, our own VPK readers) must not
+    // abort the rest of the apply. renameWithRetry in mods.ts already clears the
+    // transient case; a genuinely stuck file is logged and skipped.
     let stableHits = 0;
     let fileNameHits = 0;
     let unmatched = 0;
     let refusedCrossmatches = 0;
-    for (const profileMod of profile.mods) {
-        const resolution = resolveProfileMod(profileMod);
-        if (resolution.mod !== undefined) {
-            profileModByCurrentId.set(resolution.mod.id, profileMod);
-            if (resolution.via === 'stable') {
-                stableHits++;
-                console.log(
-                    `[profiles] resolve stable: ${describeProfileMod(profileMod)} ` +
-                    `-> ${resolution.mod.fileName}`
-                );
-            } else {
-                fileNameHits++;
-                console.log(
-                    `[profiles] resolve fileName (local-to-local): ` +
-                    `${describeProfileMod(profileMod)} -> ${resolution.mod.fileName}`
-                );
-            }
-        } else if (resolution.via === 'refused-crossmatch') {
-            refusedCrossmatches++;
-            console.warn(
-                `[profiles] resolve refused: ${describeProfileMod(profileMod)} ` +
-                `would have cross-matched current mod ${resolution.candidateFileName} ` +
-                `(stable-id mismatch). Entry left unmatched to avoid enabling the wrong mod.`
-            );
-        } else {
-            unmatched++;
-            console.log(
-                `[profiles] resolve miss: ${describeProfileMod(profileMod)} ` +
-                `(mod not currently installed)`
-            );
-        }
-    }
-    console.log(
-        `[profiles] resolution summary: ${stableHits} stable, ${fileNameHits} fileName, ` +
-        `${refusedCrossmatches} refused, ${unmatched} unmatched`
-    );
-
     let enabledCount = 0;
     let disabledCount = 0;
     let orphanedDisabledCount = 0;
+    const failures: string[] = [];
 
-    // Two passes, disables BEFORE enables. The disabled library is uncapped now,
-    // so a profile that swaps a large enabled set for a large disabled one could,
-    // in a single interleaved pass, enable past the 99 active-slot ceiling before
-    // freeing the slots it's about to vacate - throwing mid-apply and leaving a
-    // half-applied profile. Freeing first guarantees every slot the profile needs
-    // is available, and the enable pass can never exceed 99 (a profile holds at
-    // most 99 enabled mods). The two passes act on disjoint sets of currentMods
-    // (was-enabled vs was-disabled), so the snapshot ids stay valid across both.
-    for (const mod of currentMods) {
-        if (!mod.enabled) continue;
-        // Locker-managed VPKs (hero cards + ability sounds) aren't part of any
-        // profile: they're hidden, auto-pinned, and owned by the Locker. Never
-        // disable them on a profile switch, or applied cosmetics would silently
-        // stop loading. They get re-pinned to the front after the reorder pass.
-        if (isLockerManaged(mod.metaKey)) continue;
-        const profileMod = profileModByCurrentId.get(mod.id);
-        if (profileMod && profileMod.enabled) continue; // keep it enabled
-        await disableMod(deadlockPath, mod.id);
-        if (profileMod) {
-            console.log(`[profiles] toggle disable: ${mod.fileName}`);
-            disabledCount++;
-        } else {
-            console.log(`[profiles] toggle disable (not in profile): ${mod.fileName}`);
-            orphanedDisabledCount++;
-        }
-    }
-    for (const mod of currentMods) {
-        if (mod.enabled) continue;
-        const profileMod = profileModByCurrentId.get(mod.id);
-        if (!profileMod || !profileMod.enabled) continue;
-        console.log(`[profiles] toggle enable: ${mod.fileName}`);
-        await enableMod(deadlockPath, mod.id);
-        enabledCount++;
-    }
-    console.log(
-        `[profiles] toggle summary: ${enabledCount} enabled, ${disabledCount} disabled, ` +
-        `${orphanedDisabledCount} disabled-not-in-profile`
-    );
+    await runExclusiveModMutation(async () => {
+        // Resolve each profile mod against the current scan by stable id
+        // (gameBananaId + gameBananaFileId) first, then by fileName ONLY when
+        // both sides are stable-id-less (custom mods + truly-local current
+        // mods). See buildProfileModResolver for the cross-match refusal that
+        // landed in response to "Profile apply misrecognizing mods to turn on".
+        const currentMods = await scanMods(deadlockPath);
+        const resolveProfileMod = buildProfileModResolver(currentMods);
 
-    // 1b. Apply priority order in a single two-phase pass via reorderMods.
-    // The previous implementation called setModPriority per mod and swallowed
-    // "Priority X is already in use" errors. Common when switching between
-    // profiles, since the OTHER profile's mods still occupy the target slots
-    // until later iterations move them. reorderMods stages every rename via
-    // a tmp prefix first, so transient mid-loop collisions can't happen.
-    //
-    // Re-resolve after enable/disable: enableMod assigns a fresh pakNN slot and
-    // disableMod renames to a free-form name, so the previous resolver's
-    // id-to-mod (and fileName) mapping is stale.
-    const refreshedMods = await scanMods(deadlockPath);
-    const resolveAgainstRefreshed = buildProfileModResolver(refreshedMods);
-    const orderedIds: string[] = [];
-    const seen = new Set<string>();
-    let reorderSkippedDisabled = 0;
-    let reorderSkippedUnmatched = 0;
-    for (const pm of [...profile.mods].sort((a, b) => a.priority - b.priority)) {
-        if (!pm.enabled) continue;
-        const resolution = resolveAgainstRefreshed(pm);
-        if (resolution.mod === undefined) {
-            reorderSkippedUnmatched++;
-            continue;
+        // currentMod.id → ProfileMod, when matched. Drives the enable/disable
+        // loop and the reorder pass below.
+        const profileModByCurrentId = new Map<string, ProfileMod>();
+        for (const profileMod of profile.mods) {
+            const resolution = resolveProfileMod(profileMod);
+            if (resolution.mod !== undefined) {
+                profileModByCurrentId.set(resolution.mod.id, profileMod);
+                if (resolution.via === 'stable') {
+                    stableHits++;
+                    console.log(
+                        `[profiles] resolve stable: ${describeProfileMod(profileMod)} ` +
+                        `-> ${resolution.mod.fileName}`
+                    );
+                } else {
+                    fileNameHits++;
+                    console.log(
+                        `[profiles] resolve fileName (local-to-local): ` +
+                        `${describeProfileMod(profileMod)} -> ${resolution.mod.fileName}`
+                    );
+                }
+            } else if (resolution.via === 'refused-crossmatch') {
+                refusedCrossmatches++;
+                console.warn(
+                    `[profiles] resolve refused: ${describeProfileMod(profileMod)} ` +
+                    `would have cross-matched current mod ${resolution.candidateFileName} ` +
+                    `(stable-id mismatch). Entry left unmatched to avoid enabling the wrong mod.`
+                );
+            } else {
+                unmatched++;
+                console.log(
+                    `[profiles] resolve miss: ${describeProfileMod(profileMod)} ` +
+                    `(mod not currently installed)`
+                );
+            }
         }
-        if (!resolution.mod.enabled) {
-            reorderSkippedDisabled++;
-            continue;
-        }
-        if (seen.has(resolution.mod.id)) continue;
-        seen.add(resolution.mod.id);
-        orderedIds.push(resolution.mod.id);
-    }
-    if (orderedIds.length > 0) {
         console.log(
-            `[profiles] reorder: ${orderedIds.length} mods laid out densely across addon folders ` +
-            `(skipped ${reorderSkippedUnmatched} unmatched, ${reorderSkippedDisabled} disabled)`
+            `[profiles] resolution summary: ${stableHits} stable, ${fileNameHits} fileName, ` +
+            `${refusedCrossmatches} refused, ${unmatched} unmatched`
         );
-        await reorderMods(deadlockPath, orderedIds);
-    } else {
-        console.log(`[profiles] reorder: nothing to reorder`);
+
+        // Two passes, disables BEFORE enables. The disabled library is uncapped now,
+        // so a profile that swaps a large enabled set for a large disabled one could,
+        // in a single interleaved pass, enable past the 99 active-slot ceiling before
+        // freeing the slots it's about to vacate - throwing mid-apply and leaving a
+        // half-applied profile. Freeing first guarantees every slot the profile needs
+        // is available, and the enable pass can never exceed 99 (a profile holds at
+        // most 99 enabled mods). The two passes act on disjoint sets of currentMods
+        // (was-enabled vs was-disabled), so the snapshot ids stay valid across both.
+        for (const mod of currentMods) {
+            if (!mod.enabled) continue;
+            // Locker-managed VPKs (hero cards + ability sounds) aren't part of any
+            // profile: they're hidden, auto-pinned, and owned by the Locker. Never
+            // disable them on a profile switch, or applied cosmetics would silently
+            // stop loading. They get re-pinned to the front after the reorder pass.
+            if (isLockerManaged(mod.metaKey)) continue;
+            const profileMod = profileModByCurrentId.get(mod.id);
+            if (profileMod && profileMod.enabled) continue; // keep it enabled
+            try {
+                await disableModUnlocked(deadlockPath, mod.id);
+            } catch (err) {
+                failures.push(`disable ${mod.fileName}: ${String(err)}`);
+                console.warn(`[profiles] disable failed (continuing): ${mod.fileName}: ${String(err)}`);
+                continue;
+            }
+            if (profileMod) {
+                console.log(`[profiles] toggle disable: ${mod.fileName}`);
+                disabledCount++;
+            } else {
+                console.log(`[profiles] toggle disable (not in profile): ${mod.fileName}`);
+                orphanedDisabledCount++;
+            }
+        }
+        for (const mod of currentMods) {
+            if (mod.enabled) continue;
+            const profileMod = profileModByCurrentId.get(mod.id);
+            if (!profileMod || !profileMod.enabled) continue;
+            console.log(`[profiles] toggle enable: ${mod.fileName}`);
+            try {
+                await enableModUnlocked(deadlockPath, mod.id);
+                enabledCount++;
+            } catch (err) {
+                failures.push(`enable ${mod.fileName}: ${String(err)}`);
+                console.warn(`[profiles] enable failed (continuing): ${mod.fileName}: ${String(err)}`);
+            }
+        }
+        console.log(
+            `[profiles] toggle summary: ${enabledCount} enabled, ${disabledCount} disabled, ` +
+            `${orphanedDisabledCount} disabled-not-in-profile`
+        );
+
+        // 1b. Apply priority order in a single two-phase pass via reorderMods.
+        // The previous implementation called setModPriority per mod and swallowed
+        // "Priority X is already in use" errors. Common when switching between
+        // profiles, since the OTHER profile's mods still occupy the target slots
+        // until later iterations move them. reorderMods stages every rename via
+        // a tmp prefix first, so transient mid-loop collisions can't happen.
+        //
+        // Re-resolve after enable/disable: enableMod assigns a fresh pakNN slot and
+        // disableMod renames to a free-form name, so the previous resolver's
+        // id-to-mod (and fileName) mapping is stale.
+        const refreshedMods = await scanMods(deadlockPath);
+        const resolveAgainstRefreshed = buildProfileModResolver(refreshedMods);
+        const orderedIds: string[] = [];
+        const seen = new Set<string>();
+        let reorderSkippedDisabled = 0;
+        let reorderSkippedUnmatched = 0;
+        for (const pm of [...profile.mods].sort((a, b) => a.priority - b.priority)) {
+            if (!pm.enabled) continue;
+            const resolution = resolveAgainstRefreshed(pm);
+            if (resolution.mod === undefined) {
+                reorderSkippedUnmatched++;
+                continue;
+            }
+            if (!resolution.mod.enabled) {
+                reorderSkippedDisabled++;
+                continue;
+            }
+            if (seen.has(resolution.mod.id)) continue;
+            seen.add(resolution.mod.id);
+            orderedIds.push(resolution.mod.id);
+        }
+        if (orderedIds.length > 0) {
+            console.log(
+                `[profiles] reorder: ${orderedIds.length} mods laid out densely across addon folders ` +
+                `(skipped ${reorderSkippedUnmatched} unmatched, ${reorderSkippedDisabled} disabled)`
+            );
+            await reorderModsUnlocked(deadlockPath, orderedIds);
+        } else {
+            console.log(`[profiles] reorder: nothing to reorder`);
+        }
+    });
+
+    if (failures.length > 0) {
+        console.warn(
+            `[profiles] apply '${profile.name}' completed with ${failures.length} ` +
+            `mod op failure(s) (file likely locked by the running game): ${failures.join('; ')}`
+        );
     }
 
     // Re-assert the Locker-managed VPKs at the front: the profile reorder only

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -22,6 +22,25 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 // (the "added a custom mod but can't act on it until I refresh" bug).
 let modsGeneration = 0;
 
+// Serialize mod enable/disable toggles. A mod's id is its filename, which the
+// main process renames on every enable/disable, so two toggles fired in the same
+// tick (rapid Locker clicking, the exact repro in #bugs "disabled a lot of them
+// without replacing them with the mods i turned on") would race: the second
+// reads a now-stale id and either no-ops or hits "Mod not found", silently
+// dropping the click the user expected to take effect. The main process already
+// serializes the file ops; chaining here makes the SECOND toggle observe the
+// store state the first one wrote, so it dispatches a live id. Toggles still
+// queue instantly from the UI's view; they just resolve in order.
+let toggleChain: Promise<unknown> = Promise.resolve();
+function enqueueToggle<T>(fn: () => Promise<T>): Promise<T> {
+  const run = toggleChain.then(fn, fn);
+  toggleChain = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
+}
+
 // Reuse existing Mod object (and array) identities when a rescan returns
 // unchanged data. Silent refreshes fire on every Installed mount and on
 // window focus; without this each one replaced the whole list, and every
@@ -523,8 +542,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  // Toggle mod enabled/disabled
-  toggleMod: async (modId: string) => {
+  // Toggle mod enabled/disabled. Runs through enqueueToggle so concurrent
+  // clicks resolve in order and each sees the previous one's renamed id.
+  toggleMod: (modId: string) => enqueueToggle(async () => {
     const mod = get().mods.find((m) => m.id === modId);
     if (!mod) return false;
 
@@ -557,7 +577,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ modsError: String(err) });
       return false;
     }
-  },
+  }),
 
   clearModsNotice: () => set({ modsNotice: null }),
 


### PR DESCRIPTION
## What

Fixes a cluster of mod-state desync bugs reported by carcass in `#bugs` ("3D preview showing wrong model" thread, v1.21.1). Symptoms: applying a profile dropped ~5 mods, the `addons` folder drifted out of sync with the Locker UI, rapid toggling "disabled a bunch without turning the new ones on," and duplicate VPKs appeared. Diagnosed from his diagnostic log + exported profile.

The mutation queue from #243 stopped slot clobbering but didn't make profile apply atomic, didn't handle Windows file locks, and didn't dedupe.

## Root causes & fixes

1. **`applyProfile` not atomic.** It took the mutation lock per sub-call, so a Locker toggle (or second apply) could slip between disable/enable/reorder, rename files, and invalidate the scan ids the apply was driving off of -> `Mod not found` aborted it partway and dropped every remaining mod. Now the whole disable -> enable -> reorder runs inside one `runExclusiveModMutation` (new `*Unlocked` variants for use inside the batch; the locked exports would re-enter and deadlock).

2. **A single locked VPK aborted the whole apply.** Per-mod enable/disable failures are now caught, counted, and logged instead of rethrown.

3. **`EBUSY`/`EPERM`/`EACCES` on rename** (game running, antivirus, or Grimoire's own VPK readers like the 3D pose export / conflict scan). His log had 2 real `disable-mod` EBUSY failures. Added `renameWithRetry` (short backoff) on the folder-move + reorder rename paths.

4. **No dedupe by GameBanana file on profile save.** A race left two physical copies of one VPK enabled, so `createProfile`/`updateProfile` baked a phantom entry into the profile (his "Bunnydicta at priority 21 AND 31" repro). `dedupeEnabledForProfile` drops the duplicate, keeping the lower-priority (higher load-order) copy.

5. **Renderer toggles raced on the renamed id.** Two toggles in the same tick dispatched a stale id and silently dropped a click. `appStore.toggleMod` now serializes through a toggle chain.

## Test plan

- `pnpm typecheck` (tsc -b) clean
- `pnpm lint` clean
- Manual: rapid Locker skin toggling no longer leaves enabled-in-UI/missing-on-disk mods; profile apply with the game running survives locked files instead of aborting; re-saving a profile that had a duplicate produces a single entry.

## Known remaining gaps (not in scope)

- Duplicate VPKs already on disk are deduped only at profile-save, not auto-cleaned from `addons/` (avoided auto-deleting user files).
- The install/merge allocate-then-write slot path can still race a concurrent toggle (pre-existing, noted in modMerger).
- Separate open bugs from the same thread: 3+ skins 3D preview stuck on the first two, and Mina preview showing Calico.
