### PR TITLE
fix(locker): thumbnail fallback and harden the soul-container canvas

### DIFF
--- a/src/components/locker/SoulContainerCanvas.tsx
+++ b/src/components/locker/SoulContainerCanvas.tsx
@@ -48,6 +48,10 @@ function TiledRenderer({ paneRef }: { paneRef: RefObject<HTMLElement | null> }) 
       cam.position.set(0, 0.35, 3);
       cam.lookAt(0, 0, 0);
       cameraRef.current = cam;
+      // Force a fully transparent clear so this full-window overlay can never
+      // composite an opaque (black) buffer over the card grid, regardless of the
+      // driver's default clearAlpha for an alpha:true context.
+      gl.setClearColor(0x000000, 0);
     }
     if (!sceneRef.current) {
       // One lit scene reused for every tile, with a dedicated holder group the

--- a/src/components/locker/SoulContainerTile.tsx
+++ b/src/components/locker/SoulContainerTile.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type * as THREE from 'three';
 import { Loader2 } from 'lucide-react';
 import { getSoulModelInfo, exportSoulModel } from '../../lib/api';
 import { loadGltfPreview } from '../../lib/loadGltfPreview';
 import { buildNormalizedRoot, disposeScene, meshUrlFor } from './soulModel';
 import { useSoulRegistry } from './soulRegistry';
+import ModThumbnail from '../ModThumbnail';
 
 /**
  * One soul-container card's 3D preview, for the Locker's Global view.
@@ -23,13 +25,19 @@ import { useSoulRegistry } from './soulRegistry';
  * until the new one is ready, so selecting a card never flickers.
  *
  * The whole Locker card is the enable/disable control, so the track element is
- * pointer-events-none; clicks pass through to toggle the mod. On any failure it
- * renders nothing, leaving the card's clear window.
+ * pointer-events-none; clicks pass through to toggle the mod. When the model
+ * can't be exported/decoded (e.g. a legacy-layout mesh older vpkmerge builds
+ * couldn't read), it falls back to the mod's 2D GameBanana thumbnail rather than
+ * leaving an empty window.
  */
 export default function SoulContainerTile({
   tileId,
   modKey,
   entry,
+  thumbnailUrl,
+  name,
+  nsfw,
+  hideNsfw,
 }: {
   /** Content-stable id (sha256) used as the registry key, so the model survives
    *  the metaKey change that a toggle causes. */
@@ -41,7 +49,14 @@ export default function SoulContainerTile({
   /** Model entry to export. Defaults to the soul-container model; a spirit urn
    *  passes its own entry (`idol_urn.vmdl_c`) so the tile shows the urn model. */
   entry?: string;
+  /** GameBanana thumbnail, shown as the 2D fallback when the model fails. */
+  thumbnailUrl?: string;
+  /** Mod name, used as the thumbnail's alt text. */
+  name?: string;
+  nsfw?: boolean;
+  hideNsfw?: boolean;
 }) {
+  const { t } = useTranslation();
   const registry = useSoulRegistry();
   const trackRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<THREE.Object3D | null>(null);
@@ -116,17 +131,30 @@ export default function SoulContainerTile({
     };
   }, [tileId, registry]);
 
-  // Failure: render nothing so the card's clear window shows.
-  if (failed) return null;
-
-  // The track element always renders (even before load) so the shared canvas
-  // has a rect to scissor into once the model is ready.
+  // The track element always renders (even before load, and on failure) so the
+  // shared canvas keeps a stable rect to register; on failure the model is never
+  // set, so the canvas skips this tile and only the 2D thumbnail shows.
   return (
     <div ref={trackRef} className="pointer-events-none absolute inset-0">
-      {generating && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/30">
-          <Loader2 className="h-5 w-5 animate-spin text-white/80" />
-        </div>
+      {failed ? (
+        <ModThumbnail
+          src={thumbnailUrl}
+          alt={name ?? ''}
+          nsfw={nsfw}
+          hideNsfw={hideNsfw}
+          className="h-full w-full"
+          fallback={
+            <div className="flex h-full w-full items-center justify-center text-xs text-text-secondary">
+              {t('locker.page.noPreview')}
+            </div>
+          }
+        />
+      ) : (
+        generating && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+            <Loader2 className="h-5 w-5 animate-spin text-white/80" />
+          </div>
+        )
       )}
     </div>
   );

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -14,6 +14,7 @@ import { getAssetPath } from '../lib/assetPath';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import { LockerHeroView } from './LockerHero';
 import ModThumbnail from '../components/ModThumbnail';
+import { ErrorBoundary } from '../components/common/ErrorBoundary';
 
 // Heavy (three.js): only pulled in when the soul-container type is viewed.
 import { SoulRegistryProvider } from '../components/locker/SoulRegistryProvider';
@@ -1478,6 +1479,10 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                               tileId={mod.sha256 ?? mod.id}
                               modKey={mod.metaKey}
                               entry={activeType === 'spirit-urn' ? URN_MODEL_ENTRY : undefined}
+                              thumbnailUrl={mod.thumbnailUrl}
+                              name={mod.name}
+                              nsfw={mod.nsfw}
+                              hideNsfw={hideNsfw}
                             />
                           </Suspense>
                         ) : (
@@ -1643,9 +1648,14 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             non-prop tab and back was the main source of the model flicker. On a
             non-prop tab the registry is empty, so it simply paints nothing (a
             transparent, pointer-events-none overlay), which is cheap. */}
-        <Suspense fallback={null}>
-          <SoulContainerCanvas paneRef={paneRef} />
-        </Suspense>
+        {/* Local boundary: a WebGL context-creation / r3f failure degrades to no
+            live canvas (tiles fall back to 2D thumbnails) instead of bubbling to
+            the app-level boundary, which would replace the whole app shell. */}
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <SoulContainerCanvas paneRef={paneRef} />
+          </Suspense>
+        </ErrorBoundary>
       </div>
 
       {/* Retag menu (fixed-positioned, anchored at the kebab's viewport coords so

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1649,8 +1649,10 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             non-prop tab the registry is empty, so it simply paints nothing (a
             transparent, pointer-events-none overlay), which is cheap. */}
         {/* Local boundary: a WebGL context-creation / r3f failure degrades to no
-            live canvas (tiles fall back to 2D thumbnails) instead of bubbling to
-            the app-level boundary, which would replace the whole app shell. */}
+            live canvas instead of bubbling to the app-level boundary, which would
+            replace the whole app shell. Tiles that already failed to export keep
+            showing their 2D thumbnails; tiles that exported fine just lose the live
+            3D preview (the card chrome stays). */}
         <ErrorBoundary fallback={null}>
           <Suspense fallback={null}>
             <SoulContainerCanvas paneRef={paneRef} />


### PR DESCRIPTION
## Problem

Reported in Discord (help > "black screen upon entering locker > global"): entering Locker > Global showed a fully black content pane for some users on modern hardware, not reproducible for most.

Root cause: a soul-container mod whose `soul_container.vmdl_c` uses the legacy VBIB/`MBUF` mesh layout couldn't be decoded by the bundled vpkmerge, so its `export-soul-model` handler failed on every Global-tab load. The tile then rendered an empty window, and the shared full-window WebGL overlay could composite an opaque buffer over the whole pane.

## Fix (client-side resilience)

- **`SoulContainerTile`**: on export/decode failure, fall back to the mod's 2D GameBanana thumbnail instead of leaving an empty window.
- **`SoulContainerCanvas`**: force a fully transparent clear (`setClearColor(0,0,0,0)`) so the full-window overlay can never composite an opaque (black) buffer over the card grid.
- **`Locker`**: wrap the shared canvas in a local `ErrorBoundary` so a WebGL context-creation / r3f failure degrades to the 2D fallback rather than bubbling to the app-level boundary (which would blank the whole shell).

## The actual decode fix

The undecodable mesh is fixed upstream in vpkmerge (`fix(model): decode legacy VBIB/MBUF embedded-mesh layout`). This PR is the client-side resilience so one bad mod can never take down the entire Global pane. Shipping the decoder fix to users is a follow-up: cut a vpkmerge release, then bump `VPKMERGE_VERSION` + the sha256s in `scripts/fetch-vpkmerge.mjs`.

## Verification

- `tsc` + `eslint` clean on the changed files.
- Decoder fix verified separately: GameBanana mods #600780 / #618599 now export valid GLBs via the rebuilt binary.
- GUI smoke test (open Locker > Global with a legacy-layout soul container) still to run with a local Deadlock install.
