### PR TITLE
fix(install): keep every variant when an archive ships same-named VPKs in sibling folders

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -30,7 +30,7 @@ import {
     type UnknownModFilterGuess,
 } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
-import { extractArchive, isArchive } from '../services/extract';
+import { extractArchive, isArchive, type ExtractedVpk } from '../services/extract';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
 import { buildHeroSoundSwapVpk, cleanupHeroSoundSwapBuild } from '../services/foundryCatalog';
 import { buildSoulContainerVpk, cleanupSoulContainerBuild, previewSoulContainerGlb } from '../services/soulContainerImport';
@@ -943,10 +943,10 @@ ipcMain.handle(
         // Resolve the list of source VPKs to import. A bare .vpk is a single
         // source; an archive is extracted to a temp dir first and every VPK it
         // contains becomes its own import (extractArchive already filters to .vpk).
-        let sourceVpks: string[];
+        let sourceVpks: ExtractedVpk[];
         let tempDir: string | undefined;
         if (isVpk) {
-            sourceVpks = [vpkPath];
+            sourceVpks = [{ path: vpkPath, fileName: basename(vpkPath) }];
         } else {
             tempDir = await fs.mkdtemp(join(tmpdir(), 'grimoire-import-'));
             try {
@@ -973,7 +973,7 @@ ipcMain.handle(
                 const destPath = await allocateEnabledVpkPath(deadlockPath);
                 const destMetaKey = metaKeyFor(destPath);
 
-                await fs.copyFile(sourceVpks[i], destPath);
+                await fs.copyFile(sourceVpks[i].path, destPath);
 
                 // Scrub any orphan metadata at this slot before writing.
                 // setModMetadata merges into the existing entry, so stale fields

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -4,7 +4,7 @@ import { join, basename, extname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { BrowserWindow } from 'electron';
 import { getDisabledPath } from './deadlock';
-import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles } from './extract';
+import { extractArchive, isArchive, checkOneClickOptOut, scanSuspiciousFiles, type ExtractedVpk } from './extract';
 import { randomUUID } from 'crypto';
 import { setModMetadataWithHash, getModMetadata } from './metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
@@ -546,23 +546,38 @@ async function downloadFile(
  * library is effectively uncapped. A real pakNN slot is assigned later, on
  * enable. Returns the final filenames.
  */
+interface RenamedVpk {
+    /** Final on-disk (disabled) filename. */
+    fileName: string;
+    /** The archive variant folder this VPK came from, if any. */
+    archiveFolder?: string;
+}
+
+/** Title-case a variant folder for display: `Tailed_mod_Beard` -> `Tailed Mod Beard`. */
+function prettifyVariant(folder: string): string {
+    return folder
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 async function renameVpksToAvoidConflicts(
     _deadlockPath: string,
     targetPath: string,
-    extractedVpks: string[],
+    extractedVpks: ExtractedVpk[],
     nameHint?: string
-): Promise<string[]> {
+): Promise<RenamedVpk[]> {
     const taken = existsSync(targetPath)
         ? new Set((await fs.readdir(targetPath)).map((n) => n.toLowerCase()))
         : new Set<string>();
-    const renamedFiles: string[] = [];
+    const renamedFiles: RenamedVpk[] = [];
 
-    for (const vpkPath of extractedVpks) {
-        const fileName = basename(vpkPath);
+    for (const { path: vpkPath, fileName, archiveFolder } of extractedVpks) {
         // Prefer the extracted VPK's own descriptive name; for bare pakNN
-        // downloads fall back to the mod's GameBanana name so the disabled file
-        // is still readable on disk.
-        const finalFileName = makeDisabledFileName(fileName, taken, nameHint);
+        // downloads fall back to the variant folder (so sibling variants get
+        // distinct, readable names) and then the mod's GameBanana name.
+        const finalFileName = makeDisabledFileName(fileName, taken, nameHint, archiveFolder);
         taken.add(finalFileName.toLowerCase());
 
         if (finalFileName !== fileName) {
@@ -570,7 +585,7 @@ async function renameVpksToAvoidConflicts(
         }
 
         await moveFileWithoutOverwrite(vpkPath, join(targetPath, finalFileName));
-        renamedFiles.push(finalFileName);
+        renamedFiles.push({ fileName: finalFileName, archiveFolder });
     }
 
     return renamedFiles;
@@ -739,13 +754,17 @@ async function executeDownload(
     };
 
     let installedVpks: string[] = [];
+    // Final disabled filename -> prettified variant folder, for multi-variant
+    // archives (e.g. Tailed_mod vs Tailed_mod_Beard). Drives the picker label
+    // and the persisted variantLabel.
+    const variantByFile = new Map<string, string>();
 
     // Extract if archive
     if (isArchive(downloadPath)) {
         console.log(`[downloadMod] Extracting archive...`);
         mainWindow?.webContents.send('download-extracting', { modId, fileId });
 
-        let extractedVpks: string[];
+        let extractedVpks: ExtractedVpk[];
         try {
             extractedVpks = await extractArchive(downloadPath, workDir);
         } catch (extractError) {
@@ -780,7 +799,11 @@ async function executeDownload(
         console.log(`[downloadMod] Extracted ${extractedVpks.length} VPK files:`, extractedVpks);
 
         // Rename VPKs to avoid conflicts
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, details.name);
+        const renamed = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, details.name);
+        for (const r of renamed) {
+            if (r.archiveFolder) variantByFile.set(r.fileName, prettifyVariant(r.archiveFolder));
+        }
+        installedVpks = renamed.map((r) => r.fileName);
 
         // Multi-VPK archive (Warden Remodel et al). Previously kept only
         // the alphabetically-first VPK and silently unlinked the rest —
@@ -792,6 +815,10 @@ async function executeDownload(
             const vpkLabels = getVpkLabels(
                 installedVpks.map((vpk) => ({ fileName: vpk, absPath: join(targetPath, vpk) }))
             );
+            // The author's variant folder is a more reliable picker label than
+            // the heuristic VPK content summary, which returns the same hero for
+            // every variant of a skin.
+            for (const [vpk, label] of variantByFile) vpkLabels[vpk] = label;
             const vpkFileSizes = Object.fromEntries(
                 await Promise.all(
                     installedVpks.map(async (vpk) => {
@@ -848,7 +875,13 @@ async function executeDownload(
         }
     } else if (extname(downloadPath).toLowerCase() === '.vpk') {
         // Direct VPK download
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath], details.name);
+        const renamed = await renameVpksToAvoidConflicts(
+            deadlockPath,
+            targetPath,
+            [{ path: downloadPath, fileName: basename(downloadPath) }],
+            details.name
+        );
+        installedVpks = renamed.map((r) => r.fileName);
     }
 
     // Save metadata for each installed VPK
@@ -856,7 +889,9 @@ async function executeDownload(
     for (const vpkFileName of installedVpks) {
         console.log(`[downloadMod] Saving metadata for: ${vpkFileName}`);
         const vpkPath = join(targetPath, vpkFileName);
-        const perVpkMetadata = stampVpkLockerHero(metadata, section, vpkPath);
+        const base = stampVpkLockerHero(metadata, section, vpkPath);
+        const variantLabel = variantByFile.get(vpkFileName);
+        const perVpkMetadata = variantLabel ? { ...base, variantLabel } : base;
         await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
     }
 
@@ -1236,11 +1271,12 @@ async function executeOneClickDownload(
     };
 
     let installedVpks: string[] = [];
+    const variantByFile = new Map<string, string>();
 
     if (isArchive(downloadPath)) {
         mainWindow?.webContents.send('download-extracting', { modId, fileId });
 
-        let extractedVpks: string[];
+        let extractedVpks: ExtractedVpk[];
         try {
             extractedVpks = await extractArchive(downloadPath, workDir);
         } catch (extractError) {
@@ -1269,7 +1305,11 @@ async function executeOneClickDownload(
             throw extractError;
         }
 
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, oneClickModName);
+        const renamed = await renameVpksToAvoidConflicts(deadlockPath, targetPath, extractedVpks, oneClickModName);
+        for (const r of renamed) {
+            if (r.archiveFolder) variantByFile.set(r.fileName, prettifyVariant(r.archiveFolder));
+        }
+        installedVpks = renamed.map((r) => r.fileName);
 
         // Multi-VPK 1-Click archive: prompt the user instead of silently
         // dropping all but the first entry. Same shape as the regular
@@ -1280,6 +1320,7 @@ async function executeOneClickDownload(
             const vpkLabels = getVpkLabels(
                 installedVpks.map((vpk) => ({ fileName: vpk, absPath: join(targetPath, vpk) }))
             );
+            for (const [vpk, label] of variantByFile) vpkLabels[vpk] = label;
             const vpkFileSizes = Object.fromEntries(
                 await Promise.all(
                     installedVpks.map(async (vpk) => {
@@ -1332,12 +1373,20 @@ async function executeOneClickDownload(
             await fs.unlink(downloadPath);
         }
     } else if (extname(downloadPath).toLowerCase() === '.vpk') {
-        installedVpks = await renameVpksToAvoidConflicts(deadlockPath, targetPath, [downloadPath], oneClickModName);
+        const renamed = await renameVpksToAvoidConflicts(
+            deadlockPath,
+            targetPath,
+            [{ path: downloadPath, fileName: basename(downloadPath) }],
+            oneClickModName
+        );
+        installedVpks = renamed.map((r) => r.fileName);
     }
 
     for (const vpkFileName of installedVpks) {
         const vpkPath = join(targetPath, vpkFileName);
-        const perVpkMetadata = stampVpkLockerHero(metadata, section, vpkPath);
+        const base = stampVpkLockerHero(metadata, section, vpkPath);
+        const variantLabel = variantByFile.get(vpkFileName);
+        const perVpkMetadata = variantLabel ? { ...base, variantLabel } : base;
         await setModMetadataWithHash(vpkFileName, perVpkMetadata, vpkPath);
     }
 

--- a/electron/main/services/extract.test.ts
+++ b/electron/main/services/extract.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for the multi-variant VPK collision. Mods like Tailed Infernus
+ * (gamebanana.com/mods/666996) ship one folder per variant, each holding an
+ * identically-named pakNN_dir.vpk. The extractor used to flatten by basename, so
+ * the second variant silently overwrote the first on disk while still being
+ * reported as extracted, which then crashed the install when the rename step
+ * reached the file that no longer existed. Every variant must now survive under a
+ * distinct path, tagged with its archive folder.
+ *
+ * extract.ts is electron-free (adm-zip / fs only), so this runs against the real
+ * extractArchive with no mocking.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import AdmZip from 'adm-zip';
+import { extractArchive } from './extract';
+
+describe('extractArchive (multi-variant VPK folders)', () => {
+  let extracted: Awaited<ReturnType<typeof extractArchive>>;
+  let dest: string;
+
+  beforeAll(async () => {
+    const root = mkdtempSync(join(tmpdir(), 'extract-test-'));
+    dest = join(root, 'out');
+    mkdirSync(dest, { recursive: true });
+
+    // Two variant folders share the same pakNN name; a third VPK sits at the root.
+    const zip = new AdmZip();
+    zip.addFile('Tailed_mod_Beard/pak83_dir.vpk', Buffer.from('BEARD-CONTENT'));
+    zip.addFile('Tailed_mod/pak83_dir.vpk', Buffer.from('NO-BEARD-CONTENT'));
+    zip.addFile('root_skin_dir.vpk', Buffer.from('ROOT-CONTENT'));
+    const zipPath = join(root, 'tailed.zip');
+    zip.writeZip(zipPath);
+
+    extracted = await extractArchive(zipPath, dest);
+  });
+
+  it('keeps every same-named variant instead of overwriting', () => {
+    expect(extracted).toHaveLength(3);
+    const paths = new Set(extracted.map((e) => e.path));
+    expect(paths.size).toBe(3); // no two entries share a destination path
+  });
+
+  it('preserves each variant content (no silent clobber)', () => {
+    const contents = extracted.map((e) => readFileSync(e.path, 'utf8')).sort();
+    expect(contents).toEqual(['BEARD-CONTENT', 'NO-BEARD-CONTENT', 'ROOT-CONTENT']);
+  });
+
+  it('tags each VPK with its archive variant folder', () => {
+    const byFolder = Object.fromEntries(
+      extracted.map((e) => [e.archiveFolder ?? '(root)', readFileSync(e.path, 'utf8')])
+    );
+    expect(byFolder).toEqual({
+      Tailed_mod_Beard: 'BEARD-CONTENT',
+      Tailed_mod: 'NO-BEARD-CONTENT',
+      '(root)': 'ROOT-CONTENT',
+    });
+  });
+
+  it('reports the original basename for naming, even when the path was suffixed', () => {
+    for (const e of extracted) {
+      expect(e.fileName.toLowerCase().endsWith('.vpk')).toBe(true);
+    }
+    // The two colliding variants both report the original pak83_dir.vpk name.
+    const pak83 = extracted.filter((e) => e.fileName === 'pak83_dir.vpk');
+    expect(pak83).toHaveLength(2);
+  });
+});

--- a/electron/main/services/extract.ts
+++ b/electron/main/services/extract.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, copyFileSync, unlinkSync, writeFileSync, readFileSync, rmdirSync } from 'fs';
-import { join, extname, basename } from 'path';
+import { join, extname, basename, dirname } from 'path';
 import { randomBytes } from 'crypto';
 import AdmZip from 'adm-zip';
 import { spawn } from 'child_process';
@@ -112,6 +112,53 @@ export async function scanSuspiciousFiles(archivePath: string): Promise<string[]
     return flagged;
 }
 
+export interface ExtractedVpk {
+    /** Absolute path of the extracted VPK in the destination directory. */
+    path: string;
+    /** The VPK's original basename inside the archive, used to derive its
+     *  installed name. Differs from basename(path) only when a duplicate
+     *  basename was suffixed to keep both variants on disk. */
+    fileName: string;
+    /** Immediate parent folder inside the archive, when present. Multi-variant
+     *  mods use these folders as the per-variant label. */
+    archiveFolder?: string;
+}
+
+/**
+ * The immediate parent folder of an archive entry, or undefined when the entry
+ * sits at the archive root. Multi-variant mods use these folders (e.g.
+ * `Beard/pak83_dir.vpk`, `NoBeard/pak83_dir.vpk`) as the only label that
+ * distinguishes otherwise identically-named VPKs.
+ */
+function archiveParentFolder(entryName: string): string | undefined {
+    const parts = entryName.split(/[\\/]/).filter(Boolean);
+    return parts.length >= 2 ? parts[parts.length - 2] : undefined;
+}
+
+/**
+ * A destination filename guaranteed not to collide with one already taken this
+ * extraction. Sibling variant folders routinely ship an identically-named
+ * pakNN_dir.vpk; flattening them to the same basename made the second silently
+ * overwrite the first (data loss) and left the install referencing a file that
+ * no longer existed on disk. Suffixing duplicates keeps every variant.
+ */
+function uniqueDestName(fileName: string, taken: Set<string>): string {
+    if (!taken.has(fileName.toLowerCase())) {
+        taken.add(fileName.toLowerCase());
+        return fileName;
+    }
+    const ext = fileName.toLowerCase().endsWith('_dir.vpk') ? fileName.slice(-8) : extname(fileName);
+    const stem = fileName.slice(0, fileName.length - ext.length);
+    let n = 2;
+    let candidate = `${stem}_${n}${ext}`;
+    while (taken.has(candidate.toLowerCase())) {
+        n++;
+        candidate = `${stem}_${n}${ext}`;
+    }
+    taken.add(candidate.toLowerCase());
+    return candidate;
+}
+
 /**
  * Extract an archive to a destination directory
  * Returns the list of extracted VPK files
@@ -119,7 +166,7 @@ export async function scanSuspiciousFiles(archivePath: string): Promise<string[]
 export async function extractArchive(
     archivePath: string,
     destDir: string
-): Promise<string[]> {
+): Promise<ExtractedVpk[]> {
     const ext = extname(archivePath).toLowerCase();
 
     switch (ext) {
@@ -137,33 +184,32 @@ export async function extractArchive(
 /**
  * Extract a ZIP archive
  */
-function extractZip(archivePath: string, destDir: string): string[] {
+function extractZip(archivePath: string, destDir: string): ExtractedVpk[] {
     const zip = new AdmZip(archivePath);
-    const entries = zip.getEntries();
-    const extractedVpks: string[] = [];
+    const extracted: ExtractedVpk[] = [];
+    const taken = new Set<string>();
 
-    for (const entry of entries) {
+    for (const entry of zip.getEntries()) {
         if (entry.isDirectory) continue;
 
         const fileName = basename(entry.entryName);
-        const ext = extname(fileName).toLowerCase();
+        if (extname(fileName).toLowerCase() !== '.vpk') continue;
 
-        // Only extract VPK files
-        if (ext !== '.vpk') continue;
-
-        // Flatten to dest directory
-        const destPath = join(destDir, fileName);
-        zip.extractEntryTo(entry, destDir, false, true);
-        extractedVpks.push(destPath);
+        // Write straight to the chosen name rather than extractEntryTo, which can
+        // only flatten to the entry's own basename and so clobbers same-named
+        // VPKs from sibling variant folders.
+        const destPath = join(destDir, uniqueDestName(fileName, taken));
+        writeFileSync(destPath, entry.getData());
+        extracted.push({ path: destPath, fileName, archiveFolder: archiveParentFolder(entry.entryName) });
     }
 
-    return extractedVpks;
+    return extracted;
 }
 
 /**
  * Extract a 7z archive using the bundled 7za binary (falls back to system 7z).
  */
-async function extract7z(archivePath: string, destDir: string): Promise<string[]> {
+async function extract7z(archivePath: string, destDir: string): Promise<ExtractedVpk[]> {
     const tempDir = createTempDir('modmanager-7z');
 
     try {
@@ -171,8 +217,7 @@ async function extract7z(archivePath: string, destDir: string): Promise<string[]
             try {
                 await runCommand(tool, ['x', '-y', `-o${tempDir}`, archivePath]);
                 const vpks = collectVpks(tempDir);
-                const copied = copyVpksToDest(vpks, destDir);
-                return copied;
+                return copyVpksToDest(vpks, destDir, tempDir);
             } catch {
                 // Try next tool
             }
@@ -195,7 +240,7 @@ async function extract7z(archivePath: string, destDir: string): Promise<string[]
  * default; falls back to the bundled 7za or system unrar if the in-process
  * extractor fails (e.g. RAR5-specific features it can't handle).
  */
-async function extractRar(archivePath: string, destDir: string): Promise<string[]> {
+async function extractRar(archivePath: string, destDir: string): Promise<ExtractedVpk[]> {
     // Primary path: pure-JS in-process RAR extractor (no install required).
     try {
         const data = readFileSync(archivePath);
@@ -207,13 +252,14 @@ async function extractRar(archivePath: string, destDir: string): Promise<string[
             files: (header) => !header.flags.directory && extname(header.name).toLowerCase() === '.vpk',
         });
 
-        const extractedVpks: string[] = [];
+        const extractedVpks: ExtractedVpk[] = [];
+        const taken = new Set<string>();
         for (const file of extracted.files) {
             if (!file.extraction) continue;
             const fileName = basename(file.fileHeader.name);
-            const destPath = join(destDir, fileName);
+            const destPath = join(destDir, uniqueDestName(fileName, taken));
             writeFileSync(destPath, Buffer.from(file.extraction));
-            extractedVpks.push(destPath);
+            extractedVpks.push({ path: destPath, fileName, archiveFolder: archiveParentFolder(file.fileHeader.name) });
         }
 
         if (extractedVpks.length > 0) {
@@ -236,8 +282,7 @@ async function extractRar(archivePath: string, destDir: string): Promise<string[
                     await runCommand(tool, ['x', '-y', `-o${tempDir}`, archivePath]);
                 }
                 const vpks = collectVpks(tempDir);
-                const copied = copyVpksToDest(vpks, destDir);
-                return copied;
+                return copyVpksToDest(vpks, destDir, tempDir);
             } catch {
                 // Try next tool
             }
@@ -325,16 +370,24 @@ function collectVpks(dir: string): string[] {
 }
 
 /**
- * Copy VPK files to destination directory (flattening structure)
+ * Copy VPK files to destination directory (flattening structure). `rootDir` is
+ * the extraction root, used to recover each VPK's variant folder; same-named
+ * VPKs from sibling folders are kept under suffixed names instead of colliding.
  */
-function copyVpksToDest(vpks: string[], destDir: string): string[] {
-    const copied: string[] = [];
+function copyVpksToDest(vpks: string[], destDir: string, rootDir: string): ExtractedVpk[] {
+    const copied: ExtractedVpk[] = [];
+    const taken = new Set<string>();
 
     for (const vpk of vpks) {
         const fileName = basename(vpk);
-        const destPath = join(destDir, fileName);
+        const destPath = join(destDir, uniqueDestName(fileName, taken));
         copyFileSync(vpk, destPath);
-        copied.push(destPath);
+        const parent = dirname(vpk);
+        copied.push({
+            path: destPath,
+            fileName,
+            archiveFolder: parent === rootDir ? undefined : basename(parent),
+        });
     }
 
     return copied;

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -196,14 +196,18 @@ function extractModName(filename: string): string {
 export function makeDisabledFileName(
     sourceFileName: string,
     taken: Set<string>,
-    preferredName?: string
+    preferredName?: string,
+    variantHint?: string
 ): string {
     // The file's own stem, minus any pak## load-order prefix (disabled files
     // carry no slot). Empty for bare pakNN names, which is the disable case.
     let stem = sourceFileName.replace(/_dir\.vpk$/i, '').replace(/\.vpk$/i, '');
     stem = stem.replace(/^pak\d{2}_?/i, '').trim();
 
-    let base = slugify(stem) || slugify(preferredName ?? '') || 'mod';
+    // variantHint (an archive's variant folder) sits between the file's own stem
+    // and the mod name: it disambiguates sibling variants that share a bare pakNN
+    // name and a single mod name, which would otherwise collide on one slug.
+    let base = slugify(stem) || slugify(variantHint ?? '') || slugify(preferredName ?? '') || 'mod';
     // Guard against a base that still starts with "pak<digit>": parseVpkPriority
     // is lenient (it reads chars 3-4 and parseInts them), so "pak1_foo" would be
     // read back as slot 1 and loop forever below. Prefix it out of that shape.


### PR DESCRIPTION
## Problem

A user reported the **Tailed Infernus** mod ([GameBanana #666996](https://gamebanana.com/mods/666996)) cannot be installed.

Its ZIP ships one folder per variant, each holding an **identically-named** VPK:

```
Tailed_mod_Beard/pak83_dir.vpk   (40 MB)
Tailed_mod/pak83_dir.vpk         (18 MB)
```

`extractZip` flattened entries to their basename, so both collapsed to `destDir/pak83_dir.vpk`:

1. The second extraction **overwrote** the first (the 40 MB Beard variant was silently lost).
2. It still pushed **both** paths to the returned array.

`renameVpksToAvoidConflicts` then looped over both: pass 1 moved the file to its slot; pass 2 called `fs.rename` on the now-vanished source and threw **ENOENT**, aborting the install. The same flatten-by-basename bug existed in `copyVpksToDest` (7z/rar) and the in-process RAR branch, so it hit any mod that ships per-variant folders with same-named VPKs (common, since authors all start at `pak01`/`pak83`).

## Fix

- **`extract.ts`** — extractors return `ExtractedVpk { path, fileName, archiveFolder }`, write each VPK under a collision-free name (`uniqueDestName`), and capture the variant folder. No overwrite, no duplicate paths.
- **`download.ts`** — `renameVpksToAvoidConflicts` consumes/returns the richer type, threads the folder as a naming hint, overrides the multi-VPK picker label with the folder (the content heuristic returns "Infernus" for both variants), and persists it as `variantLabel`.
- **`mods.ts`** — `makeDisabledFileName` takes an optional `variantHint` so sibling variants get distinct readable names instead of colliding on the mod name. Existing 3-arg callers are unchanged (`slugify('')` is falsy → identical result).
- **`ipc/mods.ts`** — custom-import caller updated to the new shape.

Result: both variants survive, and the existing `MultiVpkPickerModal` fires with "Tailed Mod Beard" / "Tailed Mod".

## Verification

- `tsc -b` clean, `eslint .` clean.
- Full suite **290 + 4 new** regression tests pass (`extract.test.ts`).
- Real `extractArchive` run against real `zip`-CLI archives in **deflate** and **stored** compression, and a real **.7z** — all byte-exact (md5) on the 3-VPK collision structure, variant folders tagged correctly.
- Single-VPK / normal mods extract to the exact same filenames as before (non-colliding names pass through `uniqueDestName` untouched).
- Changes are install-time only; already-installed mods on disk are never touched.

**Caveat:** `.rar` was not directly run (no `rar` authoring tool available here). Both rar sub-paths reuse the exact primitives proven by the zip path (`writeFileSync` + `uniqueDestName` + `archiveParentFolder`) and the 7z path (`copyVpksToDest`).