### PR TITLE
Conflict ignore controls (per-file / global / whole-mod / artifact filter) + local archive import + merged-VPK load-order fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,10 @@ docs/screenshots/mod-details.png
 target/
 # Cloth solver visual testbed (generated)
 .cloth-testbed/
+
+# Local scratch from manual testing (exported profiles, lookups, prompts).
+# Root-anchored so real fixtures elsewhere are never caught.
+/*.modprofile.json
+/*.sharecode.txt
+/gb-deadlock-lookup.tsv
+/grimoire-import-prompt.md

--- a/electron/main/ipc/conflicts.ts
+++ b/electron/main/ipc/conflicts.ts
@@ -81,3 +81,59 @@ ipcMain.handle('unignore-conflict', async (_, modA: string, modB: string): Promi
     }
     return next;
 });
+
+// --- Per-file ignores ---------------------------------------------------
+// Finer-grained than whole-pair ignores: dismiss individual overlapping file
+// paths while keeping the pair flagged for any files that still overlap. Keyed
+// by the same stable identity pair key (ignoreKey) the detector emits, so the
+// renderer passes that key straight back rather than re-resolving mod ids.
+
+// get-ignored-conflict-files — the full pairKey -> ignored-paths map, used to
+// render the "Ignored files" management panel.
+ipcMain.handle('get-ignored-conflict-files', async (): Promise<Record<string, string[]>> => {
+    return loadSettings().ignoredConflictFiles ?? {};
+});
+
+// ignore-conflict-file — add one overlapping path to a pair's ignore list.
+// Idempotent. Returns the updated map.
+ipcMain.handle(
+    'ignore-conflict-file',
+    async (_, ignoreKey: string, filePath: string): Promise<Record<string, string[]>> => {
+        const settings = loadSettings();
+        const map = { ...(settings.ignoredConflictFiles ?? {}) };
+        const existing = map[ignoreKey] ?? [];
+        if (!existing.includes(filePath)) {
+            map[ignoreKey] = [...existing, filePath];
+            saveSettings({ ...settings, ignoredConflictFiles: map });
+        }
+        return map;
+    }
+);
+
+// unignore-conflict-file — remove a single path, or the whole pair entry when
+// filePath is null. Empties prune themselves so the map stays clean. Accepts
+// the stable key directly so the panel can clear entries even after a mod was
+// uninstalled.
+ipcMain.handle(
+    'unignore-conflict-file',
+    async (_, ignoreKey: string, filePath: string | null): Promise<Record<string, string[]>> => {
+        const settings = loadSettings();
+        const current = settings.ignoredConflictFiles ?? {};
+        if (!(ignoreKey in current)) {
+            return current;
+        }
+        const map = { ...current };
+        if (filePath === null) {
+            delete map[ignoreKey];
+        } else {
+            const next = (map[ignoreKey] ?? []).filter((f) => f !== filePath);
+            if (next.length === 0) {
+                delete map[ignoreKey];
+            } else {
+                map[ignoreKey] = next;
+            }
+        }
+        saveSettings({ ...settings, ignoredConflictFiles: map });
+        return map;
+    }
+);

--- a/electron/main/ipc/conflicts.ts
+++ b/electron/main/ipc/conflicts.ts
@@ -137,3 +137,36 @@ ipcMain.handle(
         return map;
     }
 );
+
+// --- Global file ignores ------------------------------------------------
+// Silence a path for EVERY pair, not just one (the user-curated companion to
+// the built-in compiler-artifact filter). For files that are never a real
+// conflict no matter which mods ship them.
+
+ipcMain.handle('get-ignored-conflict-files-global', async (): Promise<string[]> => {
+    return loadSettings().ignoredConflictFilesGlobal ?? [];
+});
+
+// ignore-conflict-file-global — add a path to the global ignore list.
+// Idempotent. Returns the updated list.
+ipcMain.handle('ignore-conflict-file-global', async (_, filePath: string): Promise<string[]> => {
+    const settings = loadSettings();
+    const current = settings.ignoredConflictFilesGlobal ?? [];
+    if (current.includes(filePath)) {
+        return current;
+    }
+    const next = [...current, filePath];
+    saveSettings({ ...settings, ignoredConflictFilesGlobal: next });
+    return next;
+});
+
+// unignore-conflict-file-global — drop a path from the global ignore list.
+ipcMain.handle('unignore-conflict-file-global', async (_, filePath: string): Promise<string[]> => {
+    const settings = loadSettings();
+    const current = settings.ignoredConflictFilesGlobal ?? [];
+    const next = current.filter((f) => f !== filePath);
+    if (next.length !== current.length) {
+        saveSettings({ ...settings, ignoredConflictFilesGlobal: next });
+    }
+    return next;
+});

--- a/electron/main/ipc/conflicts.ts
+++ b/electron/main/ipc/conflicts.ts
@@ -170,3 +170,35 @@ ipcMain.handle('unignore-conflict-file-global', async (_, filePath: string): Pro
     }
     return next;
 });
+
+// --- Whole-mod ignores --------------------------------------------------
+// Suppress every conflict that involves a given mod, against any other mod.
+// Keyed by the stable per-mod identity the detector already stamps onto each
+// conflict (modAIdentity/modBIdentity), so the renderer passes that back.
+
+ipcMain.handle('get-ignored-conflict-mods', async (): Promise<string[]> => {
+    return loadSettings().ignoredConflictMods ?? [];
+});
+
+// ignore-conflict-mod — add a mod identity to the ignore list. Idempotent.
+ipcMain.handle('ignore-conflict-mod', async (_, identity: string): Promise<string[]> => {
+    const settings = loadSettings();
+    const current = settings.ignoredConflictMods ?? [];
+    if (current.includes(identity)) {
+        return current;
+    }
+    const next = [...current, identity];
+    saveSettings({ ...settings, ignoredConflictMods: next });
+    return next;
+});
+
+// unignore-conflict-mod — drop a mod identity from the ignore list.
+ipcMain.handle('unignore-conflict-mod', async (_, identity: string): Promise<string[]> => {
+    const settings = loadSettings();
+    const current = settings.ignoredConflictMods ?? [];
+    const next = current.filter((id) => id !== identity);
+    if (next.length !== current.length) {
+        saveSettings({ ...settings, ignoredConflictMods: next });
+    }
+    return next;
+});

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -1,6 +1,7 @@
 import { ipcMain, shell } from 'electron';
 import { promises as fs, existsSync } from 'fs';
 import { extname, basename, join, resolve, sep } from 'path';
+import { tmpdir } from 'os';
 import { loadSettings, saveSettings, getActiveDeadlockPath } from '../services/settings';
 import {
     scanMods,
@@ -29,6 +30,7 @@ import {
     type UnknownModFilterGuess,
 } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
+import { extractArchive, isArchive } from '../services/extract';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
 import { buildHeroSoundSwapVpk, cleanupHeroSoundSwapBuild } from '../services/foundryCatalog';
 import { buildSoulContainerVpk, cleanupSoulContainerBuild, previewSoulContainerGlb } from '../services/soulContainerImport';
@@ -908,6 +910,12 @@ ipcMain.handle('read-renderer-asset', async (_, relPath: string): Promise<string
 // The Deadlock engine requires strict `pakXX_dir.vpk` naming (see apply-mina-variant),
 // so custom imports always get a naked `pakNN_dir.vpk` filename - no slug. The
 // human-readable name lives in metadata.modName and is shown in the UI instead.
+//
+// The source can be a bare `.vpk` or an archive (`.zip`/`.7z`/`.rar`). Archives are
+// extracted to a temp dir and every contained `.vpk` is imported as its own slot.
+// This lets users drag the whole zip in (the reliable path) instead of dragging a
+// `.vpk` out of Windows' built-in zip viewer, which hands over a virtual shell file
+// with no on-disk path and locks the window while the OS materializes it.
 ipcMain.handle(
     'import-custom-mod',
     async (_, args: ImportCustomModArgs): Promise<Mod[]> => {
@@ -919,35 +927,71 @@ ipcMain.handle(
         const { vpkPath, name, thumbnailDataUrl, nsfw } = args;
 
         if (!vpkPath || !existsSync(vpkPath)) {
-            throw new Error('VPK file not found');
-        }
-        if (!vpkPath.toLowerCase().endsWith('.vpk')) {
-            throw new Error('Selected file is not a .vpk');
+            throw new Error('File not found');
         }
         if (!name?.trim()) {
             throw new Error('A name is required');
         }
+        const trimmedName = name.trim();
 
-        // Imports install ENABLED, so reserve a slot via the overflow-aware
-        // allocator: it fills base addons first and spills into an overflow
-        // folder (creating one + patching gameinfo) when base is full, instead of
-        // failing once a >99 user has filled citadel/addons. Metadata is keyed by
-        // the destination's metaKey (folder-prefixed for an overflow slot).
-        const destPath = await allocateEnabledVpkPath(deadlockPath);
-        const destMetaKey = metaKeyFor(destPath);
+        const lower = vpkPath.toLowerCase();
+        const isVpk = lower.endsWith('.vpk');
+        if (!isVpk && !isArchive(vpkPath)) {
+            throw new Error('Selected file is not a .vpk or supported archive (.zip, .7z, .rar)');
+        }
 
-        await fs.copyFile(vpkPath, destPath);
+        // Resolve the list of source VPKs to import. A bare .vpk is a single
+        // source; an archive is extracted to a temp dir first and every VPK it
+        // contains becomes its own import (extractArchive already filters to .vpk).
+        let sourceVpks: string[];
+        let tempDir: string | undefined;
+        if (isVpk) {
+            sourceVpks = [vpkPath];
+        } else {
+            tempDir = await fs.mkdtemp(join(tmpdir(), 'grimoire-import-'));
+            try {
+                sourceVpks = await extractArchive(vpkPath, tempDir);
+            } catch (err) {
+                await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+                throw err;
+            }
+            if (sourceVpks.length === 0) {
+                await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+                throw new Error('No .vpk file was found inside the archive.');
+            }
+        }
 
-        // Scrub any orphan metadata at this slot before writing. setModMetadata
-        // merges into the existing entry, so stale fields (gameBananaId,
-        // categoryName, etc.) from a prior occupant would otherwise stick to
-        // the new local mod and visually merge it with unrelated mods.
-        removeModMetadata(destMetaKey);
-        await setModMetadataWithHash(destMetaKey, {
-            modName: name.trim(),
-            thumbnailUrl: thumbnailDataUrl,
-            nsfw: !!nsfw,
-        }, destPath);
+        try {
+            // Imports install ENABLED, so reserve a slot via the overflow-aware
+            // allocator: it fills base addons first and spills into an overflow
+            // folder (creating one + patching gameinfo) when base is full, instead
+            // of failing once a >99 user has filled citadel/addons. Metadata is
+            // keyed by the destination's metaKey (folder-prefixed for an overflow
+            // slot). Copying before the next allocate marks the slot taken, so a
+            // multi-VPK archive lands in distinct slots.
+            for (let i = 0; i < sourceVpks.length; i++) {
+                const destPath = await allocateEnabledVpkPath(deadlockPath);
+                const destMetaKey = metaKeyFor(destPath);
+
+                await fs.copyFile(sourceVpks[i], destPath);
+
+                // Scrub any orphan metadata at this slot before writing.
+                // setModMetadata merges into the existing entry, so stale fields
+                // (gameBananaId, categoryName, etc.) from a prior occupant would
+                // otherwise stick to the new local mod and visually merge it with
+                // unrelated mods.
+                removeModMetadata(destMetaKey);
+                await setModMetadataWithHash(destMetaKey, {
+                    modName: sourceVpks.length > 1 ? `${trimmedName} (${i + 1})` : trimmedName,
+                    thumbnailUrl: thumbnailDataUrl,
+                    nsfw: !!nsfw,
+                }, destPath);
+            }
+        } finally {
+            if (tempDir) {
+                await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+            }
+        }
 
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -22,6 +22,18 @@ const IGNORED_CONFLICT_FILES = new Set([
     'info.txt',
 ]);
 
+// Exact paths of Source 2 compiler artifacts that any mod touching a given
+// subsystem co-ships, regardless of what it actually changes. The panorama
+// image compiler writes panorama/image_compiler.vdata_c (an atlas/manifest)
+// into every mod that includes any panorama image, so two unrelated mods that
+// each touched panorama collide on it even though the real assets they edit
+// don't overlap (those are still detected on their own paths). Same class of
+// false positive as the default fallback textures below; matched by full path
+// so a legitimately-named file elsewhere isn't swept up.
+const IGNORED_CONFLICT_PATHS = new Set([
+    'panorama/image_compiler.vdata_c',
+]);
+
 // Path prefixes for files the VPK packer commonly bundles even when the mod
 // doesn't really touch them. Two mods both shipping a copy of the engine's
 // default fallback textures isn't a real conflict between them — it's just
@@ -37,6 +49,7 @@ const IGNORED_CONFLICT_PREFIXES = [
  */
 function shouldIgnoreFile(filePath: string): boolean {
     const normalizedPath = filePath.toLowerCase();
+    if (IGNORED_CONFLICT_PATHS.has(normalizedPath)) return true;
     const fileName = normalizedPath.split('/').pop() || normalizedPath;
     if (IGNORED_CONFLICT_FILES.has(fileName)) return true;
     for (const prefix of IGNORED_CONFLICT_PREFIXES) {
@@ -237,6 +250,9 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             ignoredFilesByKey.set(key, new Set(files));
         }
     }
+    // Globally ignored paths: never count as a conflict for any pair (the
+    // user-curated companion to the built-in IGNORED_CONFLICT_PATHS filter).
+    const globalIgnored = new Set(settings.ignoredConflictFilesGlobal ?? []);
     const identityById = new Map<string, string>();
     for (const mod of enabledMods) {
         identityById.set(mod.id, modConflictIdentity(mod));
@@ -254,10 +270,11 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             const filesA = modFileLists.get(modA.id)!;
             const filesB = modFileLists.get(modB.id)!;
 
-            // Find overlapping files (excluding metadata files)
+            // Find overlapping files (excluding metadata files and any path
+            // the user has globally silenced)
             const overlapping: string[] = [];
             for (const file of filesA) {
-                if (filesB.has(file) && !shouldIgnoreFile(file)) {
+                if (filesB.has(file) && !shouldIgnoreFile(file) && !globalIgnored.has(file)) {
                     overlapping.push(file);
                 }
             }

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -55,6 +55,10 @@ export interface ModConflict {
     ignoreKey: string;    // stable sorted pair key
     conflictType: 'priority' | 'file';
     details: string;
+    /** For `file` conflicts: every overlapping path still flagged for this pair
+     *  (after subtracting any individually ignored files). Drives the per-file
+     *  ignore UI. Undefined for `priority` conflicts. */
+    files?: string[];
 }
 
 function normalizeIdentityPart(value: string): string {
@@ -76,6 +80,13 @@ function priorityConflictDetail(mod: Mod): string {
     const folder = folderOf(mod);
     const pak = `pak${String(mod.priority).padStart(2, '0')}`;
     return folder === 'addons' ? `Both use ${pak}` : `Both use ${folder}/${pak}`;
+}
+
+/** Header line for a file (overlapping-path) conflict. Caps the inline preview
+ *  at three names; the full list rides along on ModConflict.files for the
+ *  per-file ignore UI. */
+function fileConflictDetail(files: string[]): string {
+    return `${files.length} shared file(s): ${files.slice(0, 3).join(', ')}${files.length > 3 ? '...' : ''}`;
 }
 
 export function modConflictIdentity(mod: Mod): string {
@@ -120,7 +131,8 @@ function createConflict(
     modA: Mod,
     modB: Mod,
     conflictType: ModConflict['conflictType'],
-    details: string
+    details: string,
+    files?: string[]
 ): ModConflict {
     const modAIdentity = modConflictIdentity(modA);
     const modBIdentity = modConflictIdentity(modB);
@@ -134,6 +146,7 @@ function createConflict(
         ignoreKey: conflictPairKey(modAIdentity, modBIdentity),
         conflictType,
         details,
+        files,
     };
 }
 
@@ -213,6 +226,22 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         }
     }
 
+    // Load settings once for both per-file (in-loop) and whole-pair (end)
+    // filtering. Per-file ignores are keyed by the same stable identity pair
+    // key as whole-pair ignores, so resolve each enabled mod's identity up
+    // front and reuse it.
+    const settings = loadSettings();
+    const ignoredFilesByKey = new Map<string, Set<string>>();
+    for (const [key, files] of Object.entries(settings.ignoredConflictFiles ?? {})) {
+        if (Array.isArray(files) && files.length > 0) {
+            ignoredFilesByKey.set(key, new Set(files));
+        }
+    }
+    const identityById = new Map<string, string>();
+    for (const mod of enabledMods) {
+        identityById.set(mod.id, modConflictIdentity(mod));
+    }
+
     // Find file conflicts (overlapping files between mods)
     const modsWithFiles = enabledMods.filter(m => modFileLists.has(m.id));
 
@@ -234,13 +263,29 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
             }
 
             if (overlapping.length > 0) {
-                conflicts.push(createConflict(
-                    modA,
-                    modB,
-                    'file',
-                    `${overlapping.length} shared file(s): ${overlapping.slice(0, 3).join(', ')}${overlapping.length > 3 ? '...' : ''}`
-                ));
-                markReported(modA, modB);
+                // Subtract any individually ignored files for this pair. If
+                // every overlapping file has been dismissed the pair is no
+                // longer a conflict at all, so it drops out like a whole-pair
+                // ignore.
+                const ignoreKey = conflictPairKey(
+                    identityById.get(modA.id)!,
+                    identityById.get(modB.id)!
+                );
+                const ignoredForPair = ignoredFilesByKey.get(ignoreKey);
+                const remaining = ignoredForPair
+                    ? overlapping.filter((file) => !ignoredForPair.has(file))
+                    : overlapping;
+
+                if (remaining.length > 0) {
+                    conflicts.push(createConflict(
+                        modA,
+                        modB,
+                        'file',
+                        fileConflictDetail(remaining),
+                        remaining
+                    ));
+                    markReported(modA, modB);
+                }
             }
         }
     }
@@ -248,7 +293,6 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
     // Strip out any pairs the user has explicitly dismissed. We do this at
     // the end rather than inside the loops so the ignored list stays a clean
     // post-filter: easy to reason about and easy to disable later.
-    const settings = loadSettings();
     if (settings.ignoreConflictsByDefault) {
         return [];
     }

--- a/electron/main/services/conflicts.ts
+++ b/electron/main/services/conflicts.ts
@@ -314,12 +314,15 @@ export async function detectConflicts(deadlockPath: string): Promise<ModConflict
         return [];
     }
     const ignored = new Set(settings.ignoredConflicts ?? []);
-    const filtered = ignored.size === 0
-        ? conflicts
-        : conflicts.filter((c) =>
-            !ignored.has(c.ignoreKey) &&
-            !ignored.has(conflictPairKey(c.modA, c.modB))
-        );
+    // Mods the user has dismissed wholesale: drop every conflict that involves
+    // one, against any other mod. Matched on the stable per-mod identity.
+    const ignoredMods = new Set(settings.ignoredConflictMods ?? []);
+    const filtered = conflicts.filter((c) =>
+        !ignored.has(c.ignoreKey) &&
+        !ignored.has(conflictPairKey(c.modA, c.modB)) &&
+        !ignoredMods.has(c.modAIdentity) &&
+        !ignoredMods.has(c.modBIdentity)
+    );
 
     console.log(
         `[detectConflicts] enabled=${enabledMods.length} ` +

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -29,6 +29,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     ignoreConflictsByDefault: false,
     ignoredConflictFiles: {},
     ignoredConflictFilesGlobal: [],
+    ignoredConflictMods: [],
     accentColor: '#f97316',
     sidebarHeroHighlight: 'Abrams',
     dateFormat: 'MM/DD/YYYY',

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -27,6 +27,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     hasCompletedSetup: false,
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,
+    ignoredConflictFiles: {},
     accentColor: '#f97316',
     sidebarHeroHighlight: 'Abrams',
     dateFormat: 'MM/DD/YYYY',

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -28,6 +28,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     ignoredConflicts: [],
     ignoreConflictsByDefault: false,
     ignoredConflictFiles: {},
+    ignoredConflictFilesGlobal: [],
     accentColor: '#f97316',
     sidebarHeroHighlight: 'Abrams',
     dateFormat: 'MM/DD/YYYY',

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -449,6 +449,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('ignore-conflict-file', ignoreKey, filePath),
     unignoreConflictFile: (ignoreKey: string, filePath: string | null) =>
         ipcRenderer.invoke('unignore-conflict-file', ignoreKey, filePath),
+    getIgnoredConflictFilesGlobal: () => ipcRenderer.invoke('get-ignored-conflict-files-global'),
+    ignoreConflictFileGlobal: (filePath: string) =>
+        ipcRenderer.invoke('ignore-conflict-file-global', filePath),
+    unignoreConflictFileGlobal: (filePath: string) =>
+        ipcRenderer.invoke('unignore-conflict-file-global', filePath),
 
     // Profiles
     getProfiles: () => ipcRenderer.invoke('get-profiles'),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -454,6 +454,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('ignore-conflict-file-global', filePath),
     unignoreConflictFileGlobal: (filePath: string) =>
         ipcRenderer.invoke('unignore-conflict-file-global', filePath),
+    getIgnoredConflictMods: () => ipcRenderer.invoke('get-ignored-conflict-mods'),
+    ignoreConflictMod: (identity: string) =>
+        ipcRenderer.invoke('ignore-conflict-mod', identity),
+    unignoreConflictMod: (identity: string) =>
+        ipcRenderer.invoke('unignore-conflict-mod', identity),
 
     // Profiles
     getProfiles: () => ipcRenderer.invoke('get-profiles'),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -444,6 +444,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('ignore-conflict', modA, modB),
     unignoreConflict: (modA: string, modB: string) =>
         ipcRenderer.invoke('unignore-conflict', modA, modB),
+    getIgnoredConflictFiles: () => ipcRenderer.invoke('get-ignored-conflict-files'),
+    ignoreConflictFile: (ignoreKey: string, filePath: string) =>
+        ipcRenderer.invoke('ignore-conflict-file', ignoreKey, filePath),
+    unignoreConflictFile: (ignoreKey: string, filePath: string | null) =>
+        ipcRenderer.invoke('unignore-conflict-file', ignoreKey, filePath),
 
     // Profiles
     getProfiles: () => ipcRenderer.invoke('get-profiles'),

--- a/src/components/MergedContentsModal.tsx
+++ b/src/components/MergedContentsModal.tsx
@@ -66,6 +66,16 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
 
   const createdLabel = formatRelativeDate(merged.createdAt) || merged.createdAt;
 
+  // merged.sources is stored in the merger's argv order (descending priority,
+  // because vpkmerge is last-input-wins). Display it in load order instead:
+  // ascending pakNN, so the lowest-pakNN source (the collision winner that
+  // loads first) sits at the top, matching the Installed load-order list and
+  // the merge modal. Sort a copy so the stored snapshot (used by extract /
+  // unmerge) is untouched.
+  const orderedSources = [...merged.sources].sort(
+    (a, b) => a.priorityAtMergeTime - b.priorityAtMergeTime
+  );
+
   return (
     <Modal onClose={onClose} labelledBy="merged-contents-title" size="lg">
         <div className="flex items-center justify-between p-5 border-b border-border">
@@ -125,7 +135,7 @@ export default function MergedContentsModal({ mod, hideNsfw, onClose, onUnmerge,
               )}
             </div>
             <ul className="space-y-1.5 max-h-72 overflow-y-auto pr-1">
-              {merged.sources.map((src) => {
+              {orderedSources.map((src) => {
                 const busy = busyFileName === src.fileName;
                 // Dim and lock other rows while an extract is in flight.
                 const rowLocked = busyFileName !== null && !busy;

--- a/src/components/conflicts/ConflictFileList.tsx
+++ b/src/components/conflicts/ConflictFileList.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { ChevronRight, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import Tx from '../translation/Tx';
+
+interface ConflictFileListProps {
+  /** Overlapping paths still flagged for this pair. */
+  files: string[];
+  /** True while an ignore/unignore for this pair is in flight. */
+  busy: boolean;
+  /** Dismiss a single overlapping file forever (per-pair). */
+  onIgnoreFile: (filePath: string) => void;
+}
+
+/**
+ * Collapsible list of the files a `file` conflict shares, with a per-file
+ * "Ignore" action. Ignoring the last remaining file removes the conflict
+ * entirely (handled upstream). Collapsed by default so the card stays compact;
+ * the count is always visible in the toggle.
+ */
+export default function ConflictFileList({ files, busy, onIgnoreFile }: ConflictFileListProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  if (files.length === 0) return null;
+
+  return (
+    <div className="border-t border-border/60">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 px-4 py-2 text-xs text-text-secondary transition-colors hover:text-text-primary cursor-pointer"
+      >
+        <ChevronRight className={`h-3.5 w-3.5 transition-transform ${open ? 'rotate-90' : ''}`} />
+        <Tx
+          k="conflicts.files.heading"
+          values={{ count: files.length }}
+          fallback={`Shared files (${files.length})`}
+        />
+      </button>
+      {open && (
+        <ul className="max-h-44 space-y-1 overflow-auto px-4 pb-3">
+          {files.map((file) => (
+            <li key={file} className="flex items-center gap-2">
+              <span
+                className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-tertiary"
+                title={file}
+              >
+                {file}
+              </span>
+              <button
+                type="button"
+                onClick={() => onIgnoreFile(file)}
+                disabled={busy}
+                title={t('conflicts.files.ignoreFileTitle')}
+                aria-label={t('conflicts.files.ignoreFileTitle')}
+                className="inline-flex flex-shrink-0 items-center gap-1 rounded px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+              >
+                <EyeOff className="h-3 w-3" />
+                <Tx k="conflicts.files.ignoreFile" fallback="Ignore" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/conflicts/ConflictFileList.tsx
+++ b/src/components/conflicts/ConflictFileList.tsx
@@ -16,11 +16,9 @@ interface ConflictFileListProps {
 }
 
 /**
- * Collapsible list of the files a `file` conflict shares. Left-clicking a row's
- * Ignore button dismisses it for this pair; right-clicking the row opens a menu
- * with both scopes, including "ignore in all mods" for shared build artifacts
- * that are never a real conflict. Collapsed by default so the card stays
- * compact; the count is always visible in the toggle.
+ * Collapsible list of the files a `file` conflict shares. A row's Ignore button
+ * dismisses that file for this pair; right-clicking opens a menu that adds the
+ * "ignore in all mods" scope. Collapsed by default.
  */
 export default function ConflictFileList({
   files,

--- a/src/components/conflicts/ConflictFileList.tsx
+++ b/src/components/conflicts/ConflictFileList.tsx
@@ -1,24 +1,33 @@
 import { useState } from 'react';
-import { ChevronRight, EyeOff } from 'lucide-react';
+import { ChevronRight, EyeOff, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tx from '../translation/Tx';
+import { MenuRoot, MenuTrigger, MenuContent, MenuItem, MenuLabel } from '../common/menu';
 
 interface ConflictFileListProps {
   /** Overlapping paths still flagged for this pair. */
   files: string[];
   /** True while an ignore/unignore for this pair is in flight. */
   busy: boolean;
-  /** Dismiss a single overlapping file forever (per-pair). */
+  /** Dismiss a single overlapping file for this pair only. */
   onIgnoreFile: (filePath: string) => void;
+  /** Silence a file for every mod pair (never flag it as a conflict again). */
+  onIgnoreFileEverywhere: (filePath: string) => void;
 }
 
 /**
- * Collapsible list of the files a `file` conflict shares, with a per-file
- * "Ignore" action. Ignoring the last remaining file removes the conflict
- * entirely (handled upstream). Collapsed by default so the card stays compact;
- * the count is always visible in the toggle.
+ * Collapsible list of the files a `file` conflict shares. Left-clicking a row's
+ * Ignore button dismisses it for this pair; right-clicking the row opens a menu
+ * with both scopes, including "ignore in all mods" for shared build artifacts
+ * that are never a real conflict. Collapsed by default so the card stays
+ * compact; the count is always visible in the toggle.
  */
-export default function ConflictFileList({ files, busy, onIgnoreFile }: ConflictFileListProps) {
+export default function ConflictFileList({
+  files,
+  busy,
+  onIgnoreFile,
+  onIgnoreFileEverywhere,
+}: ConflictFileListProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -42,25 +51,38 @@ export default function ConflictFileList({ files, busy, onIgnoreFile }: Conflict
       {open && (
         <ul className="max-h-44 space-y-1 overflow-auto px-4 pb-3">
           {files.map((file) => (
-            <li key={file} className="flex items-center gap-2">
-              <span
-                className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-tertiary"
-                title={file}
-              >
-                {file}
-              </span>
-              <button
-                type="button"
-                onClick={() => onIgnoreFile(file)}
-                disabled={busy}
-                title={t('conflicts.files.ignoreFileTitle')}
-                aria-label={t('conflicts.files.ignoreFileTitle')}
-                className="inline-flex flex-shrink-0 items-center gap-1 rounded px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
-              >
-                <EyeOff className="h-3 w-3" />
-                <Tx k="conflicts.files.ignoreFile" fallback="Ignore" />
-              </button>
-            </li>
+            <MenuRoot key={file}>
+              <MenuTrigger asChild>
+                <li className="flex items-center gap-2 rounded data-[state=open]:bg-bg-tertiary/60">
+                  <span
+                    className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-tertiary"
+                    title={file}
+                  >
+                    {file}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onIgnoreFile(file)}
+                    disabled={busy}
+                    title={t('conflicts.files.ignoreFileTitle')}
+                    aria-label={t('conflicts.files.ignoreFileTitle')}
+                    className="inline-flex flex-shrink-0 items-center gap-1 rounded px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                  >
+                    <EyeOff className="h-3 w-3" />
+                    <Tx k="conflicts.files.ignoreFile" fallback="Ignore" />
+                  </button>
+                </li>
+              </MenuTrigger>
+              <MenuContent>
+                <MenuLabel>{file}</MenuLabel>
+                <MenuItem icon={EyeOff} disabled={busy} onSelect={() => onIgnoreFile(file)}>
+                  <Tx k="conflicts.files.ignoreForPair" fallback="Ignore for this pair" />
+                </MenuItem>
+                <MenuItem icon={Globe} disabled={busy} onSelect={() => onIgnoreFileEverywhere(file)}>
+                  <Tx k="conflicts.files.ignoreEverywhere" fallback="Ignore in all mods" />
+                </MenuItem>
+              </MenuContent>
+            </MenuRoot>
           ))}
         </ul>
       )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -928,6 +928,22 @@ export async function unignoreConflictFileGlobal(filePath: string): Promise<stri
   return window.electronAPI.unignoreConflictFileGlobal(filePath);
 }
 
+/** Stable mod identities suppressed across all their conflicts. */
+export async function getIgnoredConflictMods(): Promise<string[]> {
+  return window.electronAPI.getIgnoredConflictMods();
+}
+
+/** Suppress every conflict involving a mod (right-click "ignore this mod
+ *  everywhere"). `identity` is the conflict's modAIdentity/modBIdentity. */
+export async function ignoreConflictMod(identity: string): Promise<string[]> {
+  return window.electronAPI.ignoreConflictMod(identity);
+}
+
+/** Drop a mod identity from the ignore list so its conflicts flag again. */
+export async function unignoreConflictMod(identity: string): Promise<string[]> {
+  return window.electronAPI.unignoreConflictMod(identity);
+}
+
 /** Build the ignored-list key for a pair of mod ids or stable identities.
  *  Mirrors the backend helper so the renderer can match locally without an
  *  extra IPC roundtrip. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -855,6 +855,10 @@ export interface ModConflict {
   ignoreKey: string;
   conflictType: 'priority' | 'file';
   details: string;
+  /** For `file` conflicts: every overlapping path still flagged for this pair
+   *  (after subtracting any individually ignored files). Undefined for
+   *  `priority` conflicts. */
+  files?: string[];
 }
 
 // Conflict detection re-parses every enabled VPK on the main process, so
@@ -884,6 +888,29 @@ export async function ignoreConflict(modA: string, modB: string): Promise<string
 
 export async function unignoreConflict(modA: string, modB: string): Promise<string[]> {
   return window.electronAPI.unignoreConflict(modA, modB);
+}
+
+/** Map of stable pair key -> individually ignored overlapping file paths. */
+export async function getIgnoredConflictFiles(): Promise<Record<string, string[]>> {
+  return window.electronAPI.getIgnoredConflictFiles();
+}
+
+/** Dismiss a single overlapping file for a conflict pair. `ignoreKey` is the
+ *  conflict's stable identity key (ModConflict.ignoreKey). */
+export async function ignoreConflictFile(
+  ignoreKey: string,
+  filePath: string
+): Promise<Record<string, string[]>> {
+  return window.electronAPI.ignoreConflictFile(ignoreKey, filePath);
+}
+
+/** Restore an ignored file (or the whole pair entry when filePath is null) to
+ *  conflict detection. */
+export async function unignoreConflictFile(
+  ignoreKey: string,
+  filePath: string | null
+): Promise<Record<string, string[]>> {
+  return window.electronAPI.unignoreConflictFile(ignoreKey, filePath);
 }
 
 /** Build the ignored-list key for a pair of mod ids or stable identities.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -913,6 +913,21 @@ export async function unignoreConflictFile(
   return window.electronAPI.unignoreConflictFile(ignoreKey, filePath);
 }
 
+/** Paths globally silenced: never flagged as a conflict for any mod pair. */
+export async function getIgnoredConflictFilesGlobal(): Promise<string[]> {
+  return window.electronAPI.getIgnoredConflictFilesGlobal();
+}
+
+/** Silence a path for every pair (right-click "ignore this file everywhere"). */
+export async function ignoreConflictFileGlobal(filePath: string): Promise<string[]> {
+  return window.electronAPI.ignoreConflictFileGlobal(filePath);
+}
+
+/** Drop a path from the global ignore list so it can flag conflicts again. */
+export async function unignoreConflictFileGlobal(filePath: string): Promise<string[]> {
+  return window.electronAPI.unignoreConflictFileGlobal(filePath);
+}
+
 /** Build the ignored-list key for a pair of mod ids or stable identities.
  *  Mirrors the backend helper so the renderer can match locally without an
  *  extra IPC roundtrip. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -890,13 +890,10 @@ export async function unignoreConflict(modA: string, modB: string): Promise<stri
   return window.electronAPI.unignoreConflict(modA, modB);
 }
 
-/** Map of stable pair key -> individually ignored overlapping file paths. */
 export async function getIgnoredConflictFiles(): Promise<Record<string, string[]>> {
   return window.electronAPI.getIgnoredConflictFiles();
 }
 
-/** Dismiss a single overlapping file for a conflict pair. `ignoreKey` is the
- *  conflict's stable identity key (ModConflict.ignoreKey). */
 export async function ignoreConflictFile(
   ignoreKey: string,
   filePath: string
@@ -904,8 +901,7 @@ export async function ignoreConflictFile(
   return window.electronAPI.ignoreConflictFile(ignoreKey, filePath);
 }
 
-/** Restore an ignored file (or the whole pair entry when filePath is null) to
- *  conflict detection. */
+// filePath === null clears the whole pair entry, not just one path.
 export async function unignoreConflictFile(
   ignoreKey: string,
   filePath: string | null
@@ -913,33 +909,26 @@ export async function unignoreConflictFile(
   return window.electronAPI.unignoreConflictFile(ignoreKey, filePath);
 }
 
-/** Paths globally silenced: never flagged as a conflict for any mod pair. */
 export async function getIgnoredConflictFilesGlobal(): Promise<string[]> {
   return window.electronAPI.getIgnoredConflictFilesGlobal();
 }
 
-/** Silence a path for every pair (right-click "ignore this file everywhere"). */
 export async function ignoreConflictFileGlobal(filePath: string): Promise<string[]> {
   return window.electronAPI.ignoreConflictFileGlobal(filePath);
 }
 
-/** Drop a path from the global ignore list so it can flag conflicts again. */
 export async function unignoreConflictFileGlobal(filePath: string): Promise<string[]> {
   return window.electronAPI.unignoreConflictFileGlobal(filePath);
 }
 
-/** Stable mod identities suppressed across all their conflicts. */
 export async function getIgnoredConflictMods(): Promise<string[]> {
   return window.electronAPI.getIgnoredConflictMods();
 }
 
-/** Suppress every conflict involving a mod (right-click "ignore this mod
- *  everywhere"). `identity` is the conflict's modAIdentity/modBIdentity. */
 export async function ignoreConflictMod(identity: string): Promise<string[]> {
   return window.electronAPI.ignoreConflictMod(identity);
 }
 
-/** Drop a mod identity from the ignore list so its conflicts flag again. */
 export async function unignoreConflictMod(identity: string): Promise<string[]> {
   return window.electronAPI.unignoreConflictMod(identity);
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -541,6 +541,7 @@
       "ignoreAllTitle": "Move every active conflict pair to the Ignored section. Reversible per-pair via Unignore.",
       "ignoreCount_one": "Ignore {{count}}",
       "ignoreCount_other": "Ignore {{count}}",
+      "ignoreModEverywhere": "Ignore this mod everywhere",
       "ignoreTitle": "Stop flagging this pair as a conflict",
       "ignoring": "Ignoring…",
       "unignore": "Unignore"
@@ -601,6 +602,11 @@
     "ignoredFilesGlobal": {
       "title": "Ignored in all mods",
       "unignoreTitle": "Flag this file as a conflict again (across all mods)"
+    },
+    "ignoredMods": {
+      "tag": "Ignored",
+      "title": "Ignored mods",
+      "unignoreTitle": "Flag this mod's conflicts again"
     },
     "noPreview": "No Preview",
     "removedMod": "(removed mod)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -574,6 +574,12 @@
       "ignoreFailed_other": "Failed to ignore {{count}} pairs. See console for details."
     },
     "errorTitle": "Error Loading Conflicts",
+    "files": {
+      "heading_one": "Shared file ({{count}})",
+      "heading_other": "Shared files ({{count}})",
+      "ignoreFile": "Ignore",
+      "ignoreFileTitle": "Stop flagging just this file for these two mods (reversible below)"
+    },
     "header": {
       "description": "Resolve conflicts between installed mods",
       "noActiveDescription": "No active conflicts — review or restore your ignored pairs below."
@@ -583,6 +589,12 @@
       "title_one": "Ignored ({{count}})",
       "title_other": "Ignored ({{count}})",
       "unignoreTitle": "Restore conflict detection for this pair"
+    },
+    "ignoredFiles": {
+      "restoreAll": "Restore all",
+      "restoreAllTitle": "Restore conflict detection for every ignored file in this pair",
+      "title": "Ignored files",
+      "unignoreFileTitle": "Restore this file to conflict detection"
     },
     "noPreview": "No Preview",
     "removedMod": "(removed mod)",
@@ -1029,14 +1041,15 @@
       "saveCustom": "Save Custom Mod",
       "alreadyInstalledHint": "This VPK is already installed. Saving will only add custom metadata to it.",
       "title": "Import Custom Mod",
-      "vpkHelp": "The file will be copied into your addons folder and renamed with the next available pak## priority.",
-      "selectVpk": "Select VPK file",
-      "expectedVpk": "Expected a .vpk file - got \"{{name}}\".",
-      "vpkFile": "VPK file",
-      "vpkSelected": "VPK selected: {{path}}. Press Enter to change.",
-      "vpkSelectedLocked": "VPK selected: {{path}}",
-      "vpkAriaBrowse": "Drop a VPK file here or press Enter to browse",
-      "dropVpkHere": "Drop a <code>.vpk</code> here",
+      "vpkHelp": "Drop a .vpk or an archive (.zip, .7z, .rar) and it will be copied into your addons folder with the next available pak## priority. Tip: drag the .zip file itself, not a file dragged out of an opened zip window.",
+      "selectVpk": "Select VPK or archive",
+      "expectedVpk": "Expected a .vpk or archive (.zip, .7z, .rar) - got \"{{name}}\".",
+      "dropUnresolved": "Could not read that file. If you dragged it out of an opened zip window, drag the .zip file itself here instead.",
+      "vpkFile": "VPK or archive",
+      "vpkSelected": "File selected: {{path}}. Press Enter to change.",
+      "vpkSelectedLocked": "File selected: {{path}}",
+      "vpkAriaBrowse": "Drop a .vpk or archive here or press Enter to browse",
+      "dropVpkHere": "Drop a <code>.vpk</code> or <code>.zip</code> here",
       "orClickToBrowse": "or click to browse",
       "modName": "Mod name",
       "modNamePlaceholder": "My awesome skin",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -577,8 +577,10 @@
     "files": {
       "heading_one": "Shared file ({{count}})",
       "heading_other": "Shared files ({{count}})",
+      "ignoreEverywhere": "Ignore in all mods",
       "ignoreFile": "Ignore",
-      "ignoreFileTitle": "Stop flagging just this file for these two mods (reversible below)"
+      "ignoreFileTitle": "Stop flagging just this file for these two mods (reversible below)",
+      "ignoreForPair": "Ignore for this pair"
     },
     "header": {
       "description": "Resolve conflicts between installed mods",
@@ -595,6 +597,10 @@
       "restoreAllTitle": "Restore conflict detection for every ignored file in this pair",
       "title": "Ignored files",
       "unignoreFileTitle": "Restore this file to conflict detection"
+    },
+    "ignoredFilesGlobal": {
+      "title": "Ignored in all mods",
+      "unignoreTitle": "Flag this file as a conflict again (across all mods)"
     },
     "noPreview": "No Preview",
     "removedMod": "(removed mod)",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,17 +1,17 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1830,
+  "totalKeys": 1839,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1623,
-      "pct": 89
+      "pct": 88
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1830,
+      "translatedKeys": 1839,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1843,
+  "totalKeys": 1847,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1843,
+      "translatedKeys": 1847,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1839,
+  "totalKeys": 1843,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1839,
+      "translatedKeys": 1843,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1830,
-      "pct": 100
+      "pct": 99
     },
     {
       "code": "ru",

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -8,6 +8,9 @@ import {
   getIgnoredConflicts,
   ignoreConflict,
   unignoreConflict,
+  getIgnoredConflictFiles,
+  ignoreConflictFile,
+  unignoreConflictFile,
   conflictPairKey,
   reorderMods,
 } from '../lib/api';
@@ -17,6 +20,7 @@ import { useAppStore } from '../stores/appStore';
 import { Button } from '../components/common/ui';
 import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, PageLayout, type ViewMode } from '../components/common/PageComponents';
 import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
+import ConflictFileList from '../components/conflicts/ConflictFileList';
 import Tx from '../components/translation/Tx';
 
 const CONFLICTS_VIEW_MODE_KEY = 'grimoire:conflicts-view-mode';
@@ -124,6 +128,10 @@ export default function Conflicts() {
   // filter detected conflicts (defense-in-depth — backend already filters)
   // and to render the "Ignored" panel.
   const [ignored, setIgnored] = useState<Set<string>>(new Set());
+  // Map of stable pair key -> individually ignored overlapping file paths.
+  // Drives the "Ignored files" management panel; the detector already filters
+  // these out of the active list.
+  const [ignoredFiles, setIgnoredFiles] = useState<Record<string, string[]>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
@@ -151,10 +159,11 @@ export default function Conflicts() {
     setLoading(true);
     setError(null);
     try {
-      const [conflictResult, modsResult, ignoredResult] = await Promise.all([
+      const [conflictResult, modsResult, ignoredResult, ignoredFilesResult] = await Promise.all([
         getConflicts(),
         getMods(),
         getIgnoredConflicts(),
+        getIgnoredConflictFiles(),
       ]);
 
       const map = new Map<string, ModWithThumbnail>();
@@ -196,6 +205,7 @@ export default function Conflicts() {
       );
       setConflicts(conflictResult);
       setIgnored(new Set(ignoredResult));
+      setIgnoredFiles(ignoredFilesResult);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -218,6 +228,43 @@ export default function Conflicts() {
       // Sidebar's badge count is derived from getConflicts() and only refreshes
       // on mods-list changes. Ignore/unignore don't touch mods, so notify the
       // Sidebar explicitly — otherwise the badge stays stale until restart.
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  // Dismiss a single overlapping file for this pair forever. Re-detects after
+  // persisting: the detector recomputes `details`/`files` from what's left and
+  // drops the pair if that was the last shared file (no skeleton flash, same
+  // as handleUnignore).
+  const handleIgnoreFile = async (conflict: ModConflict, filePath: string) => {
+    const key = getConflictIgnoreKey(conflict);
+    setPendingPair(key);
+    try {
+      const map = await ignoreConflictFile(key, filePath);
+      setIgnoredFiles(map);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  // Restore an ignored file (filePath) or every ignored file for a pair
+  // (filePath === null). Re-detects so a still-overlapping file resurfaces.
+  const handleUnignoreFile = async (key: string, filePath: string | null) => {
+    setPendingPair(key);
+    try {
+      const map = await unignoreConflictFile(key, filePath);
+      setIgnoredFiles(map);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
       window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
     } catch (err) {
       setError(String(err));
@@ -395,7 +442,9 @@ export default function Conflicts() {
     );
   }
 
-  if (conflicts.length === 0 && ignored.size === 0) {
+  const ignoredFilePairCount = Object.keys(ignoredFiles).length;
+
+  if (conflicts.length === 0 && ignored.size === 0 && ignoredFilePairCount === 0) {
     return (
       <div className="h-full flex items-center justify-center p-6">
         <EmptyState
@@ -563,6 +612,13 @@ export default function Conflicts() {
                   </span>
                   {renderListSide(modB, variantB)}
                 </div>
+                {conflict.conflictType === 'file' && conflict.files && conflict.files.length > 0 && (
+                  <ConflictFileList
+                    files={conflict.files}
+                    busy={pendingPair === getConflictIgnoreKey(conflict)}
+                    onIgnoreFile={(filePath) => handleIgnoreFile(conflict, filePath)}
+                  />
+                )}
                 <ConflictReorderActions
                   conflict={conflict}
                   modA={{ id: modA.id, name: modA.name }}
@@ -696,6 +752,14 @@ export default function Conflicts() {
                   </div>
                 </div>
 
+                {conflict.conflictType === 'file' && conflict.files && conflict.files.length > 0 && (
+                  <ConflictFileList
+                    files={conflict.files}
+                    busy={pendingPair === getConflictIgnoreKey(conflict)}
+                    onIgnoreFile={(filePath) => handleIgnoreFile(conflict, filePath)}
+                  />
+                )}
+
                 <ConflictReorderActions
                   conflict={conflict}
                   modA={{ id: modA.id, name: modA.name }}
@@ -771,6 +835,70 @@ export default function Conflicts() {
                     <Eye className="w-3.5 h-3.5" />
                     <Tx k="conflicts.actions.unignore" fallback="Unignore" />
                   </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Ignored files panel — finer-grained companion to the ignored-pairs
+          panel above. Each group is one mod pair; restoring a file (or the
+          whole group) re-runs detection so a still-overlapping path reappears
+          as an active conflict. */}
+      {ignoredFilePairCount > 0 && (
+        <div className="mt-10">
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+            <EyeOff className="w-4 h-4" />
+            <Tx k="conflicts.ignoredFiles.title" fallback="Ignored files" />
+          </h3>
+          <div className="space-y-3">
+            {Object.entries(ignoredFiles).map(([key, paths]) => {
+              const [idA, idB] = key.split('::');
+              const a = modsMap.get(idA);
+              const b = modsMap.get(idB);
+              const aName = a?.name ?? t('conflicts.removedMod');
+              const bName = b?.name ?? t('conflicts.removedMod');
+              return (
+                <div key={key} className="rounded-xl border border-border bg-bg-secondary">
+                  <div className="flex items-center gap-3 border-b border-border px-4 py-2.5">
+                    <div className="min-w-0 flex-1 flex items-center gap-2 text-sm">
+                      <span className="truncate text-text-primary" title={aName}>{aName}</span>
+                      <span className="flex-shrink-0 text-xs text-text-tertiary">
+                        <Tx k="common.versusLower" fallback="vs" />
+                      </span>
+                      <span className="truncate text-text-primary" title={bName}>{bName}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleUnignoreFile(key, null)}
+                      disabled={pendingPair === key}
+                      title={t('conflicts.ignoredFiles.restoreAllTitle')}
+                      className="flex-shrink-0 inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                      <Tx k="conflicts.ignoredFiles.restoreAll" fallback="Restore all" />
+                    </button>
+                  </div>
+                  <ul className="divide-y divide-border/60">
+                    {paths.map((p) => (
+                      <li key={p} className="flex items-center gap-2 px-4 py-2">
+                        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-tertiary" title={p}>
+                          {p}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleUnignoreFile(key, p)}
+                          disabled={pendingPair === key}
+                          title={t('conflicts.ignoredFiles.unignoreFileTitle')}
+                          className="flex-shrink-0 inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                        >
+                          <Eye className="h-3 w-3" />
+                          <Tx k="conflicts.actions.unignore" fallback="Unignore" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               );
             })}

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye, List, LayoutGrid, Trash2 } from 'lucide-react';
+import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye, List, LayoutGrid, Trash2, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   getConflicts,
@@ -11,6 +11,9 @@ import {
   getIgnoredConflictFiles,
   ignoreConflictFile,
   unignoreConflictFile,
+  getIgnoredConflictFilesGlobal,
+  ignoreConflictFileGlobal,
+  unignoreConflictFileGlobal,
   conflictPairKey,
   reorderMods,
 } from '../lib/api';
@@ -132,6 +135,11 @@ export default function Conflicts() {
   // Drives the "Ignored files" management panel; the detector already filters
   // these out of the active list.
   const [ignoredFiles, setIgnoredFiles] = useState<Record<string, string[]>>({});
+  // Paths silenced for every pair (right-click "ignore in all mods").
+  const [ignoredFilesGlobal, setIgnoredFilesGlobal] = useState<string[]>([]);
+  // The global path currently being unignored from its panel, so just that
+  // row's button disables during the round-trip.
+  const [pendingGlobalFile, setPendingGlobalFile] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
@@ -159,12 +167,14 @@ export default function Conflicts() {
     setLoading(true);
     setError(null);
     try {
-      const [conflictResult, modsResult, ignoredResult, ignoredFilesResult] = await Promise.all([
-        getConflicts(),
-        getMods(),
-        getIgnoredConflicts(),
-        getIgnoredConflictFiles(),
-      ]);
+      const [conflictResult, modsResult, ignoredResult, ignoredFilesResult, ignoredFilesGlobalResult] =
+        await Promise.all([
+          getConflicts(),
+          getMods(),
+          getIgnoredConflicts(),
+          getIgnoredConflictFiles(),
+          getIgnoredConflictFilesGlobal(),
+        ]);
 
       const map = new Map<string, ModWithThumbnail>();
       const gameBananaCounts = new Map<number, number>();
@@ -206,6 +216,7 @@ export default function Conflicts() {
       setConflicts(conflictResult);
       setIgnored(new Set(ignoredResult));
       setIgnoredFiles(ignoredFilesResult);
+      setIgnoredFilesGlobal(ignoredFilesGlobalResult);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -253,6 +264,41 @@ export default function Conflicts() {
       setError(String(err));
     } finally {
       setPendingPair(null);
+    }
+  };
+
+  // Silence a file for EVERY pair (right-click "ignore in all mods"). Pass the
+  // conflict so we can disable that card during the round-trip; re-detects
+  // because every pair sharing this file is affected.
+  const handleIgnoreFileEverywhere = async (conflict: ModConflict, filePath: string) => {
+    const key = getConflictIgnoreKey(conflict);
+    setPendingPair(key);
+    try {
+      const next = await ignoreConflictFileGlobal(filePath);
+      setIgnoredFilesGlobal(next);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  // Drop a path from the global ignore list so it can flag conflicts again.
+  const handleUnignoreFileGlobal = async (filePath: string) => {
+    setPendingGlobalFile(filePath);
+    try {
+      const next = await unignoreConflictFileGlobal(filePath);
+      setIgnoredFilesGlobal(next);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingGlobalFile(null);
     }
   };
 
@@ -444,7 +490,12 @@ export default function Conflicts() {
 
   const ignoredFilePairCount = Object.keys(ignoredFiles).length;
 
-  if (conflicts.length === 0 && ignored.size === 0 && ignoredFilePairCount === 0) {
+  if (
+    conflicts.length === 0 &&
+    ignored.size === 0 &&
+    ignoredFilePairCount === 0 &&
+    ignoredFilesGlobal.length === 0
+  ) {
     return (
       <div className="h-full flex items-center justify-center p-6">
         <EmptyState
@@ -617,6 +668,7 @@ export default function Conflicts() {
                     files={conflict.files}
                     busy={pendingPair === getConflictIgnoreKey(conflict)}
                     onIgnoreFile={(filePath) => handleIgnoreFile(conflict, filePath)}
+                    onIgnoreFileEverywhere={(filePath) => handleIgnoreFileEverywhere(conflict, filePath)}
                   />
                 )}
                 <ConflictReorderActions
@@ -757,6 +809,7 @@ export default function Conflicts() {
                     files={conflict.files}
                     busy={pendingPair === getConflictIgnoreKey(conflict)}
                     onIgnoreFile={(filePath) => handleIgnoreFile(conflict, filePath)}
+                    onIgnoreFileEverywhere={(filePath) => handleIgnoreFileEverywhere(conflict, filePath)}
                   />
                 )}
 
@@ -902,6 +955,37 @@ export default function Conflicts() {
                 </div>
               );
             })}
+          </div>
+        </div>
+      )}
+
+      {/* Globally ignored files panel: paths silenced for every pair via the
+          right-click "ignore in all mods" action. Unignoring re-runs detection
+          so any pair that genuinely overlaps on the path reappears. */}
+      {ignoredFilesGlobal.length > 0 && (
+        <div className="mt-10">
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+            <Globe className="w-4 h-4" />
+            <Tx k="conflicts.ignoredFilesGlobal.title" fallback="Ignored in all mods" />
+          </h3>
+          <div className="rounded-xl border border-border bg-bg-secondary divide-y divide-border">
+            {ignoredFilesGlobal.map((file) => (
+              <div key={file} className="flex items-center gap-3 px-4 py-2.5">
+                <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-tertiary" title={file}>
+                  {file}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleUnignoreFileGlobal(file)}
+                  disabled={pendingGlobalFile === file}
+                  title={t('conflicts.ignoredFilesGlobal.unignoreTitle')}
+                  className="flex-shrink-0 inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                >
+                  <Eye className="h-3.5 w-3.5" />
+                  <Tx k="conflicts.actions.unignore" fallback="Unignore" />
+                </button>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye, List, LayoutGrid, Trash2, Globe } from 'lucide-react';
+import { AlertTriangle, CheckCircle, RefreshCw, X, EyeOff, Eye, List, LayoutGrid, Trash2, Globe, Ban } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   getConflicts,
@@ -14,6 +14,9 @@ import {
   getIgnoredConflictFilesGlobal,
   ignoreConflictFileGlobal,
   unignoreConflictFileGlobal,
+  getIgnoredConflictMods,
+  ignoreConflictMod,
+  unignoreConflictMod,
   conflictPairKey,
   reorderMods,
 } from '../lib/api';
@@ -24,9 +27,38 @@ import { Button } from '../components/common/ui';
 import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, PageLayout, type ViewMode } from '../components/common/PageComponents';
 import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
 import ConflictFileList from '../components/conflicts/ConflictFileList';
+import { MenuRoot, MenuTrigger, MenuContent, MenuItem, MenuLabel } from '../components/common/menu';
 import Tx from '../components/translation/Tx';
 
 const CONFLICTS_VIEW_MODE_KEY = 'grimoire:conflicts-view-mode';
+
+/** Wraps a conflict card's mod thumbnail in a right-click menu. The thumbnails
+ *  are how you tell the two sides apart (the shared file path is identical), so
+ *  the per-mod "ignore everywhere" lives here rather than on a filename. */
+function ModThumbMenu({
+  modName,
+  busy,
+  onIgnoreMod,
+  children,
+}: {
+  modName: string;
+  busy: boolean;
+  onIgnoreMod: () => void;
+  children: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  return (
+    <MenuRoot>
+      <MenuTrigger asChild>{children}</MenuTrigger>
+      <MenuContent>
+        <MenuLabel>{modName}</MenuLabel>
+        <MenuItem icon={Ban} disabled={busy} onSelect={onIgnoreMod}>
+          {t('conflicts.actions.ignoreModEverywhere')}
+        </MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  );
+}
 
 /** Global load-order rank of a mod: lower = loads first. The pakNN (mod.priority)
  *  repeats per overflow folder, so fold in the folder index from metaKey
@@ -140,6 +172,10 @@ export default function Conflicts() {
   // The global path currently being unignored from its panel, so just that
   // row's button disables during the round-trip.
   const [pendingGlobalFile, setPendingGlobalFile] = useState<string | null>(null);
+  // Stable mod identities ignored wholesale (right-click "ignore this mod
+  // everywhere"), plus the one currently being unignored from its panel.
+  const [ignoredMods, setIgnoredMods] = useState<string[]>([]);
+  const [pendingIgnoredMod, setPendingIgnoredMod] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disableTarget, setDisableTarget] = useState<ModWithThumbnail | null>(null);
@@ -167,14 +203,21 @@ export default function Conflicts() {
     setLoading(true);
     setError(null);
     try {
-      const [conflictResult, modsResult, ignoredResult, ignoredFilesResult, ignoredFilesGlobalResult] =
-        await Promise.all([
-          getConflicts(),
-          getMods(),
-          getIgnoredConflicts(),
-          getIgnoredConflictFiles(),
-          getIgnoredConflictFilesGlobal(),
-        ]);
+      const [
+        conflictResult,
+        modsResult,
+        ignoredResult,
+        ignoredFilesResult,
+        ignoredFilesGlobalResult,
+        ignoredModsResult,
+      ] = await Promise.all([
+        getConflicts(),
+        getMods(),
+        getIgnoredConflicts(),
+        getIgnoredConflictFiles(),
+        getIgnoredConflictFilesGlobal(),
+        getIgnoredConflictMods(),
+      ]);
 
       const map = new Map<string, ModWithThumbnail>();
       const gameBananaCounts = new Map<number, number>();
@@ -217,6 +260,7 @@ export default function Conflicts() {
       setIgnored(new Set(ignoredResult));
       setIgnoredFiles(ignoredFilesResult);
       setIgnoredFilesGlobal(ignoredFilesGlobalResult);
+      setIgnoredMods(ignoredModsResult);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -283,6 +327,42 @@ export default function Conflicts() {
       setError(String(err));
     } finally {
       setPendingPair(null);
+    }
+  };
+
+  // Ignore a whole mod everywhere (right-click a conflict thumbnail). `identity`
+  // is the conflict's modAIdentity/modBIdentity; pass the conflict so its card
+  // disables during the round-trip. Re-detects because every conflict the mod
+  // is in is now suppressed.
+  const handleIgnoreMod = async (conflict: ModConflict, identity: string) => {
+    const key = getConflictIgnoreKey(conflict);
+    setPendingPair(key);
+    try {
+      const next = await ignoreConflictMod(identity);
+      setIgnoredMods(next);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingPair(null);
+    }
+  };
+
+  // Drop a mod identity from the ignore list so its conflicts flag again.
+  const handleUnignoreMod = async (identity: string) => {
+    setPendingIgnoredMod(identity);
+    try {
+      const next = await unignoreConflictMod(identity);
+      setIgnoredMods(next);
+      const fresh = await getConflicts();
+      setConflicts(fresh);
+      window.dispatchEvent(new CustomEvent('grimoire:conflicts-changed'));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setPendingIgnoredMod(null);
     }
   };
 
@@ -494,7 +574,8 @@ export default function Conflicts() {
     conflicts.length === 0 &&
     ignored.size === 0 &&
     ignoredFilePairCount === 0 &&
-    ignoredFilesGlobal.length === 0
+    ignoredFilesGlobal.length === 0 &&
+    ignoredMods.length === 0
   ) {
     return (
       <div className="h-full flex items-center justify-center p-6">
@@ -597,17 +678,23 @@ export default function Conflicts() {
             const variantA = getVariantLabel(modA);
             const variantB = getVariantLabel(modB);
 
-            const renderListSide = (mod: ModWithThumbnail, variant: string | null) => (
+            const renderListSide = (mod: ModWithThumbnail, variant: string | null, identity: string) => (
               <div className="min-w-0 flex items-center gap-3">
-                <div className="h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-bg-tertiary">
-                  {mod.thumbnailUrl ? (
-                    <img src={mod.thumbnailUrl} alt={mod.name} className="h-full w-full object-cover" />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center text-[11px] text-text-tertiary">
-                      <Tx k="conflicts.noPreview" fallback="No Preview" />
-                    </div>
-                  )}
-                </div>
+                <ModThumbMenu
+                  modName={mod.name}
+                  busy={pendingPair === getConflictIgnoreKey(conflict)}
+                  onIgnoreMod={() => handleIgnoreMod(conflict, identity)}
+                >
+                  <div className="h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-bg-tertiary">
+                    {mod.thumbnailUrl ? (
+                      <img src={mod.thumbnailUrl} alt={mod.name} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-[11px] text-text-tertiary">
+                        <Tx k="conflicts.noPreview" fallback="No Preview" />
+                      </div>
+                    )}
+                  </div>
+                </ModThumbMenu>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-medium text-text-primary" title={mod.name}>
                     {mod.name}
@@ -657,11 +744,11 @@ export default function Conflicts() {
                   </button>
                 </div>
                 <div className="grid grid-cols-[minmax(0,1fr)_2rem_minmax(0,1fr)] items-center gap-3 p-4">
-                  {renderListSide(modA, variantA)}
+                  {renderListSide(modA, variantA, conflict.modAIdentity)}
                   <span className="text-center text-sm font-bold text-text-tertiary">
                     <Tx k="common.versus" fallback="VS" />
                   </span>
-                  {renderListSide(modB, variantB)}
+                  {renderListSide(modB, variantB, conflict.modBIdentity)}
                 </div>
                 {conflict.conflictType === 'file' && conflict.files && conflict.files.length > 0 && (
                   <ConflictFileList
@@ -718,29 +805,35 @@ export default function Conflicts() {
                 <div className="p-4 grid grid-cols-[minmax(0,1fr)_2rem_minmax(0,1fr)] gap-3 items-start">
                   {/* Mod A Card */}
                   <div className="min-w-0 group">
-                    <div className="relative w-full aspect-video bg-bg-tertiary rounded-lg overflow-hidden mb-2">
-                      {modA.thumbnailUrl ? (
-                        <img
-                          src={modA.thumbnailUrl}
-                          alt={modA.name}
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-text-tertiary">
-                          <Tx k="conflicts.noPreview" fallback="No Preview" />
-                        </div>
-                      )}
-                      <button
-                        onClick={() => setDisableTarget(modA)}
-                        aria-label={t('conflicts.actions.disableNamed', { name: modA.name })}
-                        className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
-                      >
-                        <span className="text-white text-sm font-medium flex items-center gap-1">
-                          <X className="w-4 h-4" />
-                          <Tx k="conflicts.actions.disable" fallback="Disable" />
-                        </span>
-                      </button>
-                    </div>
+                    <ModThumbMenu
+                      modName={modA.name}
+                      busy={pendingPair === getConflictIgnoreKey(conflict)}
+                      onIgnoreMod={() => handleIgnoreMod(conflict, conflict.modAIdentity)}
+                    >
+                      <div className="relative w-full aspect-video bg-bg-tertiary rounded-lg overflow-hidden mb-2">
+                        {modA.thumbnailUrl ? (
+                          <img
+                            src={modA.thumbnailUrl}
+                            alt={modA.name}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-text-tertiary">
+                            <Tx k="conflicts.noPreview" fallback="No Preview" />
+                          </div>
+                        )}
+                        <button
+                          onClick={() => setDisableTarget(modA)}
+                          aria-label={t('conflicts.actions.disableNamed', { name: modA.name })}
+                          className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
+                        >
+                          <span className="text-white text-sm font-medium flex items-center gap-1">
+                            <X className="w-4 h-4" />
+                            <Tx k="conflicts.actions.disable" fallback="Disable" />
+                          </span>
+                        </button>
+                      </div>
+                    </ModThumbMenu>
                     <p className="text-sm font-medium text-text-primary text-center break-words" title={modA.name}>
                       {modA.name}
                     </p>
@@ -765,29 +858,35 @@ export default function Conflicts() {
 
                   {/* Mod B Card */}
                   <div className="min-w-0 group">
-                    <div className="relative w-full aspect-video bg-bg-tertiary rounded-lg overflow-hidden mb-2">
-                      {modB.thumbnailUrl ? (
-                        <img
-                          src={modB.thumbnailUrl}
-                          alt={modB.name}
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-text-tertiary">
-                          <Tx k="conflicts.noPreview" fallback="No Preview" />
-                        </div>
-                      )}
-                      <button
-                        onClick={() => setDisableTarget(modB)}
-                        aria-label={t('conflicts.actions.disableNamed', { name: modB.name })}
-                        className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
-                      >
-                        <span className="text-white text-sm font-medium flex items-center gap-1">
-                          <X className="w-4 h-4" />
-                          <Tx k="conflicts.actions.disable" fallback="Disable" />
-                        </span>
-                      </button>
-                    </div>
+                    <ModThumbMenu
+                      modName={modB.name}
+                      busy={pendingPair === getConflictIgnoreKey(conflict)}
+                      onIgnoreMod={() => handleIgnoreMod(conflict, conflict.modBIdentity)}
+                    >
+                      <div className="relative w-full aspect-video bg-bg-tertiary rounded-lg overflow-hidden mb-2">
+                        {modB.thumbnailUrl ? (
+                          <img
+                            src={modB.thumbnailUrl}
+                            alt={modB.name}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-text-tertiary">
+                            <Tx k="conflicts.noPreview" fallback="No Preview" />
+                          </div>
+                        )}
+                        <button
+                          onClick={() => setDisableTarget(modB)}
+                          aria-label={t('conflicts.actions.disableNamed', { name: modB.name })}
+                          className="absolute inset-x-0 bottom-0 bg-red-600 hover:bg-red-500 flex items-center justify-center py-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white cursor-pointer"
+                        >
+                          <span className="text-white text-sm font-medium flex items-center gap-1">
+                            <X className="w-4 h-4" />
+                            <Tx k="conflicts.actions.disable" fallback="Disable" />
+                          </span>
+                        </button>
+                      </div>
+                    </ModThumbMenu>
                     <p className="text-sm font-medium text-text-primary text-center break-words" title={modB.name}>
                       {modB.name}
                     </p>
@@ -986,6 +1085,62 @@ export default function Conflicts() {
                 </button>
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Ignored mods panel: mods dismissed wholesale via the thumbnail
+          right-click. Shows each mod's preview with an "Ignored" tag so it's
+          easy to see what's silenced; unignoring re-runs detection. */}
+      {ignoredMods.length > 0 && (
+        <div className="mt-10">
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+            <Ban className="w-4 h-4" />
+            <Tx k="conflicts.ignoredMods.title" fallback="Ignored mods" />
+          </h3>
+          <div className="rounded-xl border border-border bg-bg-secondary divide-y divide-border">
+            {ignoredMods.map((identity) => {
+              const m = modsMap.get(identity);
+              const name = m?.name ?? t('conflicts.removedMod');
+              const variant = m ? getVariantLabel(m) : null;
+              return (
+                <div key={identity} className="flex items-center gap-3 px-4 py-2.5">
+                  <div className="h-12 w-16 flex-shrink-0 overflow-hidden rounded bg-bg-tertiary">
+                    {m?.thumbnailUrl ? (
+                      <img src={m.thumbnailUrl} alt={name} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-[10px] text-text-tertiary">
+                        <Tx k="conflicts.noPreview" fallback="No Preview" />
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm text-text-primary" title={name}>{name}</span>
+                      <span className="flex-shrink-0 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-400">
+                        <Tx k="conflicts.ignoredMods.tag" fallback="Ignored" />
+                      </span>
+                    </div>
+                    {variant && (
+                      <p className="truncate text-xs text-accent" title={variant}>{variant}</p>
+                    )}
+                    {m?.fileName && (
+                      <p className="truncate text-[11px] font-mono text-text-tertiary" title={m.fileName}>{m.fileName}</p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleUnignoreMod(identity)}
+                    disabled={pendingIgnoredMod === identity}
+                    title={t('conflicts.ignoredMods.unignoreTitle')}
+                    className="flex-shrink-0 inline-flex items-center gap-1 rounded px-2.5 py-1 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+                  >
+                    <Eye className="h-3.5 w-3.5" />
+                    <Tx k="conflicts.actions.unignore" fallback="Unignore" />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -291,10 +291,8 @@ export default function Conflicts() {
     }
   };
 
-  // Dismiss a single overlapping file for this pair forever. Re-detects after
-  // persisting: the detector recomputes `details`/`files` from what's left and
-  // drops the pair if that was the last shared file (no skeleton flash, same
-  // as handleUnignore).
+  // Dismiss one overlapping file for this pair; re-detect drops the pair if it
+  // was the last shared file.
   const handleIgnoreFile = async (conflict: ModConflict, filePath: string) => {
     const key = getConflictIgnoreKey(conflict);
     setPendingPair(key);
@@ -311,9 +309,8 @@ export default function Conflicts() {
     }
   };
 
-  // Silence a file for EVERY pair (right-click "ignore in all mods"). Pass the
-  // conflict so we can disable that card during the round-trip; re-detects
-  // because every pair sharing this file is affected.
+  // Silence a file for every pair (right-click "ignore in all mods"); pass the
+  // conflict so its card disables during the round-trip.
   const handleIgnoreFileEverywhere = async (conflict: ModConflict, filePath: string) => {
     const key = getConflictIgnoreKey(conflict);
     setPendingPair(key);
@@ -330,10 +327,8 @@ export default function Conflicts() {
     }
   };
 
-  // Ignore a whole mod everywhere (right-click a conflict thumbnail). `identity`
-  // is the conflict's modAIdentity/modBIdentity; pass the conflict so its card
-  // disables during the round-trip. Re-detects because every conflict the mod
-  // is in is now suppressed.
+  // Ignore a whole mod everywhere (right-click a conflict thumbnail); `identity`
+  // is the conflict's modAIdentity/modBIdentity.
   const handleIgnoreMod = async (conflict: ModConflict, identity: string) => {
     const key = getConflictIgnoreKey(conflict);
     setPendingPair(key);

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -7039,10 +7039,14 @@ interface ImportCustomModModalProps {
 }
 
 const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
+// Local mod import accepts a bare VPK or an archive we extract on the main side.
+const VPK_IMPORT_EXTS = ['vpk', 'zip', '7z', 'rar'];
+const VPK_IMPORT_RE = /\.(vpk|zip|7z|rar)$/i;
 
 function deriveModNameFromPath(p: string): string {
   const base = p.split(/[\\/]/).pop() ?? '';
   return base
+    .replace(/\.(zip|7z|rar)$/i, '')
     .replace(/_dir\.vpk$/i, '')
     .replace(/\.vpk$/i, '')
     .replace(/^pak\d{2}_/, '')
@@ -7096,7 +7100,7 @@ function ImportCustomModModal({
     if (lockVpk) return;
     const picked = await showOpenDialog({
       title: t('installed.import.selectVpk'),
-      filters: [{ name: 'VPK files', extensions: ['vpk'] }],
+      filters: [{ name: 'VPK or archive', extensions: VPK_IMPORT_EXTS }],
     });
     if (picked) acceptVpkPath(picked);
   };
@@ -7116,13 +7120,15 @@ function ImportCustomModModal({
     if (lockVpk) return;
     const file = e.dataTransfer.files?.[0];
     if (!file) return;
-    if (!/\.vpk$/i.test(file.name)) {
+    if (!VPK_IMPORT_RE.test(file.name)) {
       setError(t('installed.import.expectedVpk', { name: file.name }));
       return;
     }
     const path = window.electronAPI.getDroppedFilePath(file);
     if (!path) {
-      setError(t('locker.soulImport.errors.dropPathUnresolved'));
+      // No real on-disk path: almost always a file dragged out of Windows'
+      // built-in zip viewer (a virtual shell file). Point them at the zip itself.
+      setError(t('installed.import.dropUnresolved'));
       return;
     }
     acceptVpkPath(path);

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -822,6 +822,9 @@ export interface ElectronAPI {
     getIgnoredConflictFilesGlobal: () => Promise<string[]>;
     ignoreConflictFileGlobal: (filePath: string) => Promise<string[]>;
     unignoreConflictFileGlobal: (filePath: string) => Promise<string[]>;
+    getIgnoredConflictMods: () => Promise<string[]>;
+    ignoreConflictMod: (identity: string) => Promise<string[]>;
+    unignoreConflictMod: (identity: string) => Promise<string[]>;
 
     // Profiles
     getProfiles: () => Promise<Profile[]>;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -816,6 +816,9 @@ export interface ElectronAPI {
     getIgnoredConflicts: () => Promise<string[]>;
     ignoreConflict: (modA: string, modB: string) => Promise<string[]>;
     unignoreConflict: (modA: string, modB: string) => Promise<string[]>;
+    getIgnoredConflictFiles: () => Promise<Record<string, string[]>>;
+    ignoreConflictFile: (ignoreKey: string, filePath: string) => Promise<Record<string, string[]>>;
+    unignoreConflictFile: (ignoreKey: string, filePath: string | null) => Promise<Record<string, string[]>>;
 
     // Profiles
     getProfiles: () => Promise<Profile[]>;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -819,6 +819,9 @@ export interface ElectronAPI {
     getIgnoredConflictFiles: () => Promise<Record<string, string[]>>;
     ignoreConflictFile: (ignoreKey: string, filePath: string) => Promise<Record<string, string[]>>;
     unignoreConflictFile: (ignoreKey: string, filePath: string | null) => Promise<Record<string, string[]>>;
+    getIgnoredConflictFilesGlobal: () => Promise<string[]>;
+    ignoreConflictFileGlobal: (filePath: string) => Promise<string[]>;
+    unignoreConflictFileGlobal: (filePath: string) => Promise<string[]>;
 
     // Profiles
     getProfiles: () => Promise<Profile[]>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -801,6 +801,10 @@ export interface ModConflict {
   ignoreKey: string;
   conflictType: 'priority' | 'file';
   details: string;
+  /** For `file` conflicts: every overlapping path still flagged for this pair
+   *  (after subtracting any individually ignored files). Drives the per-file
+   *  ignore UI. Undefined for `priority` conflicts. */
+  files?: string[];
 }
 
 /** The customizable launcher/sidebar art surfaces (issue: unify launcher
@@ -872,6 +876,12 @@ export interface AppSettings {
    *  pair is hidden without persisting it to ignoredConflicts, so toggling
    *  back off restores the original conflict view. */
   ignoreConflictsByDefault: boolean;
+  /** Per-pair ignored overlapping file paths. Keyed by the same stable
+   *  identity pair key as ignoredConflicts ("identityA::identityB" sorted);
+   *  the value lists individual paths the user dismissed. A file conflict is
+   *  only hidden entirely when every overlapping path lands here. Lets users
+   *  silence one shared file forever while still being warned about others. */
+  ignoredConflictFiles?: Record<string, string[]>;
   /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
    *  focus rings throughout the app. */
   accentColor: string;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -882,6 +882,11 @@ export interface AppSettings {
    *  only hidden entirely when every overlapping path lands here. Lets users
    *  silence one shared file forever while still being warned about others. */
   ignoredConflictFiles?: Record<string, string[]>;
+  /** Overlapping file paths the user has globally silenced: never counted as a
+   *  conflict for ANY mod pair (the user-curated companion to the built-in
+   *  compiler-artifact filter). For files that are never a real conflict no
+   *  matter which mods ship them, e.g. a shared build artifact. */
+  ignoredConflictFilesGlobal?: string[];
   /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
    *  focus rings throughout the app. */
   accentColor: string;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -887,6 +887,11 @@ export interface AppSettings {
    *  compiler-artifact filter). For files that are never a real conflict no
    *  matter which mods ship them, e.g. a shared build artifact. */
   ignoredConflictFilesGlobal?: string[];
+  /** Stable mod identities (same scheme as the halves of an ignoredConflicts
+   *  pair key) the user has dismissed wholesale: any conflict involving the
+   *  mod, against any other mod, is suppressed. Right-click a mod in a
+   *  conflict -> "ignore this mod everywhere". */
+  ignoredConflictMods?: string[];
   /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
    *  focus rings throughout the app. */
   accentColor: string;


### PR DESCRIPTION
This PR bundles conflict-handling improvements plus two smaller changes.

---

## 1. Conflict ignore controls

Reduces false-positive conflicts and gives finer control over what gets flagged. Three layers:

**a. Built-in artifact filter.** `panorama/image_compiler.vdata_c` is a Source 2 panorama image-compiler artifact co-shipped by any mod that touches panorama, so unrelated mods collide on it even though the assets they actually change don't overlap. It's now treated as a non-conflict (matched by full path), same class as the existing `materials/default/default_*` fallback-texture filter. Pairs colliding only on it disappear automatically.

**b. Per-pair file ignore "forever".** Adds per-file granularity to dismissal. Within a conflict you can dismiss **specific overlapping file paths** while the pair stays flagged for any files that still overlap; when every overlapping path is ignored, the conflict drops out entirely.
- Detector returns the full overlap list on `ModConflict.files` and subtracts per-pair ignored files (`ignoredConflictFiles: Record<pairKey, string[]>`, keyed by the same stable identity pair key as `ignoredConflicts`, so it survives reinstalls/re-downloads).
- UI: collapsible "Shared files (N)" list with a per-file Ignore button (grid + list views) and an "Ignored files" management panel (per-file Unignore + Restore all).

**c. Global file ignore.** Right-click a shared file -> "Ignore in all mods": the path is never flagged for **any** pair again (`ignoredConflictFilesGlobal: string[]`, subtracted from every pair). The user-curated companion to the built-in artifact filter, for files that are never a real conflict no matter which mods ship them. An "Ignored in all mods" panel lists and restores them.

**d. Whole-mod ignore.** Right-click a mod in a conflict -> "Ignore this mod everywhere": every conflict that mod is in, against any other mod, is suppressed (`ignoredConflictMods: string[]`, matched on the stable per-mod identity the detector already stamps as `modAIdentity`/`modBIdentity`, so it survives reinstalls/re-downloads). The coarsest dismissal: for a mod you never want flagged regardless of what it collides with. An "Ignored mods" panel lists and restores them.

New IPC for (b), (c), and (d) is wired through the single-sourced contract (`electron.ts`), preload, and `api.ts`. Everything is reversible. Priority (same-slot) conflicts are unaffected (no `files`).

---

## 2. Import `.zip` / `.7z` / `.rar` archives for local mods (`93f051b`)

Lets users drag a whole archive (or pick one) into the custom-mod import, not just a bare `.vpk`. Archives are extracted on the main side via the existing extract service and every contained `.vpk` is imported into its own enabled slot (multi-VPK archives get a numeric suffix). Steers people away from dragging a `.vpk` out of Windows' built-in zip viewer (a virtual shell file with no on-disk path); the drop zone shows a clear hint if a dropped file resolves to no real path.

---

## 3. Merged-VPK contents shown in load order (`0706275`)

The merged-VPK contents popup (`MergedContentsModal`) rendered `merged.sources` in the merger's stored order, which is sorted descending by priority because vpkmerge is last-input-wins. That displayed the collision winner (loads first) at the bottom, inverted vs every other load-order list in the app. Now renders a copy sorted ascending by `priorityAtMergeTime` so the lowest-pakNN source (loads first, wins collisions) is on top, matching the Installed load-order list and the Merge Mods modal. Display-only: the stored snapshot that drives extract/unmerge is untouched.

---

## Verification

- `pnpm lint`: clean on all touched files
- `pnpm i18n:check`: passes (all referenced keys exist); manifest regenerated, `--check` green
- TypeScript: feature files compile clean
