### PR TITLE
fix(installed): protect merged source identity

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -276,10 +276,6 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     // the Installed list would only let the user disable or reorder them and
     // silently break their applied cosmetics.
     const visible = mods.filter((m) => !isLockerManaged(m.metaKey));
-    if (settings.verboseModTrace) {
-        const hidden = mods.length - visible.length;
-        console.log(`[modTrace] get-mods: scanned ${mods.length}, returning ${visible.length} to renderer (${hidden} locker-managed hidden)`);
-    }
     // Pre-warm the VPK parse cache across the worker pool for mods whose lazy
     // classifications will parse inside enrichMod below. enrichMod stays sync;
     // its parseVpkDirectoryCached calls hit the warmed cache instead of
@@ -289,7 +285,50 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     if (warmPaths.length > 0) {
         await parseVpkDirectoriesAsync(warmPaths);
     }
-    return visible.map(enrichMod);
+    const enriched = visible.map(enrichMod);
+    if (settings.verboseModTrace) {
+        const hidden = mods.length - visible.length;
+        // The renderer (Installed.tsx visibleMods) also hides disabled source
+        // VPKs that are folded into a merged mod. Replicate its identity checks
+        // here so the boundary line is honest about end-user visibility.
+        const absorbedSources = enriched.flatMap((m) => m.merged?.sources ?? []);
+        const matchesAbsorbedSource = (
+            mod: WireMod,
+            source: NonNullable<WireMod['merged']>['sources'][number]
+        ): boolean => {
+            if (mod.enabled || mod.fileName !== source.fileName) return false;
+
+            const sourceSha = source.sha256AtMergeTime?.toLowerCase();
+            const modSha = mod.sha256?.toLowerCase();
+            if (sourceSha && modSha) return sourceSha === modSha;
+
+            if (typeof source.gameBananaId === 'number' && typeof mod.gameBananaId === 'number') {
+                if (source.gameBananaId !== mod.gameBananaId) return false;
+                if (
+                    typeof source.gameBananaFileId === 'number' &&
+                    typeof mod.gameBananaFileId === 'number'
+                ) {
+                    return source.gameBananaFileId === mod.gameBananaFileId;
+                }
+                return !sourceSha;
+            }
+
+            return !sourceSha;
+        };
+        const rendererHidden = enriched.filter((m) =>
+            absorbedSources.some((source) => matchesAbsorbedSource(m, source))
+        );
+        console.log(
+            `[modTrace] get-mods: scanned ${mods.length}, returning ${visible.length} to renderer ` +
+                `(${hidden} locker-managed hidden; ${rendererHidden.length} more will be hidden by the renderer as merge sources)`
+        );
+        for (const m of rendererHidden) {
+            console.log(
+                `[modTrace]   RENDERER-HIDDEN disabled key=${m.metaKey} name="${m.name}" (identity matches a merged mod source -> absent from Installed list)`
+            );
+        }
+    }
+    return enriched;
 });
 
 // enable-mod

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -1,11 +1,19 @@
 import { promises as fs, existsSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, basename } from 'path';
 import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
 import { metaKeyFor } from './deadlock';
-import { scanMods, disableMod, enableMod, allocateEnabledVpkPath, type Mod } from './mods';
+import { loadSettings } from './settings';
+import {
+    scanMods,
+    disableModUnlocked,
+    enableModUnlocked,
+    allocateEnabledVpkPath,
+    runExclusiveModMutation,
+    type Mod,
+} from './mods';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { encodeShareCode } from './portableProfile';
@@ -24,6 +32,38 @@ import type {
 
 const DEADLOCK_STEAM_APP_ID = 1422450;
 const DEADLOCK_GAMEBANANA_GAME_ID = 20948;
+
+/** Verbose merge-lifecycle trace, gated on the same `verboseModTrace` setting as
+ *  services/mods.ts. Merge/rebuild operations were previously silent, so an
+ *  interrupted rebuild left a half-written manifest with no record of how it got
+ *  that way. A `start` line with no matching `done` line localizes the crash. */
+function mergeTrace(message: string): void {
+    try {
+        if (loadSettings().verboseModTrace) console.log(`[modTrace] ${message}`);
+    } catch {
+        /* never let tracing break a merge */
+    }
+}
+
+/** Compact one-line render of a source list for the trace: each source's
+ *  recorded fileName plus whether we captured the stable identities (gb id /
+ *  sha) that the Installed-list hide logic needs to avoid a pakNN collision. */
+function describeSources(sources: MergedModSource[]): string {
+    return sources
+        .map(
+            (s) =>
+                `${s.fileName}(${s.gameBananaId ? `gb=${s.gameBananaId}` : 'local'},${s.sha256AtMergeTime ? 'sha' : 'NO-sha'})`
+        )
+        .join(', ');
+}
+
+/** Source filenames recorded as a bare enabled slot (pakNN_dir.vpk). A finished
+ *  merge rewrites these to the disabled free-form name; a leftover means the
+ *  disable/rebuild loop was interrupted, and that recyclable name can later
+ *  collide with an unrelated mod that lands in the slot. */
+function stalePakSources(sources: MergedModSource[]): MergedModSource[] {
+    return sources.filter((s) => /^pak\d+_dir\.vpk$/i.test(s.fileName));
+}
 
 type SupportedPlatform = 'linux-x64' | 'darwin-arm64' | 'win32-x64';
 
@@ -273,6 +313,15 @@ export async function mergeMods(
     if (!trimmedName) throw new Error('A name is required for the merged mod.');
     if (modIds.length < 2) throw new Error('Select at least two mods to merge.');
 
+    return runExclusiveModMutation(() => mergeModsLocked(deadlockPath, modIds, options, trimmedName));
+}
+
+async function mergeModsLocked(
+    deadlockPath: string,
+    modIds: string[],
+    options: MergeOptions,
+    trimmedName: string
+): Promise<MergeResult> {
     const installed = await scanMods(deadlockPath);
     const sources: Mod[] = [];
     for (const id of modIds) {
@@ -292,6 +341,12 @@ export async function mergeMods(
     // last-input-wins, so sort DESCENDING to put that highest-priority
     // (lowest-pakNN) source LAST in the argv and reproduce the in-game winner.
     sources.sort((a, b) => b.priority - a.priority);
+
+    mergeTrace(
+        `merge start "${trimmedName}": ${sources.length} sources -> ${sources
+            .map((s) => `${s.fileName}(pri ${s.priority}${s.enabled ? '' : ',disabled'})`)
+            .join(', ')}`
+    );
 
     // Hash every source BEFORE any filesystem mutation. sha256AtMergeTime
     // is the content-identity fallback unmerge uses when the manifest
@@ -368,8 +423,8 @@ export async function mergeMods(
     });
 
     // Disable each enabled source so its priority slot frees up and the
-    // engine stops loading the original. disableMod returns the post-move
-    // Mod so we record the actual on-disk filename (it may have been
+    // engine stops loading the original. The disable helper returns the
+    // post-move Mod so we record the actual on-disk filename (it may have been
     // renamed by reconcileEnabledDisabledCollisions). We re-stamp the
     // manifest after each successful disable so a mid-loop failure leaves
     // the manifest as up-to-date as it can be: sources processed already
@@ -378,7 +433,7 @@ export async function mergeMods(
     for (let i = 0; i < sources.length; i++) {
         const src = sources[i];
         if (src.enabled) {
-            const after = await disableMod(deadlockPath, src.id);
+            const after = await disableModUnlocked(deadlockPath, src.id);
             disabledSources.push(after);
             preDisableSnapshot[i].fileName = after.fileName;
             setModMetadata(mergedMetaKey, {
@@ -391,6 +446,16 @@ export async function mergeMods(
             disabledSources.push(src);
         }
     }
+
+    const stale = stalePakSources(preDisableSnapshot);
+    if (stale.length > 0) {
+        mergeTrace(
+            `merge WARNING "${trimmedName}": ${stale.length} source(s) still recorded under a recyclable pakNN name (${stale
+                .map((s) => s.fileName)
+                .join(', ')}) -> a future slot reuse can collide with merge-source reconciliation`
+        );
+    }
+    mergeTrace(`merge done "${trimmedName}" key=${mergedMetaKey} sources: ${describeSources(preDisableSnapshot)}`);
 
     const finalMods = await scanMods(deadlockPath);
     const newMod = finalMods.find((m) => m.metaKey === mergedMetaKey);
@@ -513,6 +578,13 @@ export async function unmergeMod(
     deadlockPath: string,
     mergedModId: string
 ): Promise<UnmergeModResult> {
+    return runExclusiveModMutation(() => unmergeModLocked(deadlockPath, mergedModId));
+}
+
+async function unmergeModLocked(
+    deadlockPath: string,
+    mergedModId: string
+): Promise<UnmergeModResult> {
     const installed = await scanMods(deadlockPath);
     const target = installed.find((m) => m.id === mergedModId);
     if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
@@ -537,7 +609,7 @@ export async function unmergeMod(
             continue;
         }
         if (src.enabledAtMergeTime && !onDisk.enabled) {
-            recovered.push(await enableMod(deadlockPath, onDisk.id));
+            recovered.push(await enableModUnlocked(deadlockPath, onDisk.id));
         } else {
             recovered.push(onDisk);
         }
@@ -564,6 +636,16 @@ export async function unmergeMod(
  * the merged VPK is deleted (a normal full unmerge for what's left).
  */
 export async function extractMergeSource(
+    deadlockPath: string,
+    mergedModId: string,
+    sourceFileName: string
+): Promise<ExtractMergeSourceResult> {
+    return runExclusiveModMutation(() =>
+        extractMergeSourceLocked(deadlockPath, mergedModId, sourceFileName)
+    );
+}
+
+async function extractMergeSourceLocked(
     deadlockPath: string,
     mergedModId: string,
     sourceFileName: string
@@ -599,7 +681,7 @@ export async function extractMergeSource(
     const restoreExtracted = async (): Promise<void> => {
         if (!removedOnDisk) return;
         if (removedSnapshot.enabledAtMergeTime && !removedOnDisk.enabled) {
-            restored.push(await enableMod(deadlockPath, removedOnDisk.id));
+            restored.push(await enableModUnlocked(deadlockPath, removedOnDisk.id));
         } else {
             restored.push(removedOnDisk);
         }
@@ -612,7 +694,7 @@ export async function extractMergeSource(
             const onDisk = await locator.locate(survivor);
             if (onDisk) {
                 if (survivor.enabledAtMergeTime && !onDisk.enabled) {
-                    restored.push(await enableMod(deadlockPath, onDisk.id));
+                    restored.push(await enableModUnlocked(deadlockPath, onDisk.id));
                 } else {
                     restored.push(onDisk);
                 }
@@ -659,11 +741,15 @@ export async function extractMergeSource(
     // move the merge to the base folder) for a merge that lives in an overflow folder.
     const targetDir = dirname(target.path);
     const buildPath = join(targetDir, `.merge-rebuild-${randomUUID()}.vpk`);
+    mergeTrace(
+        `rebuild start merge=${manifest.id} key=${target.metaKey}: ${ordered.length} sources -> ${basename(buildPath)} (removed "${sourceFileName}")`
+    );
     try {
         await runVpkmerge([buildPath, ...ordered.map((m) => m.path)]);
         await verifyVpkOutput(buildPath);
     } catch (err) {
         try { await fs.unlink(buildPath); } catch { /* ignore partial-output cleanup */ }
+        mergeTrace(`rebuild FAILED merge=${manifest.id}: ${String(err)} (build temp removed)`);
         throw err;
     }
 
@@ -691,6 +777,7 @@ export async function extractMergeSource(
         sha256,
         merged: newManifest,
     });
+    mergeTrace(`rebuild done merge=${manifest.id} key=${target.metaKey}: ${describeSources(remainingSnapshots)}`);
 
     await restoreExtracted();
 

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -303,7 +303,15 @@ async function scanFolder(folder: string, enabled: boolean): Promise<Mod[]> {
                 // Grimoire (the scan only counts the dir VPK). The likeliest cause
                 // of a local mod "present in the folder but missing from the list".
                 if (trace && entry.toLowerCase().endsWith('.vpk')) {
-                    modTrace(`scanFolder ${basename(folder)}: SKIPPED "${entry}" (not *_dir.vpk -> never shown in Grimoire)`);
+                    if (entry.toLowerCase().includes('.merge-rebuild')) {
+                        // A finished mergeMods rebuild renames this temp into place and
+                        // deletes it. A leftover means an interrupted/failed rebuild, so
+                        // the merged mod's source list may need extra scrutiny in the
+                        // source reconciliation trace below.
+                        modTrace(`scanFolder ${basename(folder)}: STALE merge-rebuild artifact "${entry}" (interrupted mergeMods rebuild never cleaned up; merged source list may be half-updated)`);
+                    } else {
+                        modTrace(`scanFolder ${basename(folder)}: SKIPPED "${entry}" (not *_dir.vpk -> never shown in Grimoire)`);
+                    }
                 }
                 continue;
             }
@@ -349,6 +357,7 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
     // addons1, addons2, ...) and the single shared .disabled parking lot. Each
     // mod's metaKey is stamped in scanFolder from its folder location.
     const enabledFolders = getAddonFolderPaths(deadlockPath);
+    await cleanupStaleMergeRebuildArtifacts(enabledFolders);
     const scanned = await Promise.all([
         ...enabledFolders.map((folder) => scanFolder(folder, true)),
         scanFolder(disabledPath, false),
@@ -366,14 +375,114 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
     if (modTraceEnabled()) {
         const enabled = mods.filter((m) => m.enabled).length;
         modTrace(`scanMods: ${mods.length} VPKs on disk (${enabled} enabled, ${mods.length - enabled} disabled)`);
+        // fileName -> mod, so we can resolve a merge's recorded source filenames
+        // against what's actually on disk right now (see reconciliation below).
+        const byFileName = new Map(mods.map((m) => [m.fileName, m] as const));
         for (const m of mods) {
             const meta = getModMetadata(m.metaKey);
             const gb = meta?.gameBananaId ? `gb=${meta.gameBananaId}` : 'local';
-            modTrace(`  ${m.enabled ? 'ENABLED ' : 'disabled'} pri=${String(m.priority).padStart(2, '0')} ${gb} key=${m.metaKey} name="${meta?.modName ?? m.name}"`);
+            // Surface the flags that drive the renderer's own hide logic
+            // (Installed.tsx visibleMods): merge output + Locker-managed VPKs.
+            const flags: string[] = [];
+            if (meta?.merged) flags.push(`merged(${meta.merged.sources.length}src)`);
+            if (meta?.lockerCosmetics) flags.push('lockerCosmetics');
+            if (meta?.lockerSounds) flags.push('lockerSounds');
+            if (meta?.lockerColors) flags.push('lockerColors');
+            if (meta?.lockerTrippySkins) flags.push('lockerTrippySkins');
+            const flagStr = flags.length ? ` [${flags.join(',')}]` : '';
+            modTrace(`  ${m.enabled ? 'ENABLED ' : 'disabled'} pri=${String(m.priority).padStart(2, '0')} ${gb} key=${m.metaKey} name="${meta?.modName ?? m.name}"${flagStr}`);
+        }
+        // Absorbed-source reconciliation. The Installed list hides disabled VPKs
+        // that are folded into a merged mod, but it must not hide by filename
+        // alone: pakNN slots are recycled, so a stale source filename can point
+        // at an unrelated enabled mod. Log filename hits and classify whether
+        // the current identity-aware renderer will hide them or keep them visible.
+        const matchesAbsorbedSource = (
+            hit: Mod,
+            hitMeta: ReturnType<typeof getModMetadata>,
+            src: import('../../../src/types/mod').MergedModSource
+        ): boolean => {
+            if (hit.enabled || hit.fileName !== src.fileName) return false;
+
+            const sourceSha = src.sha256AtMergeTime?.toLowerCase();
+            const hitSha = hitMeta?.sha256?.toLowerCase();
+            if (sourceSha && hitSha) return sourceSha === hitSha;
+
+            if (typeof src.gameBananaId === 'number' && typeof hitMeta?.gameBananaId === 'number') {
+                if (src.gameBananaId !== hitMeta.gameBananaId) return false;
+                if (
+                    typeof src.gameBananaFileId === 'number' &&
+                    typeof hitMeta.gameBananaFileId === 'number'
+                ) {
+                    return src.gameBananaFileId === hitMeta.gameBananaFileId;
+                }
+                return !sourceSha;
+            }
+
+            return !sourceSha;
+        };
+        for (const m of mods) {
+            const merged = getModMetadata(m.metaKey)?.merged;
+            if (!merged) continue;
+            for (const src of merged.sources) {
+                const hit = byFileName.get(src.fileName);
+                if (!hit) continue;
+                const hitMeta = getModMetadata(hit.metaKey);
+                const hitGb = hitMeta?.gameBananaId;
+                const gbMismatch =
+                    src.gameBananaId !== undefined && hitGb !== undefined && src.gameBananaId !== hitGb;
+                const rendererHides = matchesAbsorbedSource(hit, hitMeta, src);
+                const collision = !rendererHides && (hit.enabled || gbMismatch);
+                modTrace(
+                    `  ${rendererHides ? 'absorbed' : collision ? 'COLLIDE ' : 'VISIBLE '} merge="${merged.id}" source fileName=${src.fileName} (gb=${src.gameBananaId ?? 'local'}) ` +
+                        `matches on-disk ${hit.enabled ? 'ENABLED' : 'disabled'} key=${hit.metaKey} (gb=${hitGb ?? 'local'}) -> renderer ${rendererHides ? 'hides it' : 'keeps it visible'}` +
+                        (collision ? ' [filename collision protected by identity check]' : '')
+                );
+            }
         }
     }
 
     return mods;
+}
+
+/** Remove orphaned `.merge-rebuild-*.vpk` temps. A finished rebuild renames its
+ *  temp into place and deletes it; a leftover means an interrupted rebuild (app
+ *  killed mid-swap), whose merged mod's manifest may be half-written. The temp
+ *  is harmless on disk (the scan skips non-`_dir.vpk`), but we clear it and log
+ *  it -- always on, NOT gated on verboseModTrace, so it surfaces in any
+ *  diagnostic. Age-gated so a temp from a rebuild still in flight is never
+ *  touched (a rebuild completes in well under the threshold). */
+async function cleanupStaleMergeRebuildArtifacts(folders: string[]): Promise<void> {
+    const STALE_MS = 2 * 60 * 1000;
+    const now = Date.now();
+    let removed = 0;
+    for (const folder of folders) {
+        if (!existsSync(folder)) continue;
+        let entries: string[];
+        try {
+            entries = await fs.readdir(folder);
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const lower = entry.toLowerCase();
+            if (!lower.includes('.merge-rebuild') || !lower.endsWith('.vpk')) continue;
+            const full = join(folder, entry);
+            try {
+                const stats = await fs.stat(full);
+                if (now - stats.mtimeMs < STALE_MS) continue; // may be an in-flight rebuild
+                await fs.unlink(full);
+                removed++;
+            } catch {
+                /* best-effort: a concurrent rebuild may have renamed/removed it */
+            }
+        }
+    }
+    if (removed > 0) {
+        console.log(
+            `[merge] removed ${removed} stale .merge-rebuild artifact(s) (interrupted rebuild leftover)`
+        );
+    }
 }
 
 async function reconcileEnabledDisabledCollisions(

--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -11,11 +11,15 @@ export type { SearchOptions, SearchResult };
 /**
  * Escape special FTS5 characters in search terms
  * FTS5 treats these as operators: AND, OR, NOT, -, ", *, ^, :
+ * and ' opens a string literal, so an unbalanced one is a syntax error
+ * (a name like "Tu'er Shen" crashed the whole query). The unicode61
+ * tokenizer already splits on these, so replacing them with a space and
+ * prefix-matching each token matches the same content.
  */
 function escapeFts5Term(term: string): string {
     // Remove characters that could break FTS5 queries
     // Keep alphanumeric and basic punctuation that's safe
-    return term.replace(/["\-*^:()]/g, ' ').trim();
+    return term.replace(/["\-*^:()']/g, ' ').trim();
 }
 
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -647,9 +647,10 @@ export default function Installed() {
 
   // Source mods absorbed into a merged VPK still live on disk (disabled) so
   // unmerge can restore them, but the user shouldn't see them as separate
-  // cards: the merged mod is now the source of truth. Build the absorbed
-  // fileName set once and derive a filtered view; downstream rendering,
-  // reorder, and update checks all run off `visibleMods`.
+  // cards: the merged mod is now the source of truth. Match by identity instead
+  // of filename alone because recyclable pakNN slots can later hold unrelated
+  // enabled mods; downstream rendering, reorder, and update checks all run off
+  // `visibleMods`.
   // The Locker cosmetics VPK (applied hero cards) and the Locker sound VPK
   // (applied per-ability sounds) are Locker-managed artifacts, not user-
   // installed mods, so they never show as cards here. They're managed entirely
@@ -657,14 +658,35 @@ export default function Installed() {
   // Memoized so the array identity (and the entry identities derived from it)
   // only changes when `mods` does; the memoized card grid depends on that.
   const visibleMods = useMemo(() => {
-    const absorbedFileNames = new Set<string>();
-    for (const m of mods) {
-      if (m.merged?.sources) {
-        for (const src of m.merged.sources) absorbedFileNames.add(src.fileName);
+    const absorbedSources: MergedModSource[] = [];
+    for (const m of mods) absorbedSources.push(...(m.merged?.sources ?? []));
+
+    const matchesAbsorbedSource = (mod: Mod, source: MergedModSource): boolean => {
+      if (mod.enabled || mod.fileName !== source.fileName) return false;
+
+      const sourceSha = source.sha256AtMergeTime?.toLowerCase();
+      const modSha = mod.sha256?.toLowerCase();
+      if (sourceSha && modSha) return sourceSha === modSha;
+
+      if (typeof source.gameBananaId === 'number' && typeof mod.gameBananaId === 'number') {
+        if (source.gameBananaId !== mod.gameBananaId) return false;
+        if (
+          typeof source.gameBananaFileId === 'number' &&
+          typeof mod.gameBananaFileId === 'number'
+        ) {
+          return source.gameBananaFileId === mod.gameBananaFileId;
+        }
+        return !sourceSha;
       }
-    }
+
+      return !sourceSha;
+    };
+
     return mods.filter(
-      (m) => !m.lockerCosmetics && !m.lockerSounds && !absorbedFileNames.has(m.fileName)
+      (m) =>
+        !m.lockerCosmetics &&
+        !m.lockerSounds &&
+        !absorbedSources.some((source) => matchesAbsorbedSource(m, source))
     );
   }, [mods]);
   // Layout = the user's structural choice (cards grid vs horizontal list).


### PR DESCRIPTION
## What

Harden merged-mod source handling so absorbed source VPKs are matched by **identity**, not filename alone, plus serialize merge mutations and clean up interrupted rebuilds.

## Why

`pakNN_dir.vpk` slots are recyclable. The Installed list hid merge-source VPKs by filename, so once a freed `pakNN` slot was later reused by an unrelated **enabled** mod, that mod silently vanished from the list (or a stale source name pointed at the wrong mod).

## Changes

- **Identity-based hide logic** (`Installed.tsx`, `mods.ts` trace, `ipc/mods.ts` trace): a disabled VPK is treated as an absorbed merge source only when its `sha256` (preferred) or GameBanana id + fileId matches the recorded source. Filename collisions with unrelated/enabled mods are no longer hidden.
- **Serialized merge mutations**: `mergeMods` / `unmergeMod` / `extractMergeSource` now run inside `runExclusiveModMutation`, calling new `enableModUnlocked` / `disableModUnlocked` helpers to avoid races between concurrent merge operations and scans.
- **Stale rebuild cleanup**: orphaned `.merge-rebuild-*.vpk` temps from an interrupted/killed rebuild are age-gated, removed, and logged (always-on, not gated on verbose trace). An in-flight rebuild is never touched.
- **Merge-lifecycle tracing**: start/done/warning lines for merge and rebuild paths, gated on `verboseModTrace`, so an interrupted rebuild leaves a localizable trace.
- **FTS5 fix** (`searchService.ts`): escape the single quote so names like `Tu'er Shen` no longer throw a syntax error and crash the whole search query.

## Checks

`tsc -b`, `eslint .`, `vitest` (239 passed), `i18n:check`, and `electron-vite build` all pass locally.
