### PR TITLE
fix(mods): PR #273 follow-ups (dedup, spawn storm, i18n, launch grace)

### DIFF
--- a/electron/main/ipc/launch.ts
+++ b/electron/main/ipc/launch.ts
@@ -20,6 +20,7 @@ import {
     captureLoadedGameMods,
     clearLoadedGameMods,
     hasRunningGameModSnapshot,
+    markLaunchGrace,
     syncKnownRunningGameModSnapshot,
 } from '../services/gameSessionMods';
 
@@ -37,7 +38,10 @@ ipcMain.handle('launch-modded', async (): Promise<void> => {
         await launchModded({
             deadlockPath,
             onRestoreComplete: emitRestore,
-            beforeLaunch: async () => captureLoadedGameMods(await scanMods(deadlockPath)),
+            beforeLaunch: async () => {
+                captureLoadedGameMods(await scanMods(deadlockPath));
+                markLaunchGrace();
+            },
         });
     } catch (err) {
         clearLoadedGameMods();

--- a/electron/main/services/autoexec.ts
+++ b/electron/main/services/autoexec.ts
@@ -15,8 +15,13 @@ export interface AutoexecData {
 }
 
 function getExecutableAutoexecLine(line: string): string {
-    const commentIndex = line.indexOf('//');
-    return (commentIndex >= 0 ? line.slice(0, commentIndex) : line).trim();
+    // A line comment starts at the first // that begins the line or follows
+    // whitespace. A // inside a token (e.g. a URL in an echo) is left intact.
+    const match = /(^|\s)\/\//.exec(line);
+    if (match) {
+        return line.slice(0, match.index + match[1].length).trim();
+    }
+    return line.trim();
 }
 
 export function getManualAutoexecCommands(data: AutoexecData): string[] {

--- a/electron/main/services/gameSessionMods.ts
+++ b/electron/main/services/gameSessionMods.ts
@@ -10,6 +10,14 @@ interface RunningGameSnapshot {
 
 let snapshot: RunningGameSnapshot | null = null;
 
+// Running state computed once per mod-mutation batch (see beginModMutationRunningScope).
+let lockScopedRunning: boolean | undefined;
+
+// While Deadlock is launching it isn't visible to pgrep/tasklist for ~10-30s.
+// markLaunchGrace keeps the beforeLaunch snapshot alive across that window so
+// the 3s status poll can't wipe it before the process appears.
+let launchGraceUntil = 0;
+
 function makeSnapshot(mods: Mod[]): RunningGameSnapshot {
     const enabled = mods.filter((mod) => mod.enabled);
     return {
@@ -31,6 +39,7 @@ export function captureEmptyGameMods(): void {
 
 export function clearLoadedGameMods(): void {
     snapshot = null;
+    launchGraceUntil = 0;
 }
 
 export function hasRunningGameModSnapshot(): boolean {
@@ -54,17 +63,43 @@ export function assertCanMoveLoadedGameMods(mods: Array<Pick<Mod, 'id' | 'metaKe
     }
 }
 
+/**
+ * A single mod-folder mutation can fan out into many snapshot syncs
+ * (applyProfile disables/enables/reorders N mods under one lock). Without this,
+ * each sync spawns its own pgrep/tasklist. The mutation lock computes the
+ * running state once via beginModMutationRunningScope and parks it here for the
+ * whole batch; endModMutationRunningScope clears it in a finally.
+ */
+export async function beginModMutationRunningScope(): Promise<void> {
+    lockScopedRunning = await isDeadlockRunning();
+}
+
+export function endModMutationRunningScope(): void {
+    lockScopedRunning = undefined;
+}
+
+export function markLaunchGrace(ms = 60_000): void {
+    launchGraceUntil = Date.now() + ms;
+}
+
 export async function syncRunningGameModSnapshotFromMods(mods: Mod[]): Promise<{ running: boolean }> {
-    const running = await isDeadlockRunning();
+    const running = lockScopedRunning ?? (await isDeadlockRunning());
     return syncKnownRunningGameModSnapshot(running, mods);
 }
 
 export function syncKnownRunningGameModSnapshot(running: boolean, mods: Mod[]): { running: boolean } {
     if (!running) {
+        // Keep the beforeLaunch snapshot during the launch grace window: the
+        // game isn't visible to pgrep/tasklist yet, but its loaded mods are
+        // already locked in.
+        if (snapshot && Date.now() < launchGraceUntil) {
+            return { running: false };
+        }
         clearLoadedGameMods();
         return { running: false };
     }
 
+    launchGraceUntil = 0;
     if (!snapshot) {
         captureLoadedGameMods(mods);
     }

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -11,6 +11,8 @@ import {
     assertCanMoveLoadedGameMod,
     assertCanMoveLoadedGameMods,
     syncRunningGameModSnapshotFromMods,
+    beginModMutationRunningScope,
+    endModMutationRunningScope,
 } from './gameSessionMods';
 
 /** Verbose mod-mutation trace, gated on the `verboseModTrace` setting. Lands in
@@ -723,7 +725,18 @@ export async function allocateEnabledVpkPath(deadlockPath: string): Promise<stri
  */
 let modMutationQueue: Promise<unknown> = Promise.resolve();
 function withModMutationLock<T>(fn: () => Promise<T>): Promise<T> {
-    const run = modMutationQueue.then(fn, fn);
+    // Compute the game-running state once per locked batch and park it for the
+    // duration, so applyProfile's per-mod snapshot syncs don't each spawn a
+    // pgrep/tasklist (turning N+M+2 spawns into 1).
+    const scoped = async (): Promise<T> => {
+        await beginModMutationRunningScope();
+        try {
+            return await fn();
+        } finally {
+            endModMutationRunningScope();
+        }
+    };
+    const run = modMutationQueue.then(scoped, scoped);
     // Keep the chain alive regardless of this op's outcome, so one rejection
     // doesn't poison every operation queued behind it.
     modMutationQueue = run.then(

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -102,11 +102,15 @@ function dedupeEnabledForProfile<T extends { metaKey: string; fileName: string; 
         const gbId = meta?.gameBananaId;
         const fileId = meta?.gameBananaFileId;
         const sha256 = normalizeSha256(meta?.sha256);
-        if (typeof gbId !== 'number' || typeof fileId !== 'number' || sha256 === null) {
+        if (typeof gbId !== 'number' || typeof fileId !== 'number') {
             out.push(mod);
             continue;
         }
-        const key = `${gbId}:${fileId}:${sha256}`;
+        // sha256 is only a tiebreaker. When it's missing (legacy or not-yet
+        // backfilled metadata) we must still dedupe on gbId:fileId, or the same
+        // physical mod can land in a profile at two priorities (the duplicate
+        // load-order corruption this guard exists to prevent).
+        const key = sha256 !== null ? `${gbId}:${fileId}:${sha256}` : `${gbId}:${fileId}`;
         const existing = byGbFileAndHash.get(key);
         if (!existing) {
             byGbFileAndHash.set(key, mod);

--- a/src/components/MergeModsModal.tsx
+++ b/src/components/MergeModsModal.tsx
@@ -153,7 +153,7 @@ export default function MergeModsModal({ sources, hideNsfw, onCancel, onConfirm 
               </div>
               {groups.some((g) => g.kind === 'variants') && (
                 <div className="text-xs text-text-secondary">
-                  Pick one or more variants per mod
+                  {t('mergeMods.oneVariant')}
                 </div>
               )}
             </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -24,7 +24,12 @@ import type {
 import type { DownloadedLocale, LocaleManifest } from '../types/locales';
 import { parseFeModel, type ClothModel } from './feModel';
 import { showToast } from '../stores/toastStore';
+import i18n from '../i18n';
 
+// Sentinel that matches the Error thrown by the main process
+// (GAME_RUNNING_MOD_LOCK_MESSAGE in gameSessionMods.ts). It crosses the IPC
+// boundary as a raw string, so it must NOT be translated. The user-facing
+// toast is translated separately.
 const GAME_RUNNING_NOTICE = 'Game is running';
 
 function isGameRunningModLockError(err: unknown): boolean {
@@ -36,7 +41,7 @@ async function withGameRunningWarning<T>(operation: () => Promise<T>): Promise<T
     return await operation();
   } catch (err) {
     if (isGameRunningModLockError(err)) {
-      showToast(GAME_RUNNING_NOTICE, { tone: 'warning' });
+      showToast(i18n.t('common.gameRunningWarning'), { tone: 'warning' });
     }
     throw err;
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "view": "View",
+    "gameRunningWarning": "Game is running. Close Deadlock to change loaded mods.",
     "actions": {
       "cancel": "Cancel",
       "clear": "Clear",
@@ -1941,7 +1942,7 @@
     "selectedSummary": "{{selected}} of {{total}} selected"
   },
   "mergeMods": {
-    "oneVariant": "One variant per mod",
+    "oneVariant": "Pick one or more variants per mod",
     "strictDescription": "Stop if two mods touch the same file. Off lets the higher-priority mod win.",
     "localNote": "Local mods merge fine but aren't in the share code. Delete the disabled originals and they can't be recovered on unmerge.",
     "title": "Merge {{count}} mods",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1861,
+  "totalKeys": 1862,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1861,
+      "translatedKeys": 1862,
       "pct": 100
     },
     {


### PR DESCRIPTION
## Summary

Follow-ups to #273 (merged). These address the review findings on that PR. They land separately because #273's head was a contributor fork (`tinyderp:main`) and could not be pushed to. **Land this before any release that includes #273.**

## Fixes (most important first)

### 1. profiles: dedupe corruption when `sha256` is null (correctness)
#273 changed `dedupeEnabledForProfile` to skip dedupe entirely when `sha256` is null. Two enabled VPKs sharing the same `gbId:fileId` where one lacks a hash (legacy / not-yet-backfilled metadata, or a save during the async startup backfill) would then both be written into the profile at different priorities, reopening the duplicate load-order corruption the guard exists to prevent. Fixed by falling back to a `gbId:fileId` key when `sha256` is absent (hash stays a precision tiebreaker when present).

### 2. mods/gameSessionMods: stop spawning a process per mutation (perf)
Every `*Impl` calls `syncRunningGameModSnapshotFromMods` -> `isDeadlockRunning()`, which spawns `pgrep`/`tasklist`. These ran inside the serialized mutation lock, so `applyProfile` over N+M mods fired **N+M+2** spawns back-to-back while the UI was blocked. Now the lock (`withModMutationLock`, the single chokepoint) computes the running state **once per batch** via a lock-scoped cache (`beginModMutationRunningScope`/`endModMutationRunningScope`); single ops stay at 1 spawn, batches drop to 1. No `*Impl` signatures change.

### 3. gameSessionMods/launch: launch-time snapshot survives the status poll (feature gap)
The `beforeLaunch` snapshot was wiped within one 3s `get-game-running-status` poll, because the game isn't visible to `pgrep`/`tasklist` for ~10-30s after launch. Added a launch grace window (`markLaunchGrace`) so the snapshot is preserved until the process appears or the grace expires.

### 4. i18n: wire two hardcoded English strings
- `MergeModsModal` variant hint -> `t('mergeMods.oneVariant')` (re-wires the orphaned key; value updated to the multi-variant wording).
- `api.ts` "game is running" toast -> `i18n.t('common.gameRunningWarning')`. The cross-process error-matching sentinel stays a literal (it matches the raw `Error` thrown by the main process and must not be translated).
- Manifest regenerated (`pnpm i18n:manifest`).

### 5. autoexec: don't truncate commands containing `//`
`getExecutableAutoexecLine` cut at the first `//`, so a command with an inline `//` (e.g. a URL) lost its tail. Now only a `//` at line start or after whitespace begins a comment.

## Not changed (noted)
- `reorderModsImpl` runs its loaded-mod assert after overflow-folder creation + `fixGameinfo`; the side effect is benign (empty dir, healed on next op). Left as a separate cleanup.
- `buildProfileModResolver`'s narrowed sha256 fallback is left as-is (arguably more correct for multi-VPK).

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm exec vitest run` (290/290) all clean.
- `pnpm i18n:check` + `pnpm i18n:manifest` clean (pre-push gate passes).
- Verified live in `pnpm dev`: main process rebuilt and reloaded cleanly across all edits.
