### PR TITLE
fix(sidebar): settle settings gear spin on hover rest position

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1065,21 +1065,27 @@ body {
 .settings-gear {
   transform-origin: 50% 50%;
   transition: transform 480ms cubic-bezier(0.22, 1, 0.36, 1);
+  /* Where the click spin lands. Matches the resting transform below so that when
+     the --spin class is stripped on animationend the gear settles in place with
+     no snap: 0deg at rest, a full extra turn (450deg ≡ 90deg) while hovered. */
+  --gear-spin-end: 360deg;
 }
 
 .group:hover .settings-gear {
   transform: rotate(90deg);
+  --gear-spin-end: 450deg;
 }
 
 /* One-shot mechanical spin: a touch past a full turn, then settles back, like a
-   gear clicking into its seat. Overrides the hover rotate while it runs. */
+   gear clicking into its seat. Overrides the hover rotate while it runs and ends
+   on the current rest position (--gear-spin-end) so staying hovered doesn't jump. */
 .settings-gear--spin {
   animation: settingsGearSpin 640ms cubic-bezier(0.34, 1.45, 0.5, 1);
 }
 
 @keyframes settingsGearSpin {
   0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  100% { transform: rotate(var(--gear-spin-end)); }
 }
 
 /* Skeleton shimmer — used for async-loading placeholders. Surfaces apply


### PR DESCRIPTION
## Problem

The Settings gear in the sidebar does a one-shot spin on click. If you keep the cursor over the button after clicking, the gear's final frame doesn't settle where it should: it does an extra unwanted quarter-turn at the end.

## Cause

The click spin (`settingsGearSpin`) animates to `rotate(360deg)` (visually 0deg). But while the button is hovered, the gear's resting transform is `rotate(90deg)` (the hover tease). When the animation ends, `onAnimationEnd` strips the `--spin` class and the gear snaps from 0deg to the hovered 90deg rest.

## Fix

Route the spin endpoint through a `--gear-spin-end` custom property that tracks the active rest position:

- `360deg` (≡ 0deg) at rest, matching the base resting transform.
- `450deg` (≡ 90deg mod 360) while hovered, matching the hover rest.

The final frame now lands exactly on whatever rest state is active, so staying hovered after a click no longer jumps. The `prefers-reduced-motion` block already disables both the transition and the animation, so it's unaffected.

CSS-only change in `src/index.css`.