### PR TITLE
chore(release): v1.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.17.0';
+const VPKMERGE_VERSION = 'v0.17.1';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '455cd1711a4746714a258f74ba1a2d812a059270478ea3f44a72dc0ffc86be32' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '7fa95e5c455840a1f647f1f648ac451c528413b0da0c1f6d21fb8d1d086ef502' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '3a94713b216644cc468f182cf4cf18d9066a9b87f86dbb91766e3bec663ea26d' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: '7e22cc767da0b0db36af71ddde3b4fbf71c5ea97d06e3f0911b130426537392e' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: 'd5016dea8caa86b0522581be1300a99abcb0ad10c0bf7fddfcd5749e6c5ff9e3' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '62518c4d04e18ebc0d37534bbaff974e4582e457a8724cb9a34b7eaae4ad0b23' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Release cut for **v1.21.2**. Bumps the version and the bundled vpkmerge pin; the feature/fix work is already on `main`.

## In this release (commits since v1.21.1)
- feat(browse): WiP mod support + file-picker scroll fix + copy-link on GameBanana links + open gameinfo.gi (#245)
- fix(profiles): stop profile apply from dropping mods + dedupe duplicate VPKs (#247)
- fix(locker): Infernus 3D preview showing vanilla skin (#246)
- fix(locker): two bugs from heavy mod toggling (wrong 3D model + clobbered VPKs) (#243)
- i18n: translation optimizations (#244)

## This PR
- Bump `package.json` to `1.21.2`.
- Bump the bundled vpkmerge pin v0.17.0 -> v0.17.1 (`scripts/fetch-vpkmerge.mjs`), with all three CLI sha256 hashes updated. v0.17.1's GLB export preserves additive glow/emissive overlays, so the hero/prop 3D previews match in-game appearance. CLI API unchanged.

## Verification (local)
- `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check`, locale manifest `--check`, and `pnpm exec vitest run` (239 passed) all green.
- vpkmerge v0.17.1 confirmed published; binaries downloaded and sha256-verified; `--version` reports 0.17.1.
- Linux package built and launched locally for smoke test.

After merge: tag `v1.21.2` from `main` to trigger the release workflow.