### PR TITLE
fix(window): persist and restore main-window bounds

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, session, protocol, nativeTheme } from 'electron';
+import { app, BrowserWindow, shell, session, protocol, nativeTheme, screen } from 'electron';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -146,12 +146,67 @@ async function backfillStartupMetadataHashes(): Promise<void> {
     }
 }
 
+const DEFAULT_WINDOW_WIDTH = 1280;
+const DEFAULT_WINDOW_HEIGHT = 800;
+const MIN_WINDOW_WIDTH = 900;
+const MIN_WINDOW_HEIGHT = 600;
+
+/**
+ * Resolve the saved window rectangle into safe constructor bounds. We only
+ * honour a saved position when it still lands on a connected display: on some
+ * multi-monitor Linux/Wayland setups the OS otherwise placed the window on the
+ * wrong screen at the wrong size, and a stale x/y from an unplugged monitor
+ * would strand the window offscreen. When the saved spot is gone (or nothing
+ * was saved yet) we omit x/y so Electron centers on the primary display.
+ */
+function resolveInitialBounds(): {
+    width: number;
+    height: number;
+    x?: number;
+    y?: number;
+    isMaximized: boolean;
+} {
+    const saved = loadSettings().windowBounds;
+    if (!saved) {
+        return { width: DEFAULT_WINDOW_WIDTH, height: DEFAULT_WINDOW_HEIGHT, isMaximized: false };
+    }
+
+    const width = Math.max(MIN_WINDOW_WIDTH, Math.round(saved.width) || DEFAULT_WINDOW_WIDTH);
+    const height = Math.max(MIN_WINDOW_HEIGHT, Math.round(saved.height) || DEFAULT_WINDOW_HEIGHT);
+
+    // Only restore the position if the saved rectangle visibly overlaps some
+    // display's work area; otherwise the monitor it was on is gone.
+    let x: number | undefined;
+    let y: number | undefined;
+    if (typeof saved.x === 'number' && typeof saved.y === 'number') {
+        const onScreen = screen.getAllDisplays().some((display) => {
+            const wa = display.workArea;
+            return (
+                saved.x! < wa.x + wa.width &&
+                saved.x! + width > wa.x &&
+                saved.y! < wa.y + wa.height &&
+                saved.y! + height > wa.y
+            );
+        });
+        if (onScreen) {
+            x = Math.round(saved.x);
+            y = Math.round(saved.y);
+        }
+    }
+
+    return { width, height, x, y, isMaximized: !!saved.isMaximized };
+}
+
 function createWindow(): void {
+    const initial = resolveInitialBounds();
     mainWindow = new BrowserWindow({
-        width: 1280,
-        height: 800,
-        minWidth: 900,
-        minHeight: 600,
+        width: initial.width,
+        height: initial.height,
+        ...(initial.x !== undefined && initial.y !== undefined
+            ? { x: initial.x, y: initial.y }
+            : {}),
+        minWidth: MIN_WINDOW_WIDTH,
+        minHeight: MIN_WINDOW_HEIGHT,
         title: 'Grimoire',
         show: false, // Don't show until ready to prevent white flash
         backgroundColor: '#0f0f0f', // Dark background matching app theme
@@ -171,7 +226,53 @@ function createWindow(): void {
 
     // Show window when ready to prevent white screen flash
     mainWindow.once('ready-to-show', () => {
+        if (initial.isMaximized) mainWindow?.maximize();
         mainWindow?.show();
+    });
+
+    // Persist position and size so the app reopens where the user left it.
+    // We record the *normal* (non-maximized) bounds via getNormalBounds so a
+    // maximized session still restores to a sensible windowed rectangle, plus
+    // the maximized flag itself. Debounced because move/resize fire rapidly
+    // during a drag.
+    let saveBoundsTimer: NodeJS.Timeout | null = null;
+    const writeBounds = () => {
+        if (!mainWindow || mainWindow.isDestroyed() || mainWindow.isMinimized()) return;
+        try {
+            const bounds = mainWindow.getNormalBounds();
+            saveSettings({
+                ...loadSettings(),
+                windowBounds: {
+                    x: bounds.x,
+                    y: bounds.y,
+                    width: bounds.width,
+                    height: bounds.height,
+                    isMaximized: mainWindow.isMaximized(),
+                },
+            });
+        } catch (err) {
+            console.warn('[Main] Failed to persist window bounds:', err);
+        }
+    };
+    const persistBounds = () => {
+        if (saveBoundsTimer) clearTimeout(saveBoundsTimer);
+        saveBoundsTimer = setTimeout(() => {
+            saveBoundsTimer = null;
+            writeBounds();
+        }, 400);
+    };
+    mainWindow.on('resize', persistBounds);
+    mainWindow.on('move', persistBounds);
+    mainWindow.on('maximize', persistBounds);
+    mainWindow.on('unmaximize', persistBounds);
+    // Flush the final rectangle synchronously: a move/resize immediately before
+    // quitting would otherwise be swallowed by the debounce.
+    mainWindow.on('close', () => {
+        if (saveBoundsTimer) {
+            clearTimeout(saveBoundsTimer);
+            saveBoundsTimer = null;
+        }
+        writeBounds();
     });
 
     mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -907,4 +907,17 @@ export interface AppSettings {
    *  (.gi maps to text/plain, which often resolves to a word processor, so
    *  "default" alone makes a bad Edit File experience.) */
   externalEditorPath?: string | null;
+  /** Last main-window position and size, persisted so the app reopens where
+   *  the user left it instead of letting the OS/compositor place it (on some
+   *  multi-monitor Linux setups that meant the secondary screen at a wrong
+   *  size). Restored only when the saved rectangle still intersects a
+   *  currently-connected display; otherwise we fall back to a centered default.
+   *  Undefined until the first move/resize is recorded. */
+  windowBounds?: {
+    x?: number;
+    y?: number;
+    width: number;
+    height: number;
+    isMaximized?: boolean;
+  };
 }


### PR DESCRIPTION
## Problem

On Bazzite (multi-monitor Linux/Wayland), Grimoire always opened on the **secondary** monitor at a wrong (4:3-ish) size, and never remembered where you moved/resized it.

Root cause: the main `BrowserWindow` was hardcoded to `1280x800` with **no position and no state persistence at all**. Nothing was saved on exit, so the compositor was free to place and size the window however it liked on every launch.

## Fix

- **Restore on launch** (`resolveInitialBounds`): apply the saved rectangle (width/height/x/y) to the window, re-maximizing if it was maximized last.
- **Off-screen guard**: honor the saved x/y only when the rectangle still intersects a currently-connected display's work area. If that monitor is gone (or nothing was saved yet), omit x/y so Electron centers on the primary display. Prevents stranding the window offscreen.
- **Persist on change**: debounced (400ms) save on `resize`/`move`/`maximize`/`unmaximize`, plus a synchronous flush on `close` so a last-moment drag isn't lost. Records `getNormalBounds()` + the maximized flag, so a maximized session restores to a sensible windowed size when unmaximized.

Reuses the existing `loadSettings`/`saveSettings` JSON store (same pattern `zoomFactor` already uses) via a new optional `windowBounds` field on `AppSettings`.

## Notes

- First launch after this lands still uses the centered `1280x800` default (no bounds saved yet); position/size stick from then on.
- `pnpm typecheck` and ESLint pass.
- Not verified on real multi-monitor hardware from the dev box; logic-only change.