### PR TITLE
feat(foundry): hero sound-swap with import editor (trim + match-volume)

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -30,14 +30,15 @@ import {
 } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
+import { buildHeroSoundSwapVpk, cleanupHeroSoundSwapBuild } from '../services/foundryCatalog';
 import { buildSoulContainerVpk, cleanupSoulContainerBuild, previewSoulContainerGlb } from '../services/soulContainerImport';
 import { buildSpiritUrnVpk, cleanupSpiritUrnBuild, previewSpiritUrnGlb } from '../services/spiritUrnImport';
 import { resolveModVpk, clearSoulModelCache } from '../services/soulContainerModels';
 import { exportVpkViaDialog, exportVpkFileName } from '../services/foundryExport';
 import { getMainWindow } from '../index';
 import type { ImportCustomModArgs, ImportSoulContainerGlbArgs, PreviewSoulContainerGlbArgs, SoulContainerPreview, ImportSpiritUrnGlbArgs, PreviewSpiritUrnGlbArgs, SpiritUrnPreview } from '../../../src/types/electron';
-import type { VpkExportResult } from '../../../src/types/foundry';
-import type { AbilitySoundClassification, ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, AssociateUnknownModArgs, EditLocalModArgs, GlobalModType, LockerHeroSource, MergeModsArgs, Mod as WireMod, SoulContainerImportInfo, UrnImportInfo, UnmergeModResult, ExtractMergeSourceResult, UnknownModFileList } from '../../../src/types/mod';
+import type { VpkExportResult, HeroSoundSwapRequest } from '../../../src/types/foundry';
+import type { AbilitySoundClassification, ApplyUnknownCustomModArgs, ApplyUnknownModMatchArgs, AssociateUnknownModArgs, EditLocalModArgs, GlobalModType, LockerHeroSource, MergeModsArgs, Mod as WireMod, SoulContainerImportInfo, SoundSwapInfo, UrnImportInfo, UnmergeModResult, ExtractMergeSourceResult, UnknownModFileList } from '../../../src/types/mod';
 
 const unknownDetectionControllers = new Map<string, AbortController>();
 
@@ -950,6 +951,109 @@ ipcMain.handle(
 
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);
+    }
+);
+
+// foundry:swapSound
+// Build a hero sound-swap addon VPK (drop your own MP3 onto a hero gameplay
+// sound event) and install it as a tracked local mod, mirroring
+// import-soul-container-glb's build -> allocate -> copy -> metadata flow. Event
+// mode with --pool all: every clip in the event's randomizer pool is overridden
+// with the user audio, so the swapped sound always plays. Tagged with lockerHero
+// so it groups under the hero in the Locker. v1 takes MP3 only (the mint path
+// parses the rate/channels from MP3 frame headers, no ffmpeg).
+ipcMain.handle(
+    'foundry:swapSound',
+    async (_, args: HeroSoundSwapRequest): Promise<WireMod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        const {
+            heroCodename,
+            heroName,
+            event,
+            audioPath,
+            name,
+            loop,
+            thumbnailDataUrl,
+            nsfw,
+            trimStartMs,
+            trimEndMs,
+            gainDb,
+        } = args;
+        if (!name?.trim()) {
+            throw new Error('A name is required');
+        }
+        if (!event?.trim()) {
+            throw new Error('A sound event is required');
+        }
+        if (!audioPath || !existsSync(audioPath)) {
+            throw new Error('Audio file not found');
+        }
+        if (!audioPath.toLowerCase().endsWith('.mp3')) {
+            throw new Error('Audio must be an MP3 file (other formats are not supported yet).');
+        }
+
+        // 1. Build the swap VPK to a temp staging path.
+        const built = await buildHeroSoundSwapVpk(deadlockPath, {
+            heroCodename,
+            event: event.trim(),
+            audioPath,
+            loop: loop ?? 'auto',
+            trimStartMs,
+            trimEndMs,
+            gainDb,
+        });
+
+        try {
+            // 2. Allocate the next free ENABLED slot (same as import-custom-mod).
+            const destPath = await allocateEnabledVpkPath(deadlockPath);
+            const destMetaKey = metaKeyFor(destPath);
+
+            await fs.copyFile(built.vpkPath, destPath);
+
+            const soundSwap: SoundSwapInfo = {
+                heroCodename: built.soundCodename,
+                event: event.trim(),
+                audioFileName: basename(audioPath),
+                loop: loop ?? 'auto',
+                pool: 'all',
+            };
+
+            // 3. Scrub orphan metadata, then write the local-import entry. Tag it
+            //    with lockerHero (display name) so it groups under the hero in the
+            //    Locker; sourceSection marks it a Foundry sound swap.
+            removeModMetadata(destMetaKey);
+            await setModMetadataWithHash(
+                destMetaKey,
+                {
+                    modName: name.trim(),
+                    thumbnailUrl: thumbnailDataUrl,
+                    nsfw: !!nsfw,
+                    // 'Sound' routes the mod through the Locker's Sounds bucket
+                    // (isLockerManagedSound) instead of the hero-skin pile
+                    // (isLockerManagedMod treats any non-'Sound' + lockerHero mod
+                    // as a skin card). The lockerHero tag makes it hero-specific,
+                    // which short-circuits the global-sound-category drop. The
+                    // Foundry-swap provenance lives in `soundSwap`, not the section.
+                    sourceSection: 'Sound',
+                    categoryName: 'Sounds',
+                    ...(heroName?.trim()
+                        ? { lockerHero: heroName.trim(), lockerHeroSource: 'manual' as LockerHeroSource }
+                        : {}),
+                    soundSwap,
+                },
+                destPath
+            );
+
+            const mods = await scanMods(deadlockPath);
+            return mods.map(enrichMod);
+        } finally {
+            // 4. Always remove the temp staging dir (the installed copy is
+            //    byte-identical, so nothing is lost).
+            await cleanupHeroSoundSwapBuild(built.vpkPath);
+        }
     }
 );
 

--- a/electron/main/services/foundryCatalog.ts
+++ b/electron/main/services/foundryCatalog.ts
@@ -16,11 +16,12 @@
  *   userData/foundry-catalog-cache/                    (the engine's own index cache)
  */
 import { promises as fs } from 'fs';
-import { createHash } from 'crypto';
-import { join } from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 import { app, protocol, net } from 'electron';
-import { runVpkmerge, runVpkmergeStdout } from './modMerger';
+import { runVpkmerge, runVpkmergeStdout, verifyVpkOutput } from './modMerger';
 import { getCitadelPath } from './deadlock';
 import { soundCodenameForHero } from './heroSoundCodenames';
 import type {
@@ -155,6 +156,95 @@ export async function getHeroSounds(
     if (filters.search) args.push('--search', filters.search);
     if (typeof filters.limit === 'number') args.push('--limit', String(filters.limit));
     return runCatalogJson<HeroSound[]>(args);
+}
+
+// ----- Hero sound-swap build (drop your own audio onto a sound event) --------
+
+export type SoundSwapLoop = 'auto' | 'on' | 'off';
+
+export interface BuildHeroSoundSwapOptions {
+    /** Roster codename from the Foundry hero picker (e.g. `atlas`); resolved here
+     *  to the sound-path codename the `soundevents/hero/` tree is keyed by. */
+    heroCodename: string;
+    /** The soundevent to swap, verbatim from the catalog (a `HeroSound.event`,
+     *  e.g. `Gigawatt.LightningBall.Damage`). */
+    event: string;
+    /** Absolute path to the user's MP3 (validated by the caller). */
+    audioPath: string;
+    /** Loop handling for the minted clip. */
+    loop: SoundSwapLoop;
+    /** Optional trim window in milliseconds (frame-snapped, ~26 ms). Both ends
+     *  must be set together; omitted = use the whole clip. */
+    trimStartMs?: number;
+    trimEndMs?: number;
+    /** Optional loudness gain in decibels applied losslessly before minting (the
+     *  "match volume" normalizer). Omitted / 0 = no gain. */
+    gainDb?: number;
+}
+
+export interface HeroSoundSwapBuild {
+    /** The built addon VPK on disk (temp staging path; the caller installs the
+     *  copy into the managed mod list and then cleans this up). */
+    vpkPath: string;
+    /** The sound-path codename the event was resolved under (e.g. `gigawatt`),
+     *  recorded in the installed mod's metadata. */
+    soundCodename: string;
+}
+
+/**
+ * Build a hero sound-swap addon VPK via `vpkmerge soundswap --event --pool all`:
+ * every clip in the event's randomizer pool is overridden with the user's MP3,
+ * each minted around that clip's own donor container so loop/format/GUID are
+ * preserved. Returns a temp staging VPK the caller installs into the managed mod
+ * list (mirrors buildSoulContainerVpk's build-to-temp contract). The audio must
+ * be an MP3 (the mint path parses rate/channels/duration from the MP3 frame
+ * headers, no ffmpeg); transcoding other formats is a caller concern.
+ */
+export async function buildHeroSoundSwapVpk(
+    deadlockPath: string,
+    opts: BuildHeroSoundSwapOptions
+): Promise<HeroSoundSwapBuild> {
+    const soundCodename = await rosterToSoundCodename(deadlockPath, opts.heroCodename);
+    const dir = join(tmpdir(), `grimoire-soundswap-${randomUUID()}`);
+    await fs.mkdir(dir, { recursive: true });
+    const vpkPath = join(dir, 'soundswap_dir.vpk');
+    try {
+        const swapArgs = [
+            'soundswap',
+            '--from-vpk', pak01Path(deadlockPath),
+            '--event', opts.event,
+            '--hero', soundCodename,
+            '--pool', 'all',
+            '--audio', opts.audioPath,
+            '--loop', opts.loop,
+            '--encode-vpk', vpkPath,
+        ];
+        // Optional pre-mint edits: trim (both ends required together) then gain.
+        if (
+            typeof opts.trimStartMs === 'number' &&
+            typeof opts.trimEndMs === 'number' &&
+            opts.trimEndMs > opts.trimStartMs
+        ) {
+            swapArgs.push(
+                '--trim-start', String(Math.round(opts.trimStartMs)),
+                '--trim-end', String(Math.round(opts.trimEndMs))
+            );
+        }
+        if (typeof opts.gainDb === 'number' && Number.isFinite(opts.gainDb) && opts.gainDb !== 0) {
+            swapArgs.push('--gain-db', opts.gainDb.toFixed(2));
+        }
+        await runVpkmerge(swapArgs);
+        await verifyVpkOutput(vpkPath);
+    } catch (err) {
+        await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+        throw err;
+    }
+    return { vpkPath, soundCodename };
+}
+
+/** Remove a sound-swap build's temp staging dir (call after installing the copy). */
+export async function cleanupHeroSoundSwapBuild(vpkPath: string): Promise<void> {
+    await fs.rm(dirname(vpkPath), { recursive: true, force: true }).catch(() => {});
 }
 
 /** The texture/icon index, optionally filtered (all filters AND-combined). */

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -82,6 +82,10 @@ export interface ModMetadata {
      *  The orientation/span transform + tracking status; presence marks the slot
      *  for idempotent re-import (replace the previous build). */
     urnImport?: import('../../../src/types/mod').UrnImportInfo;
+    /** Set when this VPK was built via the Foundry hero sound-swap (drop your own
+     *  MP3 onto a hero sound event). Labels the mod and records what was swapped;
+     *  presence marks the slot as a local sound swap. */
+    soundSwap?: import('../../../src/types/mod').SoundSwapInfo;
     /** Load-order slot this mod last held while enabled. Disabled mods now
      *  get free-form filenames (no pakNN), so the priority is no longer encoded
      *  in the name; we stash it here on disable and try to restore it on enable

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -8,6 +8,7 @@ import type { SocialSessionStatus } from '../../src/types/social';
 import type {
     HeroEffectExportRequest,
     HeroSoundFilters,
+    HeroSoundSwapRequest,
     TextureCategory,
     TextureFilters,
     VoicelineFilters,
@@ -572,6 +573,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         warmCache: () => ipcRenderer.invoke('foundry:warmCache'),
         exportHeroEffect: (req: HeroEffectExportRequest) =>
             ipcRenderer.invoke('foundry:exportHeroEffect', req),
+        swapSound: (req: HeroSoundSwapRequest) =>
+            ipcRenderer.invoke('foundry:swapSound', req),
     },
 
     // Language packs (downloaded on demand from GitHub)

--- a/src/components/foundry/SoundBrowse.tsx
+++ b/src/components/foundry/SoundBrowse.tsx
@@ -15,12 +15,25 @@ import {
     Swords,
     AudioLines,
     MessageSquare,
+    Wand2,
+    Upload,
+    X,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '../common/PageComponents';
 import Tx from '../translation/Tx';
-import { foundryHeroSounds, foundryVoicelines, foundryVoiceclip } from '../../lib/api';
+import { SoundImportEditor, type SoundImportEdits } from './SoundImportEditor';
+import { foundryHeroSounds, foundryVoicelines, foundryVoiceclip, foundrySwapSound } from '../../lib/api';
+import { showToast } from '../../stores/toastStore';
+import { useAppStore } from '../../stores/appStore';
 import type { HeroInfo, HeroSound, HeroSoundCategory, VoiceLine } from '../../types/foundry';
+
+/** Hero context threaded to the gameplay rows so each can offer an inline
+ *  sound-swap (drop your own MP3 onto the event). VO rows don't get this. */
+interface SwapContext {
+    hero: string;
+    heroName: string;
+}
 
 interface SoundBrowseProps {
     heroes: HeroInfo[];
@@ -75,6 +88,8 @@ export default function SoundBrowse({ heroes, heroNames }: SoundBrowseProps) {
     const [picked, setPicked] = useState('');
     const [search, setSearch] = useState('');
     const hero = picked || heroOptions[0]?.code || '';
+    const heroName = heroOptions.find((h) => h.code === hero)?.name ?? hero;
+    const swapContext = useMemo<SwapContext>(() => ({ hero, heroName }), [hero, heroName]);
 
     // Gameplay-sound fetch, tagged with the hero it belongs to so loading/error
     // derive from whether it matches the current hero (the effect only sets state
@@ -193,7 +208,12 @@ export default function SoundBrowse({ heroes, heroNames }: SoundBrowseProps) {
                                 })}
                             </p>
                             {sections.map((section) => (
-                                <CategorySection key={section.category} section={section} player={player} />
+                                <CategorySection
+                                    key={section.category}
+                                    section={section}
+                                    player={player}
+                                    swap={swapContext}
+                                />
                             ))}
                         </>
                     )}
@@ -274,9 +294,11 @@ function abilityOrder(a: AbilityGroup, b: AbilityGroup): number {
 function CategorySection({
     section,
     player,
+    swap,
 }: {
     section: CategorySectionData;
     player: ClipPlayer;
+    swap: SwapContext;
 }) {
     const { t } = useTranslation();
     const Icon = CATEGORY_ICON[section.category];
@@ -314,6 +336,8 @@ function CategorySection({
                                 duration={row.duration}
                                 state={player.stateFor(row.event)}
                                 onToggle={() => player.toggle(row)}
+                                swap={swap}
+                                targetClip={row.vsnd[0]}
                             />
                         ))}
                     </div>
@@ -468,42 +492,268 @@ interface SoundRowProps {
     duration: number | null;
     state: RowState;
     onToggle: () => void;
+    /** When present, the row offers an inline sound-swap (gameplay rows only). */
+    swap?: SwapContext;
+    /** First clip path of this row, used as the swap normalizer's volume target. */
+    targetClip?: string;
 }
 
-function SoundRow({ label, event, clips, duration, state, onToggle }: SoundRowProps) {
+function SoundRow({ label, event, clips, duration, state, onToggle, swap, targetClip }: SoundRowProps) {
     const { t } = useTranslation();
+    const [swapOpen, setSwapOpen] = useState(false);
     const seconds = duration && duration > 0 ? `${duration.toFixed(1)}s` : null;
     return (
-        <div
-            className="flex items-center gap-3 rounded-sm border border-border bg-bg-secondary px-3 py-2"
-            style={{ contentVisibility: 'auto', containIntrinsicSize: '0 44px' }}
-        >
+        <div style={{ contentVisibility: 'auto', containIntrinsicSize: '0 44px' }}>
+            <div className="flex items-center gap-3 rounded-sm border border-border bg-bg-secondary px-3 py-2">
+                <button
+                    type="button"
+                    onClick={onToggle}
+                    title={t('foundry.sound.play', 'Audition')}
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-bg-tertiary text-accent transition-colors hover:bg-accent/15"
+                >
+                    {state === 'loading' ? (
+                        <Loader2 size={15} className="animate-spin" />
+                    ) : state === 'playing' ? (
+                        <Pause size={15} />
+                    ) : (
+                        <Play size={15} className="translate-x-px" />
+                    )}
+                </button>
+                <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-text-primary" title={label}>
+                        {label || event}
+                    </p>
+                    <p className="truncate text-[11px] text-text-secondary" title={event}>
+                        {event}
+                        {clips > 1 ? ` · ${clips} clips` : ''}
+                    </p>
+                </div>
+                {seconds && (
+                    <span className="shrink-0 text-[11px] tabular-nums text-text-secondary">
+                        {seconds}
+                    </span>
+                )}
+                {swap && (
+                    <button
+                        type="button"
+                        onClick={() => setSwapOpen((o) => !o)}
+                        title={t('foundry.sound.swap.button', 'Swap this sound for your own audio')}
+                        className={`flex h-8 shrink-0 items-center gap-1.5 rounded-sm border px-2 text-xs transition-colors ${
+                            swapOpen
+                                ? 'border-accent/50 bg-accent/15 text-accent'
+                                : 'border-border bg-bg-tertiary text-text-secondary hover:text-text-primary'
+                        }`}
+                    >
+                        <Wand2 size={14} />
+                        <Tx k="foundry.sound.swap.buttonLabel" fallback="Swap" />
+                    </button>
+                )}
+            </div>
+            {swap && swapOpen && (
+                <SwapPanel
+                    hero={swap.hero}
+                    heroName={swap.heroName}
+                    event={event}
+                    label={label}
+                    clips={clips}
+                    targetClip={targetClip}
+                    onClose={() => setSwapOpen(false)}
+                />
+            )}
+        </div>
+    );
+}
+
+// ----- Sound-swap panel (drop your own MP3 onto an event) ------------------
+
+/**
+ * Inline forge for one sound event: drop or pick an MP3, name it, and build +
+ * install a managed local mod that overrides every clip in the event's
+ * randomizer pool (`soundswap --event --pool all`). The donor template comes
+ * from the live pak, so loop/format are preserved. v1 takes MP3 only (the mint
+ * path parses rate/channels from MP3 frame headers, no ffmpeg).
+ */
+function SwapPanel({
+    hero,
+    heroName,
+    event,
+    label,
+    clips,
+    targetClip,
+    onClose,
+}: {
+    hero: string;
+    heroName: string;
+    event: string;
+    label: string;
+    clips: number;
+    /** A clip of the sound being replaced, decoded as the normalizer's loudness
+     *  target in the import editor. */
+    targetClip?: string;
+    onClose: () => void;
+}) {
+    const { t } = useTranslation();
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const [audioPath, setAudioPath] = useState<string | null>(null);
+    const [audioName, setAudioName] = useState('');
+    const [audioFile, setAudioFile] = useState<File | null>(null);
+    const [edits, setEdits] = useState<SoundImportEdits>({});
+    const [name, setName] = useState(`${heroName} ${label}`.trim());
+    const [loop, setLoop] = useState<'auto' | 'on' | 'off'>('auto');
+    const [busy, setBusy] = useState(false);
+    const [dragOver, setDragOver] = useState(false);
+
+    const accept = useCallback(
+        (file: File | undefined | null) => {
+            if (!file) return;
+            if (!file.name.toLowerCase().endsWith('.mp3')) {
+                showToast(t('foundry.sound.swap.mp3only', 'Audio must be an MP3 file.'), {
+                    tone: 'error',
+                });
+                return;
+            }
+            const path = window.electronAPI.getDroppedFilePath(file);
+            setAudioPath(path);
+            setAudioName(file.name);
+            setAudioFile(file);
+            setEdits({});
+        },
+        [t]
+    );
+
+    const forge = useCallback(async () => {
+        if (!audioPath || busy) return;
+        const finalName = name.trim() || `${heroName} ${label}`.trim();
+        setBusy(true);
+        try {
+            await foundrySwapSound({
+                heroCodename: hero,
+                heroName,
+                event,
+                audioPath,
+                name: finalName,
+                loop,
+                trimStartMs: edits.trimStartMs,
+                trimEndMs: edits.trimEndMs,
+                gainDb: edits.gainDb,
+            });
+            await useAppStore.getState().loadMods({ silent: true });
+            showToast(
+                t('foundry.sound.swap.done', 'Installed "{{name}}" - enable it in the Installed tab', {
+                    name: finalName,
+                }),
+                { tone: 'success', duration: 6000 }
+            );
+            onClose();
+        } catch (e) {
+            showToast(e instanceof Error ? e.message : String(e), { tone: 'error', duration: 8000 });
+        } finally {
+            setBusy(false);
+        }
+    }, [audioPath, busy, name, heroName, label, hero, event, loop, edits, t, onClose]);
+
+    return (
+        <div className="mt-1.5 rounded-sm border border-accent/30 bg-bg-tertiary/40 p-3">
+            <div className="mb-2 flex items-center justify-between">
+                <p className="text-[11px] font-medium uppercase tracking-wide text-accent">
+                    <Tx k="foundry.sound.swap.title" fallback="Swap with your own audio" />
+                </p>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="text-text-secondary transition-colors hover:text-text-primary"
+                    title={t('common.close', 'Close')}
+                >
+                    <X size={14} />
+                </button>
+            </div>
+
+            {/* Drop / pick zone */}
             <button
                 type="button"
-                onClick={onToggle}
-                title={t('foundry.sound.play', 'Audition')}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-bg-tertiary text-accent transition-colors hover:bg-accent/15"
+                onClick={() => inputRef.current?.click()}
+                onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={(e) => {
+                    e.preventDefault();
+                    setDragOver(false);
+                    accept(e.dataTransfer.files?.[0]);
+                }}
+                className={`flex w-full items-center justify-center gap-2 rounded-sm border border-dashed px-3 py-3 text-xs transition-colors ${
+                    dragOver
+                        ? 'border-accent bg-accent/10 text-accent'
+                        : 'border-border text-text-secondary hover:border-accent/50 hover:text-text-primary'
+                }`}
             >
-                {state === 'loading' ? (
-                    <Loader2 size={15} className="animate-spin" />
-                ) : state === 'playing' ? (
-                    <Pause size={15} />
+                <Upload size={14} />
+                {audioName ? (
+                    <span className="truncate text-text-primary" title={audioName}>
+                        {audioName}
+                    </span>
                 ) : (
-                    <Play size={15} className="translate-x-px" />
+                    <Tx k="foundry.sound.swap.drop" fallback="Drop an MP3 here, or click to pick" />
                 )}
             </button>
-            <div className="min-w-0 flex-1">
-                <p className="truncate text-sm text-text-primary" title={label}>
-                    {label || event}
-                </p>
-                <p className="truncate text-[11px] text-text-secondary" title={event}>
-                    {event}
-                    {clips > 1 ? ` · ${clips} clips` : ''}
-                </p>
-            </div>
-            {seconds && (
-                <span className="shrink-0 text-[11px] tabular-nums text-text-secondary">{seconds}</span>
+            <input
+                ref={inputRef}
+                type="file"
+                accept=".mp3,audio/mpeg"
+                className="hidden"
+                onChange={(e) => {
+                    accept(e.target.files?.[0]);
+                    e.target.value = '';
+                }}
+            />
+
+            {/* Trim + normalize the imported clip before forging */}
+            {audioFile && (
+                <SoundImportEditor
+                    file={audioFile}
+                    targetClipPath={targetClip}
+                    onChange={setEdits}
+                />
             )}
+
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+                <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder={t('foundry.sound.swap.namePlaceholder', 'Mod name')}
+                    className="min-w-[160px] flex-1 rounded-sm border border-border bg-bg-secondary px-2 py-1.5 text-sm text-text-primary placeholder:text-text-secondary/60 focus:border-accent/50 focus:outline-none"
+                />
+                <select
+                    value={loop}
+                    onChange={(e) => setLoop(e.target.value as 'auto' | 'on' | 'off')}
+                    title={t('foundry.sound.swap.loop', 'Loop the swapped clip')}
+                    className="rounded-sm border border-border bg-bg-secondary px-2 py-1.5 text-sm text-text-primary focus:outline-none"
+                >
+                    <option value="auto">{t('foundry.sound.swap.loopAuto', 'Loop: auto')}</option>
+                    <option value="on">{t('foundry.sound.swap.loopOn', 'Loop: on')}</option>
+                    <option value="off">{t('foundry.sound.swap.loopOff', 'Loop: off')}</option>
+                </select>
+                <button
+                    type="button"
+                    disabled={!audioPath || busy}
+                    onClick={forge}
+                    className="flex items-center gap-1.5 rounded-sm bg-accent px-3 py-1.5 text-sm font-medium text-bg-primary transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                    {busy ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+                    <Tx k="foundry.sound.swap.forge" fallback="Forge & install" />
+                </button>
+            </div>
+
+            <p className="mt-2 text-[11px] text-text-secondary">
+                {clips > 1
+                    ? t(
+                          'foundry.sound.swap.poolNote',
+                          'Replaces all {{count}} clips in this sound so it always plays your audio.',
+                          { count: clips }
+                      )
+                    : t('foundry.sound.swap.singleNote', 'Replaces this sound with your audio.')}
+            </p>
         </div>
     );
 }

--- a/src/components/foundry/SoundImportEditor.tsx
+++ b/src/components/foundry/SoundImportEditor.tsx
@@ -1,0 +1,450 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Pause, Play, RotateCcw, Volume2 } from 'lucide-react';
+
+import { foundryVoiceclip } from '../../lib/api';
+import { useAppStore } from '../../stores/appStore';
+
+/** Pre-mint edits the editor reports up to the swap panel. All optional: an
+ *  untouched clip reports `{}` (whole clip, no gain). */
+export interface SoundImportEdits {
+    trimStartMs?: number;
+    trimEndMs?: number;
+    gainDb?: number;
+}
+
+interface SoundImportEditorProps {
+    /** The user's picked MP3 (decoded in-renderer via Web Audio, no IPC). */
+    file: File;
+    /** A clip path of the sound being replaced (`HeroSound.vsnd[0]`), decoded as
+     *  the loudness target for the "match volume" normalizer. Omit to hide it. */
+    targetClipPath?: string | null;
+    /** Called whenever the authored edits change (debounced by React state). Must
+     *  be referentially stable (wrap in useCallback). */
+    onChange: (edits: SoundImportEdits) => void;
+}
+
+const WAVE_HEIGHT = 64;
+const WAVE_BUCKETS = 600;
+/** Keep the trim window at least this wide so a handle drag cannot invert it. */
+const MIN_WINDOW_MS = 50;
+/** Clamp the auto-gain so a near-silent import can't be boosted into noise. */
+const MAX_GAIN_DB = 18;
+
+/** Peak (abs-max) amplitude per horizontal bucket of channel 0, for the
+ *  waveform. */
+function computePeaks(buffer: AudioBuffer, buckets: number): Float32Array {
+    const ch = buffer.getChannelData(0);
+    const out = new Float32Array(buckets);
+    const size = Math.max(1, Math.floor(ch.length / buckets));
+    for (let i = 0; i < buckets; i++) {
+        let max = 0;
+        const start = i * size;
+        const end = Math.min(ch.length, start + size);
+        for (let j = start; j < end; j++) {
+            const a = Math.abs(ch[j]);
+            if (a > max) max = a;
+        }
+        out[i] = max;
+    }
+    return out;
+}
+
+/** RMS amplitude across all channels over a sample range (the loudness proxy the
+ *  normalizer matches). Strides long buffers to stay cheap on big clips. */
+function rmsOf(buffer: AudioBuffer, startSample: number, endSample: number): number {
+    const s = Math.max(0, startSample);
+    const e = Math.min(buffer.length, endSample);
+    if (e <= s) return 0;
+    const stride = Math.max(1, Math.floor((e - s) / 200_000));
+    let sum = 0;
+    let count = 0;
+    for (let c = 0; c < buffer.numberOfChannels; c++) {
+        const d = buffer.getChannelData(c);
+        for (let i = s; i < e; i += stride) {
+            sum += d[i] * d[i];
+            count++;
+        }
+    }
+    return count ? Math.sqrt(sum / count) : 0;
+}
+
+/** Read a Tailwind theme color var, falling back to a literal for canvas use. */
+function themeColor(varName: string, fallback: string): string {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+    return v || fallback;
+}
+
+function fmt(ms: number): string {
+    return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/**
+ * Trim + normalize editor for an imported MP3. Decodes the file with Web Audio
+ * (no backend, no ffmpeg), draws a waveform, exposes draggable in/out handles
+ * and a play-selection preview, and computes a "match volume" gain by comparing
+ * the selected region's loudness against the clip it replaces. The actual trim /
+ * gain are applied losslessly in Rust at mint time; this only authors the
+ * numbers and previews them.
+ */
+export function SoundImportEditor({ file, targetClipPath, onChange }: SoundImportEditorProps) {
+    const { t } = useTranslation();
+    const soundVolume = useAppStore((s) => s.soundVolume);
+
+    const ctxRef = useRef<AudioContext | null>(null);
+    const [buffer, setBuffer] = useState<AudioBuffer | null>(null);
+    const [decodeError, setDecodeError] = useState<string | null>(null);
+
+    const [startMs, setStartMs] = useState(0);
+    const [endMs, setEndMs] = useState(0);
+
+    const [normalize, setNormalize] = useState(false);
+    const [targetRms, setTargetRms] = useState<number | null>(null);
+    const [targetState, setTargetState] = useState<'idle' | 'loading' | 'missing'>('idle');
+    const [gainDb, setGainDb] = useState(0);
+
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const srcRef = useRef<AudioBufferSourceNode | null>(null);
+    const [playing, setPlaying] = useState(false);
+    const [playheadMs, setPlayheadMs] = useState<number | null>(null);
+
+    const acquireCtx = useCallback((): AudioContext => {
+        const Ctor =
+            window.AudioContext ??
+            (window as unknown as { webkitAudioContext?: typeof AudioContext })
+                .webkitAudioContext;
+        ctxRef.current ??= new Ctor!();
+        return ctxRef.current;
+    }, []);
+
+    // Decode the picked file to an AudioBuffer for the waveform + measurement.
+    useEffect(() => {
+        let cancelled = false;
+        setBuffer(null);
+        setDecodeError(null);
+        setTargetRms(null);
+        setTargetState('idle');
+        (async () => {
+            try {
+                const ab = await file.arrayBuffer();
+                const decoded = await acquireCtx().decodeAudioData(ab.slice(0));
+                if (cancelled) return;
+                setBuffer(decoded);
+                setStartMs(0);
+                setEndMs(Math.round(decoded.duration * 1000));
+            } catch {
+                if (!cancelled) {
+                    setDecodeError(
+                        t('foundry.sound.import.decodeError', 'Could not read this MP3 for preview.')
+                    );
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [file, acquireCtx, t]);
+
+    const durationMs = buffer ? buffer.duration * 1000 : 0;
+    const peaks = useMemo(() => (buffer ? computePeaks(buffer, WAVE_BUCKETS) : null), [buffer]);
+
+    // Fetch + decode the replaced clip once, when the normalizer is first enabled.
+    useEffect(() => {
+        if (!normalize || !targetClipPath || targetRms !== null || targetState !== 'idle') return;
+        let cancelled = false;
+        setTargetState('loading');
+        (async () => {
+            try {
+                const url = await foundryVoiceclip(targetClipPath);
+                if (!url) {
+                    if (!cancelled) setTargetState('missing');
+                    return;
+                }
+                const ab = await (await fetch(url)).arrayBuffer();
+                const decoded = await acquireCtx().decodeAudioData(ab.slice(0));
+                if (cancelled) return;
+                setTargetRms(rmsOf(decoded, 0, decoded.length));
+                setTargetState('idle');
+            } catch {
+                if (!cancelled) setTargetState('missing');
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [normalize, targetClipPath, targetRms, targetState, acquireCtx]);
+
+    // Recompute the match gain from the selected region whenever it (or the
+    // target) changes. Gain matches what actually ships: the trimmed region.
+    useEffect(() => {
+        if (!normalize || !buffer || targetRms === null) {
+            setGainDb(0);
+            return;
+        }
+        const rate = buffer.sampleRate;
+        const userRms = rmsOf(
+            buffer,
+            Math.floor((startMs / 1000) * rate),
+            Math.floor((endMs / 1000) * rate)
+        );
+        if (userRms < 1e-6 || targetRms < 1e-6) {
+            setGainDb(0);
+            return;
+        }
+        const raw = 20 * Math.log10(targetRms / userRms);
+        const clamped = Math.max(-MAX_GAIN_DB, Math.min(MAX_GAIN_DB, raw));
+        setGainDb(Math.round(clamped * 10) / 10);
+    }, [normalize, buffer, targetRms, startMs, endMs]);
+
+    // Report authored edits upward. Trim only when the window is narrower than the
+    // whole clip; gain only when the normalizer produced a non-zero value.
+    useEffect(() => {
+        if (!buffer) {
+            onChange({});
+            return;
+        }
+        const full = Math.round(buffer.duration * 1000);
+        const trimmed = startMs > 0 || endMs < full;
+        onChange({
+            trimStartMs: trimmed ? startMs : undefined,
+            trimEndMs: trimmed ? endMs : undefined,
+            gainDb: normalize && gainDb !== 0 ? gainDb : undefined,
+        });
+    }, [buffer, startMs, endMs, normalize, gainDb, onChange]);
+
+    const stopPlayback = useCallback(() => {
+        if (srcRef.current) {
+            srcRef.current.onended = null;
+            try {
+                srcRef.current.stop();
+            } catch {
+                /* already stopped */
+            }
+            srcRef.current = null;
+        }
+        setPlaying(false);
+        setPlayheadMs(null);
+    }, []);
+
+    // Tear down audio on unmount.
+    useEffect(
+        () => () => {
+            stopPlayback();
+            ctxRef.current?.close().catch(() => {});
+            ctxRef.current = null;
+        },
+        [stopPlayback]
+    );
+
+    const playSelection = useCallback(() => {
+        if (!buffer) return;
+        if (playing) {
+            stopPlayback();
+            return;
+        }
+        const ctx = acquireCtx();
+        if (ctx.state === 'suspended') void ctx.resume();
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        const gainNode = ctx.createGain();
+        const previewGain = normalize ? 10 ** (gainDb / 20) : 1;
+        gainNode.gain.value = previewGain * soundVolume;
+        src.connect(gainNode).connect(ctx.destination);
+
+        const offset = startMs / 1000;
+        const span = Math.max(0, (endMs - startMs) / 1000);
+        const startedAt = ctx.currentTime;
+        src.start(0, offset, span);
+        srcRef.current = src;
+        setPlaying(true);
+        src.onended = () => {
+            if (srcRef.current === src) stopPlayback();
+        };
+        const tick = () => {
+            if (srcRef.current !== src) return;
+            const elapsed = ctx.currentTime - startedAt;
+            setPlayheadMs(startMs + elapsed * 1000);
+            if (elapsed < span) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+    }, [buffer, playing, stopPlayback, acquireCtx, normalize, gainDb, soundVolume, startMs, endMs]);
+
+    // Stop a running preview if the window moves under it.
+    useEffect(() => {
+        if (playing) stopPlayback();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [startMs, endMs]);
+
+    // Draw the waveform, the dimmed out-of-selection regions, and the playhead.
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const cont = containerRef.current;
+        if (!canvas || !cont || !peaks) return;
+        const w = cont.clientWidth;
+        const h = WAVE_HEIGHT;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.max(1, Math.floor(w * dpr));
+        canvas.height = Math.floor(h * dpr);
+        canvas.style.width = `${w}px`;
+        canvas.style.height = `${h}px`;
+        const g = canvas.getContext('2d');
+        if (!g) return;
+        g.scale(dpr, dpr);
+        g.clearRect(0, 0, w, h);
+
+        const accent = themeColor('--color-accent', '#b07a3c');
+        const muted = themeColor('--color-text-secondary', '#9a8a72');
+        const mid = h / 2;
+        const sx = durationMs ? (startMs / durationMs) * w : 0;
+        const ex = durationMs ? (endMs / durationMs) * w : w;
+        const barW = Math.max(1, w / peaks.length);
+
+        for (let i = 0; i < peaks.length; i++) {
+            const x = (i / peaks.length) * w;
+            const amp = Math.max(0.5, peaks[i] * mid);
+            g.fillStyle = x >= sx && x <= ex ? accent : muted;
+            g.fillRect(x, mid - amp, barW, amp * 2);
+        }
+        g.fillStyle = 'rgba(0,0,0,0.28)';
+        if (sx > 0) g.fillRect(0, 0, sx, h);
+        if (ex < w) g.fillRect(ex, 0, w - ex, h);
+
+        if (playheadMs != null && durationMs) {
+            const px = (playheadMs / durationMs) * w;
+            g.fillStyle = '#ffffff';
+            g.fillRect(px - 0.5, 0, 1.5, h);
+        }
+    }, [peaks, startMs, endMs, durationMs, playheadMs]);
+
+    const dragHandle = useCallback(
+        (which: 'start' | 'end') => (e: React.PointerEvent) => {
+            e.preventDefault();
+            const cont = containerRef.current;
+            if (!cont || !durationMs) return;
+            const move = (ev: PointerEvent) => {
+                const rect = cont.getBoundingClientRect();
+                const frac = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
+                const ms = Math.round(frac * durationMs);
+                if (which === 'start') {
+                    setStartMs(Math.min(ms, endMs - MIN_WINDOW_MS));
+                } else {
+                    setEndMs(Math.max(ms, startMs + MIN_WINDOW_MS));
+                }
+            };
+            const up = () => {
+                window.removeEventListener('pointermove', move);
+                window.removeEventListener('pointerup', up);
+            };
+            window.addEventListener('pointermove', move);
+            window.addEventListener('pointerup', up);
+        },
+        [durationMs, startMs, endMs]
+    );
+
+    const resetTrim = useCallback(() => {
+        if (!buffer) return;
+        setStartMs(0);
+        setEndMs(Math.round(buffer.duration * 1000));
+    }, [buffer]);
+
+    if (decodeError) {
+        return <p className="mt-2 text-[11px] text-red-400">{decodeError}</p>;
+    }
+    if (!buffer) {
+        return (
+            <p className="mt-2 flex items-center gap-1.5 text-[11px] text-text-secondary">
+                <Loader2 size={12} className="animate-spin" />
+                {t('foundry.sound.import.decoding', 'Reading audio...')}
+            </p>
+        );
+    }
+
+    const leftPct = durationMs ? (startMs / durationMs) * 100 : 0;
+    const rightPct = durationMs ? (endMs / durationMs) * 100 : 100;
+    const trimmed = startMs > 0 || endMs < Math.round(buffer.duration * 1000);
+
+    return (
+        <div className="mt-2 space-y-2">
+            {/* Waveform + draggable in/out handles */}
+            <div ref={containerRef} className="relative select-none" style={{ height: WAVE_HEIGHT }}>
+                <canvas ref={canvasRef} className="block h-full w-full rounded-sm bg-bg-secondary" />
+                <div
+                    role="slider"
+                    aria-label={t('foundry.sound.import.trimStart', 'Trim start')}
+                    aria-valuenow={Math.round(startMs)}
+                    tabIndex={0}
+                    onPointerDown={dragHandle('start')}
+                    className="absolute top-0 z-10 h-full w-2 -translate-x-1/2 cursor-ew-resize rounded-sm bg-accent/80 hover:bg-accent"
+                    style={{ left: `${leftPct}%` }}
+                />
+                <div
+                    role="slider"
+                    aria-label={t('foundry.sound.import.trimEnd', 'Trim end')}
+                    aria-valuenow={Math.round(endMs)}
+                    tabIndex={0}
+                    onPointerDown={dragHandle('end')}
+                    className="absolute top-0 z-10 h-full w-2 -translate-x-1/2 cursor-ew-resize rounded-sm bg-accent/80 hover:bg-accent"
+                    style={{ left: `${rightPct}%` }}
+                />
+            </div>
+
+            {/* Transport + trim readout */}
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={playSelection}
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-bg-tertiary text-accent transition-colors hover:bg-accent/15"
+                    title={t('foundry.sound.import.playSelection', 'Play selection')}
+                >
+                    {playing ? <Pause size={14} /> : <Play size={14} className="translate-x-px" />}
+                </button>
+                <span className="text-[11px] tabular-nums text-text-secondary">
+                    {fmt(startMs)} - {fmt(endMs)}
+                    <span className="text-text-secondary/60"> ({fmt(endMs - startMs)})</span>
+                </span>
+                {trimmed && (
+                    <button
+                        type="button"
+                        onClick={resetTrim}
+                        className="ml-auto flex items-center gap-1 text-[11px] text-text-secondary transition-colors hover:text-text-primary"
+                        title={t('foundry.sound.import.resetTrim', 'Use the whole clip')}
+                    >
+                        <RotateCcw size={11} />
+                        <span>{t('foundry.sound.import.reset', 'Reset')}</span>
+                    </button>
+                )}
+            </div>
+
+            {/* Normalizer */}
+            {targetClipPath && (
+                <label className="flex cursor-pointer items-center gap-2 text-[11px] text-text-secondary">
+                    <input
+                        type="checkbox"
+                        checked={normalize}
+                        onChange={(e) => setNormalize(e.target.checked)}
+                        className="accent-accent"
+                    />
+                    <Volume2 size={12} />
+                    <span className="text-text-primary">
+                        {t('foundry.sound.import.matchVolume', 'Match the original volume')}
+                    </span>
+                    {normalize && targetState === 'loading' && (
+                        <Loader2 size={11} className="animate-spin" />
+                    )}
+                    {normalize && targetState === 'missing' && (
+                        <span className="text-amber-500">
+                            {t('foundry.sound.import.matchUnavailable', 'original unavailable')}
+                        </span>
+                    )}
+                    {normalize && targetRms !== null && (
+                        <span className="tabular-nums text-accent">
+                            {gainDb >= 0 ? '+' : ''}
+                            {gainDb.toFixed(1)} dB
+                        </span>
+                    )}
+                </label>
+            )}
+        </div>
+    );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1212,3 +1212,12 @@ export async function foundryExportHeroEffect(
 ): Promise<import('../types/foundry').VpkExportResult> {
   return window.electronAPI.foundry.exportHeroEffect(req);
 }
+
+/** Swap a hero gameplay sound event's audio with a user MP3 and install the
+ *  result as a managed local mod. Resolves with the refreshed installed mod list
+ *  (the new swap appears under the hero, tagged as a Foundry sound swap). */
+export async function foundrySwapSound(
+  req: import('../types/foundry').HeroSoundSwapRequest
+): Promise<import('../types/mod').Mod[]> {
+  return window.electronAPI.foundry.swapSound(req);
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -49,7 +49,8 @@
     "emptyValue": "(empty)",
     "none": "None",
     "versus": "VS",
-    "versusLower": "vs"
+    "versusLower": "vs",
+    "close": "Close"
   },
   "sync": {
     "syncing": "Syncing {{section}}: {{percent}}%",
@@ -190,6 +191,33 @@
         "empty": "No voice lines match your search.",
         "count": "{{shown}} of {{total}} voice lines",
         "capped": "Showing the first {{cap}}. Refine your search to see more."
+      },
+      "swap": {
+        "button": "Swap this sound for your own audio",
+        "buttonLabel": "Swap",
+        "title": "Swap with your own audio",
+        "drop": "Drop an MP3 here, or click to pick",
+        "namePlaceholder": "Mod name",
+        "loop": "Loop the swapped clip",
+        "loopAuto": "Loop: auto",
+        "loopOn": "Loop: on",
+        "loopOff": "Loop: off",
+        "forge": "Forge & install",
+        "mp3only": "Audio must be an MP3 file.",
+        "done": "Installed \"{{name}}\" - enable it in the Installed tab",
+        "poolNote": "Replaces all {{count}} clips in this sound so it always plays your audio.",
+        "singleNote": "Replaces this sound with your audio."
+      },
+      "import": {
+        "decoding": "Reading audio...",
+        "decodeError": "Could not read this MP3 for preview.",
+        "trimStart": "Trim start",
+        "trimEnd": "Trim end",
+        "playSelection": "Play selection",
+        "resetTrim": "Use the whole clip",
+        "reset": "Reset",
+        "matchVolume": "Match the original volume",
+        "matchUnavailable": "original unavailable"
       }
     }
   },

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1811,
+  "totalKeys": 1835,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1623,
-      "pct": 90
+      "pct": 88
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1811,
+      "translatedKeys": 1835,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1802,
-      "pct": 100
+      "pct": 98
     },
     {
       "code": "ru",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -954,6 +954,9 @@ export interface ElectronAPI {
         exportHeroEffect: (
             req: import('./foundry').HeroEffectExportRequest
         ) => Promise<import('./foundry').VpkExportResult>;
+        swapSound: (
+            req: import('./foundry').HeroSoundSwapRequest
+        ) => Promise<import('./mod').Mod[]>;
     };
 
     // Language packs (downloaded on demand from GitHub)

--- a/src/types/foundry.ts
+++ b/src/types/foundry.ts
@@ -148,3 +148,30 @@ export interface VpkExportResult {
     exported: boolean;
     path?: string;
 }
+
+/**
+ * Request to swap a hero gameplay sound event's audio with a user-supplied MP3
+ * and install the result as a managed local mod. `heroCodename` is the roster
+ * codename from the Foundry hero picker (resolved main-side to the sound-path
+ * codename); `heroName` is the display name (tagged as the mod's Locker hero);
+ * `event` is the verbatim soundevent (a `HeroSound.event`); `audioPath` is the
+ * dropped/picked MP3 on disk. v1 replaces every clip in the event's randomizer
+ * pool (`--pool all`). `loop` defaults to `auto` (inherit the donor clip's flag).
+ */
+export interface HeroSoundSwapRequest {
+    heroCodename: string;
+    heroName: string;
+    event: string;
+    audioPath: string;
+    name: string;
+    loop?: 'auto' | 'on' | 'off';
+    thumbnailDataUrl?: string;
+    nsfw?: boolean;
+    /** Optional trim window (ms) authored in the import editor; both ends set
+     *  together, frame-snapped (~26 ms) by the minter. Omitted = whole clip. */
+    trimStartMs?: number;
+    trimEndMs?: number;
+    /** Optional loudness gain (dB) from the "match volume" normalizer, applied
+     *  losslessly before minting. Omitted / 0 = no change. */
+    gainDb?: number;
+}

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -568,6 +568,26 @@ export interface UrnImportInfo {
   status: SoulImportStatus;
 }
 
+/**
+ * Set on a mod built via the Foundry hero sound-swap (drop your own MP3 onto a
+ * hero gameplay sound event). Labels the mod as a local sound swap and records
+ * what was swapped, so the UI can show it and a later pass can reproduce it.
+ * One addon per swap; v1 uses `--pool all`, overriding every clip in the event's
+ * randomizer pool so the swapped sound always plays.
+ */
+export interface SoundSwapInfo {
+  /** Sound-path codename whose soundevents tree was edited (e.g. `gigawatt`). */
+  heroCodename: string;
+  /** The soundevent that was swapped (e.g. `Gigawatt.LightningBall.Damage`). */
+  event: string;
+  /** Original audio filename (basename), for display. */
+  audioFileName: string;
+  /** Loop handling chosen in the swap UI. */
+  loop: 'auto' | 'on' | 'off';
+  /** How the event's randomizer pool was handled. v1 always 'all'. */
+  pool: 'all' | 'collapse';
+}
+
 export interface Mod {
   id: string;
   name: string;


### PR DESCRIPTION
## What

Foundry hero sound-swap: drop your own MP3 onto a hero gameplay sound event and install it as a managed local mod. Event mode with `--pool all` overrides every clip in the event's randomizer pool so the swapped sound always plays; the mod is tagged with the hero so it groups under them in the Locker.

## Import editor (preview + trim + match-volume)

New `SoundImportEditor` in the Foundry SwapPanel, all in-renderer via Web Audio (no IPC round-trip, no ffmpeg):

- **Waveform** decoded from the dropped MP3, with **draggable in/out trim handles** and a **play-selection** preview.
- **"Match volume" normalizer**: measures the import's RMS against the clip it replaces (fetched via `foundry:voiceclip`) and computes a gain, shown live and clamped to +-18 dB.

The trim window and gain are applied **losslessly in Rust at mint time** (`vpkmerge soundswap --trim-start/--trim-end/--gain-db`), so nothing is transcoded.

## Wiring

`foundrySwapSound` -> `foundry:swapSound` -> `buildHeroSoundSwapVpk` -> `vpkmerge soundswap`. Trim/gain are optional fields on `HeroSoundSwapRequest`; `SoundSwapInfo` / `ModMetadata.soundSwap` tag the installed mod.

Depends on the vpkmerge soundswap CLI (Slush97/vpkmerge#34) at runtime.

## Verification

`tsc -b` clean (0 errors); eslint clean on the new/edited files. Not yet click-tested in the running app; in-game reconfirm of a built addon is pending.
