### PR TITLE
fix: improve mod management safety and multi-VPK workflows

### DIFF
--- a/electron/main/ipc/crosshairPresets.ts
+++ b/electron/main/ipc/crosshairPresets.ts
@@ -9,7 +9,7 @@ import {
     normalizeCrosshairSettings,
     parseMachineConvarsCrosshair,
 } from '../../../src/lib/crosshair';
-import { readAutoexec, writeAutoexec, getAutoexecPath } from '../services/autoexec';
+import { getManualAutoexecCommands, readAutoexec, writeAutoexec, getAutoexecPath } from '../services/autoexec';
 export type { CrosshairSettings, CrosshairPreset };
 
 interface PresetsData {
@@ -213,15 +213,19 @@ ipcMain.handle('crosshair:importFromGame', async (_event, gamePath: string) => {
 // Get autoexec commands (non-crosshair)
 ipcMain.handle('autoexec:getCommands', async (_event, gamePath: string) => {
     if (!gamePath) {
-        return { commands: [], exists: false };
+        return { commands: [], manualCommands: [], exists: false };
     }
 
     if (!fs.existsSync(getAutoexecPath(gamePath))) {
-        return { commands: [], exists: false };
+        return { commands: [], manualCommands: [], exists: false };
     }
 
     const autoexec = readAutoexec(gamePath);
-    return { commands: autoexec.commands, exists: true };
+    return {
+        commands: autoexec.commands,
+        manualCommands: getManualAutoexecCommands(autoexec),
+        exists: true,
+    };
 });
 
 // Save autoexec commands (preserves the crosshair section and any manual

--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -14,6 +14,14 @@ import {
 import { readLaunchOptions, isSteamRunning } from '../services/launchOptions';
 import { healLockerVpks } from '../services/lockerVpk';
 import { getMainWindow } from '../index';
+import { scanMods } from '../services/mods';
+import {
+    captureEmptyGameMods,
+    captureLoadedGameMods,
+    clearLoadedGameMods,
+    hasRunningGameModSnapshot,
+    syncKnownRunningGameModSnapshot,
+} from '../services/gameSessionMods';
 
 function emitRestore(result: RestoreResult): void {
     const win = getMainWindow();
@@ -25,7 +33,16 @@ ipcMain.handle('launch-modded', async (): Promise<void> => {
     if (!deadlockPath) {
         throw new Error('No Deadlock path configured');
     }
-    await launchModded({ deadlockPath, onRestoreComplete: emitRestore });
+    try {
+        await launchModded({
+            deadlockPath,
+            onRestoreComplete: emitRestore,
+            beforeLaunch: async () => captureLoadedGameMods(await scanMods(deadlockPath)),
+        });
+    } catch (err) {
+        clearLoadedGameMods();
+        throw err;
+    }
 });
 
 ipcMain.handle('launch-vanilla', async (): Promise<void> => {
@@ -33,17 +50,40 @@ ipcMain.handle('launch-vanilla', async (): Promise<void> => {
     if (!deadlockPath) {
         throw new Error('No Deadlock path configured');
     }
-    await launchVanilla({ deadlockPath, onRestoreComplete: emitRestore });
+    try {
+        await launchVanilla({
+            deadlockPath,
+            onRestoreComplete: emitRestore,
+            beforeLaunch: captureEmptyGameMods,
+        });
+    } catch (err) {
+        clearLoadedGameMods();
+        throw err;
+    }
 });
 
 ipcMain.handle('get-game-running-status', async (): Promise<{ running: boolean }> => {
-    return { running: await isDeadlockRunning() };
+    const running = await isDeadlockRunning();
+    if (!running) {
+        clearLoadedGameMods();
+        return { running: false };
+    }
+    const deadlockPath = getActiveDeadlockPath();
+    if (!deadlockPath) {
+        return { running: true };
+    }
+    const mods = hasRunningGameModSnapshot() ? [] : await scanMods(deadlockPath);
+    syncKnownRunningGameModSnapshot(true, mods);
+    return { running: true };
 });
 
 ipcMain.handle('stop-game', async (): Promise<StopDeadlockResult & {
     restoreResult?: RestoreResult;
 }> => {
     const stopResult = await stopDeadlockGame();
+    if (stopResult.stopped) {
+        clearLoadedGameMods();
+    }
     const deadlockPath = getActiveDeadlockPath();
     const stash = await readStash();
 

--- a/electron/main/services/autoexec.ts
+++ b/electron/main/services/autoexec.ts
@@ -14,6 +14,18 @@ export interface AutoexecData {
     other: string;
 }
 
+function getExecutableAutoexecLine(line: string): string {
+    const commentIndex = line.indexOf('//');
+    return (commentIndex >= 0 ? line.slice(0, commentIndex) : line).trim();
+}
+
+export function getManualAutoexecCommands(data: AutoexecData): string[] {
+    return [data.header, data.other]
+        .flatMap((section) => section.split('\n'))
+        .map(getExecutableAutoexecLine)
+        .filter((line) => line.length > 0);
+}
+
 // Helper to parse autoexec into sections
 export function parseAutoexec(content: string): AutoexecData {
     const lines = content.split('\n');
@@ -25,16 +37,18 @@ export function parseAutoexec(content: string): AutoexecData {
     let section: 'header' | 'crosshair' | 'commands' | 'other' = 'header';
 
     for (const line of lines) {
-        if (line.includes(CROSSHAIR_START)) {
+        const trimmed = line.trim();
+
+        if (trimmed === CROSSHAIR_START) {
             section = 'crosshair';
             continue;
-        } else if (line.includes(CROSSHAIR_END)) {
+        } else if (trimmed === CROSSHAIR_END) {
             section = 'other';
             continue;
-        } else if (line.includes(COMMANDS_START)) {
+        } else if (trimmed === COMMANDS_START) {
             section = 'commands';
             continue;
-        } else if (line.includes(COMMANDS_END)) {
+        } else if (trimmed === COMMANDS_END) {
             section = 'other';
             continue;
         }
@@ -43,7 +57,7 @@ export function parseAutoexec(content: string): AutoexecData {
             // Old-style crosshair commands (written without section markers by
             // pre-1.18 applyPreset) are rescued into the crosshair section so a
             // rewrite upgrades them instead of silently deleting them.
-            if (line.trim().startsWith('citadel_crosshair_') || line.trim().startsWith('// Preset:')) {
+            if (trimmed.startsWith('citadel_crosshair_') || trimmed.startsWith('// Preset:')) {
                 crosshair.push(line);
             } else if (!line.includes('Mod Manager')) {
                 header.push(line);
@@ -51,9 +65,10 @@ export function parseAutoexec(content: string): AutoexecData {
         } else if (section === 'crosshair') {
             crosshair.push(line);
         } else if (section === 'commands') {
-            if (line.trim()) commands.push(line.trim());
+            const command = getExecutableAutoexecLine(line);
+            if (command) commands.push(command);
         } else if (section === 'other') {
-            if (line.trim().startsWith('citadel_crosshair_')) {
+            if (trimmed.startsWith('citadel_crosshair_')) {
                 crosshair.push(line);
             } else if (!line.includes('Crosshair settings from Deadlock Mod Manager') &&
                 !line.includes('// Preset:')) {

--- a/electron/main/services/gameSessionMods.ts
+++ b/electron/main/services/gameSessionMods.ts
@@ -1,0 +1,73 @@
+import { isDeadlockRunning } from './launch';
+import type { Mod } from './mods';
+
+export const GAME_RUNNING_MOD_LOCK_MESSAGE = 'Game is running';
+
+interface RunningGameSnapshot {
+    lockedModIds: Set<string>;
+    lockedMetaKeys: Set<string>;
+}
+
+let snapshot: RunningGameSnapshot | null = null;
+
+function makeSnapshot(mods: Mod[]): RunningGameSnapshot {
+    const enabled = mods.filter((mod) => mod.enabled);
+    return {
+        lockedModIds: new Set(enabled.map((mod) => mod.id)),
+        lockedMetaKeys: new Set(enabled.map((mod) => mod.metaKey)),
+    };
+}
+
+export function captureLoadedGameMods(mods: Mod[]): void {
+    snapshot = makeSnapshot(mods);
+}
+
+export function captureEmptyGameMods(): void {
+    snapshot = {
+        lockedModIds: new Set(),
+        lockedMetaKeys: new Set(),
+    };
+}
+
+export function clearLoadedGameMods(): void {
+    snapshot = null;
+}
+
+export function hasRunningGameModSnapshot(): boolean {
+    return snapshot !== null;
+}
+
+export function isLoadedGameModLocked(mod: Pick<Mod, 'id' | 'metaKey' | 'enabled'>): boolean {
+    if (!mod.enabled || !snapshot) return false;
+    return snapshot.lockedModIds.has(mod.id) || snapshot.lockedMetaKeys.has(mod.metaKey);
+}
+
+export function assertCanMoveLoadedGameMod(mod: Pick<Mod, 'id' | 'metaKey' | 'enabled'>): void {
+    if (isLoadedGameModLocked(mod)) {
+        throw new Error(GAME_RUNNING_MOD_LOCK_MESSAGE);
+    }
+}
+
+export function assertCanMoveLoadedGameMods(mods: Array<Pick<Mod, 'id' | 'metaKey' | 'enabled'>>): void {
+    if (mods.some(isLoadedGameModLocked)) {
+        throw new Error(GAME_RUNNING_MOD_LOCK_MESSAGE);
+    }
+}
+
+export async function syncRunningGameModSnapshotFromMods(mods: Mod[]): Promise<{ running: boolean }> {
+    const running = await isDeadlockRunning();
+    return syncKnownRunningGameModSnapshot(running, mods);
+}
+
+export function syncKnownRunningGameModSnapshot(running: boolean, mods: Mod[]): { running: boolean } {
+    if (!running) {
+        clearLoadedGameMods();
+        return { running: false };
+    }
+
+    if (!snapshot) {
+        captureLoadedGameMods(mods);
+    }
+
+    return { running: true };
+}

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -430,6 +430,7 @@ async function triggerSteamLaunch(): Promise<void> {
 export interface LaunchOptions {
     deadlockPath: string;
     onRestoreComplete?: (result: RestoreResult) => void;
+    beforeLaunch?: () => void | Promise<void>;
 }
 
 /**
@@ -440,6 +441,7 @@ export interface LaunchOptions {
 export async function launchModded({
     deadlockPath,
     onRestoreComplete,
+    beforeLaunch,
 }: LaunchOptions): Promise<void> {
     if (launchInFlight) {
         throw new Error('Another launch is already in progress');
@@ -456,6 +458,7 @@ export async function launchModded({
                 );
             }
         }
+        await beforeLaunch?.();
         await syncLaunchOptionsToSteam();
         await triggerSteamLaunch();
     } finally {
@@ -473,6 +476,7 @@ export async function launchModded({
 export async function launchVanilla({
     deadlockPath,
     onRestoreComplete,
+    beforeLaunch,
 }: LaunchOptions): Promise<void> {
     if (launchInFlight) {
         throw new Error('Another launch is already in progress');
@@ -503,6 +507,7 @@ export async function launchVanilla({
     }
 
     try {
+        await beforeLaunch?.();
         await syncLaunchOptionsToSteam();
         await triggerSteamLaunch();
     } catch (err) {

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -205,6 +205,12 @@ export async function setModMetadataWithHash(
     });
 }
 
+export function normalizeSha256(value: string | undefined): string | null {
+    return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value)
+        ? value.toLowerCase()
+        : null;
+}
+
 /**
  * Backfill SHA-256 values for metadata written before hashes existed.
  * This runs without renaming/moving files; entries whose VPK no longer exists
@@ -257,7 +263,7 @@ async function collectInstalledVpkPaths(deadlockPath: string): Promise<Map<strin
 }
 
 function isValidSha256(value: string | undefined): boolean {
-    return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value);
+    return normalizeSha256(value) !== null;
 }
 
 async function hashFileSha256(filePath: string): Promise<string> {

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -18,6 +18,11 @@ import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { fingerprintFile } from './fileMatch';
 import { encodeShareCode } from './portableProfile';
 import {
+    assertCanMoveLoadedGameMod,
+    assertCanMoveLoadedGameMods,
+    syncRunningGameModSnapshotFromMods,
+} from './gameSessionMods';
+import {
     PORTABLE_PROFILE_FORMAT,
     PORTABLE_PROFILE_SCHEMA_VERSION,
     type PortableProfile,
@@ -323,6 +328,7 @@ async function mergeModsLocked(
     trimmedName: string
 ): Promise<MergeResult> {
     const installed = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(installed);
     const sources: Mod[] = [];
     for (const id of modIds) {
         const found = installed.find((m) => m.id === id);
@@ -335,6 +341,7 @@ async function mergeModsLocked(
         }
         sources.push(found);
     }
+    assertCanMoveLoadedGameMods(sources.filter((source) => source.enabled));
 
     // In Deadlock a LOWER pakNN wins a file collision (pak09 overrides pak10),
     // so the lowest-pakNN source is the highest priority. vpkmerge is
@@ -586,6 +593,7 @@ async function unmergeModLocked(
     mergedModId: string
 ): Promise<UnmergeModResult> {
     const installed = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(installed);
     const target = installed.find((m) => m.id === mergedModId);
     if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
 
@@ -593,6 +601,7 @@ async function unmergeModLocked(
     if (!meta?.merged) {
         throw new Error(`"${meta?.modName || target.name}" is not a merged mod.`);
     }
+    assertCanMoveLoadedGameMod(target);
     const manifest = meta.merged;
 
     // Recover each source from disk via the shared locator (disabled folder by
@@ -651,6 +660,7 @@ async function extractMergeSourceLocked(
     sourceFileName: string
 ): Promise<ExtractMergeSourceResult> {
     const installed = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(installed);
     const target = installed.find((m) => m.id === mergedModId);
     if (!target) throw new Error(`Merged mod not found (id: ${mergedModId}).`);
 
@@ -658,6 +668,7 @@ async function extractMergeSourceLocked(
     if (!meta?.merged) {
         throw new Error(`"${meta?.modName || target.name}" is not a merged mod.`);
     }
+    assertCanMoveLoadedGameMod(target);
     const manifest = meta.merged;
 
     const removedSnapshot = manifest.sources.find((s) => s.fileName === sourceFileName);

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -7,6 +7,11 @@ import { fixGameinfo } from './system';
 import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
 import { compareFileContents, fingerprintFile } from './fileMatch';
 import { loadSettings } from './settings';
+import {
+    assertCanMoveLoadedGameMod,
+    assertCanMoveLoadedGameMods,
+    syncRunningGameModSnapshotFromMods,
+} from './gameSessionMods';
 
 /** Verbose mod-mutation trace, gated on the `verboseModTrace` setting. Lands in
  *  main.log (captured by the diagnostic report) so a desync between the UI and
@@ -688,6 +693,7 @@ async function allocateSlot(
  * metaKeyFor(path), since an overflow destination uses a folder-prefixed key.
  */
 export async function allocateEnabledVpkPath(deadlockPath: string): Promise<string> {
+    await syncRunningGameModSnapshotFromMods(await scanMods(deadlockPath));
     const disabledForbidden = await folderPakNumbers(getDisabledPath(deadlockPath));
     const { folder, fileName } = await allocateSlot(deadlockPath, { disabledForbidden, preferred: [] });
     return join(folder, fileName);
@@ -765,6 +771,7 @@ export function reorderModsUnlocked(deadlockPath: string, orderedIds: string[]):
 
 async function enableModImpl(deadlockPath: string, modId: string): Promise<Mod> {
     const mods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(mods);
     const targetMod = mods.find((m) => m.id === modId);
 
     if (!targetMod) {
@@ -808,6 +815,7 @@ export function disableMod(deadlockPath: string, modId: string): Promise<Mod> {
 
 async function disableModImpl(deadlockPath: string, modId: string): Promise<Mod> {
     const mods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(mods);
     const targetMod = mods.find((m) => m.id === modId);
 
     if (!targetMod) {
@@ -817,6 +825,7 @@ async function disableModImpl(deadlockPath: string, modId: string): Promise<Mod>
     if (!targetMod.enabled) {
         return targetMod;
     }
+    assertCanMoveLoadedGameMod(targetMod);
 
     const disabledPath = getDisabledPath(deadlockPath);
 
@@ -846,11 +855,13 @@ export function deleteMod(deadlockPath: string, modId: string): Promise<void> {
 
 async function deleteModImpl(deadlockPath: string, modId: string): Promise<void> {
     const mods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(mods);
     const targetMod = mods.find((m) => m.id === modId);
 
     if (!targetMod) {
         throw new Error(`Mod not found: ${modId}`);
     }
+    assertCanMoveLoadedGameMod(targetMod);
 
     await fs.unlink(targetMod.path);
 
@@ -886,11 +897,13 @@ async function setModPriorityImpl(
     newPriority: number
 ): Promise<Mod> {
     const mods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(mods);
     const targetMod = mods.find((m) => m.id === modId);
 
     if (!targetMod) {
         throw new Error(`Mod not found: ${modId}`);
     }
+    assertCanMoveLoadedGameMod(targetMod);
 
     const parentDir = dirname(targetMod.path);
     const newFileName = renameWithPriority(targetMod.fileName, newPriority);
@@ -959,6 +972,7 @@ export function reorderMods(deadlockPath: string, orderedIds: string[]): Promise
 // this directly; the exported reorderMods wraps it in the lock.
 async function reorderModsImpl(deadlockPath: string, orderedIds: string[]): Promise<void> {
     const allMods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(allMods);
     const modById = new Map(allMods.map((m) => [m.id, m]));
 
     const targets: Mod[] = [];
@@ -1028,6 +1042,7 @@ async function reorderModsImpl(deadlockPath: string, orderedIds: string[]): Prom
         }
     }
     if (assignments.length === 0) return;
+    assertCanMoveLoadedGameMods(assignments.map(({ mod }) => mod));
 
     // Two-phase rename: source -> temp (in the TARGET folder) -> final. Unique
     // temp names make cross-folder moves and same-folder slot swaps collision-free.
@@ -1096,12 +1111,14 @@ async function swapModPriorityImpl(
     modIdB: string
 ): Promise<void> {
     const mods = await scanMods(deadlockPath);
+    await syncRunningGameModSnapshotFromMods(mods);
     const a = mods.find((m) => m.id === modIdA);
     const b = mods.find((m) => m.id === modIdB);
 
     if (!a || !b) {
         throw new Error('Mod not found for swap');
     }
+    assertCanMoveLoadedGameMods([a, b]);
     if (a.priority === b.priority) {
         throw new Error('Cannot swap mods with identical priorities');
     }

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -11,6 +11,10 @@ import {
 import { getModMetadata, normalizeSha256 } from './metadata';
 import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
+import {
+    assertCanMoveLoadedGameMods,
+    syncRunningGameModSnapshotFromMods,
+} from './gameSessionMods';
 import { generateCrosshairCommands, normalizeCrosshairSettings } from '../../../src/lib/crosshair';
 
 // The Profile wire types are single-sourced in src/types/electron.ts
@@ -438,6 +442,7 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
         // Resolve by archive id first, using hash for multi-VPK siblings.
         // FileName fallback is only for stable-id-less local mods.
         const currentMods = await scanMods(deadlockPath);
+        await syncRunningGameModSnapshotFromMods(currentMods);
         const resolveProfileMod = buildProfileModResolver(currentMods);
 
         // currentMod.id -> ProfileMod, when matched. Drives the enable/disable
@@ -480,6 +485,12 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
             `[profiles] resolution summary: ${stableHits} stable, ${fileNameHits} fileName, ` +
             `${refusedCrossmatches} refused, ${unmatched} unmatched`
         );
+
+        assertCanMoveLoadedGameMods(currentMods.filter((mod) => {
+            if (!mod.enabled || isLockerManaged(mod.metaKey)) return false;
+            const profileMod = profileModByCurrentId.get(mod.id);
+            return !profileMod || !profileMod.enabled || profileMod.priority !== mod.priority;
+        }));
 
         // Two passes, disables BEFORE enables. The disabled library is uncapped now,
         // so a profile that swaps a large enabled set for a large disabled one could,

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -8,7 +8,7 @@ import {
     disableModUnlocked,
     reorderModsUnlocked,
 } from './mods';
-import { getModMetadata } from './metadata';
+import { getModMetadata, normalizeSha256 } from './metadata';
 import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
 import { generateCrosshairCommands, normalizeCrosshairSettings } from '../../../src/lib/crosshair';
@@ -87,48 +87,39 @@ function saveProfiles(profiles: Profile[]): void {
     }
 }
 
-/**
- * Drop duplicate physical VPKs that resolve to the SAME GameBanana file before
- * they're written into a profile. A toggle/apply race can leave two copies of
- * one mod enabled in different pakNN slots; without this dedup, createProfile /
- * updateProfile would record both (same gameBananaId:fileId, different fileName/
- * priority) and the saved profile carries a phantom entry forever - exactly the
- * corrupt "Bunnydicta at priority 21 AND 31" a reporter's exported profile
- * showed (#bugs: profile/mods desync, leftover/duplicate vpk). We keep the
- * lower-priority-number copy (loads first / wins conflicts). Mods without a
- * GameBanana file id are left untouched: those are genuinely distinct locals.
- */
+/** Drop duplicate physical VPKs before they're written into a profile. */
 function dedupeEnabledForProfile<T extends { metaKey: string; fileName: string; priority: number }>(
     mods: T[]
 ): T[] {
-    const byGbFile = new Map<string, T>();
+    const byGbFileAndHash = new Map<string, T>();
     const out: T[] = [];
     for (const mod of mods) {
         const meta = getModMetadata(mod.metaKey);
         const gbId = meta?.gameBananaId;
         const fileId = meta?.gameBananaFileId;
-        if (typeof gbId !== 'number' || typeof fileId !== 'number') {
+        const sha256 = normalizeSha256(meta?.sha256);
+        if (typeof gbId !== 'number' || typeof fileId !== 'number' || sha256 === null) {
             out.push(mod);
             continue;
         }
-        const key = `${gbId}:${fileId}`;
-        const existing = byGbFile.get(key);
+        const key = `${gbId}:${fileId}:${sha256}`;
+        const existing = byGbFileAndHash.get(key);
         if (!existing) {
-            byGbFile.set(key, mod);
+            byGbFileAndHash.set(key, mod);
             out.push(mod);
         } else if (mod.priority < existing.priority) {
             // Prefer the higher-load-order copy; swap it in place.
             const idx = out.indexOf(existing);
             if (idx !== -1) out[idx] = mod;
-            byGbFile.set(key, mod);
+            byGbFileAndHash.set(key, mod);
             console.warn(
                 `[profiles] dedupe: dropping duplicate VPK ${existing.fileName} ` +
-                `(same GameBanana file ${key} as ${mod.fileName})`
+                `(same GameBanana file/hash as ${mod.fileName})`
             );
         } else {
             console.warn(
                 `[profiles] dedupe: dropping duplicate VPK ${mod.fileName} ` +
-                `(same GameBanana file ${key} as ${existing.fileName})`
+                `(same GameBanana file/hash as ${existing.fileName})`
             );
         }
     }
@@ -285,8 +276,9 @@ type ResolvedMatch =
  * Build a resolver that maps a ProfileMod to one of the current scanned mods.
  *
  * Tries stable id first (`gameBananaId` + `gameBananaFileId`) so a mod can be
- * found after a fileName change. Falls back to fileName ONLY when neither the
- * profile entry nor the candidate currentMod carry GameBanana ids: this keeps
+ * found after a fileName change. If several installed VPKs came from that same
+ * GameBanana file, SHA-256 picks the exact sibling. Falls back to fileName ONLY
+ * when neither the profile entry nor the candidate currentMod carry ids: this keeps
  * local-to-local fileName matching working for custom mods, while refusing to
  * cross-match a legacy stable-id-less profile entry to an unrelated
  * GameBanana mod that just happens to occupy the same pakNN_ slot today. The
@@ -294,17 +286,16 @@ type ResolvedMatch =
  * any reorder rotated pakNN_ prefixes (Discord #bugs:
  * "Profile apply misrecognizing mods to turn on", 1.11.2).
  *
- * Stable-id matches that resolve to the same current mod are deduped on a
- * first-come basis so a profile with two entries pointing at the same
- * archive (shouldn't happen but possible after manual edits) can't double-
- * assign the same file.
+ * Matches are deduped on a first-come basis so duplicate profile entries can't
+ * double-assign the same file.
  */
 function buildProfileModResolver(
     currentMods: Array<import('../../../src/types/mod').Mod>
 ): (pm: ProfileMod) => ResolvedMatch {
     const byFileName = new Map<string, typeof currentMods[number]>();
-    const byGbFile = new Map<string, typeof currentMods[number]>();
+    const byGbFile = new Map<string, Array<typeof currentMods[number]>>();
     const bySha256 = new Map<string, typeof currentMods[number]>();
+    const shaByModId = new Map<string, string>();
     const metaByFileName = new Map<string, ReturnType<typeof getModMetadata>>();
     for (const mod of currentMods) {
         byFileName.set(mod.fileName, mod);
@@ -314,10 +305,19 @@ function buildProfileModResolver(
         const fileId = meta?.gameBananaFileId;
         if (typeof gbId === 'number' && typeof fileId === 'number') {
             const key = `${gbId}:${fileId}`;
-            if (!byGbFile.has(key)) byGbFile.set(key, mod);
+            const matches = byGbFile.get(key);
+            if (matches) {
+                matches.push(mod);
+            } else {
+                byGbFile.set(key, [mod]);
+            }
         }
-        if (typeof meta?.sha256 === 'string' && !bySha256.has(meta.sha256)) {
-            bySha256.set(meta.sha256, mod);
+        const sha256 = normalizeSha256(meta?.sha256);
+        if (sha256 !== null) {
+            shaByModId.set(mod.id, sha256);
+            if (!bySha256.has(sha256)) {
+                bySha256.set(sha256, mod);
+            }
         }
     }
     const claimed = new Set<string>();
@@ -326,20 +326,27 @@ function buildProfileModResolver(
             typeof pm.gameBananaId === 'number' &&
             typeof pm.gameBananaFileId === 'number';
 
+        const profileSha = normalizeSha256(pm.sha256);
+        const stableCandidates = profileHasStableIds
+            ? byGbFile.get(`${pm.gameBananaId}:${pm.gameBananaFileId}`) ?? []
+            : [];
         if (profileHasStableIds) {
-            const stable = byGbFile.get(`${pm.gameBananaId}:${pm.gameBananaFileId}`);
+            const stable =
+                (profileSha !== null
+                    ? stableCandidates.find(
+                        (mod) => shaByModId.get(mod.id) === profileSha && !claimed.has(mod.id)
+                    )
+                    : undefined) ??
+                stableCandidates.find((mod) => mod.fileName === pm.fileName && !claimed.has(mod.id)) ??
+                stableCandidates.find((mod) => !claimed.has(mod.id));
             if (stable && !claimed.has(stable.id)) {
                 claimed.add(stable.id);
                 return { mod: stable, via: 'stable' };
             }
         }
 
-        // Content fingerprint: a reliable identity that survives a fileName
-        // change, so it's tried before the (slot-reuse-prone) fileName fallback.
-        // Mainly rescues custom/local mods after they've been renamed free-form
-        // by a disable, which no plain-fileName lookup could match.
-        if (typeof pm.sha256 === 'string') {
-            const byHash = bySha256.get(pm.sha256);
+        if (profileSha !== null && (!profileHasStableIds || stableCandidates.length === 0)) {
+            const byHash = bySha256.get(profileSha);
             if (byHash && !claimed.has(byHash.id)) {
                 claimed.add(byHash.id);
                 return { mod: byHash, via: 'stable' };
@@ -428,15 +435,12 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
     const failures: string[] = [];
 
     await runExclusiveModMutation(async () => {
-        // Resolve each profile mod against the current scan by stable id
-        // (gameBananaId + gameBananaFileId) first, then by fileName ONLY when
-        // both sides are stable-id-less (custom mods + truly-local current
-        // mods). See buildProfileModResolver for the cross-match refusal that
-        // landed in response to "Profile apply misrecognizing mods to turn on".
+        // Resolve by archive id first, using hash for multi-VPK siblings.
+        // FileName fallback is only for stable-id-less local mods.
         const currentMods = await scanMods(deadlockPath);
         const resolveProfileMod = buildProfileModResolver(currentMods);
 
-        // currentMod.id → ProfileMod, when matched. Drives the enable/disable
+        // currentMod.id -> ProfileMod, when matched. Drives the enable/disable
         // loop and the reorder pass below.
         const profileModByCurrentId = new Map<string, ProfileMod>();
         for (const profileMod of profile.mods) {
@@ -471,6 +475,7 @@ export async function applyProfile(deadlockPath: string, profileId: string): Pro
                 );
             }
         }
+
         console.log(
             `[profiles] resolution summary: ${stableHits} stable, ${fileNameHits} fileName, ` +
             `${refusedCrossmatches} refused, ${unmatched} unmatched`

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -13,6 +13,8 @@ const DEFAULT_SETTINGS: AppSettings = {
     devMode: false,
     devDeadlockPath: null,
     hideNsfwPreviews: true,
+    browseNsfwContentMode: 'blur',
+    installedHideNsfwPreviews: true,
     hideOutdatedMods: false,
     lockerCardsExpandedByDefault: false,
     autoDisableSiblingVariants: true,
@@ -55,7 +57,17 @@ export function loadSettings(): AppSettings {
     try {
         const content = readFileSync(path, 'utf-8');
         const settings = JSON.parse(content) as Partial<AppSettings>;
-        return { ...DEFAULT_SETTINGS, ...settings };
+        return {
+            ...DEFAULT_SETTINGS,
+            ...settings,
+            browseNsfwContentMode:
+                settings.browseNsfwContentMode ??
+                (settings.hideNsfwPreviews === false ? 'show' : DEFAULT_SETTINGS.browseNsfwContentMode),
+            installedHideNsfwPreviews:
+                settings.installedHideNsfwPreviews ??
+                settings.hideNsfwPreviews ??
+                DEFAULT_SETTINGS.installedHideNsfwPreviews,
+        };
     } catch (error) {
         console.warn('[Settings] Failed to load settings, resetting to defaults:', error);
         return { ...DEFAULT_SETTINGS };

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -17,9 +17,8 @@ interface Props {
 /**
  * Confirmation modal for combining multiple installed mods into a single
  * merged VPK. Sources that share a GameBanana submission (color variants,
- * preset versions, etc.) collapse into a variant picker: exactly one
- * variant per group enters the merge, because variants of the same mod
- * occupy the same in-game file paths and would just override each other.
+ * preset versions, etc.) collapse into a variant picker. One variant is
+ * selected by default, and users can include more from the same group.
  *
  * The merger itself orders inputs by priority so the highest-priority source
  * (the lowest pakNN) wins on collisions, matching Deadlock's lower-pakNN-wins
@@ -32,9 +31,9 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
   const { t } = useTranslation();
   const groups = useMemo(() => buildSourceGroups(sources), [sources]);
 
-  // Picks: one chosen variant id per multi-variant group. Singles + single-
+  // Picks: selected variant ids per multi-variant group. Singles + single-
   // variant groups have no picker (they're always-on).
-  const [picks, setPicks] = useState<Record<string, string>>(() => initialPicks(groups));
+  const [picks, setPicks] = useState<Record<string, string[]>>(() => initialPicks(groups));
 
   const effectiveSources = useMemo(
     () => resolveEffectiveSources(groups, picks),
@@ -81,6 +80,25 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
       setError(err instanceof Error ? err.message : String(err));
       setSubmitting(false);
     }
+  };
+
+  const toggleVariantPick = (group: Extract<SourceGroup, { kind: 'variants' }>, variantId: string) => {
+    setPicks((prev) => {
+      const current = prev[group.key] ?? [defaultVariantForGroup(group).id];
+      const alreadyPicked = current.includes(variantId);
+      if (alreadyPicked && current.length <= 1) return prev;
+
+      const selected = new Set(current);
+      if (alreadyPicked) selected.delete(variantId);
+      else selected.add(variantId);
+
+      return {
+        ...prev,
+        [group.key]: group.variants
+          .filter((variant) => selected.has(variant.id))
+          .map((variant) => variant.id),
+      };
+    });
   };
 
   return (
@@ -135,7 +153,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
               </div>
               {groups.some((g) => g.kind === 'variants') && (
                 <div className="text-xs text-text-secondary">
-                  {t('mergeMods.oneVariant')}
+                  Pick one or more variants per mod
                 </div>
               )}
             </div>
@@ -172,8 +190,8 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
                     </div>
                     <div className="space-y-1">
                       {group.variants.map((variant) => {
-                        const id = picks[group.key];
-                        const isPicked = id === variant.id;
+                        const ids = picks[group.key] ?? [defaultVariantForGroup(group).id];
+                        const isPicked = ids.includes(variant.id);
                         return (
                           <label
                             key={variant.id}
@@ -184,10 +202,9 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
                             }`}
                           >
                             <input
-                              type="radio"
-                              name={`variant-${group.key}`}
+                              type="checkbox"
                               checked={isPicked}
-                              onChange={() => setPicks((prev) => ({ ...prev, [group.key]: variant.id }))}
+                              onChange={() => toggleVariantPick(group, variant.id)}
                               className="w-3.5 h-3.5 accent-accent cursor-pointer"
                             />
                             <span className="font-mono text-[11px] text-text-secondary tabular-nums w-6 text-right">
@@ -324,25 +341,28 @@ function primaryPriority(group: SourceGroup): number {
 
 /** Pick the most reasonable default variant for each multi-variant group:
  *  the first enabled variant if any, else the first by priority. */
-function initialPicks(groups: SourceGroup[]): Record<string, string> {
-  const picks: Record<string, string> = {};
+function initialPicks(groups: SourceGroup[]): Record<string, string[]> {
+  const picks: Record<string, string[]> = {};
   for (const g of groups) {
     if (g.kind !== 'variants') continue;
-    const defaultVariant = g.variants.find((v) => v.enabled) ?? g.variants[0];
-    picks[g.key] = defaultVariant.id;
+    picks[g.key] = [defaultVariantForGroup(g).id];
   }
   return picks;
 }
 
-function resolveEffectiveSources(groups: SourceGroup[], picks: Record<string, string>): Mod[] {
+function defaultVariantForGroup(group: Extract<SourceGroup, { kind: 'variants' }>): Mod {
+  return group.variants.find((v) => v.enabled) ?? group.variants[0];
+}
+
+function resolveEffectiveSources(groups: SourceGroup[], picks: Record<string, string[]>): Mod[] {
   const out: Mod[] = [];
   for (const g of groups) {
     if (g.kind === 'single') {
       out.push(g.mod);
     } else {
-      const pickedId = picks[g.key];
-      const picked = g.variants.find((v) => v.id === pickedId) ?? g.variants[0];
-      out.push(picked);
+      const pickedIds = new Set(picks[g.key] ?? [defaultVariantForGroup(g).id]);
+      const picked = g.variants.filter((v) => pickedIds.has(v.id));
+      out.push(...(picked.length > 0 ? picked : [defaultVariantForGroup(g)]));
     }
   }
   return out;

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -493,7 +493,7 @@ function ModDetailsModal({
     return (
       <div
         key={file.id}
-        className={`grid grid-cols-[auto,minmax(0,1fr)] items-center gap-x-3 gap-y-2 p-3 rounded-lg border transition-colors sm:grid-cols-[auto,minmax(0,1fr),auto] ${
+        className={`flex flex-wrap items-center gap-3 p-3 rounded-lg border transition-colors sm:flex-nowrap ${
           isUpdate
             ? 'border-accent/40 bg-accent/5'
             : isActive
@@ -518,15 +518,10 @@ function ModDetailsModal({
         }`}>
           <FileArchive className="w-5 h-5" />
         </div>
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1 text-left">
           <div className="flex min-w-0 max-w-full items-center gap-2">
             <p className="min-w-0 flex-1 truncate text-sm font-medium" title={file.fileName}>{file.fileName}</p>
             {archived && <ArchivedTag />}
-            {isActive && (
-              <span className="flex-shrink-0 text-[10px] uppercase tracking-wide bg-accent/20 text-accent rounded px-1.5 py-0.5">
-                {t('common.status.active')}
-              </span>
-            )}
           </div>
           {file.description && (
             <p className="text-xs text-text-secondary/90 mt-0.5 truncate" title={file.description}>
@@ -559,7 +554,12 @@ function ModDetailsModal({
             </div>
           )}
         </div>
-        <div className="col-start-2 flex min-w-0 flex-wrap items-center justify-end gap-2 sm:col-start-3 sm:row-start-1">
+        <div className="ml-[52px] flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2 sm:ml-0 sm:flex-none">
+          {isActive && (
+            <span className="flex-shrink-0 self-center rounded bg-accent/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent">
+              {t('common.status.active')}
+            </span>
+          )}
           {showEnablePill && installedFileState && (
             <Button
               type="button"

--- a/src/components/VariantPickerModal.tsx
+++ b/src/components/VariantPickerModal.tsx
@@ -182,8 +182,14 @@ export default function VariantPickerModal({
     const enabledCount = variants.filter((v) => v.enabled).length;
     const anyActive = enabledCount > 0;
 
+    const variantDisplayName = (v: Mod) =>
+        v.variantLabel ??
+        v.fileDescription ??
+        v.sourceFileName ??
+        v.fileName;
+
     const startRename = (v: Mod) => {
-        setEditing({ id: v.id, draft: v.variantLabel ?? '' });
+        setEditing({ id: v.id, draft: variantDisplayName(v) });
     };
 
     const cancelRename = () => setEditing(null);
@@ -191,7 +197,7 @@ export default function VariantPickerModal({
     const commitRename = async (v: Mod) => {
         if (!editing || editing.id !== v.id || pending) return;
         const next = editing.draft.trim();
-        if (next === (v.variantLabel ?? '')) {
+        if (next === variantDisplayName(v)) {
             setEditing(null);
             return;
         }
@@ -301,11 +307,7 @@ export default function VariantPickerModal({
         const isMoveDownPending = pending === `move:${v.id}:down`;
         const hasUpdate = variantsWithUpdate?.has(v.id) ?? false;
         const conflictDetails = conflictsByVariantId[v.id] ?? [];
-        const primaryTitle =
-            v.variantLabel ??
-            v.fileDescription ??
-            v.sourceFileName ??
-            v.fileName;
+        const primaryTitle = variantDisplayName(v);
         const showSecondaryFileName =
             !!v.variantLabel || !!v.fileDescription || !!v.sourceFileName;
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,24 @@ import type {
 } from '../types/gamebanana';
 import type { DownloadedLocale, LocaleManifest } from '../types/locales';
 import { parseFeModel, type ClothModel } from './feModel';
+import { showToast } from '../stores/toastStore';
+
+const GAME_RUNNING_NOTICE = 'Game is running';
+
+function isGameRunningModLockError(err: unknown): boolean {
+  return String(err).includes(GAME_RUNNING_NOTICE);
+}
+
+async function withGameRunningWarning<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (err) {
+    if (isGameRunningModLockError(err)) {
+      showToast(GAME_RUNNING_NOTICE, { tone: 'warning' });
+    }
+    throw err;
+  }
+}
 
 // Re-export types for convenience
 export type {
@@ -77,11 +95,11 @@ export async function enableMod(modId: string): Promise<Mod> {
 }
 
 export async function disableMod(modId: string): Promise<Mod> {
-  return window.electronAPI.disableMod(modId);
+  return withGameRunningWarning(() => window.electronAPI.disableMod(modId));
 }
 
 export async function deleteMod(modId: string): Promise<void> {
-  return window.electronAPI.deleteMod(modId);
+  return withGameRunningWarning(() => window.electronAPI.deleteMod(modId));
 }
 
 export async function revealModInFolder(modId: string): Promise<void> {
@@ -413,15 +431,15 @@ export async function backfillGameBananaFileId(
 }
 
 export async function setModPriority(modId: string, priority: number): Promise<Mod> {
-  return window.electronAPI.setModPriority(modId, priority);
+  return withGameRunningWarning(() => window.electronAPI.setModPriority(modId, priority));
 }
 
 export async function reorderMods(orderedIds: string[]): Promise<Mod[]> {
-  return window.electronAPI.reorderMods(orderedIds);
+  return withGameRunningWarning(() => window.electronAPI.reorderMods(orderedIds));
 }
 
 export async function swapModPriority(modIdA: string, modIdB: string): Promise<Mod[]> {
-  return window.electronAPI.swapModPriority(modIdA, modIdB);
+  return withGameRunningWarning(() => window.electronAPI.swapModPriority(modIdA, modIdB));
 }
 
 export async function importCustomMod(args: {
@@ -620,18 +638,18 @@ export async function getAppearanceImageEdit(
 }
 
 export async function mergeMods(args: MergeModsArgs): Promise<Mod> {
-  return window.electronAPI.mergeMods(args);
+  return withGameRunningWarning(() => window.electronAPI.mergeMods(args));
 }
 
 export async function unmergeMod(mergedModId: string): Promise<UnmergeModResult> {
-  return window.electronAPI.unmergeMod(mergedModId);
+  return withGameRunningWarning(() => window.electronAPI.unmergeMod(mergedModId));
 }
 
 export async function extractMergeSource(
   mergedModId: string,
   sourceFileName: string,
 ): Promise<ExtractMergeSourceResult> {
-  return window.electronAPI.extractMergeSource(mergedModId, sourceFileName);
+  return withGameRunningWarning(() => window.electronAPI.extractMergeSource(mergedModId, sourceFileName));
 }
 
 export type { UnmergeModResult, ExtractMergeSourceResult };
@@ -737,7 +755,7 @@ export async function downloadMod(
   categoryId?: number,
   modName?: string
 ): Promise<void> {
-  return window.electronAPI.downloadMod({ modId, fileId, fileName, section, categoryId, modName });
+  return withGameRunningWarning(() => window.electronAPI.downloadMod({ modId, fileId, fileName, section, categoryId, modName }));
 }
 
 export async function getGamebananaSections(): Promise<GameBananaSection[]> {
@@ -969,7 +987,7 @@ export async function updateProfile(profileId: string, crosshairSettings?: Profi
 }
 
 export async function applyProfile(profileId: string): Promise<Profile> {
-  return window.electronAPI.applyProfile(profileId);
+  return withGameRunningWarning(() => window.electronAPI.applyProfile(profileId));
 }
 
 export async function deleteProfile(profileId: string): Promise<void> {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -220,6 +220,7 @@
     "commands": {
       "emptyTitle": "No commands added",
       "emptyDescription": "Select from presets on the left",
+      "manualTooltip": "This command was already in autoexec.cfg and is shown read-only.",
       "title_one": "Your Commands ({{count}})",
       "title_other": "Your Commands ({{count}})"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -243,6 +243,8 @@
       "title": "Launch Options"
     },
     "presets": {
+      "title": "Premade Commands",
+      "toggle": "Toggle premade commands",
       "performance": {
         "category": "Performance",
         "uncapFps": {
@@ -290,6 +292,10 @@
         "disablePostMatchSurvey": {
           "name": "Disable Post-Match Survey",
           "description": "Skip the survey after matches"
+        },
+        "offscreenDamageIndicator": {
+          "name": "Offscreen Damage Indicators",
+          "description": "Show minion indicators through walls when a teammate sees a droid"
         }
       },
       "minimap": {
@@ -305,6 +311,10 @@
         "largerPlayerIcons": {
           "name": "Larger Player Icons",
           "description": "Bigger player icons on minimap"
+        },
+        "largerLocalPlayerIcon": {
+          "name": "Larger Local Player Icon",
+          "description": "Make your own minimap icon larger"
         },
         "thickerZiplines": {
           "name": "Thicker Ziplines",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -727,6 +727,8 @@
       "hideNsfw": "Hide NSFW Content",
       "hideNsfwDescription": "Blur thumbnail images for mods marked as NSFW.",
       "hideOutdated": "Hide Outdated Mods",
+      "blurInstalledNsfw": "Blur Installed NSFW Content",
+      "blurInstalledNsfwDescription": "Blur thumbnail images for installed mods marked as NSFW.",
       "expandLocker": "Expand Locker cards by default",
       "switchVariants": "Switch variants instead of stacking them",
       "enableAfterDownload": "Enable mods after download",
@@ -2110,7 +2112,12 @@
       "cardStyle": "Card style",
       "cardDesign": "Browse card design",
       "detailsView": "Details view",
-      "modDetailsView": "Mod details view"
+      "modDetailsView": "Mod details view",
+      "nsfwContent": "NSFW Content",
+      "outdatedContent": "Outdated Content",
+      "show": "Show",
+      "blur": "Blur",
+      "hide": "Hide"
     },
     "cardStyle": {
       "default": "Default",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1847,
+  "totalKeys": 1854,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1847,
+      "translatedKeys": 1854,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1855,
+  "totalKeys": 1861,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1855,
+      "translatedKeys": 1861,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1830,
-      "pct": 99
+      "pct": 98
     },
     {
       "code": "ru",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,17 +1,17 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1854,
+  "totalKeys": 1855,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1623,
-      "pct": 88
+      "pct": 87
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1854,
+      "translatedKeys": 1855,
       "pct": 100
     },
     {

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -87,6 +87,7 @@ export default function Autoexec() {
     const [gamePath, setGamePath] = useState<string | null>(null);
     const [status, setStatus] = useState<AutoexecStatus | null>(null);
     const [commands, setCommands] = useState<string[]>([]);
+    const [manualCommands, setManualCommands] = useState<string[]>([]);
     const [customCommand, setCustomCommand] = useState('');
     const [searchTerm, setSearchTerm] = useState('');
     const [copied, setCopied] = useState(false);
@@ -118,9 +119,8 @@ export default function Autoexec() {
                 setStatus(s);
 
                 const result = await window.electronAPI.getAutoexecCommands(settings.deadlockPath);
-                if (result.commands.length > 0) {
-                    setCommands(result.commands);
-                }
+                setCommands(result.commands);
+                setManualCommands(result.manualCommands);
             }
             try {
                 const status = await window.electronAPI.getSteamLaunchOptionsStatus();
@@ -176,8 +176,12 @@ export default function Autoexec() {
         })).filter(cat => cat.commands.length > 0);
     }, [searchTerm, t]);
 
+    const visibleCommandCount = commands.length + manualCommands.length;
+    const copiedCommands = useMemo(() => [...commands, ...manualCommands], [commands, manualCommands]);
+    const commandAlreadyPresent = (command: string) => commands.includes(command) || manualCommands.includes(command);
+
     const handleAddCommand = (command: string) => {
-        if (commands.includes(command)) return;
+        if (commandAlreadyPresent(command)) return;
         setCommands(prev => [...prev, command]);
         setHasUnsaved(true);
     };
@@ -194,7 +198,7 @@ export default function Autoexec() {
     };
 
     const handleCopy = async () => {
-        await navigator.clipboard.writeText(commands.join('\n'));
+        await navigator.clipboard.writeText(copiedCommands.join('\n'));
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
     };
@@ -216,6 +220,9 @@ export default function Autoexec() {
             // Refresh status
             const s = await window.electronAPI.getAutoexecStatus(gamePath);
             setStatus(s);
+            const result = await window.electronAPI.getAutoexecCommands(gamePath);
+            setCommands(result.commands);
+            setManualCommands(result.manualCommands);
             setTimeout(() => setSaveMessage(null), 3000);
         } catch (err) {
             setSaveMessage(t('autoexec.status.error', { error: String(err) }) + memeToastSuffix('error'));
@@ -258,7 +265,11 @@ export default function Autoexec() {
                                     className="flex-1 font-mono"
                                     onKeyDown={(e) => e.key === 'Enter' && handleAddCustomCommand()}
                                 />
-                                <Button onClick={handleAddCustomCommand} disabled={!customCommand.trim()} icon={Plus} />
+                                <Button
+                                    onClick={handleAddCustomCommand}
+                                    disabled={!customCommand.trim() || commandAlreadyPresent(customCommand.trim())}
+                                    icon={Plus}
+                                />
                             </div>
                         </Card>
 
@@ -270,7 +281,7 @@ export default function Autoexec() {
                             >
                                 <div className="space-y-1">
                                     {category.commands.map((cmd) => {
-                                        const isAdded = commands.includes(cmd.command);
+                                        const isAdded = commandAlreadyPresent(cmd.command);
                                         return (
                                             <button
                                                 key={cmd.command}
@@ -311,8 +322,8 @@ export default function Autoexec() {
                                 <span className="truncate">
                                     <Tx
                                         k="autoexec.commands.title"
-                                        values={{ count: commands.length }}
-                                        fallback={`Your Commands (${commands.length})`}
+                                        values={{ count: visibleCommandCount }}
+                                        fallback={`Your Commands (${visibleCommandCount})`}
                                     />
                                 </span>
                                 {status ? (
@@ -334,7 +345,7 @@ export default function Autoexec() {
                                 <Button size="sm" variant="secondary" onClick={() => setClearConfirmOpen(true)} disabled={commands.length === 0} icon={RefreshCw}>
                                     <Tx k="common.actions.clear" fallback="Clear" />
                                 </Button>
-                                <Button size="sm" variant="secondary" onClick={handleCopy} disabled={commands.length === 0} icon={copied ? Check : Copy}>
+                                <Button size="sm" variant="secondary" onClick={handleCopy} disabled={copiedCommands.length === 0} icon={copied ? Check : Copy}>
                                     {copied ? (
                                         <Tx k="common.status.copied" fallback="Copied" />
                                     ) : (
@@ -380,24 +391,37 @@ export default function Autoexec() {
                         )}
 
                         <div className="overflow-y-auto space-y-2 pr-1 flex-1 min-h-0">
-                            {commands.length > 0 ? (
-                                commands.map((cmd, i) => (
-                                    <div
-                                        key={i}
-                                        className="flex items-center gap-3 p-3 bg-bg-tertiary/50 border border-white/5 rounded-lg group hover:border-white/10 transition-colors animate-fade-in"
-                                    >
-                                        <div className="flex-1 font-mono text-sm text-text-primary truncate">
-                                            {cmd}
-                                        </div>
-                                        <button
-                                            onClick={() => handleRemoveCommand(i)}
-                                            className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-text-secondary hover:text-state-danger rounded transition-all cursor-pointer"
-                                            title={t('common.actions.remove')}
+                            {visibleCommandCount > 0 ? (
+                                <>
+                                    {commands.map((cmd, i) => (
+                                        <div
+                                            key={`managed-${i}-${cmd}`}
+                                            className="flex items-center gap-3 p-3 bg-bg-tertiary/50 border border-white/5 rounded-lg group hover:border-white/10 transition-colors animate-fade-in"
                                         >
-                                            <Trash2 className="w-4 h-4" />
-                                        </button>
-                                    </div>
-                                ))
+                                            <div className="flex-1 font-mono text-sm text-text-primary truncate">
+                                                {cmd}
+                                            </div>
+                                            <button
+                                                onClick={() => handleRemoveCommand(i)}
+                                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-text-secondary hover:text-state-danger rounded transition-all cursor-pointer"
+                                                title={t('common.actions.remove')}
+                                            >
+                                                <Trash2 className="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                    ))}
+                                    {manualCommands.map((cmd, i) => (
+                                        <div
+                                            key={`manual-${i}-${cmd}`}
+                                            className="flex items-center gap-3 p-3 bg-bg-tertiary/20 border border-white/5 rounded-lg opacity-60 cursor-help animate-fade-in"
+                                            title={t('autoexec.commands.manualTooltip')}
+                                        >
+                                            <div className="flex-1 font-mono text-sm text-text-secondary truncate">
+                                                {cmd}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </>
                             ) : (
                                 <div className="flex items-center gap-3 py-6 text-text-secondary opacity-50">
                                     <Terminal className="w-6 h-6" />

--- a/src/pages/Autoexec.tsx
+++ b/src/pages/Autoexec.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket } from 'lucide-react';
+import { Terminal, Copy, Check, Plus, Trash2, RefreshCw, Zap, Globe, Layout, Map, Users, MousePointer2, Search, Save, AlertTriangle, Rocket, ChevronDown } from 'lucide-react';
 import { getSettings, setSettings } from '../lib/api';
 import { Card, Badge, Button } from '../components/common/ui';
 import { Input } from '../components/common/forms';
@@ -41,6 +41,7 @@ const COMMAND_PRESETS = [
             { nameKey: 'autoexec.presets.hud.hideHud.name', nameFallback: 'Hide HUD', command: 'citadel_hud_visible false', descriptionKey: 'autoexec.presets.hud.hideHud.description', descriptionFallback: 'Hide the entire HUD' },
             { nameKey: 'autoexec.presets.hud.showHud.name', nameFallback: 'Show HUD', command: 'citadel_hud_visible true', descriptionKey: 'autoexec.presets.hud.showHud.description', descriptionFallback: 'Show the HUD' },
             { nameKey: 'autoexec.presets.hud.disablePostMatchSurvey.name', nameFallback: 'Disable Post-Match Survey', command: 'deadlock_post_match_survey_disabled true', descriptionKey: 'autoexec.presets.hud.disablePostMatchSurvey.description', descriptionFallback: 'Skip the survey after matches' },
+            { nameKey: 'autoexec.presets.hud.offscreenDamageIndicator.name', nameFallback: 'Offscreen Damage Indicators', command: 'citadel_damage_offscreen_indicator_disabled false', descriptionKey: 'autoexec.presets.hud.offscreenDamageIndicator.description', descriptionFallback: 'Show minion indicators through walls when a teammate sees a droid' },
         ],
     },
     {
@@ -51,6 +52,7 @@ const COMMAND_PRESETS = [
             { nameKey: 'autoexec.presets.minimap.fasterMinimap.name', nameFallback: 'Faster Minimap', command: 'minimap_update_rate_hz 60', descriptionKey: 'autoexec.presets.minimap.fasterMinimap.description', descriptionFallback: 'Update minimap at 60Hz' },
             { nameKey: 'autoexec.presets.minimap.largerClickRadius.name', nameFallback: 'Larger Click Radius', command: 'citadel_minimap_unit_click_radius 200', descriptionKey: 'autoexec.presets.minimap.largerClickRadius.description', descriptionFallback: 'Easier to click units on minimap' },
             { nameKey: 'autoexec.presets.minimap.largerPlayerIcons.name', nameFallback: 'Larger Player Icons', command: 'citadel_minimap_player_width 6.5', descriptionKey: 'autoexec.presets.minimap.largerPlayerIcons.description', descriptionFallback: 'Bigger player icons on minimap' },
+            { nameKey: 'autoexec.presets.minimap.largerLocalPlayerIcon.name', nameFallback: 'Larger Local Player Icon', command: 'citadel_minimap_local_player_width 10.0', descriptionKey: 'autoexec.presets.minimap.largerLocalPlayerIcon.description', descriptionFallback: 'Make your own minimap icon larger' },
             { nameKey: 'autoexec.presets.minimap.thickerZiplines.name', nameFallback: 'Thicker Ziplines', command: 'citadel_minimap_zip_line_thickness 2', descriptionKey: 'autoexec.presets.minimap.thickerZiplines.description', descriptionFallback: 'More visible ziplines' },
         ],
     },
@@ -90,6 +92,7 @@ export default function Autoexec() {
     const [manualCommands, setManualCommands] = useState<string[]>([]);
     const [customCommand, setCustomCommand] = useState('');
     const [searchTerm, setSearchTerm] = useState('');
+    const [presetsExpanded, setPresetsExpanded] = useState(false);
     const [copied, setCopied] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
@@ -241,75 +244,106 @@ export default function Autoexec() {
     return (
         <div className="flex flex-col min-h-0 flex-1 p-6 space-y-6 overflow-auto">
             <div className="flex flex-col lg:flex-row flex-1 gap-6 min-h-0 overflow-auto">
-                {/* Left Panel - Command Presets */}
+                {/* Left Panel - Command Builder */}
                 <div className="w-full lg:w-1/2 flex flex-col gap-4 overflow-hidden order-2 lg:order-1">
-                    <div className="shrink-0">
-                        <Input
-                            icon={Search}
-                            type="text"
-                            value={searchTerm}
-                            onChange={(e) => setSearchTerm(e.target.value)}
-                            placeholder={t('autoexec.search.placeholder')}
-                        />
-                    </div>
-
                     <div className="flex-1 overflow-y-auto space-y-4 pr-2">
                         {/* Custom Command Input */}
                         <Card title={<Tx k="autoexec.customCommand.title" fallback="Custom Command" />}>
-                            <div className="flex gap-2">
-                                <Input
-                                    type="text"
-                                    value={customCommand}
-                                    onChange={(e) => setCustomCommand(e.target.value)}
-                                    placeholder={t('autoexec.customCommand.placeholder')}
-                                    className="flex-1 font-mono"
-                                    onKeyDown={(e) => e.key === 'Enter' && handleAddCustomCommand()}
-                                />
-                                <Button
-                                    onClick={handleAddCustomCommand}
-                                    disabled={!customCommand.trim() || commandAlreadyPresent(customCommand.trim())}
-                                    icon={Plus}
-                                />
+                            <div className="space-y-4">
+                                <div className="flex gap-2">
+                                    <Input
+                                        type="text"
+                                        value={customCommand}
+                                        onChange={(e) => setCustomCommand(e.target.value)}
+                                        placeholder={t('autoexec.customCommand.placeholder')}
+                                        className="flex-1 font-mono"
+                                        onKeyDown={(e) => e.key === 'Enter' && handleAddCustomCommand()}
+                                    />
+                                    <Button
+                                        onClick={handleAddCustomCommand}
+                                        disabled={!customCommand.trim() || commandAlreadyPresent(customCommand.trim())}
+                                        icon={Plus}
+                                    />
+                                </div>
+
+                                <button
+                                    type="button"
+                                    onClick={() => setPresetsExpanded((expanded) => !expanded)}
+                                    aria-expanded={presetsExpanded}
+                                    aria-label={t('autoexec.presets.toggle')}
+                                    className="flex w-full items-center justify-between border-t border-white/5 pt-4 text-left text-sm font-semibold text-text-primary transition-colors hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                                >
+                                    <span className="flex items-center gap-2">
+                                        <Terminal className="h-4 w-4 text-accent" />
+                                        <Tx k="autoexec.presets.title" fallback="Premade Commands" />
+                                    </span>
+                                    <ChevronDown className={`h-4 w-4 text-text-secondary transition-transform ${presetsExpanded ? 'rotate-180' : ''}`} />
+                                </button>
+
+                                {presetsExpanded && (
+                                    <div className="space-y-3">
+                                        <Input
+                                            icon={Search}
+                                            type="text"
+                                            value={searchTerm}
+                                            onChange={(e) => setSearchTerm(e.target.value)}
+                                            placeholder={t('autoexec.search.placeholder')}
+                                        />
+
+                                        <div className="max-h-[min(52vh,calc(100vh-20rem))] space-y-4 overflow-y-auto overscroll-contain pr-1 [scrollbar-gutter:stable]">
+                                            {filteredPresets.map((category) => {
+                                                const CategoryIcon = category.icon;
+                                                return (
+                                                    <section
+                                                        key={category.categoryKey}
+                                                        className="rounded-sm border border-white/5 bg-bg-tertiary/25 p-2.5"
+                                                    >
+                                                        <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-primary">
+                                                            <CategoryIcon className="h-4 w-4 text-accent" />
+                                                            <Tx k={category.categoryKey} fallback={category.categoryFallback} />
+                                                        </div>
+
+                                                        <div className="space-y-1">
+                                                            {category.commands.map((cmd) => {
+                                                                const isAdded = commandAlreadyPresent(cmd.command);
+                                                                const commandName = t(cmd.nameKey);
+                                                                const commandDescription = t(cmd.descriptionKey);
+                                                                return (
+                                                                    <button
+                                                                        key={cmd.command}
+                                                                        onClick={() => handleAddCommand(cmd.command)}
+                                                                        disabled={isAdded}
+                                                                        title={commandDescription}
+                                                                        aria-label={`${commandName}: ${commandDescription}. ${cmd.command}`}
+                                                                        className={`w-full p-2 rounded-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isAdded
+                                                                            ? 'bg-accent/10 border border-accent/20 cursor-default opacity-60'
+                                                                            : 'bg-bg-tertiary/50 hover:bg-bg-tertiary border border-transparent hover:border-white/5 cursor-pointer'
+                                                                            }`}
+                                                                    >
+                                                                        <div className="flex items-center justify-between gap-3">
+                                                                            <span className={`min-w-0 truncate text-left text-sm font-medium ${isAdded ? 'text-accent' : 'text-text-primary'}`}>
+                                                                                <Tx k={cmd.nameKey} fallback={cmd.nameFallback} />
+                                                                            </span>
+                                                                            <span className="flex min-w-0 shrink-0 items-center gap-2">
+                                                                                <code className="max-w-64 truncate rounded-sm bg-black/30 px-1.5 py-0.5 font-mono text-xs text-text-primary/80">
+                                                                                    {cmd.command}
+                                                                                </code>
+                                                                                {isAdded && <Check className="h-3 w-3 shrink-0 text-accent" />}
+                                                                            </span>
+                                                                        </div>
+                                                                    </button>
+                                                                );
+                                                            })}
+                                                        </div>
+                                                    </section>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         </Card>
 
-                        {filteredPresets.map((category) => (
-                            <Card
-                                key={category.categoryKey}
-                                title={<Tx k={category.categoryKey} fallback={category.categoryFallback} />}
-                                icon={category.icon}
-                            >
-                                <div className="space-y-1">
-                                    {category.commands.map((cmd) => {
-                                        const isAdded = commandAlreadyPresent(cmd.command);
-                                        return (
-                                            <button
-                                                key={cmd.command}
-                                                onClick={() => handleAddCommand(cmd.command)}
-                                                disabled={isAdded}
-                                                className={`w-full text-left p-3 rounded-lg transition-all group focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isAdded
-                                                    ? 'bg-accent/10 border border-accent/20 cursor-default opacity-60'
-                                                    : 'bg-bg-tertiary/50 hover:bg-bg-tertiary border border-transparent hover:border-white/5 cursor-pointer'
-                                                    }`}
-                                            >
-                                                <div className="flex items-center justify-between mb-1">
-                                                    <span className={`text-sm font-medium ${isAdded ? 'text-accent' : 'text-text-primary'}`}>
-                                                        <Tx k={cmd.nameKey} fallback={cmd.nameFallback} />
-                                                    </span>
-                                                    {isAdded && <Check className="w-3 h-3 text-accent" />}
-                                                </div>
-                                                <div className="flex items-center justify-between text-xs text-text-secondary">
-                                                    <span><Tx k={cmd.descriptionKey} fallback={cmd.descriptionFallback} /></span>
-                                                    <code className="bg-black/30 px-1.5 py-0.5 rounded font-mono text-text-primary/80">
-                                                        {cmd.command}
-                                                    </code>
-                                                </div>
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            </Card>
-                        ))}
                     </div>
                 </div>
 

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -335,7 +335,9 @@ function clampBrowseCardSizeMultiplier(value: number): number {
 }
 
 function readBrowseCardSizeMultiplier(): number {
-  const stored = Number(localStorage.getItem(BROWSE_CARD_SIZE_MULTIPLIER_KEY));
+  const raw = localStorage.getItem(BROWSE_CARD_SIZE_MULTIPLIER_KEY);
+  if (raw == null || raw === '') return BROWSE_CARD_SIZE_MULTIPLIER_DEFAULT;
+  const stored = Number(raw);
   return Number.isFinite(stored) ? clampBrowseCardSizeMultiplier(stored) : BROWSE_CARD_SIZE_MULTIPLIER_DEFAULT;
 }
 

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -7,6 +7,8 @@ import {
   Loader2,
   Download,
   Eye,
+  EyeClosed,
+  EyeOff,
   ThumbsUp,
   X,
   Volume2,
@@ -81,13 +83,14 @@ import {
   useAppStore,
 } from '../stores/appStore';
 import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout, BrowseArtistRef } from '../stores/appStore';
+import type { BrowseNsfwContentMode } from '../types/mod';
 import ModThumbnail from '../components/ModThumbnail';
 import BrowseFileQuickPicker from '../components/BrowseFileQuickPicker';
 import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import { DynamicSelect } from '../components/common/DynamicSelect';
 import { HeroSelect } from '../components/common/HeroSelect';
-import { Button, IconButton, SegmentedControl, Tag } from '../components/common/ui';
+import { Button, IconButton, Tag } from '../components/common/ui';
 import { Select } from '../components/common/forms';
 import { IconText } from '../components/common/IconText';
 import { EmptyState } from '../components/common/PageComponents';
@@ -1007,10 +1010,72 @@ function renderErrorWithLinks(text: string): React.ReactNode {
   });
 }
 
+function BrowseViewOptionControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  disabled = false,
+}: {
+  label: string;
+  value: T;
+  options: readonly { value: T; label: React.ReactNode; icon?: LucideIcon }[];
+  onChange: (value: T) => void;
+  disabled?: boolean;
+}) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const move = (from: number, dir: -1 | 1) => {
+    if (disabled) return;
+    const next = (from + dir + options.length) % options.length;
+    onChange(options[next].value);
+    refs.current[next]?.focus();
+  };
+
+  return (
+    <div className="flex items-center rounded-lg border border-border bg-bg-secondary p-[3px]" role="tablist" aria-label={label}>
+      {options.map((option, i) => {
+        const Icon = option.icon;
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            ref={(el) => { refs.current[i] = el; }}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            tabIndex={active ? 0 : -1}
+            disabled={disabled}
+            onClick={() => !disabled && onChange(option.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                move(i, 1);
+              } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                e.preventDefault();
+                move(i, -1);
+              }
+            }}
+            className={`flex h-7 min-w-0 flex-1 items-center justify-center gap-1 rounded-md px-2 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-default ${
+              active
+                ? 'bg-bg-tertiary text-text-primary'
+                : 'text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {Icon && <Icon className="h-3.5 w-3.5 flex-shrink-0" />}
+            <span className="min-w-0 translate-y-px truncate">{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function Browse() {
   const { t } = useTranslation();
   const settings = useAppStore((s) => s.settings);
   const loadSettings = useAppStore((s) => s.loadSettings);
+  const saveSettings = useAppStore((s) => s.saveSettings);
   const loadMods = useAppStore((s) => s.loadMods);
   const deleteMod = useAppStore((s) => s.deleteMod);
   const installedMods = useAppStore((s) => s.mods);
@@ -1052,6 +1117,18 @@ export default function Browse() {
     setBrowseCardSizeMultiplierState(clampedMultiplier);
     localStorage.setItem(BROWSE_CARD_SIZE_MULTIPLIER_KEY, String(clampedMultiplier));
   }, []);
+  const browseNsfwContentMode: BrowseNsfwContentMode =
+    settings?.browseNsfwContentMode ??
+    (settings?.hideNsfwPreviews === false ? 'show' : 'blur');
+  const browseBlurNsfwPreviews = browseNsfwContentMode === 'blur';
+  const setBrowseNsfwContentMode = useCallback((mode: BrowseNsfwContentMode) => {
+    if (!settings) return;
+    void saveSettings({ ...settings, browseNsfwContentMode: mode });
+  }, [saveSettings, settings]);
+  const setBrowseHideOutdated = useCallback((checked: boolean) => {
+    if (!settings) return;
+    void saveSettings({ ...settings, hideOutdatedMods: checked });
+  }, [saveSettings, settings]);
   // Hydrate from session cache on mount so navigating away + back doesn't
   // wipe loaded results or scroll position. The cache stamp encodes current
   // filters; if filters changed in between (impossible today since they only
@@ -1250,7 +1327,7 @@ export default function Browse() {
     if (sidebarCloseTimerRef.current !== null) window.clearTimeout(sidebarCloseTimerRef.current);
   }, []);
 
-  // Load settings on mount (needed for hideNsfwPreviews)
+  // Load settings on mount for Browse content preferences.
   useEffect(() => {
     loadSettings();
   }, [loadSettings]);
@@ -2557,6 +2634,9 @@ export default function Browse() {
     if (section === 'Sound' && heroCategoryId === 'none') {
       nextMods = nextMods.filter((m) => inferHeroFromTitle(m.name) === null);
     }
+    if (browseNsfwContentMode === 'hide') {
+      nextMods = nextMods.filter((m) => !m.nsfw);
+    }
     // The NSFW filter is only enforced server-side by the local-search path.
     // The remote paths (artist mode, and the no-local-cache fallback) return
     // unfiltered records, so enforce it here too. Local results already match,
@@ -2568,7 +2648,7 @@ export default function Browse() {
     }
 
     return nextMods;
-  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId, nsfw]);
+  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId, browseNsfwContentMode, nsfw]);
   const selectedModIndex = selectedMod
     ? displayMods.findIndex((mod) => mod.id === selectedMod.id)
     : -1;
@@ -2748,7 +2828,7 @@ export default function Browse() {
         queuedFileIds={selectedQueuedFileIds}
         extracting={extracting}
         progress={downloadProgress}
-        hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+        hideNsfwPreviews={browseBlurNsfwPreviews}
         dateAdded={selectedModDates?.dateAdded}
         dateModified={selectedModDates?.dateModified}
         isNavigating={!!modalNavigation}
@@ -3007,14 +3087,13 @@ export default function Browse() {
                   <div className="space-y-4">
                     <div>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.layout')}</div>
-                      <SegmentedControl<BrowseLayout>
-                        fill
+                      <BrowseViewOptionControl<BrowseLayout>
                         label={t('browse.viewOptions.layout')}
                         value={layout}
                         onChange={setLayout}
                         options={[
-                          { value: 'grid', label: <><LayoutGrid className="h-4 w-4" />{t('browse.viewOptions.grid')}</> },
-                          { value: 'list', label: <><List className="h-4 w-4" />{t('browse.viewOptions.list')}</> },
+                          { value: 'grid', label: t('browse.viewOptions.grid'), icon: LayoutGrid },
+                          { value: 'list', label: t('browse.viewOptions.list'), icon: List },
                         ]}
                       />
                     </div>
@@ -3047,8 +3126,7 @@ export default function Browse() {
 
                     <div className={layout === 'list' ? 'opacity-45' : ''}>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.cardStyle')}</div>
-                      <SegmentedControl<BrowseCardDesign>
-                        fill
+                      <BrowseViewOptionControl<BrowseCardDesign>
                         disabled={layout === 'list'}
                         label={t('browse.viewOptions.cardDesign')}
                         value={browseCardDesign}
@@ -3062,14 +3140,40 @@ export default function Browse() {
 
                     <div>
                       <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.detailsView')}</div>
-                      <SegmentedControl<BrowseDetailsView>
-                        fill
+                      <BrowseViewOptionControl<BrowseDetailsView>
                         label={t('browse.viewOptions.modDetailsView')}
                         value={browseDetailsView}
                         onChange={setBrowseDetailsView}
                         options={[
-                          { value: 'modal', label: <><Maximize2 className="h-3.5 w-3.5" />{t('browse.detailsView.window')}</> },
-                          { value: 'sidebar', label: <><PanelRight className="h-3.5 w-3.5" />{t('browse.detailsView.sidebar')}</> },
+                          { value: 'modal', label: t('browse.detailsView.window'), icon: Maximize2 },
+                          { value: 'sidebar', label: t('browse.detailsView.sidebar'), icon: PanelRight },
+                        ]}
+                      />
+                    </div>
+
+                    <div>
+                      <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.nsfwContent')}</div>
+                      <BrowseViewOptionControl<BrowseNsfwContentMode>
+                        label={t('browse.viewOptions.nsfwContent')}
+                        value={browseNsfwContentMode}
+                        onChange={setBrowseNsfwContentMode}
+                        options={[
+                          { value: 'show', label: t('browse.viewOptions.show'), icon: Eye },
+                          { value: 'blur', label: t('browse.viewOptions.blur'), icon: EyeClosed },
+                          { value: 'hide', label: t('browse.viewOptions.hide'), icon: EyeOff },
+                        ]}
+                      />
+                    </div>
+
+                    <div>
+                      <div className="mb-2 text-xs font-medium text-text-secondary">{t('browse.viewOptions.outdatedContent')}</div>
+                      <BrowseViewOptionControl<'show' | 'hide'>
+                        label={t('browse.viewOptions.outdatedContent')}
+                        value={(settings?.hideOutdatedMods ?? false) ? 'hide' : 'show'}
+                        onChange={(mode) => setBrowseHideOutdated(mode === 'hide')}
+                        options={[
+                          { value: 'show', label: t('browse.viewOptions.show'), icon: Eye },
+                          { value: 'hide', label: t('browse.viewOptions.hide'), icon: EyeOff },
                         ]}
                       />
                     </div>
@@ -3426,7 +3530,7 @@ export default function Browse() {
                             section={section}
                             volume={soundVolume}
                             onVolumeChange={setSoundVolume}
-                            hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+                            hideNsfwPreviews={browseBlurNsfwPreviews}
                             isPlaying={playingModId === mod.id}
                             suppressHoverIntentRef={isBrowseScrollingRef}
                             enableModId={installedLocal && !installedLocal.enabled ? installedLocal.id : undefined}
@@ -3501,7 +3605,7 @@ export default function Browse() {
 
       {collectionModalOpen && (
         <ImportCollectionModal
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={browseBlurNsfwPreviews}
           installedIds={installedIds}
           queuedIds={queuedModIds}
           activeDeadlockPath={activeDeadlockPath}
@@ -3512,7 +3616,7 @@ export default function Browse() {
       {importProfileOpen && (
         <ImportProfileDialog
           activeDeadlockPath={activeDeadlockPath}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={browseBlurNsfwPreviews}
           onClose={() => setImportProfileOpen(false)}
           onImported={() => { void loadMods(); }}
         />

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2143,8 +2143,9 @@ export default function Installed() {
     }
     setBulkProgress({ verb: 'Disabling', done: 0, total: targets.length });
     for (let i = 0; i < targets.length; i++) {
-      await toggleMod(targets[i].id);
+      const ok = await toggleMod(targets[i].id);
       setBulkProgress({ verb: 'Disabling', done: i + 1, total: targets.length });
+      if (!ok) break;
     }
     setBulkProgress(null);
     exitSelectMode();
@@ -2345,12 +2346,15 @@ export default function Installed() {
     await toggleMod(target.id);
   };
 
-  const setGroupEnabled = async (group: Extract<ModEntry, { kind: 'group' }>, enabled: boolean) => {
-    for (const v of group.variants) {
-      if (v.enabled !== enabled) {
-        await toggleMod(v.id);
+  const setGroupEnabled = async (group: Extract<ModEntry, { kind: 'group' }>, enabled: boolean): Promise<boolean> => {
+    const targets = group.variants.filter((v) => v.enabled !== enabled);
+    for (const v of targets) {
+      const ok = await toggleMod(v.id);
+      if (!ok) {
+        return false;
       }
     }
+    return true;
   };
 
   const disableEntireGroup = async (group: Extract<ModEntry, { kind: 'group' }>) => {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1705,7 +1705,19 @@ export default function Installed() {
         !detailsInstalledFileIds.has(fileId) &&
         !pickedIsArchived;
       const replacing = isReinstall || isUpdate;
-      const restoreEnabled = replacing && !!sourceMod?.enabled;
+      let replacementTargets: typeof mods = [];
+      if (replacing && sourceMod) {
+        replacementTargets = mods.filter(
+          (mod) =>
+            mod.gameBananaId === sourceMod.gameBananaId &&
+            mod.gameBananaFileId === sourceMod.gameBananaFileId,
+        );
+      } else if (detailsInstalledFileIds.has(fileId)) {
+        replacementTargets = mods.filter(
+          (mod) => mod.gameBananaId === detailsMod.id && mod.gameBananaFileId === fileId,
+        );
+      }
+      const restoreEnabled = replacementTargets.some((mod) => mod.enabled);
 
       if (replacing && sourceMod) {
         // Snapshot before the destructive delete so the user can roll back,
@@ -1716,22 +1728,22 @@ export default function Installed() {
         } catch (err) {
           console.warn('[Update] failed to capture pre-update snapshot:', err);
         }
-        await deleteMod(sourceMod.id);
+      }
+      for (const mod of replacementTargets) {
+        await deleteMod(mod.id);
       }
 
       await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
 
-      // Deleting the source removes the only enabled sibling, so the backend's
-      // auto-disable promotion never fires and the freshly downloaded file stays
-      // in /disabled. Re-enable it so an update/reinstall preserves the source's
-      // enabled state instead of silently turning the mod off. (Match by GB ids;
-      // the local mod id changes on reinstall.)
+      // Replacement downloads land disabled, so restore the enabled state after
+      // reloading. Match by GB ids because local ids change on reinstall.
       if (restoreEnabled) {
         await loadMods();
-        const newMod = useAppStore
+        const newMods = useAppStore
           .getState()
-          .mods.find((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
-        if (newMod && !newMod.enabled) {
+          .mods.filter((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
+        for (const newMod of newMods) {
+          if (newMod.enabled) continue;
           try {
             await toggleMod(newMod.id);
           } catch (err) {
@@ -1835,6 +1847,7 @@ export default function Installed() {
         | { ok: true; snapshot: (typeof snapshots)[number]; fileId: number; fileName: string }
         | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };
       const resolutions: Resolution[] = [];
+      const resolvedByOldFileId = new Map<number, { fileId: number; fileName: string }>();
       // Seed claims with live files already installed as siblings outside this
       // run, so neither the fuzzy match nor the single-file fallback
       // re-downloads a variant the user already has.
@@ -1854,6 +1867,16 @@ export default function Installed() {
       }
       for (const s of group) {
         if (liveFileIds.has(s.gameBananaFileId)) continue;
+        const existingResolution = resolvedByOldFileId.get(s.gameBananaFileId);
+        if (existingResolution) {
+          resolutions.push({
+            ok: true,
+            snapshot: s,
+            fileId: existingResolution.fileId,
+            fileName: existingResolution.fileName,
+          });
+          continue;
+        }
         const match = resolveUpdateTarget(
           {
             installedFileId: s.gameBananaFileId,
@@ -1865,9 +1888,11 @@ export default function Installed() {
         );
         if (match) {
           resolutions.push({ ok: true, snapshot: s, fileId: match.id, fileName: match.fileName });
+          resolvedByOldFileId.set(s.gameBananaFileId, { fileId: match.id, fileName: match.fileName });
           claimedIds.add(match.id);
         } else if (liveFiles.length === 1 && !claimedIds.has(liveFiles[0].id)) {
           resolutions.push({ ok: true, snapshot: s, fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
+          resolvedByOldFileId.set(s.gameBananaFileId, { fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
           claimedIds.add(liveFiles[0].id);
         } else {
           resolutions.push({
@@ -1892,32 +1917,68 @@ export default function Installed() {
         }
       }
 
+      const okBatches = new Map<
+        string,
+        {
+          gameBananaId: number;
+          fileId: number;
+          fileName: string;
+          section: string;
+          categoryId: number;
+          snapshots: Array<(typeof snapshots)[number]>;
+        }
+      >();
+
       for (const r of resolutions) {
         if (!r.ok) {
           needsPick.push({ id: r.snapshot.oldId, name: r.snapshot.modName });
           console.warn(`[Update] ${r.snapshot.fileName}: ${r.reason}`);
         } else {
-          try {
-            await deleteMod(r.snapshot.oldId);
-            await downloadMod(
-              r.snapshot.gameBananaId,
-              r.fileId,
-              r.fileName,
-              r.snapshot.section,
-              r.snapshot.categoryId,
-            );
-            completed.push({
+          const batchKey = `${r.snapshot.gameBananaId}:${r.fileId}`;
+          const batch =
+            okBatches.get(batchKey) ??
+            {
               gameBananaId: r.snapshot.gameBananaId,
-              gameBananaFileId: r.fileId,
-              wasEnabled: r.snapshot.wasEnabled,
+              fileId: r.fileId,
               fileName: r.fileName,
-            });
-          } catch (err) {
-            failures.push(`${r.snapshot.fileName}: ${String(err)}`);
-          }
+              section: r.snapshot.section,
+              categoryId: r.snapshot.categoryId,
+              snapshots: [],
+            };
+          batch.snapshots.push(r.snapshot);
+          okBatches.set(batchKey, batch);
+          continue;
         }
         progress += 1;
         setUpdateAllProgress({ done: progress, total: snapshots.length });
+      }
+
+      for (const batch of okBatches.values()) {
+        try {
+          for (const snapshot of batch.snapshots) {
+            await deleteMod(snapshot.oldId);
+          }
+          await downloadMod(
+            batch.gameBananaId,
+            batch.fileId,
+            batch.fileName,
+            batch.section,
+            batch.categoryId,
+          );
+          completed.push({
+            gameBananaId: batch.gameBananaId,
+            gameBananaFileId: batch.fileId,
+            wasEnabled: batch.snapshots.some((snapshot) => snapshot.wasEnabled),
+            fileName: batch.fileName,
+          });
+        } catch (err) {
+          for (const snapshot of batch.snapshots) {
+            failures.push(`${snapshot.fileName}: ${String(err)}`);
+          }
+        } finally {
+          progress += batch.snapshots.length;
+          setUpdateAllProgress({ done: progress, total: snapshots.length });
+        }
       }
     }
 
@@ -1938,10 +1999,11 @@ export default function Installed() {
     const refreshed = useAppStore.getState().mods;
     for (const c of completed) {
       if (!c.wasEnabled) continue;
-      const newMod = refreshed.find(
+      const newMods = refreshed.filter(
         (m) => m.gameBananaId === c.gameBananaId && m.gameBananaFileId === c.gameBananaFileId,
       );
-      if (newMod && !newMod.enabled) {
+      for (const newMod of newMods) {
+        if (newMod.enabled) continue;
         try {
           await toggleMod(newMod.id);
         } catch (err) {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -797,6 +797,8 @@ export default function Installed() {
   });
   const [statusSel, setStatusSel] = useState<('enabled' | 'disabled')[]>(['enabled', 'disabled']);
   const [typeFilter, setTypeFilter] = useState<string[]>([]);
+  const installedHideNsfwPreviews =
+    settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true;
   useEffect(() => {
     localStorage.setItem('installedSortMode', sortMode);
   }, [sortMode]);
@@ -3073,7 +3075,7 @@ export default function Installed() {
   const cardPropsFor = (entry: ModEntry): InstalledEntryCardProps => ({
     entry,
     viewMode,
-    hideNsfwPreviews: settings?.hideNsfwPreviews ?? true,
+    hideNsfwPreviews: installedHideNsfwPreviews,
     soundVolume,
     conflicts: entryConflicts.get(entry.key) ?? EMPTY_CONFLICTS,
     updateAvailable:
@@ -3911,7 +3913,7 @@ export default function Installed() {
           downloadingFileId={null}
           extracting={false}
           progress={null}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={installedHideNsfwPreviews}
           dateAdded={detailsDates?.dateAdded}
           dateModified={detailsDates?.dateModified}
           updateAvailable={detailsUpdateAvailable}
@@ -3934,7 +3936,7 @@ export default function Installed() {
       {selectedUnknownState && unknownFixMode === 'single' && (
         <UnknownFilterGuessModal
           state={selectedUnknownState}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={installedHideNsfwPreviews}
           autoMatchEnabled={autoMatchEnabled}
           onApplyMatch={applyUnknownMatch}
           onAssociate={associateUnknownMatch}
@@ -3951,7 +3953,7 @@ export default function Installed() {
         <BulkUnknownFixModal
           unknownMods={unknownMods}
           state={selectedUnknownState}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={installedHideNsfwPreviews}
           autoMatchEnabled={autoMatchEnabled}
           cache={unknownFilterCacheById}
           pendingIds={unknownFilterPendingIds}
@@ -4007,7 +4009,7 @@ export default function Installed() {
       {mergeSources && (
         <MergeModsModal
           sources={mergeSources}
-          hideNsfw={settings?.hideNsfwPreviews ?? true}
+          hideNsfw={installedHideNsfwPreviews}
           onCancel={() => setMergeSources(null)}
           onConfirm={handleMergeConfirm}
         />
@@ -4016,7 +4018,7 @@ export default function Installed() {
       {mergedContentsMod && (
         <MergedContentsModal
           mod={mergedContentsMod}
-          hideNsfw={settings?.hideNsfwPreviews ?? true}
+          hideNsfw={installedHideNsfwPreviews}
           onClose={() => setMergedContentsMod(null)}
           onUnmerge={() => setUnmergeTarget(mergedContentsMod)}
           onExtractSource={handleExtractMergeSource}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -603,7 +603,9 @@ function clampCardSizeMultiplier(value: number): number {
 }
 
 function readInstalledCardSizeMultiplier(): number {
-  const stored = Number(localStorage.getItem(INSTALLED_CARD_SIZE_MULTIPLIER_KEY));
+  const raw = localStorage.getItem(INSTALLED_CARD_SIZE_MULTIPLIER_KEY);
+  if (raw == null || raw === '') return CARD_SIZE_MULTIPLIER_DEFAULT;
+  const stored = Number(raw);
   return Number.isFinite(stored) ? clampCardSizeMultiplier(stored) : CARD_SIZE_MULTIPLIER_DEFAULT;
 }
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -274,21 +274,15 @@ export default function Settings() {
     return () => document.removeEventListener('keydown', onKey);
   }, [customPickerOpen, commitCustomDraft]);
 
-  const handleHideNsfwChange = async (checked: boolean) => {
-    if (settings) {
-      await saveSettings({ ...settings, hideNsfwPreviews: checked });
-    }
-  };
-
-  const handleHideOutdatedChange = async (checked: boolean) => {
-    if (settings) {
-      await saveSettings({ ...settings, hideOutdatedMods: checked });
-    }
-  };
-
   const handleLockerCardsExpandedByDefaultChange = async (checked: boolean) => {
     if (settings) {
       await saveSettings({ ...settings, lockerCardsExpandedByDefault: checked });
+    }
+  };
+
+  const handleInstalledHideNsfwChange = async (checked: boolean) => {
+    if (settings) {
+      await saveSettings({ ...settings, installedHideNsfwPreviews: checked });
     }
   };
 
@@ -1047,19 +1041,10 @@ export default function Settings() {
         <Card title={<Tx k="settings.sections.preferences" fallback="Preferences" />} icon={Shield}>
           <div className="space-y-6">
             <Toggle
-              checked={settings?.hideNsfwPreviews ?? true}
-              onChange={handleHideNsfwChange}
-              label={<Tx k="settings.preferences.hideNsfw" fallback="Hide NSFW Content" />}
-              description={<Tx k="settings.preferences.hideNsfwDescription" fallback="Blur thumbnail images for mods marked as NSFW." />}
-            />
-
-            <div className="h-px bg-white/5" />
-
-            <Toggle
-              checked={settings?.hideOutdatedMods ?? false}
-              onChange={handleHideOutdatedChange}
-              label={<Tx k="settings.preferences.hideOutdated" fallback="Hide Outdated Mods" />}
-              description={<Tx k="settings.toggles.hideOutdated" fallback="Hide Browse mods older than the current game version." />}
+              checked={settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true}
+              onChange={handleInstalledHideNsfwChange}
+              label={<Tx k="settings.preferences.blurInstalledNsfw" fallback="Blur Installed NSFW Content" />}
+              description={<Tx k="settings.preferences.blurInstalledNsfwDescription" fallback="Blur thumbnail images for installed mods marked as NSFW." />}
             />
 
             <div className="h-px bg-white/5" />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -325,6 +325,8 @@ interface AppState {
 const ENABLE_CAP_NOTICE =
   'You can have at most 990 mods enabled at once. Disable one to make room.';
 const isEnableCapError = (err: unknown): boolean => /mods enabled at once/.test(String(err));
+const GAME_RUNNING_NOTICE = 'Game is running';
+const isGameRunningModLockError = (err: unknown): boolean => String(err).includes(GAME_RUNNING_NOTICE);
 
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
@@ -564,6 +566,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         set({ modsNotice: ENABLE_CAP_NOTICE });
         return false;
       }
+      if (isGameRunningModLockError(err)) {
+        return false;
+      }
       // Stale id: a mod's id is its filename, which an enable/disable changes.
       // When toggles for the same card fire faster than the store resyncs (the
       // main process now serializes mutations, so the second runs after the file
@@ -597,6 +602,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         set({ mods: get().mods.filter((m) => m.id !== modId) });
         return;
       }
+      if (isGameRunningModLockError(err)) {
+        return;
+      }
       set({ modsError: String(err) });
     }
   },
@@ -611,6 +619,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           .sort((a, b) => a.priority - b.priority),
       });
     } catch (err) {
+      if (isGameRunningModLockError(err)) return;
       set({ modsError: String(err) });
     }
   },
@@ -622,6 +631,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ mods: updated });
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); return; }
+      if (isGameRunningModLockError(err)) return;
       set({ modsError: String(err) });
     }
   },
@@ -634,7 +644,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ mods: updated });
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
-      else { set({ modsError: String(err) }); }
+      else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
       get().loadMods();
     }
   },

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -884,7 +884,7 @@ export interface ElectronAPI {
     /** Read the player's live in-game crosshair from machine_convars.vcfg.
      *  settings is null when the file is missing or has no crosshair convars. */
     importCrosshairFromGame: (gamePath: string) => Promise<{ found: boolean; settings: CrosshairSettings | null }>;
-    getAutoexecCommands: (gamePath: string) => Promise<{ commands: string[]; exists: boolean }>;
+    getAutoexecCommands: (gamePath: string) => Promise<{ commands: string[]; manualCommands: string[]; exists: boolean }>;
     saveAutoexecCommands: (gamePath: string, commands: string[]) => Promise<{ success: boolean; path: string }>;
 
     // Updater

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -819,6 +819,7 @@ export type AppearanceSurface = 'launchModded' | 'launchVanilla' | 'activeTab' |
  *    service and keyed by the surface id.
  *  - `none`: no art (hidden). */
 export type AppearanceBgKind = 'default' | 'hero' | 'custom' | 'none';
+export type BrowseNsfwContentMode = 'show' | 'blur' | 'hide';
 
 export interface AppearanceBg {
   kind: AppearanceBgKind;
@@ -836,7 +837,12 @@ export interface AppSettings {
    *  versa) can be traced in the diagnostic report. Off by default; meant to
    *  be flipped on temporarily to capture a repro. */
   verboseModTrace?: boolean;
+  /** Shared/legacy NSFW thumbnail blur preference for non-Installed surfaces. */
   hideNsfwPreviews: boolean;
+  /** Browser-specific handling for GameBanana mods marked as NSFW. */
+  browseNsfwContentMode: BrowseNsfwContentMode;
+  /** Blur thumbnail images for installed mods marked as NSFW. */
+  installedHideNsfwPreviews: boolean;
   /** Hide GameBanana mods flagged as outdated in Browse. */
   hideOutdatedMods: boolean;
   /** Open Locker list-view hero cards expanded on first load. */


### PR DESCRIPTION
## Summary

This PR improves several mod-management workflows and UI details:

- improves multi-VPK variant selection and profile state preservation
- refines Browser content filter controls
- shows manually-added `autoexec.cfg` commands in Autoexec
- makes Autoexec preset browsing more compact
- protects VPKs that were loaded when Deadlock started
- polishes mod details file-row alignment

## Changes

### Multi-VPK Mods
- Allow multiple VPK files to be selected in the merge/variant picker.
- Pre-fill the previous VPK filename when renaming.
- Preserve enabled/disabled state per VPK file when applying profiles.
- Improve installed-mod handling for grouped multi-VPK mods.

### Browser Filters
- Move Browser NSFW/outdated controls into view options.
- Replace toggle switches with compact segmented controls.
- Add separate `Show / Blur / Hide` behavior for NSFW content.
- Keep installed mods NSFW behavior separate as `Blur Installed NSFW Content`.

### Autoexec
- Detect manual commands already present in `autoexec.cfg` and display those commands as read-only entries.
- Move premade commands into a collapsed, scrollable section under Custom Command and made premade command rows more compact by adding hover descriptions.

### Loaded Mod Protection
- Snapshot enabled VPK-backed mods when launching Deadlock.
- Block disabling, deleting, reordering, merging, unmerging, or profile-applying changes that would move/remove loaded VPKs while the game is running.
- Mods enabled after the game starts are still allowed to be disabled.

### UI Polish
- Align mod detail file rows so text is no longer visually centered.
- Vertically center the active file tag in the same thing.
- Fixed a bug where the default size for the grid in both download and install tabs was unset when the config was jet to be made causing weird/broken ui for first time users.