### PR TITLE
feat(foundry): hero-first workshop landing

### DIFF
--- a/src/components/foundry/FoundryHeroGrid.tsx
+++ b/src/components/foundry/FoundryHeroGrid.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { HeroInfo } from '../../types/foundry';
+import { getHeroRenderPath, getHeroChipIconPath } from '../../lib/lockerUtils';
+
+interface FoundryHeroGridProps {
+  /** Full roster from `catalog heroes`. */
+  heroes: HeroInfo[];
+  /** Open the per-hero workshop for the picked hero. */
+  onPick: (hero: HeroInfo) => void;
+}
+
+/**
+ * The Foundry landing: an aesthetic roster grid. Pick a hero to open their
+ * workshop (the per-hero "edit everything" view). Mirrors the Locker's
+ * hero-first entry, but lands in the creation workflow rather than installed
+ * mods. Selectable heroes lead; in-development heroes follow, dimmed.
+ */
+export default function FoundryHeroGrid({ heroes, onPick }: FoundryHeroGridProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+
+  const ordered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return heroes
+      .filter((h) => !h.disabled)
+      .filter((h) => (q ? h.name.toLowerCase().includes(q) || h.codename.includes(q) : true))
+      // Selectable first, then in-development; alphabetical within each group.
+      .sort((a, b) => {
+        if (a.selectable !== b.selectable) return a.selectable ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+  }, [heroes, query]);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-2 rounded-sm border border-border bg-bg-tertiary px-3 py-2 w-full max-w-xs">
+        <Search size={15} className="text-text-secondary" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t('foundry.heroes.search', 'Search heroes')}
+          className="w-full bg-transparent text-sm text-text-primary placeholder:text-text-secondary/60 focus:outline-none"
+        />
+      </div>
+
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(132px,1fr))] gap-3">
+        {ordered.map((hero) => (
+          <HeroCard key={hero.codename} hero={hero} onPick={() => onPick(hero)} />
+        ))}
+      </div>
+
+      {ordered.length === 0 && (
+        <p className="text-sm text-text-secondary">
+          {t('foundry.heroes.noMatch', 'No heroes match that search.')}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function HeroCard({ hero, onPick }: { hero: HeroInfo; onPick: () => void }) {
+  // Render image -> chip icon -> name text, the same graceful fallback chain the
+  // Locker uses (in-development heroes often lack a render asset).
+  const [step, setStep] = useState(0);
+  const src = step === 0 ? getHeroRenderPath(hero.name) : step === 1 ? getHeroChipIconPath(hero.name) : '';
+
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      title={hero.name}
+      className={`group relative flex aspect-[3/4] flex-col justify-end overflow-hidden rounded-md border border-border bg-bg-secondary text-left transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:shadow-lg hover:shadow-black/30 cursor-pointer ${
+        hero.selectable ? '' : 'opacity-70'
+      }`}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt={hero.name}
+          loading="lazy"
+          onError={() => setStep((s) => s + 1)}
+          className={
+            step === 0
+              ? 'absolute inset-0 h-full w-full object-cover object-top transition-transform duration-300 group-hover:scale-105'
+              : 'absolute left-1/2 top-1/2 h-16 w-16 -translate-x-1/2 -translate-y-1/2 object-contain opacity-80'
+          }
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-sm font-medium text-text-secondary">
+          {hero.name}
+        </div>
+      )}
+
+      {/* Bottom gradient + name plate. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-2/3 bg-gradient-to-t from-black/85 via-black/30 to-transparent" />
+      <div className="relative z-10 p-2">
+        <span className="block truncate text-sm font-semibold text-white drop-shadow-[0_1px_6px_rgba(0,0,0,0.8)]">
+          {hero.name}
+        </span>
+        {!hero.selectable && (
+          <span className="text-[10px] uppercase tracking-wide text-accent/90">
+            in development
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/foundry/HeroWorkshop.tsx
+++ b/src/components/foundry/HeroWorkshop.tsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from 'react';
+import {
+  ArrowLeft,
+  Sparkles,
+  Swords,
+  Volume2,
+  Image as ImageIcon,
+  Hammer,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { HeroInfo } from '../../types/foundry';
+import {
+  getHeroRenderPath,
+  getHeroNamePath,
+  getHeroWikiUrl,
+} from '../../lib/lockerUtils';
+import { useFoundryStagingStore } from '../../stores/foundryStagingStore';
+import HeroEffectsPanel from '../locker/HeroEffectsPanel';
+import SoundBrowse from './SoundBrowse';
+import TextureBrowse from './TextureBrowse';
+import LibraryBrowse from './LibraryBrowse';
+import Tx from '../translation/Tx';
+
+interface HeroWorkshopProps {
+  hero: HeroInfo;
+  /** Full roster codename -> display name map (for the reused browse panels). */
+  heroNames: Map<string, string>;
+  onBack: () => void;
+}
+
+type SectionId = 'appearance' | 'abilities' | 'voice' | 'icons';
+
+/**
+ * The per-hero Foundry workshop: pick a hero, edit everything about them. Mirrors
+ * the Locker's hero-detail frame (full-bleed render backdrop + frosted-glass rail
+ * + section nav) but the sections are creation surfaces over the asset catalog:
+ *
+ *   Appearance  recolor / prism / body+gun materials  (HeroEffectsPanel, live)
+ *   Abilities   per-ability icon + VFX + SFX           (next phase)
+ *   Voice       hero VO browse + preview               (SoundBrowse, live browse)
+ *   Icons       ability icons + model textures         (Texture/LibraryBrowse, live browse)
+ *
+ * Edits accumulate in the Build Tray (rail, bottom) and forge into one addon VPK.
+ * Recolor (Appearance) currently bakes straight into its managed Locker slot and
+ * is not routed through the tray; swap staging + forge is the follow-on backend.
+ */
+export default function HeroWorkshop({ hero, heroNames, onBack }: HeroWorkshopProps) {
+  const { t } = useTranslation();
+  const [section, setSection] = useState<SectionId>('appearance');
+  const [renderStep, setRenderStep] = useState(0);
+  const [nameFailed, setNameFailed] = useState(false);
+
+  // A single-hero roster so the reused browse panels are pre-scoped to this hero
+  // (they each carry their own hero filter; handing them one hero pins it).
+  const scopedRoster = useMemo<HeroInfo[]>(() => [hero], [hero]);
+
+  const staged = useFoundryStagingStore((s) => s.edits).filter(
+    (e) => e.heroCodename === hero.codename,
+  );
+  const unstage = useFoundryStagingStore((s) => s.unstage);
+
+  const sections: Array<{ id: SectionId; label: string; icon: LucideIcon }> = [
+    { id: 'appearance', label: t('foundry.workshop.appearance', 'Appearance'), icon: Sparkles },
+    { id: 'abilities', label: t('foundry.workshop.abilities', 'Abilities'), icon: Swords },
+    { id: 'voice', label: t('foundry.workshop.voice', 'Voice'), icon: Volume2 },
+    { id: 'icons', label: t('foundry.workshop.icons', 'Icons & Textures'), icon: ImageIcon },
+  ];
+
+  const renderSrc =
+    renderStep === 0
+      ? getHeroRenderPath(hero.name)
+      : renderStep === 1
+        ? getHeroWikiUrl(hero.name)
+        : '';
+
+  return (
+    <div className="relative flex h-full overflow-hidden">
+      {/* Hero render backdrop, anchored right, behind the frosted rail. */}
+      <div className="hidden lg:block absolute inset-0 bg-bg-primary animate-hero-zoom-in overflow-hidden">
+        {renderSrc ? (
+          <img
+            src={renderSrc}
+            alt={hero.name}
+            onError={() => setRenderStep((s) => s + 1)}
+            className="absolute top-0 right-0 h-full w-auto max-w-none"
+          />
+        ) : null}
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
+      </div>
+
+      {/* Feathered frosted glass behind the rail + content, so the render bleeds
+          through to clear on the right. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 left-0 z-[5] hidden lg:block lg:w-[1040px] xl:w-[1160px]"
+      >
+        <div
+          className="absolute inset-0"
+          style={{
+            backdropFilter: 'blur(40px) saturate(130%)',
+            WebkitBackdropFilter: 'blur(40px) saturate(130%)',
+            WebkitMaskImage: 'linear-gradient(to right, black 0%, black 44%, transparent 94%)',
+            maskImage: 'linear-gradient(to right, black 0%, black 44%, transparent 94%)',
+          }}
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'linear-gradient(to right, var(--color-bg-secondary) 0%, rgba(26,26,26,0.95) 42%, rgba(26,26,26,0.7) 62%, rgba(26,26,26,0.3) 80%, transparent 96%)',
+          }}
+        />
+      </div>
+
+      {/* Left rail: hero identity + section nav + build tray. */}
+      <div className="relative z-10 flex w-[280px] flex-shrink-0 flex-col gap-5 overflow-y-auto scrollbar-glass bg-bg-secondary p-5 animate-slide-in-left lg:bg-transparent xl:w-[320px]">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex w-fit items-center gap-2 text-sm text-text-secondary transition-colors hover:text-text-primary cursor-pointer"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {t('foundry.workshop.back', 'All heroes')}
+        </button>
+
+        {nameFailed ? (
+          <h2 className="text-2xl font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
+            {hero.name}
+          </h2>
+        ) : (
+          <img
+            src={getHeroNamePath(hero.name)}
+            alt={hero.name}
+            className="h-8 w-auto self-start object-contain"
+            onError={() => setNameFailed(true)}
+          />
+        )}
+
+        <nav aria-label={t('foundry.workshop.sections', 'Workshop sections')} className="flex flex-col gap-1.5">
+          {sections.map(({ id, label, icon: Icon }) => {
+            const isActive = section === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => setSection(id)}
+                className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors cursor-pointer ${
+                  isActive
+                    ? 'border-accent/60 bg-accent/15'
+                    : 'border-transparent hover:bg-white/10'
+                }`}
+              >
+                <Icon className="h-4 w-4 flex-shrink-0 text-white/80" />
+                <span className="flex-1 truncate text-sm font-medium text-white">{label}</span>
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* Build Tray: the staged edits for this hero, forged into one mod. */}
+        <BuildTray heroName={hero.name} staged={staged} onRemove={unstage} />
+      </div>
+
+      {/* Content pane: the active section. */}
+      <div className="relative z-10 min-w-0 flex-1 overflow-y-auto scrollbar-glass">
+        <div className="space-y-4 p-6">
+          {section === 'appearance' ? (
+            <HeroEffectsPanel key={hero.name} heroName={hero.name} />
+          ) : section === 'voice' ? (
+            <SoundBrowse heroes={scopedRoster} heroNames={heroNames} />
+          ) : section === 'icons' ? (
+            <div className="space-y-8">
+              <TextureBrowse heroes={scopedRoster} heroNames={heroNames} />
+              <div className="space-y-2">
+                <h4 className="text-sm font-semibold text-white/90">
+                  {t('foundry.workshop.abilityIcons', 'Ability & item icons')}
+                </h4>
+                <LibraryBrowse heroNames={heroNames} initialCategory="ability-icon" />
+              </div>
+            </div>
+          ) : (
+            <AbilitiesPlaceholder heroName={hero.name} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BuildTray({
+  heroName,
+  staged,
+  onRemove,
+}: {
+  heroName: string;
+  staged: ReturnType<typeof useFoundryStagingStore.getState>['edits'];
+  onRemove: (id: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="mt-auto rounded-lg border border-border/70 bg-bg-secondary/70 p-3 backdrop-blur">
+      <div className="mb-2 flex items-center gap-2">
+        <Hammer className="h-4 w-4 text-accent" />
+        <span className="flex-1 text-sm font-semibold text-white">
+          {t('foundry.workshop.buildTray', 'Build tray')}
+        </span>
+        <span className="text-xs text-white/50">{staged.length}</span>
+      </div>
+
+      {staged.length === 0 ? (
+        <p className="text-xs leading-relaxed text-text-secondary">
+          {t(
+            'foundry.workshop.buildTrayEmpty',
+            'Stage icon, texture, and sound swaps here, then forge them into one mod for {{hero}}. (Recolor saves directly to its own managed mod.)',
+            { hero: heroName },
+          )}
+        </p>
+      ) : (
+        <ul className="space-y-1.5">
+          {staged.map((edit) => (
+            <li
+              key={edit.id}
+              className="flex items-center gap-2 rounded-sm bg-bg-tertiary/60 px-2 py-1.5 text-xs text-text-primary"
+            >
+              <span className="flex-1 truncate" title={edit.targetPath}>
+                {edit.label}
+              </span>
+              <button
+                type="button"
+                onClick={() => onRemove(edit.id)}
+                title={t('foundry.workshop.removeStaged', 'Remove')}
+                className="text-text-secondary transition-colors hover:text-red-400 cursor-pointer"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        disabled={staged.length === 0}
+        className={`mt-3 w-full rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
+          staged.length === 0
+            ? 'cursor-not-allowed bg-bg-tertiary/50 text-text-secondary/50'
+            : 'cursor-pointer bg-accent text-black hover:bg-accent-hover'
+        }`}
+      >
+        {t('foundry.workshop.forge', 'Forge mod')}
+      </button>
+    </div>
+  );
+}
+
+function AbilitiesPlaceholder({ heroName }: { heroName: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-bg-secondary/50 p-6 text-sm leading-relaxed text-text-secondary">
+      <p className="mb-1 font-medium text-text-primary">
+        <Tx k="foundry.workshop.abilitiesSoon.title" fallback="Per-ability editing is coming next" />
+      </p>
+      <Tx
+        k="foundry.workshop.abilitiesSoon.body"
+        fallback={`The Abilities view will group ${heroName}'s four abilities into rows — each with its icon, VFX color, and sound in one place. For now, recolor all ability VFX at once under Appearance, browse ability icons under Icons & Textures, and ability sounds under Voice.`}
+      />
+    </div>
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -78,8 +78,32 @@
   },
   "foundry": {
     "header": {
-      "title": "your mom goes to college",
+      "title": "Foundry",
       "description": "Browse the game's own asset catalog, built offline from your installed files."
+    },
+    "browseCatalog": "Browse full catalog",
+    "backToHeroes": "Heroes",
+    "heroes": {
+      "subtitle": "Pick a hero to edit their look, abilities, voice, and icons.",
+      "search": "Search heroes",
+      "noMatch": "No heroes match that search."
+    },
+    "workshop": {
+      "appearance": "Appearance",
+      "abilities": "Abilities",
+      "voice": "Voice",
+      "icons": "Icons & Textures",
+      "back": "All heroes",
+      "sections": "Workshop sections",
+      "abilityIcons": "Ability & item icons",
+      "buildTray": "Build tray",
+      "buildTrayEmpty": "Stage icon, texture, and sound swaps here, then forge them into one mod for {{hero}}. (Recolor saves directly to its own managed mod.)",
+      "removeStaged": "Remove",
+      "forge": "Forge mod",
+      "abilitiesSoon": {
+        "title": "Per-ability editing is coming next",
+        "body": "The Abilities view will group each ability into a row with its icon, VFX color, and sound in one place. For now, recolor all ability VFX at once under Appearance, browse ability icons under Icons & Textures, and ability sounds under Voice."
+      }
     },
     "subtools": {
       "heading": "Workshop",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,17 +1,17 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1783,
+  "totalKeys": 1801,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1608,
-      "pct": 90
+      "pct": 89
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1783,
+      "translatedKeys": 1801,
       "pct": 100
     },
     {

--- a/src/pages/Foundry.tsx
+++ b/src/pages/Foundry.tsx
@@ -6,6 +6,7 @@ import {
   Image as ImageIcon,
   ShoppingBag,
   Palette,
+  ArrowLeft,
 } from 'lucide-react';
 import { EmptyState, PageHeader } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
@@ -16,9 +17,11 @@ import LibraryBrowse from '../components/foundry/LibraryBrowse';
 import SoundBrowse from '../components/foundry/SoundBrowse';
 import TextureBrowse from '../components/foundry/TextureBrowse';
 import RecolorTool from '../components/foundry/RecolorTool';
+import FoundryHeroGrid from '../components/foundry/FoundryHeroGrid';
+import HeroWorkshop from '../components/foundry/HeroWorkshop';
 
-// Sub-tools shown in the left rail. Library / Sound / Texture / Recolor are
-// live; Items rides the Library grid (opened on item icons) for now.
+// Sub-tools shown in the left rail of the Catalog (tool-first) mode. Library /
+// Sound / Texture / Recolor are live; Items rides the Library grid for now.
 const SUBTOOLS = [
   { id: 'library', icon: Library, labelKey: 'foundry.subtools.library', enabled: true },
   { id: 'sound', icon: Volume2, labelKey: 'foundry.subtools.sound', enabled: true },
@@ -28,11 +31,16 @@ const SUBTOOLS = [
 ] as const;
 
 type SubtoolId = (typeof SUBTOOLS)[number]['id'];
+type Mode = 'heroes' | 'catalog';
 
 export default function Foundry() {
   const settings = useAppStore((s) => s.settings);
   const hasGamePath = Boolean(settings?.deadlockPath || (settings?.devMode && settings?.devDeadlockPath));
 
+  // Hero-first is the primary Foundry experience: pick a hero, edit everything.
+  // The Catalog (tool-first) mode keeps the original asset-browse rail.
+  const [mode, setMode] = useState<Mode>('heroes');
+  const [selectedHero, setSelectedHero] = useState<HeroInfo | null>(null);
   const [active, setActive] = useState<SubtoolId>('library');
   const [heroes, setHeroes] = useState<HeroInfo[]>([]);
 
@@ -60,10 +68,84 @@ export default function Foundry() {
     return map;
   }, [heroes]);
 
+  // No game path: same gate regardless of mode.
+  if (!hasGamePath) {
+    return (
+      <div className="space-y-4 p-6">
+        <PageHeader
+          title={<Tx k="foundry.header.title" fallback="Foundry" />}
+          description={
+            <Tx
+              k="foundry.header.description"
+              fallback="Browse the game's own asset catalog, built offline from your installed files."
+            />
+          }
+        />
+        <EmptyState
+          icon={Hammer}
+          title={<Tx k="foundry.empty.noPath.title" fallback="Set your Deadlock path" />}
+          description={
+            <Tx
+              k="foundry.empty.noPath.description"
+              fallback="Foundry reads the asset catalog from your installed game. Set the Deadlock path in Settings to get started."
+            />
+          }
+        />
+      </div>
+    );
+  }
+
+  // Hero workshop: full-bleed, no page chrome (mirrors the Locker hero view).
+  if (mode === 'heroes' && selectedHero) {
+    return (
+      <HeroWorkshop
+        hero={selectedHero}
+        heroNames={heroNames}
+        onBack={() => setSelectedHero(null)}
+      />
+    );
+  }
+
+  // Hero roster landing.
+  if (mode === 'heroes') {
+    return (
+      <div className="space-y-4 p-6">
+        <PageHeader
+          title={<Tx k="foundry.header.title" fallback="Foundry" />}
+          description={
+            <Tx
+              k="foundry.heroes.subtitle"
+              fallback="Pick a hero to edit their look, abilities, voice, and icons."
+            />
+          }
+          action={
+            <button
+              type="button"
+              onClick={() => setMode('catalog')}
+              className="flex items-center gap-2 rounded-sm border border-border bg-bg-tertiary px-3 py-1.5 text-sm text-text-secondary transition-colors hover:text-text-primary cursor-pointer"
+            >
+              <Library size={15} />
+              <Tx k="foundry.browseCatalog" fallback="Browse full catalog" />
+            </button>
+          }
+        />
+        <FoundryHeroGrid heroes={heroes} onPick={setSelectedHero} />
+      </div>
+    );
+  }
+
+  // Catalog (tool-first) mode: the original asset-browse rail.
   return (
     <div className="flex h-full">
-      {/* Left rail: sub-tools */}
       <aside className="flex w-44 shrink-0 flex-col gap-1 border-r border-border bg-bg-secondary/40 p-3">
+        <button
+          type="button"
+          onClick={() => setMode('heroes')}
+          className="mb-1 flex items-center gap-2 rounded-sm px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary cursor-pointer"
+        >
+          <ArrowLeft size={15} />
+          <Tx k="foundry.backToHeroes" fallback="Heroes" />
+        </button>
         <span className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-text-secondary/70">
           <Tx k="foundry.subtools.heading" fallback="Workshop" />
         </span>
@@ -96,11 +178,10 @@ export default function Foundry() {
         })}
       </aside>
 
-      {/* Center: catalog browse */}
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="space-y-4 p-6">
           <PageHeader
-            title={<Tx k="foundry.header.title" fallback="your mom goes to college" />}
+            title={<Tx k="foundry.header.title" fallback="Foundry" />}
             description={
               <Tx
                 k="foundry.header.description"
@@ -109,18 +190,7 @@ export default function Foundry() {
             }
           />
 
-          {!hasGamePath ? (
-            <EmptyState
-              icon={Hammer}
-              title={<Tx k="foundry.empty.noPath.title" fallback="Set your Deadlock path" />}
-              description={
-                <Tx
-                  k="foundry.empty.noPath.description"
-                  fallback="Foundry reads the asset catalog from your installed game. Set the Deadlock path in Settings to get started."
-                />
-              }
-            />
-          ) : active === 'sound' ? (
+          {active === 'sound' ? (
             <SoundBrowse heroes={heroes} heroNames={heroNames} />
           ) : active === 'texture' ? (
             <TextureBrowse heroes={heroes} heroNames={heroNames} />

--- a/src/stores/foundryStagingStore.ts
+++ b/src/stores/foundryStagingStore.ts
@@ -1,0 +1,91 @@
+import { create } from 'zustand';
+
+/**
+ * Foundry "Build Tray": the per-hero staging area where the user accumulates
+ * several catalog edits (an icon swap, a sound swap, a recolor, ...) and then
+ * forges them into a single named addon VPK that drops into the mod list.
+ *
+ * This is the structural differentiator of the hero-first Foundry: you compose
+ * a mod from many edits across the hero's sections, then commit once. The store
+ * is a renderer-side queue only; the actual bake (swap -> VPK fragment) and the
+ * final `merge` + local-mod registration run in the main process over IPC.
+ *
+ * v1 scope: the tray holds the user's intent (what they staged) so the workshop
+ * can show it and the forge step can pick it up. The bake/merge backend is the
+ * next phase; until it lands, the recolor section still applies directly to its
+ * managed Locker slot and is NOT routed through the tray (it is its own thing).
+ */
+
+/** The kind of catalog edit a staged entry represents. Mirrors the Foundry
+ *  sections; each kind maps to a `vpkmerge` bake primitive at forge time. */
+export type StagedEditKind = 'texture' | 'icon' | 'sound' | 'voice' | 'recolor';
+
+/** One pending edit in the tray. `targetPath` is the verbatim pak entry the
+ *  edit overrides (a `.vtex_c` / `.vsndevts_c` path); `sourcePath` is the local
+ *  file the user dropped in (a PNG / audio file), absent for parameter-only
+ *  edits like recolor. `label` is the human-readable summary shown in the tray. */
+export interface StagedEdit {
+  /** Stable id for list keys + removal. */
+  id: string;
+  kind: StagedEditKind;
+  /** Roster codename the edit belongs to (the tray is scoped per hero). */
+  heroCodename: string;
+  /** Short human summary, e.g. "Q icon swap" or "Ult music: <track>". */
+  label: string;
+  /** Verbatim pak entry this edit overrides. */
+  targetPath: string;
+  /** Local file the user supplied (PNG/audio), when the edit consumes one. */
+  sourcePath?: string;
+  /** Free-form options forwarded to the bake step (dB offset, hue, etc.). */
+  options?: Record<string, unknown>;
+}
+
+interface FoundryStagingStore {
+  /** All staged edits, across every hero, newest last. */
+  edits: StagedEdit[];
+  /** Add an edit; returns the generated id. Replaces any existing edit that
+   *  targets the same (hero, targetPath) so re-staging the same slot updates
+   *  rather than duplicates. */
+  stage: (edit: Omit<StagedEdit, 'id'>) => string;
+  /** Remove one staged edit by id. */
+  unstage: (id: string) => void;
+  /** Clear all staged edits for one hero (after a successful forge, or reset). */
+  clearHero: (heroCodename: string) => void;
+  /** Clear the entire tray. */
+  clearAll: () => void;
+  /** The staged edits for a single hero, in stage order. */
+  editsForHero: (heroCodename: string) => StagedEdit[];
+}
+
+let seq = 0;
+function nextId(): string {
+  seq += 1;
+  return `stage-${seq}`;
+}
+
+export const useFoundryStagingStore = create<FoundryStagingStore>((set, get) => ({
+  edits: [],
+
+  stage: (edit) => {
+    const id = nextId();
+    set((state) => {
+      // De-dupe by (hero, targetPath): staging the same slot twice updates it.
+      const filtered = state.edits.filter(
+        (e) => !(e.heroCodename === edit.heroCodename && e.targetPath === edit.targetPath),
+      );
+      return { edits: [...filtered, { ...edit, id }] };
+    });
+    return id;
+  },
+
+  unstage: (id) =>
+    set((state) => ({ edits: state.edits.filter((e) => e.id !== id) })),
+
+  clearHero: (heroCodename) =>
+    set((state) => ({ edits: state.edits.filter((e) => e.heroCodename !== heroCodename) })),
+
+  clearAll: () => set({ edits: [] }),
+
+  editsForHero: (heroCodename) =>
+    get().edits.filter((e) => e.heroCodename === heroCodename),
+}));


### PR DESCRIPTION
## What

Makes Foundry **hero-first**: pick a hero from a roster grid, then edit everything about them in one workspace (appearance, voice, icons), mirroring the Locker's hero-detail frame (full-bleed render backdrop, frosted-glass rail, section nav).

This is additive and non-destructive: the original tool-first catalog rail is preserved behind a "Browse full catalog" toggle.

## Changes

- **`FoundryHeroGrid`** (new): aesthetic roster picker; 3:4 hero render-image cards, search, selectable-first ordering, graceful render → chip-icon → text fallback.
- **`HeroWorkshop`** (new): the per-hero "edit everything" workspace. Sections:
  - **Appearance** → reuses `HeroEffectsPanel` (recolor / prism / body+gun) — fully working, bakes a real managed mod.
  - **Voice** → reuses `SoundBrowse` scoped to the hero — browse + preview.
  - **Icons & Textures** → reuses `TextureBrowse` + ability-icon `LibraryBrowse` scoped to the hero — browse + preview.
  - **Abilities** → placeholder pending the icon ↔ ability-name join.
  - **Build Tray** (rail) reads the staging store; the Forge button is gated until the swap-bake backend lands.
- **`foundryStagingStore`** (new): the per-hero Build Tray queue (stage/unstage, de-duped by hero + target path).
- **`Foundry.tsx`**: lands hero-first (`mode: 'heroes'`, default); catalog rail still reachable. Also fixes the placeholder header title.
- i18n: added the new `foundry.heroes.*` / `foundry.workshop.*` catalog keys + regenerated the locale manifest.

## Honest seam (next phase)

The frame is done; the **swap → bake → forge** backend that makes the Build Tray real is not built yet: bake IPC (`foundry:bakeTextureSwap` / `bakeSoundSwap`), forge IPC (`merge` staged fragments → `import-local-mod`), and the per-ability composite. The Forge button is gated until then.

## Verification

- `tsc -b` clean
- `eslint` clean on touched files
- `pnpm i18n:check` + locale manifest gate pass (run by the pre-push hook)
- Not yet run in the app / in-game.