### PR TITLE
feat(foundry): unlock Texture, Items, and Recolor sub-tabs

### DIFF
--- a/src/components/foundry/LibraryBrowse.tsx
+++ b/src/components/foundry/LibraryBrowse.tsx
@@ -11,6 +11,8 @@ import TextureLightbox from './TextureLightbox';
 interface LibraryBrowseProps {
   /** codename -> display name, resolved once by the Foundry shell. */
   heroNames: Map<string, string>;
+  /** Category the grid opens on (the Items sub-tool lands on item icons). */
+  initialCategory?: TextureCategory;
 }
 
 // The bounded, thumbnailable categories the browse grid surfaces this pass.
@@ -25,9 +27,9 @@ const CATEGORIES: { value: TextureCategory; labelKey: string; fallback: string }
  * client-side hero/search narrowing and an enlarge-on-click lightbox. One IPC
  * call per category (thumbnails decoded once and cached); filtering is local.
  */
-export default function LibraryBrowse({ heroNames }: LibraryBrowseProps) {
+export default function LibraryBrowse({ heroNames, initialCategory = 'ability-icon' }: LibraryBrowseProps) {
   const { t } = useTranslation();
-  const [category, setCategory] = useState<TextureCategory>('ability-icon');
+  const [category, setCategory] = useState<TextureCategory>(initialCategory);
   const [items, setItems] = useState<TextureGridItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/foundry/RecolorTool.tsx
+++ b/src/components/foundry/RecolorTool.tsx
@@ -1,0 +1,72 @@
+import { useMemo, useState } from 'react';
+import { Palette, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../common/PageComponents';
+import Tx from '../translation/Tx';
+import HeroEffectsPanel from '../locker/HeroEffectsPanel';
+import type { HeroInfo } from '../../types/foundry';
+
+interface RecolorToolProps {
+  /** Full roster; the recolor surface is keyed by hero display name. */
+  heroes: HeroInfo[];
+}
+
+/**
+ * The Recolor sub-tool: pick a hero, then recolor their ability VFX (single
+ * color / rainbow prism / gradient / trippy) and body/gun materials. This reuses
+ * the exact recolor surface from the Locker (HeroEffectsPanel), which keys by
+ * the hero display name and self-gates on the pinned-recipe support check, so a
+ * hero without a recipe shows its own "unavailable" note. The bake lands in the
+ * same one-recolor-per-hero Locker slot, so a pick made here shows up there too.
+ */
+export default function RecolorTool({ heroes }: RecolorToolProps) {
+  const { t } = useTranslation();
+  const [heroName, setHeroName] = useState('');
+
+  // Selectable heroes first (the ones with a real recipe live here); de-dup by
+  // display name since the panel keys on it.
+  const heroOptions = useMemo(
+    () =>
+      Array.from(new Set(heroes.map((h) => h.name)))
+        .sort((a, b) => a.localeCompare(b)),
+    [heroes],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-tertiary px-2 py-1.5 w-fit">
+        <Users size={14} className="text-text-secondary" />
+        <select
+          value={heroName}
+          onChange={(e) => setHeroName(e.target.value)}
+          className="bg-transparent text-sm text-text-primary focus:outline-none"
+        >
+          <option value="" className="bg-bg-secondary">
+            {t('foundry.recolor.pickHero', 'Select a hero')}
+          </option>
+          {heroOptions.map((name) => (
+            <option key={name} value={name} className="bg-bg-secondary">
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {heroName === '' ? (
+        <EmptyState
+          icon={Palette}
+          title={<Tx k="foundry.recolor.scope.title" fallback="Pick a hero to recolor" />}
+          description={
+            <Tx
+              k="foundry.recolor.scope.description"
+              fallback="Choose a hero to repaint their ability VFX (single color, rainbow, gradient, or trippy) and body/gun materials. The result is saved as a managed mod you can remove anytime."
+            />
+          }
+        />
+      ) : (
+        // Keyed by hero so a hero switch remounts the panel with fresh state.
+        <HeroEffectsPanel key={heroName} heroName={heroName} />
+      )}
+    </div>
+  );
+}

--- a/src/components/foundry/TextureBrowse.tsx
+++ b/src/components/foundry/TextureBrowse.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ImageIcon, Search, Loader2, AlertTriangle, Users, Box, Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../common/PageComponents';
+import Tx from '../translation/Tx';
+import { foundryTextures } from '../../lib/api';
+import type { HeroInfo, TextureCategory, TextureEntry, TextureGridItem } from '../../types/foundry';
+import TextureLightbox from './TextureLightbox';
+
+interface TextureBrowseProps {
+  /** Full roster, used to populate the hero filter the list is scoped by. */
+  heroes: HeroInfo[];
+  /** codename -> display name, resolved once by the Foundry shell. */
+  heroNames: Map<string, string>;
+}
+
+// The two large, hero-scoped texture families the reskin/VFX work targets. These
+// carry no pre-baked thumbnail batch (too many entries), so this view lists them
+// and decodes a single texture full-size on click instead of a thumbnail grid.
+const CATEGORIES: { value: TextureCategory; icon: typeof Box; labelKey: string; fallback: string }[] = [
+  { value: 'hero-model', icon: Box, labelKey: 'foundry.texture.categories.heroModel', fallback: 'Hero models' },
+  { value: 'ability-vfx', icon: Sparkles, labelKey: 'foundry.texture.categories.abilityVfx', fallback: 'Ability VFX' },
+];
+
+// Cap the list so a hero with hundreds of model textures stays responsive; the
+// engine logs a truncation note, we surface the same to the user.
+const LIMIT = 400;
+
+/**
+ * The Texture sub-tool: browse the large hero-model / ability-vfx texture
+ * families (the skin/reskin/recolor targets). Unlike the Library grid these are
+ * not pre-thumbnailed, so the list is always scoped by hero (or a search) to
+ * stay bounded, and each row decodes its texture full-size on click. One IPC
+ * call per (category, hero, search); the lightbox does the on-demand decode.
+ */
+export default function TextureBrowse({ heroes, heroNames }: TextureBrowseProps) {
+  const { t } = useTranslation();
+  const [category, setCategory] = useState<TextureCategory>('hero-model');
+  const [heroFilter, setHeroFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [items, setItems] = useState<TextureEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [lightbox, setLightbox] = useState<TextureGridItem | null>(null);
+
+  // Hero dropdown: every roster hero, by display name. Texture entries key on the
+  // codename, which is what we send as the filter.
+  const heroOptions = useMemo(
+    () =>
+      heroes
+        .map((h) => ({ code: h.codename, name: h.name }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [heroes],
+  );
+
+  // Unbounded hero-model is thousands of entries, so refuse to fetch until the
+  // list is narrowed by a hero or a search term.
+  const ready = heroFilter !== '' || search.trim().length > 0;
+
+  const load = useCallback(
+    async (cat: TextureCategory, hero: string, term: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const rows = await foundryTextures({
+          category: cat,
+          hero: hero || undefined,
+          search: term.trim() || undefined,
+          limit: LIMIT,
+        });
+        setItems(rows);
+        setTruncated(rows.length >= LIMIT);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setItems([]);
+        setTruncated(false);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  // Debounce so typing in the search box doesn't fire an IPC call per keystroke.
+  useEffect(() => {
+    if (!ready) {
+      setItems([]);
+      setTruncated(false);
+      setError(null);
+      return;
+    }
+    const handle = setTimeout(() => void load(category, heroFilter, search), 250);
+    return () => clearTimeout(handle);
+  }, [category, heroFilter, search, ready, load]);
+
+  return (
+    <>
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-tertiary px-2 py-1.5">
+          <ImageIcon size={14} className="text-text-secondary" />
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value as TextureCategory)}
+            className="bg-transparent text-sm text-text-primary focus:outline-none"
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value} className="bg-bg-secondary">
+                {t(c.labelKey, c.fallback)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-tertiary px-2 py-1.5">
+          <Users size={14} className="text-text-secondary" />
+          <select
+            value={heroFilter}
+            onChange={(e) => setHeroFilter(e.target.value)}
+            className="bg-transparent text-sm text-text-primary focus:outline-none"
+          >
+            <option value="" className="bg-bg-secondary">
+              {t('foundry.texture.pickHero', 'Select a hero')}
+            </option>
+            {heroOptions.map((h) => (
+              <option key={h.code} value={h.code} className="bg-bg-secondary">
+                {h.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="relative min-w-[200px] flex-1">
+          <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('foundry.filters.searchPlaceholder', 'Search assets...')}
+            className="w-full rounded-sm border border-border bg-bg-tertiary py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-secondary/60 focus:border-accent/50 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* List / states */}
+      {!ready ? (
+        <EmptyState
+          icon={ImageIcon}
+          title={<Tx k="foundry.texture.scope.title" fallback="Pick a hero to browse textures" />}
+          description={
+            <Tx
+              k="foundry.texture.scope.description"
+              fallback="Hero model and VFX textures are a large set, so choose a hero (or type a search) to narrow the list."
+            />
+          }
+        />
+      ) : loading ? (
+        <div className="flex items-center justify-center gap-2 py-20 text-text-secondary">
+          <Loader2 size={18} className="animate-spin" />
+          <Tx k="foundry.loading" fallback="Building catalog from your game files..." />
+        </div>
+      ) : error ? (
+        <EmptyState
+          icon={AlertTriangle}
+          variant="error"
+          title={<Tx k="foundry.error.title" fallback="Couldn't read the catalog" />}
+          description={error}
+        />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={ImageIcon}
+          title={<Tx k="foundry.texture.empty.title" fallback="No textures match" />}
+          description={
+            <Tx
+              k="foundry.texture.empty.description"
+              fallback="No textures in this category for that hero or search. Try another category or hero."
+            />
+          }
+        />
+      ) : (
+        <div className="space-y-2">
+          <p className="text-[11px] text-text-secondary">
+            {truncated
+              ? t('foundry.texture.countCapped', 'Showing the first {{count}}. Refine your search to see more.', {
+                  count: items.length,
+                })
+              : t('foundry.texture.count', '{{count}} textures', { count: items.length })}
+          </p>
+          <ul className="divide-y divide-border/60 overflow-hidden rounded-sm border border-border">
+            {items.map((entry) => (
+              <li key={entry.path}>
+                <button
+                  type="button"
+                  onClick={() => setLightbox({ ...entry, thumbUrl: null })}
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-bg-tertiary"
+                >
+                  <ImageIcon size={15} className="shrink-0 text-text-secondary/70" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm capitalize text-text-primary" title={entry.label}>
+                      {entry.label || t('foundry.lightbox.unnamed', '(unnamed)')}
+                    </span>
+                    <span className="block truncate text-[11px] text-text-secondary" title={entry.path}>
+                      {entry.path}
+                    </span>
+                  </span>
+                  {entry.hero && (
+                    <span className="shrink-0 text-[11px] text-text-secondary/70">
+                      {heroNames.get(entry.hero) ?? entry.hero}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <TextureLightbox
+        item={lightbox}
+        heroName={lightbox?.hero ? heroNames.get(lightbox.hero) : undefined}
+        onClose={() => setLightbox(null)}
+      />
+    </>
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -114,6 +114,30 @@
       "decoding": "Decoding full size...",
       "nativeSize": "Native size"
     },
+    "texture": {
+      "categories": {
+        "heroModel": "Hero models",
+        "abilityVfx": "Ability VFX"
+      },
+      "pickHero": "Select a hero",
+      "scope": {
+        "title": "Pick a hero to browse textures",
+        "description": "Hero model and VFX textures are a large set, so choose a hero (or type a search) to narrow the list."
+      },
+      "empty": {
+        "title": "No textures match",
+        "description": "No textures in this category for that hero or search. Try another category or hero."
+      },
+      "count": "{{count}} textures",
+      "countCapped": "Showing the first {{count}}. Refine your search to see more."
+    },
+    "recolor": {
+      "pickHero": "Select a hero",
+      "scope": {
+        "title": "Pick a hero to recolor",
+        "description": "Choose a hero to repaint their ability VFX (single color, rainbow, gradient, or trippy) and body/gun materials. The result is saved as a managed mod you can remove anytime."
+      }
+    },
     "sound": {
       "searchPlaceholder": "Search sounds...",
       "muteToggle": "Mute / unmute auditions",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1771,
+  "totalKeys": 1783,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1608,
-      "pct": 91
+      "pct": 90
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1771,
+      "translatedKeys": 1783,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1666,
-      "pct": 94
+      "pct": 93
     },
     {
       "code": "ru",

--- a/src/pages/Foundry.tsx
+++ b/src/pages/Foundry.tsx
@@ -14,15 +14,17 @@ import { foundryHeroes, foundryWarmCache } from '../lib/api';
 import type { HeroInfo } from '../types/foundry';
 import LibraryBrowse from '../components/foundry/LibraryBrowse';
 import SoundBrowse from '../components/foundry/SoundBrowse';
+import TextureBrowse from '../components/foundry/TextureBrowse';
+import RecolorTool from '../components/foundry/RecolorTool';
 
-// Sub-tools shown in the left rail. Library + Sound are live; the rest are
-// placeholders that telegraph the planned Foundry surface.
+// Sub-tools shown in the left rail. Library / Sound / Texture / Recolor are
+// live; Items rides the Library grid (opened on item icons) for now.
 const SUBTOOLS = [
   { id: 'library', icon: Library, labelKey: 'foundry.subtools.library', enabled: true },
   { id: 'sound', icon: Volume2, labelKey: 'foundry.subtools.sound', enabled: true },
-  { id: 'texture', icon: ImageIcon, labelKey: 'foundry.subtools.texture', enabled: false },
-  { id: 'items', icon: ShoppingBag, labelKey: 'foundry.subtools.items', enabled: false },
-  { id: 'recolor', icon: Palette, labelKey: 'foundry.subtools.recolor', enabled: false },
+  { id: 'texture', icon: ImageIcon, labelKey: 'foundry.subtools.texture', enabled: true },
+  { id: 'items', icon: ShoppingBag, labelKey: 'foundry.subtools.items', enabled: true },
+  { id: 'recolor', icon: Palette, labelKey: 'foundry.subtools.recolor', enabled: true },
 ] as const;
 
 type SubtoolId = (typeof SUBTOOLS)[number]['id'];
@@ -120,6 +122,12 @@ export default function Foundry() {
             />
           ) : active === 'sound' ? (
             <SoundBrowse heroes={heroes} heroNames={heroNames} />
+          ) : active === 'texture' ? (
+            <TextureBrowse heroes={heroes} heroNames={heroNames} />
+          ) : active === 'recolor' ? (
+            <RecolorTool heroes={heroes} />
+          ) : active === 'items' ? (
+            <LibraryBrowse heroNames={heroNames} initialCategory="item-icon" />
           ) : (
             <LibraryBrowse heroNames={heroNames} />
           )}


### PR DESCRIPTION
Unlocks the next three Foundry ("Door Stuck") left-rail sub-tabs and routes them to real views. Mostly boilerplate wiring over existing backend.

## Changes
- **Flip the gates** in `Foundry.tsx` (`texture`/`items`/`recolor` -> `enabled: true`) and route each to a view.
- **Texture** (`TextureBrowse.tsx`, new): hero-scoped browse of `hero-model` + `ability-vfx` textures via the existing `foundryTextures` IPC. These families carry no pre-baked thumbnails (thousands of entries), so it's a bounded list (pick a hero or search before fetch, 400-row cap + truncation note) with click-to-preview through the existing `TextureLightbox`.
- **Recolor** (`RecolorTool.tsx`, new): hero picker reusing the Locker's `HeroEffectsPanel` (ability VFX color/prism/gradient/trippy + body/gun materials). No new backend — keyed by display name (matching the Locker's `getHeroColorSupport` call) and self-gates on pinned-recipe support. Picks land in the same per-hero Locker slot.
- **Items**: rides the Library grid opened on item icons via a new `initialCategory` prop on `LibraryBrowse` (stopgap, per request).
- i18n: added `foundry.texture.*` / `foundry.recolor.*` keys + regenerated `manifest.json`.

## Verification
- `pnpm typecheck` (tsc -b) clean
- `eslint` clean on touched files
- Not yet click-tested in the running app.

## Notes
- Items is a stopgap (same component as Library, different default category), not a dedicated tool.
- Texture is list + click-to-preview, not a thumbnail grid; a grid would need a hero-scoped thumbnail-batch IPC on the main process.