### PR TITLE
fix(installed): adopt all VPKs per DMM mod and resolve contested slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   [![apt installs](https://img.shields.io/endpoint?url=https%3A%2F%2Fgrimoiremods.com%2Fapi%2Fapt-badge.json)](https://apt.grimoiremods.com)
   [![AUR](https://img.shields.io/aur/version/grimoire-bin?label=aur)](https://aur.archlinux.org/packages/grimoire-bin)
   [![CI](https://img.shields.io/github/actions/workflow/status/Slush97/grimoire/ci.yml?branch=main&label=ci)](../../actions/workflows/ci.yml)
-  [![GameBanana](https://img.shields.io/badge/GameBanana-FCDC2A)](https://gamebanana.com/tools/22583)
   [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/KgYGHEMq2P)
   [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 </div>

--- a/electron/main/services/dmmMigration.ts
+++ b/electron/main/services/dmmMigration.ts
@@ -302,92 +302,106 @@ export async function migrateDmmInstall(opts: DmmMigrationOptions): Promise<DmmM
     );
 
     for (const entry of ordered) {
-      const src = await locateVpk(dmmAddonsDir, entry.vpkCandidates);
-      if (!src) {
-        report.skipped.push({
-          submissionId: entry.submissionId,
-          reason: `VPK not found on disk (looked for ${entry.vpkCandidates.join(', ')})`,
-        });
-        continue;
-      }
+      // A DMM mod may own several VPKs; adopt each one, tagging all with the
+      // same submission id so the Installed page groups them into one card.
+      const meta = metadataFor(entry);
+      const adoptedKeys: string[] = [];
+      const fileSkips: string[] = [];
 
-      try {
-        let destPath: string;
-        if (entry.enabled) {
-          if (mode === 'in-place' && isLiveEnabledSlot(src, addonRoots)) {
-            // Already a live pakNN_dir.vpk slot Grimoire scans: adopt by
-            // metadata only, no copy.
+      for (const vpkName of entry.vpkFiles) {
+        const src = await locateVpk(dmmAddonsDir, [vpkName]);
+        if (!src) {
+          fileSkips.push(`${vpkName} (not found on disk)`);
+          continue;
+        }
+
+        try {
+          let destPath: string;
+          if (entry.enabled) {
+            if (mode === 'in-place' && isLiveEnabledSlot(src, addonRoots)) {
+              // Already a live pakNN_dir.vpk slot Grimoire scans: adopt by
+              // metadata only, no copy.
+              destPath = src;
+              const existing = getModMetadata(metaKeyFor(destPath));
+              // Skip anything Grimoire already manages (a prior import, or a
+              // local/Locker VPK that happens to occupy this slot): re-tagging it
+              // would hijack its identity. Only a truly unmanaged file is adopted.
+              if (existing && isGrimoireManaged(existing)) {
+                fileSkips.push(`${vpkName} (already managed by Grimoire)`);
+                continue;
+              }
+            } else {
+              // Not a live slot (copy mode, a parked `<id>_name.vpk`, or a file the
+              // fallback found in .disabled): promote into a real pakNN slot so it
+              // actually loads. Must write before the next allocation so the slot
+              // scan sees it taken.
+              destPath = await allocateEnabledVpkPath(opts.deadlockPath);
+              await fs.copyFile(src, destPath, fsConstants.COPYFILE_EXCL);
+            }
+          } else if (isLiveDisabledSlot(src, disabledPath)) {
+            // Already a valid disabled slot in Grimoire's .disabled folder (DMM
+            // shares it): adopt by metadata only, no move. Non-destructive, so
+            // DMM's recorded path keeps working and the file never shifts.
             destPath = src;
             const existing = getModMetadata(metaKeyFor(destPath));
-            // Skip anything Grimoire already manages (a prior import, or a
-            // local/Locker VPK that happens to occupy this slot): re-tagging it
-            // would hijack its identity. Only a truly unmanaged file is adopted.
+            // Don't re-tag a file Grimoire already manages (a prior import or a
+            // Locker/local surface parked here): that would hijack its identity.
             if (existing && isGrimoireManaged(existing)) {
-              report.skipped.push({
-                submissionId: entry.submissionId,
-                reason: `Already managed by Grimoire (${metaKeyFor(destPath)})`,
-              });
+              fileSkips.push(`${vpkName} (already managed by Grimoire)`);
               continue;
             }
           } else {
-            // Not a live slot (copy mode, a parked `<id>_name.vpk`, or a file the
-            // fallback found in .disabled): promote into a real pakNN slot so it
-            // actually loads. Must write before the next allocation so the slot
-            // scan sees it taken.
-            destPath = await allocateEnabledVpkPath(opts.deadlockPath);
+            // DMM's file lives outside Grimoire's scanned folders (a separate
+            // profile subfolder or copy): bring a COPY into .disabled under a
+            // free-form name. Always copy, never move, so DMM stays intact.
+            const nameHint = entry.modName ?? entry.sourceFileName ?? basename(src);
+            const disabledName = makeDisabledFileName(basename(src), disabledTaken, nameHint);
+            disabledTaken.add(disabledName.toLowerCase());
+            if (!existsSync(disabledPath)) await fs.mkdir(disabledPath, { recursive: true });
+            destPath = join(disabledPath, disabledName);
             await fs.copyFile(src, destPath, fsConstants.COPYFILE_EXCL);
           }
-        } else if (isLiveDisabledSlot(src, disabledPath)) {
-          // Already a valid disabled slot in Grimoire's .disabled folder (DMM
-          // shares it): adopt by metadata only, no move. Non-destructive, so
-          // DMM's recorded path keeps working and the file never shifts.
-          destPath = src;
-          const existing = getModMetadata(metaKeyFor(destPath));
-          // Don't re-tag a file Grimoire already manages (a prior import or a
-          // Locker/local surface parked here): that would hijack its identity.
-          if (existing && isGrimoireManaged(existing)) {
-            report.skipped.push({
-              submissionId: entry.submissionId,
-              reason: `Already managed by Grimoire (${metaKeyFor(destPath)})`,
-            });
-            continue;
-          }
-        } else {
-          // DMM's file lives outside Grimoire's scanned folders (a separate
-          // profile subfolder or copy): bring a COPY into .disabled under a
-          // free-form name. Always copy, never move, so DMM stays intact.
-          const nameHint = entry.modName ?? entry.sourceFileName ?? basename(src);
-          const disabledName = makeDisabledFileName(basename(src), disabledTaken, nameHint);
-          disabledTaken.add(disabledName.toLowerCase());
-          if (!existsSync(disabledPath)) await fs.mkdir(disabledPath, { recursive: true });
-          destPath = join(disabledPath, disabledName);
-          await fs.copyFile(src, destPath, fsConstants.COPYFILE_EXCL);
+
+          const metaKey = metaKeyFor(destPath);
+          // Clear any orphaned sidecar entry at this key first: an allocated slot
+          // is only guaranteed free on disk, so a stale entry from a deleted mod
+          // could otherwise bleed its fields (lockerHero, merged, thumbnail) into
+          // this one via setModMetadata's shallow merge.
+          removeModMetadata(metaKey);
+          await setModMetadataWithHash(metaKey, meta, destPath);
+          adoptedKeys.push(metaKey);
+        } catch (err) {
+          fileSkips.push(`${vpkName} (${err instanceof Error ? err.message : String(err)})`);
         }
+      }
 
-        const metaKey = metaKeyFor(destPath);
-        // Clear any orphaned sidecar entry at this key first: an allocated slot
-        // is only guaranteed free on disk, so a stale entry from a deleted mod
-        // could otherwise bleed its fields (lockerHero, merged, thumbnail) into
-        // this one via setModMetadata's shallow merge.
-        removeModMetadata(metaKey);
-        await setModMetadataWithHash(metaKey, metadataFor(entry), destPath);
-
+      if (adoptedKeys.length > 0) {
         report.adopted.push({
           submissionId: entry.submissionId,
           fileId: entry.fileId,
           modName: entry.modName,
-          installedAs: metaKey,
+          installedAs: adoptedKeys[0],
           enabled: entry.enabled,
           priority: entry.priority,
         });
-      } catch (err) {
+      } else {
         report.skipped.push({
           submissionId: entry.submissionId,
-          reason: err instanceof Error ? err.message : String(err),
+          reason: fileSkips.length > 0 ? fileSkips.join('; ') : 'no VPK files to adopt',
         });
       }
     }
   });
+
+  // Diagnostic summary (main-process log): the renderer only surfaces a count, so
+  // this is where a "only N imported" report can be traced to its real cause.
+  console.log(
+    `[DMM] migrate: adopted ${report.adopted.length} mod(s), skipped ${report.skipped.length} ` +
+      `(mode=${report.mode}, enrichment=${report.enrichment})`
+  );
+  for (const s of report.skipped) {
+    console.log(`[DMM]   skipped ${s.submissionId}: ${s.reason}`);
+  }
 
   return report;
 }

--- a/src/lib/dmmMigration.test.ts
+++ b/src/lib/dmmMigration.test.ts
@@ -107,8 +107,8 @@ describe('planDmmAdoption', () => {
   });
 
   it('locates the on-disk VPK from currentVpks (enabled) or disabledVpks (disabled)', () => {
-    expect(byId(549810).vpkCandidates).toEqual(['pak01_dir.vpk']);
-    expect(byId(777).vpkCandidates).toEqual(['777_quiet.vpk']);
+    expect(byId(549810).vpkFiles).toEqual(['pak01_dir.vpk']);
+    expect(byId(777).vpkFiles).toEqual(['777_quiet.vpk']);
   });
 
   it('warns about the count of mods without a resolved file id', () => {
@@ -165,10 +165,10 @@ describe('manifestFromDmmProfile (state.json without .dmm.json)', () => {
     const b = plan.entries.find((e) => e.submissionId === 222)!;
     expect(a.enabled).toBe(true);
     expect(a.fileId).toBe(900);
-    expect(a.vpkCandidates).toEqual(['pak01_dir.vpk']);
+    expect(a.vpkFiles).toEqual(['pak01_dir.vpk']);
     expect(b.enabled).toBe(false);
     expect(b.fileId).toBe(901);
-    expect(b.vpkCandidates).toEqual(['222_b.vpk']);
+    expect(b.vpkFiles).toEqual(['222_b.vpk']);
     expect(plan.resolvedFileIdCount).toBe(2);
   });
 });
@@ -276,9 +276,89 @@ describe('extraVpkBySubmission fallback', () => {
     expect(without.entries.length).toBe(0); // skipped: no filename
     const withFallback = planDmmAdoption(manifest, null, { extraVpkBySubmission: extra });
     expect(withFallback.entries.length).toBe(1);
-    expect(withFallback.entries[0].vpkCandidates).toEqual([
+    expect(withFallback.entries[0].vpkFiles).toEqual([
       '/abs/addons/90548_WarWithoutLastStand.vpk',
     ]);
+  });
+});
+
+describe('multi-VPK mods and contested slots', () => {
+  it('adopts every VPK of a multi-VPK mod under one submission id', () => {
+    const manifest: DmmManifest = {
+      version: 1,
+      mods: {
+        '650634': {
+          enabled: true,
+          order: 0,
+          currentVpks: ['pak02_dir.vpk', 'pak03_dir.vpk', '650634_pak47_dir.vpk'],
+          disabledVpks: [],
+          originalVpkNames: [],
+        },
+      },
+    };
+    const plan = planDmmAdoption(manifest, null);
+    expect(plan.entries).toHaveLength(1);
+    expect(plan.entries[0].vpkFiles).toEqual([
+      'pak02_dir.vpk',
+      'pak03_dir.vpk',
+      '650634_pak47_dir.vpk',
+    ]);
+  });
+
+  it('awards a contested slot to the single-VPK mod, not the stale pack claim', () => {
+    // 650634 (a pack) still lists pak33, but pak33 now belongs to single-VPK mod
+    // 675582. The single-VPK mod wins; the pack keeps only its uncontested files.
+    const manifest: DmmManifest = {
+      version: 1,
+      mods: {
+        '650634': {
+          enabled: true,
+          order: 0,
+          currentVpks: ['pak02_dir.vpk', 'pak33_dir.vpk'],
+          disabledVpks: [],
+          originalVpkNames: [],
+        },
+        '675582': {
+          enabled: true,
+          order: 1,
+          currentVpks: ['pak33_dir.vpk'],
+          disabledVpks: [],
+          originalVpkNames: [],
+        },
+      },
+    };
+    const plan = planDmmAdoption(manifest, null);
+    const pack = plan.entries.find((e) => e.submissionId === 650634)!;
+    const solo = plan.entries.find((e) => e.submissionId === 675582)!;
+    expect(solo.vpkFiles).toEqual(['pak33_dir.vpk']);
+    expect(pack.vpkFiles).toEqual(['pak02_dir.vpk']);
+  });
+
+  it('drops a mod whose only VPK is claimed by an earlier duplicate, with a warning', () => {
+    // Two single-VPK mods both list pak34 (stale DMM bookkeeping). The lower load
+    // order wins; the loser is skipped rather than fighting over the same slot.
+    const manifest: DmmManifest = {
+      version: 1,
+      mods: {
+        '659625': {
+          enabled: true,
+          order: 0,
+          currentVpks: ['pak34_dir.vpk'],
+          disabledVpks: [],
+          originalVpkNames: [],
+        },
+        '659672': {
+          enabled: true,
+          order: 1,
+          currentVpks: ['pak34_dir.vpk'],
+          disabledVpks: [],
+          originalVpkNames: [],
+        },
+      },
+    };
+    const plan = planDmmAdoption(manifest, null);
+    expect(plan.entries.map((e) => e.submissionId)).toEqual([659625]);
+    expect(plan.warnings.some((w) => /659672.*claimed by another mod/.test(w))).toBe(true);
   });
 });
 

--- a/src/lib/dmmMigration.ts
+++ b/src/lib/dmmMigration.ts
@@ -43,9 +43,11 @@ export interface DmmAdoptionEntry {
   enabled: boolean;
   /** Grimoire load-order priority (lower loads first). */
   priority: number;
-  /** On-disk VPK basenames in DMM's addons folder to locate + copy. The first
-   *  that exists is adopted; the rest are alternates (enable/disable variants). */
-  vpkCandidates: string[];
+  /** On-disk VPK basenames belonging to this mod, ALL of which are adopted and
+   *  tagged with this submission id (a DMM mod may ship several VPKs). Contested
+   *  files (also listed by another mod through stale DMM bookkeeping) are removed
+   *  here and awarded to a single owner, so two mods never fight over one slot. */
+  vpkFiles: string[];
 }
 
 export interface DmmAdoptionPlan {
@@ -86,10 +88,10 @@ export function planDmmAdoption(
   options: DmmAdoptionOptions = {}
 ): DmmAdoptionPlan {
   const warnings: string[] = [];
-  const entries: DmmAdoptionEntry[] = [];
   let resolvedFileIdCount = 0;
 
   const manifestEntries = Object.entries(manifest.mods ?? {});
+  const isStr = (v: unknown): v is string => typeof v === 'string' && !!v;
 
   // Compute the trailing priority for order-less mods over kept (numeric) keys
   // only, so a skipped local mod doesn't reserve an empty slot.
@@ -102,6 +104,19 @@ export function planDmmAdoption(
   }
   let trailing = maxOrder + 1;
 
+  // First pass: resolve each mod's full set of live on-disk VPK files. A DMM mod
+  // can ship several VPKs (its `currentVpks`/`disabledVpks` list has >1 entry),
+  // and ALL of them belong to that one mod, so the whole set is carried (not just
+  // the first) to be adopted together under one submission id.
+  interface Draft {
+    submissionId: number;
+    enabled: boolean;
+    priority: number;
+    files: string[];
+    info?: DmmStateMod;
+    sourceFileName?: string;
+  }
+  const drafts: Draft[] = [];
   for (const [key, rawEntry] of manifestEntries) {
     const submissionId = Number(key);
     if (!Number.isInteger(submissionId) || submissionId <= 0) {
@@ -112,20 +127,18 @@ export function planDmmAdoption(
     const enabled = e.enabled === true;
     const priority = typeof e.order === 'number' ? e.order : trailing++;
 
-    // Enabled mods carry live pakNN_dir.vpk names; disabled mods carry the
-    // "<modId>_<orig>.vpk" parked names. Either is a basename to locate on disk.
-    const vpkCandidates = [
-      ...(e.currentVpks ?? []),
-      ...(e.disabledVpks ?? []),
-    ].filter((v): v is string => typeof v === 'string' && !!v);
+    // The mod's live files: its `currentVpks` live pakNN slots when enabled, its
+    // `disabledVpks` parked "<modId>_<orig>.vpk" names when disabled. Fall back to
+    // the cross list if DMM left the expected one empty (inconsistent state), then
+    // to the disk-scanned `<submissionId>_*.vpk` files for mods DMM recorded no
+    // filename for.
+    const current = (e.currentVpks ?? []).filter(isStr);
+    const disabled = (e.disabledVpks ?? []).filter(isStr);
+    let files = enabled ? current : disabled;
+    if (files.length === 0) files = enabled ? disabled : current;
+    if (files.length === 0) files = (options.extraVpkBySubmission?.get(submissionId) ?? []).slice();
 
-    // Fallback: DMM sometimes records no filename for actively-loaded mods. If
-    // the addons folder has a `<submissionId>_*.vpk` for this mod, adopt that.
-    if (vpkCandidates.length === 0) {
-      vpkCandidates.push(...(options.extraVpkBySubmission?.get(submissionId) ?? []));
-    }
-
-    if (vpkCandidates.length === 0) {
+    if (files.length === 0) {
       warnings.push(`Skipped mod ${submissionId}: no VPK filename recorded on disk`);
       continue;
     }
@@ -134,18 +147,47 @@ export function planDmmAdoption(
     const sourceFileNameRaw = info?.downloadFileName ?? (e.originalVpkNames ?? [])[0];
     const sourceFileName = sourceFileNameRaw ? stripArchiveExt(sourceFileNameRaw) : undefined;
 
-    if (info?.fileId !== undefined) resolvedFileIdCount++;
+    drafts.push({ submissionId, enabled, priority, files, info, sourceFileName: sourceFileName || undefined });
+  }
 
+  // Resolve contested files: the same on-disk VPK is sometimes listed by more
+  // than one mod when DMM's manifest carries stale bookkeeping (a slot reused
+  // after a reorder/reinstall but never cleared off the old owner). Award each
+  // file to a single owner so two mods never get tagged onto one VPK. A single-
+  // VPK mod almost always reflects the slot's current truth over a multi-VPK
+  // pack's stale claim, so rank by fewest files first, then load order, then id
+  // for determinism.
+  const ranked = [...drafts].sort(
+    (a, b) => a.files.length - b.files.length || a.priority - b.priority || a.submissionId - b.submissionId
+  );
+  const owner = new Map<string, number>();
+  for (const d of ranked) {
+    for (const f of d.files) {
+      const k = f.toLowerCase();
+      if (!owner.has(k)) owner.set(k, d.submissionId);
+    }
+  }
+
+  const entries: DmmAdoptionEntry[] = [];
+  for (const d of drafts) {
+    const vpkFiles = d.files.filter((f) => owner.get(f.toLowerCase()) === d.submissionId);
+    if (vpkFiles.length === 0) {
+      warnings.push(
+        `Skipped mod ${d.submissionId}: its VPK(s) are already claimed by another mod (stale DMM data)`
+      );
+      continue;
+    }
+    if (d.info?.fileId !== undefined) resolvedFileIdCount++;
     entries.push({
-      submissionId,
-      fileId: info?.fileId,
-      modName: info?.name,
-      categoryName: info?.category,
-      thumbnailUrl: info?.thumbnailUrl,
-      sourceFileName: sourceFileName || undefined,
-      enabled,
-      priority,
-      vpkCandidates,
+      submissionId: d.submissionId,
+      fileId: d.info?.fileId,
+      modName: d.info?.name,
+      categoryName: d.info?.category,
+      thumbnailUrl: d.info?.thumbnailUrl,
+      sourceFileName: d.sourceFileName,
+      enabled: d.enabled,
+      priority: d.priority,
+      vpkFiles,
     });
   }
 


### PR DESCRIPTION
## Problem

DMM import (the first step of Fix Unknown) only tagged the **first** VPK of each mod. Two failure modes:

1. **Multi-VPK mods** — a mod shipping several VPKs (e.g. sample mod `650634` lists 6 `currentVpks`) got one file tagged; the rest fell through to the generic unknown flow as orphans.
2. **Contested slots** — DMM's `.dmm.json` accumulates stale bookkeeping where two mods list the same on-disk VPK (a slot reused after a reorder/reinstall). The real sample has **6 contested slots** (e.g. `pak34` claimed by both `659625` and `659672`); the old code dropped the losers silently at runtime.

Both under-import. This is the likely cause behind user reports of "it only imported one mod."

Verified against DMM's actual source (`deadlock-mod-manager/deadlock-mod-manager`, v1.0.0): Grimoire's `.dmm.json` and `state.json` parsing already match DMM's writer field-for-field, so the fix is in the adoption step, not the parser.

## Changes

- **Adopt every owned VPK per mod** under one submission id, so multi-VPK mods import 1:1 and group into a single card on the Installed page.
- **Contest resolution** in the pure planner: each on-disk VPK is awarded to a single owner. A single-VPK mod wins a contested slot over a multi-VPK pack's stale claim; ties break by load order then id. Fully-contested duplicate mods are skipped with an explicit warning instead of failing silently mid-run.
- **Diagnostics**: the main process now logs `adopted N / skipped M` plus a per-mod skip reason. Since main-process `console.*` routes to electron-log's file, a future under-import can be traced to its cause (missing files, already managed, stale duplicate, or no `.dmm.json` found).

## Verification

- Against a real `.dmm.json` (46 enabled mods, 6 contested slots): now imports **49 mods**, with pack `650634` correctly spanning its 4 genuinely-owned VPKs and the 4 stale duplicates skipped with warnings.
- `pnpm test` — 286 passing (added multi-VPK + contested-slot cases).
- `tsc -b` and `eslint` clean on changed files.

## Notes

- The DMM auto-import only fires from the **bulk** "Fix Unknown" button, not per-card single fixes (unchanged behavior, worth knowing when reproducing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)