### PR TITLE
fix(installed): drop per-card backdrop-blur to fix grid scroll jank

### DIFF
--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -122,7 +122,7 @@ export default function PriorityEditor({
         // (text-shadow on all four corners) to stay legible over bright covers.
         className={`inline-flex h-[22px] min-w-[30px] items-center justify-center rounded-md border border-white/20 px-2 text-[11px] font-bold leading-none tabular-nums text-text-primary shadow-none transition-colors duration-150 group-hover/order-chip:border-white/35 group-hover/order-chip:bg-white/10 group-focus-visible/order-chip:outline group-focus-visible/order-chip:outline-2 group-focus-visible/order-chip:outline-white/40 ${
           variant === 'overlay'
-            ? 'bg-black/60 backdrop-blur-sm [text-shadow:-1px_-1px_0_#000,1px_-1px_0_#000,-1px_1px_0_#000,1px_1px_0_#000,0_0_2px_#000]'
+            ? 'bg-black/70 [text-shadow:-1px_-1px_0_#000,1px_-1px_0_#000,-1px_1px_0_#000,1px_1px_0_#000,0_0_2px_#000]'
             : 'bg-bg-tertiary'
         }`}
       >

--- a/src/components/common/ui.tsx
+++ b/src/components/common/ui.tsx
@@ -110,7 +110,7 @@ export function Tag({
     const t = tones[tone];
     const isOverlay = variant === 'overlay';
     const surface = isOverlay
-        ? `bg-bg-primary/85 backdrop-blur-sm border ${t.overlayBorder} ${t.text} shadow-[0_1px_2px_rgba(0,0,0,0.35)]`
+        ? `bg-bg-primary/90 border ${t.overlayBorder} ${t.text} shadow-[0_1px_2px_rgba(0,0,0,0.35)]`
         : `${t.fill} border ${t.border} ${t.text} opacity-90`;
     return (
         <span

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -5551,7 +5551,7 @@ function ModMediaPreview({
       nsfw={mod.nsfw}
       hideNsfw={hideNsfwPreviews}
       className="w-full h-full"
-      imageClassName="origin-center transform-gpu will-change-transform transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
+      imageClassName="origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
       mergedSources={mod.merged?.sources}
       onRevealInFolder={onRevealInFolder}
     />
@@ -5562,7 +5562,7 @@ function ModMediaPreview({
         src={soundHeroRenderUrl}
         alt={soundHeroName ?? mod.name}
         draggable={false}
-        className="block h-full w-full object-cover origin-center transform-gpu will-change-transform transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
+        className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
         style={{ objectPosition: `${soundHeroFacePosX}% 25%` }}
       />
     </ImageContextMenu>
@@ -5968,7 +5968,7 @@ function ModListRowContent({
             hideNsfw={hideNsfwPreviews}
             className="w-full h-full"
             onRevealInFolder={onRevealInFolder}
-            imageClassName="origin-center transform-gpu will-change-transform transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
+            imageClassName="origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
             mergedSources={mod.merged?.sources}
           />
         )}
@@ -6253,8 +6253,8 @@ function ModCard({
   const mediaSpacingClasses = isCompact ? 'mb-2' : 'mb-1.5';
   const mediaFrameClasses = isCompact ? 'h-[116px]' : 'aspect-video';
   const audioOverlayClasses = isCompact
-    ? 'absolute bottom-2 left-2 right-2 z-20 flex h-[30px] cursor-pointer items-center rounded-md border border-white/[0.10] bg-bg-secondary/75 px-2 shadow-sm backdrop-blur-sm [&_*]:cursor-pointer'
-    : 'absolute bottom-2.5 left-3 right-3 z-20 flex h-[34px] cursor-pointer items-center rounded-md border border-white/[0.10] bg-bg-secondary/75 px-2.5 shadow-sm backdrop-blur-sm [&_*]:cursor-pointer';
+    ? 'absolute bottom-2 left-2 right-2 z-20 flex h-[30px] cursor-pointer items-center rounded-md border border-white/[0.10] bg-bg-secondary/85 px-2 shadow-sm [&_*]:cursor-pointer'
+    : 'absolute bottom-2.5 left-3 right-3 z-20 flex h-[34px] cursor-pointer items-center rounded-md border border-white/[0.10] bg-bg-secondary/85 px-2.5 shadow-sm [&_*]:cursor-pointer';
   const audioPlayerClassName = isCompact
     ? 'w-full gap-2 [&>button:first-of-type]:h-6 [&>button:first-of-type]:w-6 [&>div]:h-1 [&>span]:text-[10px]'
     : 'w-full gap-2.5 [&>button:first-of-type]:h-7 [&>button:first-of-type]:w-7 [&>div]:h-1 [&>span]:text-[10px]';


### PR DESCRIPTION
## Problem
The Installed-tab mod grid scrolled choppily (visibly dropping frames on any scroll, even slow), while List view stayed smooth.

## Root cause
Each grid card's overlay chrome used `backdrop-blur`, and `backdrop-filter` forces its own compositing layer per element:
- the shared `Tag` overlay variant (`src/components/common/ui.tsx`)
- the priority badge (`src/components/PriorityEditor.tsx`)
- the audio-preview overlay (`src/pages/Installed.tsx`)

With ~90 cards visible at once that is ~220 composited layers (badges plus the tooltips overlapping them) rebuilt every frame. A CDP timeline trace of a slow scroll showed `PaintArtifactCompositor::Update` and GPU rasterization dominating the frame (GPUTask ~18ms/frame, over the 16.7ms/60fps budget), which also stopped the cards' existing `transform-gpu` textures from being reused while scrolling. This matched the user-observed behavior that fewer cards on screen (larger cards, or a smaller window) scrolled fine.

## Fix
Remove `backdrop-blur` from that per-card overlay chrome (bumping background opacity a notch so text stays legible over cover art), and drop the standing `transform-gpu`/`will-change` on card thumbnails (another ~90 unnecessary layers). With the layers gone, the cards stay cached as single GPU textures and scrolling just translates them.

## Measurements (CDP, slow scroll, production build)
- GPUTask: ~956ms -> ~190ms
- Per-frame main work (`BeginMainFrame`): ~6.5ms/frame (about 2.5x under the 60fps budget)

## Notes
- `content-visibility: auto` on the cards is kept; removing it measured 2.6x worse.
- Visuals are unchanged apart from the overlay badges being marginally more opaque (the blur behind an already-opaque badge was barely visible).
- Diff is 3 files, 7 lines.
