### PR TITLE
Locker: shuffle skins on launch (per-hero opt-in pool)

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -827,17 +827,21 @@ ipcMain.handle(
 );
 
 // apply-mod-toggle-batch: disable a set then enable a set as one atomic
-// mutation, returning the fresh mod list. Backs the Locker skin randomizer.
+// mutation, returning the fresh mod list AND the per-mod failures. Backs the
+// Locker skin randomizer. setModsEnabledBatch never rethrows a per-mod lock so
+// one stuck VPK can't abort the batch; we surface the failure count instead of
+// dropping it, so the renderer can warn that the shuffle only half-applied
+// (otherwise a hero silently launches skinless and the call still looks green).
 ipcMain.handle(
     'apply-mod-toggle-batch',
-    async (_, enableIds: string[], disableIds: string[]): Promise<Mod[]> => {
+    async (_, enableIds: string[], disableIds: string[]): Promise<{ mods: Mod[]; failures: string[] }> => {
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) {
             throw new Error('No Deadlock path configured');
         }
-        await setModsEnabledBatch(deadlockPath, { enable: enableIds, disable: disableIds });
+        const result = await setModsEnabledBatch(deadlockPath, { enable: enableIds, disable: disableIds });
         const mods = await scanMods(deadlockPath);
-        return mods.map(enrichMod);
+        return { mods: mods.map(enrichMod), failures: result.failures };
     }
 );
 

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -11,6 +11,7 @@ import {
     setModPriority,
     reorderMods,
     swapModPriority,
+    setModsEnabledBatch,
     allocateEnabledVpkPath,
     type Mod,
 } from '../services/mods';
@@ -820,6 +821,21 @@ ipcMain.handle(
         }
         migrateIgnoredConflictKeysBeforeRenames(await scanMods(deadlockPath));
         await reorderMods(deadlockPath, orderedIds);
+        const mods = await scanMods(deadlockPath);
+        return mods.map(enrichMod);
+    }
+);
+
+// apply-mod-toggle-batch: disable a set then enable a set as one atomic
+// mutation, returning the fresh mod list. Backs the Locker skin randomizer.
+ipcMain.handle(
+    'apply-mod-toggle-batch',
+    async (_, enableIds: string[], disableIds: string[]): Promise<Mod[]> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        await setModsEnabledBatch(deadlockPath, { enable: enableIds, disable: disableIds });
         const mods = await scanMods(deadlockPath);
         return mods.map(enrichMod);
     }

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -786,6 +786,68 @@ export function reorderModsUnlocked(deadlockPath: string, orderedIds: string[]):
     return reorderModsImpl(deadlockPath, orderedIds);
 }
 
+/**
+ * Apply a set of disables and enables as ONE atomic batch (the Locker skin
+ * randomizer's apply step). Disables run BEFORE enables, on disjoint id sets, so
+ * the snapshot ids stay valid across both passes - the same ordering and
+ * reasoning as applyProfile (which also frees slots before claiming them). The
+ * whole sequence holds the mutation queue, so a stray Locker toggle can't slip
+ * in, rename files, and invalidate the ids mid-batch.
+ *
+ * Per-mod failures are caught and counted, never rethrown: one locked VPK (game
+ * running, antivirus, our own readers) must not abort the rest of the batch. Ids
+ * not present in the current scan are skipped (the caller's renderer view may be
+ * a beat stale). No reorder pass: the randomizer enables exactly one skin per
+ * hero, and different heroes write different files, so the result has no
+ * file-collision load-order to resolve.
+ */
+export function setModsEnabledBatch(
+    deadlockPath: string,
+    payload: { enable: string[]; disable: string[] }
+): Promise<{ enabled: number; disabled: number; failures: string[] }> {
+    return runExclusiveModMutation(async () => {
+        const enable = new Set(payload.enable);
+        const disable = new Set(payload.disable);
+        let enabled = 0;
+        let disabled = 0;
+        const failures: string[] = [];
+
+        // Fail fast when the game is running and a mod we'd disable is loaded:
+        // the per-mod catch below swallows lock errors (so one stuck file can't
+        // abort the batch), which would otherwise turn a game-running shuffle
+        // into a silent no-op reported as success. Assert upfront so the
+        // standard game-running warning surfaces instead. Mirrors applyProfile.
+        const current = await scanMods(deadlockPath);
+        await syncRunningGameModSnapshotFromMods(current);
+        assertCanMoveLoadedGameMods(current.filter((m) => m.enabled && disable.has(m.id)));
+
+        for (const modId of disable) {
+            try {
+                await disableModUnlocked(deadlockPath, modId);
+                disabled++;
+            } catch (err) {
+                failures.push(`disable ${modId}: ${String(err)}`);
+                console.warn(`[randomize] disable failed (continuing): ${modId}: ${String(err)}`);
+            }
+        }
+        for (const modId of enable) {
+            try {
+                await enableModUnlocked(deadlockPath, modId);
+                enabled++;
+            } catch (err) {
+                failures.push(`enable ${modId}: ${String(err)}`);
+                console.warn(`[randomize] enable failed (continuing): ${modId}: ${String(err)}`);
+            }
+        }
+        if (failures.length > 0) {
+            console.warn(
+                `[randomize] batch completed with ${failures.length} failure(s): ${failures.join('; ')}`
+            );
+        }
+        return { enabled, disabled, failures };
+    });
+}
+
 async function enableModImpl(deadlockPath: string, modId: string): Promise<Mod> {
     const mods = await scanMods(deadlockPath);
     await syncRunningGameModSnapshotFromMods(mods);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -240,6 +240,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-mod-priority', modId, priority),
     reorderMods: (orderedIds: string[]) =>
         ipcRenderer.invoke('reorder-mods', orderedIds),
+    applyModToggleBatch: (enableIds: string[], disableIds: string[]) =>
+        ipcRenderer.invoke('apply-mod-toggle-batch', enableIds, disableIds),
     swapModPriority: (modIdA: string, modIdB: string) =>
         ipcRenderer.invoke('swap-mod-priority', modIdA, modIdB),
     importCustomMod: (args: ImportCustomModArgs) =>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,6 +131,7 @@ export default function Sidebar() {
   const appearanceImages = useAppStore((state) => state.appearanceImages);
   const mods = useAppStore((state) => state.mods);
   const loadMods = useAppStore((state) => state.loadMods);
+  const runLaunchShuffle = useAppStore((state) => state.runLaunchShuffle);
   const soundVolume = useAppStore((state) => state.soundVolume);
   const setSoundVolume = useAppStore((state) => state.setSoundVolume);
   const previewAudioPlaying = useAppStore((state) => state.previewAudioPlaying);
@@ -618,6 +619,18 @@ export default function Sidebar() {
     setLaunchPending('modded');
     setToast(null);
     try {
+      // Re-roll the shuffled skins (no-op unless "Shuffle on launch" is armed)
+      // before the game mounts addons. Skipped when a vanilla stash is pending:
+      // launchModded restores that stash first, so a shuffle here would operate
+      // on the stashed-out files and get overwritten by the restore. Guarded so
+      // a failed shuffle never blocks the launch.
+      if (!stashStatus.active) {
+        try {
+          await runLaunchShuffle();
+        } catch (err) {
+          console.warn('[launch] shuffle skipped:', err);
+        }
+      }
       await launchModded();
       if (stashStatus.active) {
         // Modded path did an auto-restore as part of the launch.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -626,7 +626,13 @@ export default function Sidebar() {
       // a failed shuffle never blocks the launch.
       if (!stashStatus.active) {
         try {
-          await runLaunchShuffle();
+          const { failures } = await runLaunchShuffle();
+          if (failures > 0) {
+            // The shuffle half-applied (a locked VPK, antivirus, the enable
+            // cap). Warn so a hero that silently fell back to vanilla isn't a
+            // mystery; the launch still proceeds.
+            setToast({ kind: 'error', text: t('sidebar.toast.shufflePartial', { count: failures }) });
+          }
         } catch (err) {
           console.warn('[launch] shuffle skipped:', err);
         }

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ExternalLink, GripVertical, ImagePlus, Trash2 } from 'lucide-react';
+import { ChevronDown, ExternalLink, GripVertical, ImagePlus, Shuffle, Trash2 } from 'lucide-react';
 import {
   DndContext,
   KeyboardSensor,
@@ -20,6 +20,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import type { Mod } from '../../types/mod';
 import { getLockerSkinKey, modLoadOrder } from '../../lib/lockerUtils';
+import { shuffleSkinKey } from '../../lib/lockerRandomizer';
 import { useAppStore } from '../../stores/appStore';
 import ModThumbnail from '../ModThumbnail';
 import AudioPreviewPlayer from '../AudioPreviewPlayer';
@@ -110,6 +111,14 @@ interface HeroSkinsPanelProps {
     label: string;
     onClick: () => void;
   };
+  /** Skin keys (shuffleSkinKey) currently opted INTO the launch shuffle pool.
+   *  When onToggleShuffleIncluded is also set, each skin card shows an add-to-
+   *  shuffle toggle. Skins-only; the Sounds panel leaves both undefined. */
+  includedSkinKeys?: Set<string>;
+  onToggleShuffleIncluded?: (skinKey: string) => void;
+  /** When the master "shuffle on launch" switch is armed, the per-skin toggles
+   *  are always visible (not hover-only) so the pool is easy to curate. */
+  shuffleArmed?: boolean;
   /** 'list' (default): compact thumbnail rows, used by the Locker list view's
    *  narrow inline expansion. 'cards': the 2-up media-card grid used by the
    *  hero detail view, sharing the Global view's card language (glass backdrop
@@ -296,6 +305,9 @@ function SkinGroupCard({
   loadOrderPosition,
   overrideSrc,
   onPickImage,
+  isIncluded,
+  onToggleIncluded,
+  shuffleArmed,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -312,6 +324,12 @@ function SkinGroupCard({
   overrideSrc?: string;
   /** Open the image picker for this skin. Omitted for sound mods. */
   onPickImage?: () => void;
+  /** Whether this skin is in the launch-shuffle pool. */
+  isIncluded?: boolean;
+  /** Toggle this skin's launch-shuffle membership. When omitted, no toggle is shown. */
+  onToggleIncluded?: () => void;
+  /** Keep the toggle visible (not hover-only) while the shuffle switch is armed. */
+  shuffleArmed?: boolean;
 }) {
   const { t } = useTranslation();
   const isMulti = group.variants.length > 1;
@@ -345,7 +363,7 @@ function SkinGroupCard({
         groupActive
           ? 'border-accent bg-white/[0.02] hover:bg-white/[0.04]'
           : 'border-white/[0.08] bg-bg-secondary/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary'
-      } ${variantsOpen ? 'z-20' : ''}`}
+      } ${isIncluded ? 'ring-2 ring-accent/45' : ''} ${variantsOpen ? 'z-20' : ''}`}
     >
       {/* Glass backdrop: a blurred copy of the cover art bleeds behind the
           card so it's tinted by its own thumbnail, matching the Global view
@@ -451,7 +469,9 @@ function SkinGroupCard({
           }}
           aria-label={t('locker.modImage.set', { name: primary.name })}
           title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${onRequestDelete ? 'right-9' : 'right-1.5'}`}
+          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${
+            onToggleIncluded && onRequestDelete ? 'right-[4.125rem]' : onToggleIncluded || onRequestDelete ? 'right-9' : 'right-1.5'
+          }`}
         >
           <ImagePlus className="h-3.5 w-3.5" />
         </button>
@@ -471,9 +491,43 @@ function SkinGroupCard({
           }}
           aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
           title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className="absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100"
+          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100 ${
+            onToggleIncluded ? 'right-9' : 'right-1.5'
+          }`}
         >
           <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
+
+      {/* Add to shuffle: opt this skin into the launch-shuffle pool. Anchors the
+          top-right corner because it's the only always-visible control here (lit
+          when included, shown on every card while the shuffle switch is armed) -
+          the hover-only image/delete buttons extend leftward from it. */}
+      {onToggleIncluded && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleIncluded();
+          }}
+          aria-pressed={isIncluded}
+          aria-label={
+            isIncluded
+              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+              : t('locker.randomize.addToShuffle', { name: primary.name })
+          }
+          title={
+            isIncluded
+              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+              : t('locker.randomize.addToShuffle', { name: primary.name })
+          }
+          className={`absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/card:opacity-100 ${
+            isIncluded
+              ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
+              : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/65 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
+          }`}
+        >
+          <Shuffle className="h-3.5 w-3.5" />
         </button>
       )}
 
@@ -558,6 +612,9 @@ function SkinGroupRow({
   soundVolume,
   overrideSrc,
   onPickImage,
+  isIncluded,
+  onToggleIncluded,
+  shuffleArmed,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -571,6 +628,12 @@ function SkinGroupRow({
   overrideSrc?: string;
   /** Open the image picker for this skin. Omitted for sound mods. */
   onPickImage?: () => void;
+  /** Whether this skin is in the launch-shuffle pool. */
+  isIncluded?: boolean;
+  /** Toggle this skin's launch-shuffle membership. When omitted, no toggle is shown. */
+  onToggleIncluded?: () => void;
+  /** Keep the toggle visible (not hover-only) while the shuffle switch is armed. */
+  shuffleArmed?: boolean;
 }) {
   const { t } = useTranslation();
   const isMulti = group.variants.length > 1;
@@ -585,7 +648,7 @@ function SkinGroupRow({
         groupActive
           ? 'border-accent/60 bg-white/[0.04] backdrop-blur-sm'
           : 'border-border bg-bg-secondary/70 hover:border-accent/60 hover:bg-bg-secondary/85'
-      }`}
+      } ${isIncluded ? 'ring-2 ring-accent/45' : ''}`}
     >
       {onPickImage && (
         <button
@@ -596,7 +659,9 @@ function SkinGroupRow({
           }}
           aria-label={t('locker.modImage.set', { name: primary.name })}
           title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${onRequestDelete ? 'right-10' : 'right-2'}`}
+          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${
+            onToggleIncluded && onRequestDelete ? 'right-[4.5rem]' : onToggleIncluded || onRequestDelete ? 'right-10' : 'right-2'
+          }`}
         >
           <ImagePlus className="h-3.5 w-3.5" />
         </button>
@@ -613,9 +678,40 @@ function SkinGroupRow({
           }}
           aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
           title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100"
+          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100 ${
+            onToggleIncluded ? 'right-10' : 'right-2'
+          }`}
         >
           <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
+      {/* Add to shuffle (see SkinGroupCard). Anchors the top-right corner; the
+          hover-only image/delete buttons extend leftward from it. */}
+      {onToggleIncluded && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleIncluded();
+          }}
+          aria-pressed={isIncluded}
+          aria-label={
+            isIncluded
+              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+              : t('locker.randomize.addToShuffle', { name: primary.name })
+          }
+          title={
+            isIncluded
+              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+              : t('locker.randomize.addToShuffle', { name: primary.name })
+          }
+          className={`absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/row:opacity-100 ${
+            isIncluded
+              ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
+              : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/55 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
+          }`}
+        >
+          <Shuffle className="h-3.5 w-3.5" />
         </button>
       )}
       <button
@@ -739,6 +835,9 @@ export default function HeroSkinsPanel({
   emptyMessage = 'Download a skin for this hero to manage it here.',
   browseAction,
   layout = 'list',
+  includedSkinKeys,
+  onToggleShuffleIncluded,
+  shuffleArmed,
 }: HeroSkinsPanelProps) {
   const hasMods = mods.length > 0;
   const soundVolume = useAppStore((s) => s.soundVolume);
@@ -803,6 +902,13 @@ export default function HeroSkinsPanel({
                   loadOrderPosition={loadOrderByKey.get(group.key)}
                   overrideSrc={lockerModImages[group.key]}
                   onPickImage={pickImageFor(group)}
+                  isIncluded={includedSkinKeys?.has(shuffleSkinKey(group.primary))}
+                  onToggleIncluded={
+                    onToggleShuffleIncluded
+                      ? () => onToggleShuffleIncluded(shuffleSkinKey(group.primary))
+                      : undefined
+                  }
+                  shuffleArmed={shuffleArmed}
                   {...groupProps}
                 />
               ))}
@@ -814,6 +920,13 @@ export default function HeroSkinsPanel({
                 group={group}
                 overrideSrc={lockerModImages[group.key]}
                 onPickImage={pickImageFor(group)}
+                isIncluded={includedSkinKeys?.has(shuffleSkinKey(group.primary))}
+                onToggleIncluded={
+                  onToggleShuffleIncluded
+                    ? () => onToggleShuffleIncluded(shuffleSkinKey(group.primary))
+                    : undefined
+                }
+                shuffleArmed={shuffleArmed}
                 {...groupProps}
               />
             ))

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -446,7 +446,7 @@ export async function reorderMods(orderedIds: string[]): Promise<Mod[]> {
 export async function applyModToggleBatch(
   enableIds: string[],
   disableIds: string[]
-): Promise<Mod[]> {
+): Promise<{ mods: Mod[]; failures: string[] }> {
   return withGameRunningWarning(() =>
     window.electronAPI.applyModToggleBatch(enableIds, disableIds)
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -443,6 +443,15 @@ export async function reorderMods(orderedIds: string[]): Promise<Mod[]> {
   return withGameRunningWarning(() => window.electronAPI.reorderMods(orderedIds));
 }
 
+export async function applyModToggleBatch(
+  enableIds: string[],
+  disableIds: string[]
+): Promise<Mod[]> {
+  return withGameRunningWarning(() =>
+    window.electronAPI.applyModToggleBatch(enableIds, disableIds)
+  );
+}
+
 export async function swapModPriority(modIdA: string, modIdB: string): Promise<Mod[]> {
   return withGameRunningWarning(() => window.electronAPI.swapModPriority(modIdA, modIdB));
 }

--- a/src/lib/lockerRandomizer.test.ts
+++ b/src/lib/lockerRandomizer.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import type { Mod } from '../types/mod';
+import { planRandomization, shuffleSkinKey } from './lockerRandomizer';
+
+/**
+ * Minimal Mod factory. Only the fields the randomizer + lockerUtils grouping
+ * read matter (id, enabled, priority, metaKey, gameBananaId, sha256); the rest
+ * are filled with inert defaults. metaKey is a bare filename so modLoadOrder
+ * folds to priority (folder index 0).
+ */
+function mod(over: Partial<Mod> & { id: string }): Mod {
+  return {
+    name: over.id,
+    fileName: `${over.id}.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    metaKey: `${over.id}.vpk`,
+    enabled: false,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+/** rng stub returning a fixed value (picks pool[floor(value * len)]). */
+const fixedRng = (value: number) => () => value;
+
+describe('shuffleSkinKey', () => {
+  it('prefers gameBananaId, then sha256, then mod id', () => {
+    expect(shuffleSkinKey(mod({ id: 'a', gameBananaId: 42, sha256: 'deadbeef' }))).toBe(
+      'gamebanana:42'
+    );
+    expect(shuffleSkinKey(mod({ id: 'b', sha256: 'cafe' }))).toBe('sha256:cafe');
+    expect(shuffleSkinKey(mod({ id: 'c' }))).toBe('mod:c');
+  });
+
+  it('ignores a zero/absent gameBananaId', () => {
+    expect(shuffleSkinKey(mod({ id: 'd', gameBananaId: 0, sha256: 'x' }))).toBe('sha256:x');
+  });
+});
+
+describe('planRandomization', () => {
+  it('leaves a hero untouched when no skin is opted in', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }), mod({ id: 'b', gameBananaId: 2 })]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(),
+      rng: fixedRng(0),
+    });
+    expect(plan).toEqual({ enableIds: [], disableIds: [], changedHeroes: [] });
+  });
+
+  it('is a no-op when the only opted-in skin is already the lone active one', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 })]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual([]);
+    expect(plan.disableIds).toEqual([]);
+    expect(plan.changedHeroes).toEqual([]);
+  });
+
+  it('enables a disabled pick and disables the previously-active skin', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
+      ]],
+    ]);
+    // Both opted in; avoidCurrent removes the active skin A from the pool,
+    // leaving only B.
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['b']);
+    expect(plan.disableIds).toEqual(['a']);
+    expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it('disable-only when the chosen skin is already enabled alongside others', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: true, priority: 2 }),
+      ]],
+    ]);
+    // A is active (lower load order); avoidCurrent picks B, which is already on,
+    // so we only disable A.
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual([]);
+    expect(plan.disableIds).toEqual(['a']);
+    expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it('only draws from opted-in skins', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: false, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
+        mod({ id: 'c', gameBananaId: 3, enabled: false, priority: 3 }),
+      ]],
+    ]);
+    // Only B is in the pool; it's chosen regardless of rng.
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:2']),
+      rng: fixedRng(0.99),
+    });
+    expect(plan.enableIds).toEqual(['b']);
+    expect(plan.disableIds).toEqual([]);
+  });
+
+  it('equips the lone opted-in skin even when a non-included skin is active', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
+      ]],
+    ]);
+    // Only B is in the pool; A is the live skin but not included. The lone pick
+    // is B, so A is swapped out for it.
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['b']);
+    expect(plan.disableIds).toEqual(['a']);
+    expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it('never re-picks the current skin across the whole rng range when >=2 eligible', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
+        mod({ id: 'c', gameBananaId: 3, enabled: false, priority: 3 }),
+      ]],
+    ]);
+    const included = new Set(['gamebanana:1', 'gamebanana:2', 'gamebanana:3']);
+    for (const value of [0, 0.34, 0.5, 0.67, 0.99]) {
+      const plan = planRandomization({ heroSkins, heroIds: [1], included, rng: fixedRng(value) });
+      // A (current) is always turned off and never re-enabled.
+      expect(plan.disableIds).toContain('a');
+      expect(plan.enableIds).not.toContain('a');
+      expect(plan.enableIds).toHaveLength(1);
+      expect(['b', 'c']).toContain(plan.enableIds[0]);
+    }
+  });
+
+  it('can re-pick the current skin when avoidCurrent is false', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
+      ]],
+    ]);
+    // rng 0 -> pool[0] which is the priority-1 skin A (the active one).
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+      avoidCurrent: false,
+    });
+    expect(plan.enableIds).toEqual([]);
+    expect(plan.disableIds).toEqual([]);
+    expect(plan.changedHeroes).toEqual([]);
+  });
+
+  it('treats variants of one skin as a single pick and leaves one VPK active', () => {
+    // gb:1 has two VPK variants; gb:2 is a separate skin currently active.
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a1', gameBananaId: 1, enabled: false, priority: 3 }),
+        mod({ id: 'a2', gameBananaId: 1, enabled: false, priority: 4 }),
+        mod({ id: 'b', gameBananaId: 2, enabled: true, priority: 1 }),
+      ]],
+    ]);
+    // Both opted in; avoidCurrent drops B (active), leaving only the gb:1 skin.
+    // Its primary is the lowest-priority variant a1; a2 stays off, B is disabled.
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['a1']);
+    expect(plan.disableIds).toEqual(['b']);
+  });
+
+  it('honors scope: only shuffles heroes in heroIds', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [mod({ id: 'a', gameBananaId: 1, enabled: false, priority: 1 })]],
+      [2, [mod({ id: 'b', gameBananaId: 2, enabled: true, priority: 1 })]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['a']);
+    // Hero 2 was out of scope; its mod is never touched.
+    expect(plan.disableIds).not.toContain('b');
+    expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it('skips heroes with no installed skins', () => {
+    const heroSkins = new Map<number, Mod[]>([[1, []]]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1, 999],
+      included: new Set(['gamebanana:1']),
+      rng: fixedRng(0),
+    });
+    expect(plan).toEqual({ enableIds: [], disableIds: [], changedHeroes: [] });
+  });
+});

--- a/src/lib/lockerRandomizer.test.ts
+++ b/src/lib/lockerRandomizer.test.ts
@@ -134,8 +134,9 @@ describe('planRandomization', () => {
         mod({ id: 'b', gameBananaId: 2, enabled: false, priority: 2 }),
       ]],
     ]);
-    // Only B is in the pool; A is the live skin but not included. The lone pick
-    // is B, so A is swapped out for it.
+    // Only B is in the pool; A is the live skin but not included. The shuffle
+    // makes the picked skin the hero's single active skin, so A is swapped out
+    // for B even though A was never opted in.
     const plan = planRandomization({
       heroSkins,
       heroIds: [1],
@@ -145,6 +146,47 @@ describe('planRandomization', () => {
     expect(plan.enableIds).toEqual(['b']);
     expect(plan.disableIds).toEqual(['a']);
     expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it('disables a non-pooled companion mod so exactly one skin is active', () => {
+    // Hero has a pooled skin A plus a separate enabled mod W the user never
+    // opted in. Grimoire files both under "Skins", so the shuffle resets the
+    // hero's skin slot: A is the lone pick and W is disabled, leaving one skin.
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a', gameBananaId: 1, enabled: false, priority: 1 }),
+        mod({ id: 'w', gameBananaId: 2, enabled: true, priority: 2 }),
+      ]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['a']);
+    expect(plan.disableIds).toEqual(['w']);
+    expect(plan.changedHeroes).toEqual([1]);
+  });
+
+  it("leaves the chosen skin's own enabled variant VPK loaded (multi-VPK skin)", () => {
+    // One pooled submission ships two co-required VPKs (same gameBananaId), both
+    // enabled. When it's the pick, neither of its own variants may be disabled.
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [
+        mod({ id: 'a1', gameBananaId: 1, enabled: true, priority: 1 }),
+        mod({ id: 'a2', gameBananaId: 1, enabled: true, priority: 2 }),
+      ]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual([]);
+    expect(plan.disableIds).toEqual([]);
+    expect(plan.changedHeroes).toEqual([]);
   });
 
   it('never re-picks the current skin across the whole rng range when >=2 eligible', () => {

--- a/src/lib/lockerRandomizer.ts
+++ b/src/lib/lockerRandomizer.ts
@@ -1,0 +1,168 @@
+import type { Mod } from '../types/mod';
+import {
+  activeLockerSkin,
+  getEffectiveGlobalType,
+  groupLockerSkins,
+  groupModsByCategory,
+  isLockerManagedMod,
+} from './lockerUtils';
+
+/** localStorage key for the set of skin keys opted INTO the launch shuffle. */
+export const SHUFFLE_INCLUDED_KEY = 'lockerShuffleIncluded';
+/** localStorage key for the master "shuffle skins on launch" switch. */
+export const SHUFFLE_ON_LAUNCH_KEY = 'lockerShuffleOnLaunch';
+
+/**
+ * Stable identity for a skin used by the shuffle for the opt-in pool. Prefers
+ * the GameBanana archive id, then the content hash, then the volatile mod id.
+ *
+ * We deliberately do NOT reuse getLockerSkinKey: its `mod:<id>` fallback keys
+ * off mod.id, which is derived from the pakNN filename and changes every time a
+ * mod is enabled/disabled. A persisted opt-in for a local (non-GameBanana)
+ * import would then silently stop matching after the first shuffle. sha256 is
+ * content-addressed and survives the rename.
+ */
+export function shuffleSkinKey(mod: Mod): string {
+  if (typeof mod.gameBananaId === 'number' && mod.gameBananaId > 0) {
+    return `gamebanana:${mod.gameBananaId}`;
+  }
+  if (mod.sha256) {
+    return `sha256:${mod.sha256}`;
+  }
+  return `mod:${mod.id}`;
+}
+
+/**
+ * Synchronous loader for the persisted shuffle-inclusion set. Used as a lazy
+ * useState initializer so the value is present on the very first render. See
+ * readStoredFavorites (lockerUtils.ts) for the StrictMode save/load race this
+ * synchronous-seed pattern avoids.
+ */
+export function readStoredShuffleIncluded(): Set<string> {
+  try {
+    const stored = localStorage.getItem(SHUFFLE_INCLUDED_KEY);
+    if (!stored) return new Set();
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((k): k is string => typeof k === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+/** Synchronous loader for the master on-launch switch (defaults off). */
+export function readStoredShuffleOnLaunch(): boolean {
+  try {
+    return localStorage.getItem(SHUFFLE_ON_LAUNCH_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export interface RandomizePlanOptions {
+  /** Per-hero skin mods, keyed by hero category id (Locker's heroMods.map). */
+  heroSkins: Map<number, Mod[]>;
+  /** Hero ids to consider (usually every hero with installed skins). */
+  heroIds: number[];
+  /** Skin keys (shuffleSkinKey) the user opted INTO the shuffle pool. */
+  included: Set<string>;
+  /** Injectable RNG returning [0, 1); defaults to Math.random. */
+  rng?: () => number;
+  /**
+   * When a hero has >=2 eligible skins, avoid re-picking the currently-active
+   * one so a repeat shuffle visibly changes its look. Defaults to true.
+   */
+  avoidCurrent?: boolean;
+}
+
+export interface RandomizePlan {
+  enableIds: string[];
+  disableIds: string[];
+  /** Hero ids that actually changed (drives the result toast count). */
+  changedHeroes: number[];
+}
+
+/**
+ * Compute the enable/disable set for a skin shuffle. For each in-scope hero,
+ * picks one of the skins the user opted into the pool at random and makes it the
+ * single active skin: enable its primary variant, disable every other
+ * currently-enabled skin VPK for that hero (non-chosen skins and the chosen
+ * skin's non-primary variants), leaving exactly one VPK active. Heroes with no
+ * opted-in skins (or no installed skins) are left untouched - that is the
+ * per-hero opt-out: don't add any of a hero's skins and it never shuffles.
+ *
+ * Pure and deterministic given a fixed rng, so it's unit-tested directly. The
+ * returned ids are renderer-current; they stay valid because the apply runs them
+ * as one batch under the main-process mutation lock (see setModsEnabledBatch).
+ */
+export function planRandomization(options: RandomizePlanOptions): RandomizePlan {
+  const { heroSkins, heroIds, included, rng = Math.random, avoidCurrent = true } = options;
+  const enableIds: string[] = [];
+  const disableIds: string[] = [];
+  const changedHeroes: number[] = [];
+
+  for (const heroId of heroIds) {
+    const mods = heroSkins.get(heroId);
+    if (!mods || mods.length === 0) continue;
+
+    const skins = groupLockerSkins(mods);
+    const eligible = skins.filter((skin) => included.has(shuffleSkinKey(skin.primary)));
+    if (eligible.length === 0) continue;
+
+    // Bias away from the currently-active skin so each launch changes the look.
+    // Only when there's an alternative left to pick.
+    const activeMod = activeLockerSkin(mods);
+    const activeKey = activeMod ? shuffleSkinKey(activeMod) : undefined;
+    let pool = eligible;
+    if (avoidCurrent && eligible.length > 1 && activeKey) {
+      const without = eligible.filter((skin) => shuffleSkinKey(skin.primary) !== activeKey);
+      if (without.length > 0) pool = without;
+    }
+
+    const index = Math.min(pool.length - 1, Math.floor(rng() * pool.length));
+    const chosen = pool[index];
+    const chosenPrimaryId = chosen.primary.id;
+
+    let heroChanged = false;
+    if (!chosen.primary.enabled) {
+      enableIds.push(chosenPrimaryId);
+      heroChanged = true;
+    }
+    for (const mod of mods) {
+      if (mod.enabled && mod.id !== chosenPrimaryId) {
+        disableIds.push(mod.id);
+        heroChanged = true;
+      }
+    }
+    if (heroChanged) changedHeroes.push(heroId);
+  }
+
+  return { enableIds, disableIds, changedHeroes };
+}
+
+export interface LaunchShufflePlanOptions {
+  /** The full installed mod list (appStore `mods`). */
+  mods: Mod[];
+  /** Hero categories used to group skins by hero (buildHeroList output). */
+  heroList: { id: number; name: string }[];
+  /** Skin keys (shuffleSkinKey) opted into the shuffle pool. */
+  included: Set<string>;
+  /** Injectable RNG; defaults to Math.random. */
+  rng?: () => number;
+}
+
+/**
+ * Build the launch-time shuffle plan from the raw mod list. Filters to per-hero
+ * skin mods (the same predicate the Locker uses for its hero grid), groups them
+ * by hero, and shuffles every hero that has at least one opted-in skin. Keeping
+ * this here means the Locker and the launch path share one grouping + selection
+ * path, so the set of skins a launch can pick is exactly the set the Locker
+ * shows the per-skin opt-in toggle on.
+ */
+export function planLaunchShuffle(options: LaunchShufflePlanOptions): RandomizePlan {
+  const { mods, heroList, included, rng } = options;
+  if (included.size === 0) return { enableIds: [], disableIds: [], changedHeroes: [] };
+  const lockerSkins = mods.filter((m) => isLockerManagedMod(m) && !getEffectiveGlobalType(m));
+  const { map } = groupModsByCategory(lockerSkins, heroList);
+  return planRandomization({ heroSkins: map, heroIds: [...map.keys()], included, rng });
+}

--- a/src/lib/lockerRandomizer.ts
+++ b/src/lib/lockerRandomizer.ts
@@ -85,11 +85,12 @@ export interface RandomizePlan {
 /**
  * Compute the enable/disable set for a skin shuffle. For each in-scope hero,
  * picks one of the skins the user opted into the pool at random and makes it the
- * single active skin: enable its primary variant, disable every other
- * currently-enabled skin VPK for that hero (non-chosen skins and the chosen
- * skin's non-primary variants), leaving exactly one VPK active. Heroes with no
- * opted-in skins (or no installed skins) are left untouched - that is the
- * per-hero opt-out: don't add any of a hero's skins and it never shuffles.
+ * hero's single active skin: enable its primary variant and disable every other
+ * currently-enabled skin VPK for that hero, sparing only the chosen skin's own
+ * variant VPKs so a multi-file submission loads whole. Heroes with no opted-in
+ * skins (or no installed skins) are left untouched - that is the per-hero
+ * opt-out: don't add any of a hero's skins and it never shuffles. Sounds, cards
+ * and ability effects are separate axes and are never touched.
  *
  * Pure and deterministic given a fixed rng, so it's unit-tested directly. The
  * returned ids are renderer-current; they stay valid because the apply runs them
@@ -128,8 +129,14 @@ export function planRandomization(options: RandomizePlanOptions): RandomizePlan 
       enableIds.push(chosenPrimaryId);
       heroChanged = true;
     }
+    // Make the chosen skin the hero's single active skin: disable every other
+    // enabled skin VPK for this hero. We spare ONLY the chosen skin's own
+    // variant VPKs (same submission) so a skin that ships several required files
+    // isn't left half-loaded. Sounds, cards and ability effects live on other
+    // Locker axes and are never in this list, so they stay exactly as set.
+    const chosenVariantIds = new Set(chosen.variants.map((v) => v.id));
     for (const mod of mods) {
-      if (mod.enabled && mod.id !== chosenPrimaryId) {
+      if (mod.enabled && !chosenVariantIds.has(mod.id)) {
         disableIds.push(mod.id);
         heroChanged = true;
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1188,6 +1188,13 @@
     "empty": {
       "noGamePath": "Set your Deadlock path or enable dev mode."
     },
+    "randomize": {
+      "onLaunch": "Shuffle on launch",
+      "onLaunchHint": "When on, each time you launch from Grimoire one of your chosen skins is equipped per hero. Add skins to the pool with the shuffle button on each skin.",
+      "addToShuffle": "Add {{name}} to the shuffle",
+      "removeFromShuffle": "Remove {{name}} from the shuffle",
+      "inPool": "In shuffle"
+    },
     "modImage": {
       "set": "Set Locker image for {{name}}",
       "title": "Choose a Locker image",
@@ -1541,10 +1548,11 @@
       "soundCount_other": "{{count}} sounds",
       "modCount_one": "{{count}} mod",
       "modCount_other": "{{count}} mods",
-      "modsActive_one": "{{count}} mod installed (active)",
-      "modsActive_other": "{{count}} mods installed (1 active)",
-      "modsInstalled_one": "{{count}} mod installed (none active)",
-      "modsInstalled_other": "{{count}} mods installed (none active)",
+      "facetSkin": "Skin",
+      "facetSound": "Sound",
+      "facetCard": "Card",
+      "facetEffects": "Effects",
+      "facetInstalled": "{{label}} (installed, off)",
       "categoryCount_one": "{{count}} category",
       "categoryCount_other": "{{count}} categories",
       "fileCount_one": "{{count}} file",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2074,7 +2074,9 @@
       "stoppedRestoreFailed_one": "Stopped Deadlock, but couldn't restore {{count}} mod.",
       "stoppedRestoreFailed_other": "Stopped Deadlock, but couldn't restore {{count}} mods.",
       "restoredStashed_one": "Restored {{count}} stashed mod.",
-      "restoredStashed_other": "Restored {{count}} stashed mods."
+      "restoredStashed_other": "Restored {{count}} stashed mods.",
+      "shufflePartial_one": "1 skin couldn't be shuffled this launch.",
+      "shufflePartial_other": "{{count}} skins couldn't be shuffled this launch."
     },
     "brand": "Grimoire",
     "previewVolume": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1868,
+  "totalKeys": 1870,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1868,
+      "translatedKeys": 1870,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1862,
+  "totalKeys": 1868,
   "languages": [
     {
       "code": "bg",
@@ -11,13 +11,13 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1862,
+      "translatedKeys": 1868,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
-      "translatedKeys": 1830,
+      "translatedKeys": 1826,
       "pct": 98
     },
     {

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,11 +1,12 @@
-import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type ComponentType, type SVGProps } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Star, Trash2 } from 'lucide-react';
+import { ArrowLeft, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Images, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Shuffle, Sparkles, Star, Trash2 } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
   getHeroColorSupport,
+  getLockerOverview,
   setModGlobalType,
   setModLockerHero,
 } from '../lib/api';
@@ -30,9 +31,9 @@ const SpiritUrnImportModal = lazy(() => import('../components/locker/SpiritUrnIm
 const URN_MODEL_ENTRY = 'models/props_gameplay/idol_urn/idol_urn.vmdl_c';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
-import type { GlobalModType, Mod } from '../types/mod';
+import type { GlobalModType, LockerOverview, Mod } from '../types/mod';
 import { ViewModeToggle, EmptyState, SectionHeader, ConfirmModal } from '../components/common/PageComponents';
-import { Tag } from '../components/common/ui';
+import { Tag, ToggleIndicator } from '../components/common/ui';
 import { Skeleton } from '../components/common/Skeleton';
 import { HeroSelect } from '../components/common/HeroSelect';
 import {
@@ -41,6 +42,7 @@ import {
   GLOBAL_MOD_TYPE_ORDER,
   activeLockerSkin,
   buildHeroList,
+  canonicalHeroName,
   countGlobalMods,
   countLockerSkins,
   getLockerSkinKey,
@@ -60,6 +62,7 @@ import {
   type GlobalModGroups,
   type HeroCategory,
 } from '../lib/lockerUtils';
+import { shuffleSkinKey } from '../lib/lockerRandomizer';
 
 // Route changes flip the overlay state instantly, which unmounts the hero or
 // global panel on the next frame with no exit transition. Retain the last
@@ -137,9 +140,82 @@ function RainbowPaletteIcon({ className = '', title }: { className?: string; tit
   );
 }
 
+// The per-hero customization axes surfaced as gallery-card indicator icons,
+// mirroring the hero detail view's section nav (Skins/Sounds/Cards/Effects) so
+// the icon language is the same in both places. 'skin'/'sound' come from the
+// hero's enabled mods; 'card'/'effect' come from the Locker-managed override
+// manifests (applied hero card art, ability recolors / trippy paints).
+type HeroFacetKey = 'skin' | 'sound' | 'card' | 'effect';
+// 'active' = something is applied in-game right now (enabled mod or an applied
+// override). 'installed' = mods exist for this axis but none are enabled.
+type HeroFacetState = 'active' | 'installed';
+type HeroFacets = Partial<Record<HeroFacetKey, HeroFacetState>>;
+
+// Narrow icon contract shared by the lucide glyphs and the custom solid note
+// below, so both can live in HERO_FACET_ICONS. We only ever pass these props.
+type FacetIcon = ComponentType<{
+  className?: string;
+  fill?: string;
+  strokeWidth?: number;
+  'aria-hidden'?: boolean;
+}>;
+
+// Solid eighth-note glyph (Material's `music_note`): a single closed path that
+// fills cleanly with the sheen gradient. lucide's `Music` is an open
+// note-bar-plus-two-heads outline that turns into an unreadable blob when
+// filled, so the Sounds axis uses this instead. 24x24 viewBox to size with the
+// lucide icons; stroke=currentColor so it picks up the same hardening rim.
+function SolidMusicIcon({ className, fill, strokeWidth, ...rest }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...rest}
+    >
+      <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+    </svg>
+  );
+}
+
+const HERO_FACET_ORDER: readonly HeroFacetKey[] = ['skin', 'sound', 'card', 'effect'];
+const HERO_FACET_ICONS: Record<HeroFacetKey, FacetIcon> = {
+  skin: Shirt,
+  sound: SolidMusicIcon,
+  card: Images,
+  effect: Sparkles,
+};
+
+// Vertical sheen gradient used to fill the *active* customization-indicator
+// glyphs so they read as polished chips rather than flat white. Defined once as
+// a shared <defs> (FacetSheenDefs) and referenced by id from every gallery card,
+// the same url(#id) technique as RainbowPaletteIcon.
+const FACET_SHEEN_ID = 'locker-facet-sheen';
+
+function FacetSheenDefs() {
+  return (
+    <svg width="0" height="0" aria-hidden focusable="false" className="absolute">
+      <defs>
+        <linearGradient id={FACET_SHEEN_ID} x1="0" y1="0" x2="0" y2="1">
+          {/* Bright crown, a crisp highlight break across the middle, then a
+              cool steel falloff: a subtle gloss without looking garish. */}
+          <stop offset="0%" stopColor="#ffffff" />
+          <stop offset="46%" stopColor="#f1f4f8" />
+          <stop offset="54%" stopColor="#d7dde7" />
+          <stop offset="100%" stopColor="#aab3c2" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages, shuffleOnLaunch, setShuffleOnLaunch, shuffleIncluded, toggleShuffleIncluded } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(
@@ -197,6 +273,17 @@ export default function Locker() {
   const [favoriteHeroes, setFavoriteHeroes] = useState<number[]>(() =>
     readStoredFavorites()
   );
+  // Applied Locker overrides (hero card art + ability sounds + ability recolors
+  // + trippy paints), keyed by hero name. Lives off the mod list, so it's
+  // fetched separately and feeds the per-hero card/effect indicator icons.
+  const [lockerOverview, setLockerOverview] = useState<LockerOverview | null>(null);
+  const refreshLockerOverview = useCallback(async () => {
+    try {
+      setLockerOverview(await getLockerOverview());
+    } catch {
+      setLockerOverview(null);
+    }
+  }, []);
   const lockerScrollRef = useRef<HTMLDivElement | null>(null);
   const latestLockerScrollTopRef = useRef(lockerPageScrollTop);
 
@@ -303,6 +390,13 @@ export default function Locker() {
     [location.pathname]
   );
 
+  // Hero cards and ability effects can only be applied from inside a hero
+  // drill-in, so the override overview is fresh enough if we (re)load it on
+  // mount and whenever the user returns to the grid (no overlay open).
+  useEffect(() => {
+    if (selectedHeroId === null && !globalSelected) void refreshLockerOverview();
+  }, [selectedHeroId, globalSelected, refreshLockerOverview]);
+
   // Build basic hero list first (needed for mod categorization)
   const baseHeroList = useMemo(() => buildHeroList(categories), [categories]);
   const heroNamesForColorSupport = useMemo(
@@ -408,6 +502,60 @@ export default function Locker() {
     [heroSounds]
   );
 
+  // Canonical hero names that currently have an applied card / ability sound /
+  // effect (recolor or trippy paint), derived from the override overview. Keyed
+  // by canonicalHeroName so "The Doorman" and "Doorman" resolve to one hero.
+  const overrideHeroNames = useMemo(() => {
+    const cards = new Set<string>();
+    const sounds = new Set<string>();
+    const effects = new Set<string>();
+    if (lockerOverview) {
+      for (const c of lockerOverview.cards) cards.add(canonicalHeroName(c.heroName));
+      for (const s of lockerOverview.sounds) sounds.add(canonicalHeroName(s.heroName));
+      for (const c of lockerOverview.colors) effects.add(canonicalHeroName(c.heroName));
+      for (const ts of lockerOverview.trippySkins) effects.add(canonicalHeroName(ts.heroName));
+    }
+    return { cards, sounds, effects };
+  }, [lockerOverview]);
+
+  // True when the hero has any applied customization: an enabled skin or sound,
+  // or an applied card / ability sound / effect override. Drives the auto-sort
+  // tier that floats customized heroes up, matching the indicator icons below.
+  const heroHasActive = useCallback(
+    (heroId: number, heroName: string) => {
+      const canon = canonicalHeroName(heroName);
+      return (
+        (heroMods.map.get(heroId) ?? []).some((m) => m.enabled) ||
+        (heroSounds.map.get(heroId) ?? []).some((m) => m.enabled) ||
+        overrideHeroNames.cards.has(canon) ||
+        overrideHeroNames.sounds.has(canon) ||
+        overrideHeroNames.effects.has(canon)
+      );
+    },
+    [heroMods, heroSounds, overrideHeroNames]
+  );
+
+  // The active/installed customization facets for one hero, driving the gallery
+  // card's indicator icons. Skins/sounds reflect the hero's mods; cards/effects
+  // reflect the applied overrides. Card and effect have no "installed" state
+  // (an override is either applied or absent).
+  const heroFacets = useCallback(
+    (heroId: number, heroName: string): HeroFacets => {
+      const skins = heroMods.map.get(heroId) ?? [];
+      const sounds = heroSounds.map.get(heroId) ?? [];
+      const canon = canonicalHeroName(heroName);
+      const facets: HeroFacets = {};
+      if (skins.some((m) => m.enabled)) facets.skin = 'active';
+      else if (skins.length > 0) facets.skin = 'installed';
+      if (sounds.some((m) => m.enabled) || overrideHeroNames.sounds.has(canon)) facets.sound = 'active';
+      else if (sounds.length > 0) facets.sound = 'installed';
+      if (overrideHeroNames.cards.has(canon)) facets.card = 'active';
+      if (overrideHeroNames.effects.has(canon)) facets.effect = 'active';
+      return facets;
+    },
+    [heroMods, heroSounds, overrideHeroNames]
+  );
+
   // Sorted hero list for display
   const heroList = useMemo(() => {
     return [...baseHeroList].sort((a, b) => {
@@ -415,7 +563,12 @@ export default function Locker() {
       const bFav = favoriteHeroes.includes(b.id);
       // Favorites first
       if (aFav !== bFav) return aFav ? -1 : 1;
-      // Then heroes with any locker content (skins or sounds)
+      // Then heroes with any applied customization: anything active in-game floats
+      // above heroes that only have disabled skins/sounds sitting in their pile.
+      const aActive = heroHasActive(a.id, a.name);
+      const bActive = heroHasActive(b.id, b.name);
+      if (aActive !== bActive) return aActive ? -1 : 1;
+      // Then heroes with any locker content (skins or sounds), enabled or not
       const aHasContent =
         countLockerSkins(heroMods.map.get(a.id) ?? []) > 0 ||
         countLockerSkins(heroSounds.map.get(a.id) ?? []) > 0;
@@ -426,7 +579,7 @@ export default function Locker() {
       // Then alphabetically
       return a.name.localeCompare(b.name);
     });
-  }, [baseHeroList, favoriteHeroes, heroMods, heroSounds]);
+  }, [baseHeroList, favoriteHeroes, heroMods, heroSounds, heroHasActive]);
 
   // When "hide empty" is on, drop heroes with no assigned skins/sounds. Favorites
   // are kept so an intentional pin never disappears. Uses the same content test
@@ -555,6 +708,22 @@ export default function Locker() {
     if (!skins.some((m) => m.id === modId) && !sounds.some((m) => m.id === modId)) return;
     await toggleMod(modId);
   };
+
+  // Heroes that have at least one installed skin; gates the shuffle toggle.
+  const heroesWithSkins = heroMods.map.size;
+
+  // Hero ids with at least one skin in the launch-shuffle pool. Drives the
+  // gallery card's shuffle badge (only shown while the master switch is armed).
+  const shufflePoolHeroes = useMemo(() => {
+    const set = new Set<number>();
+    if (shuffleIncluded.size === 0) return set;
+    for (const [heroId, heroSkinMods] of heroMods.map) {
+      if (groupLockerSkins(heroSkinMods).some((g) => shuffleIncluded.has(shuffleSkinKey(g.primary)))) {
+        set.add(heroId);
+      }
+    }
+    return set;
+  }, [heroMods, shuffleIncluded]);
 
   // Reorder the load order of a hero's enabled skins. `orderedModIds` is the
   // new desired order of THIS hero's enabled skin VPK ids (lower index = loads
@@ -698,6 +867,8 @@ export default function Locker() {
 
   return (
     <div ref={lockerScrollRef} className="h-full overflow-y-auto">
+      {/* Shared gradient def for the active hero-card customization glyphs. */}
+      <FacetSheenDefs />
       <div className="p-6 space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm text-text-secondary">
@@ -712,6 +883,29 @@ export default function Locker() {
             .join(' • ')}
         </div>
         <div className="flex items-center gap-3">
+          {heroesWithSkins > 0 && (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={shuffleOnLaunch}
+              onClick={() => setShuffleOnLaunch(!shuffleOnLaunch)}
+              className="group/toggle flex items-center gap-2 self-stretch rounded-sm border border-border bg-bg-secondary px-3 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary cursor-pointer"
+              title={t('locker.randomize.onLaunchHint')}
+            >
+              <Shuffle className="w-4 h-4" />
+              <span>{t('locker.randomize.onLaunch')}</span>
+              {shuffleOnLaunch && (
+                <span
+                  className={`rounded-full px-1.5 text-xs tabular-nums ${
+                    shuffleIncluded.size > 0 ? 'bg-accent/15 text-accent' : 'bg-yellow-500/15 text-yellow-400'
+                  }`}
+                >
+                  {shuffleIncluded.size}
+                </span>
+              )}
+              <ToggleIndicator checked={shuffleOnLaunch} className="ml-0.5 scale-90" />
+            </button>
+          )}
           {viewMode === 'gallery' &&
             unassignedSkins.length + unassignedSounds.length > 0 && (
               <button
@@ -782,14 +976,8 @@ export default function Locker() {
             <HeroGalleryCard
               key={hero.id}
               hero={hero}
-              skinCount={countLockerSkins(heroMods.map.get(hero.id) ?? [])}
-              soundCount={countLockerSkins(heroSounds.map.get(hero.id) ?? [])}
-              isActive={Boolean(
-                activeLockerSkin([
-                  ...(heroMods.map.get(hero.id) ?? []),
-                  ...(heroSounds.map.get(hero.id) ?? []),
-                ])
-              )}
+              facets={heroFacets(hero.id, hero.name)}
+              inShufflePool={shuffleOnLaunch && shufflePoolHeroes.has(hero.id)}
               cardImage={heroCardImage(hero.id)}
               hideHeroName={heroHideName(hero.id)}
               isFavorite={favoriteHeroes.includes(hero.id)}
@@ -853,6 +1041,9 @@ export default function Locker() {
               onSelect={(modId) => setActiveSkin(hero.id, modId)}
               onToggleVariant={(modId) => toggleHeroVariant(hero.id, modId)}
               onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
+              includedSkinKeys={shuffleIncluded}
+              onToggleShuffleIncluded={toggleShuffleIncluded}
+              shuffleArmed={shuffleOnLaunch}
               isFavorite={favoriteHeroes.includes(hero.id)}
               onToggleFavorite={() =>
                 setFavoriteHeroes((prev) =>
@@ -961,6 +1152,9 @@ export default function Locker() {
             onReorderSkins={(orderedModIds) => reorderHeroSkins(overlayHero.id, orderedModIds)}
             onRequestDeleteSkin={(ids, name) => setDeletePrompt({ ids, name })}
             hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+            includedSkinKeys={shuffleIncluded}
+            onToggleShuffleIncluded={toggleShuffleIncluded}
+            shuffleArmed={shuffleOnLaunch}
           />
         </div>
       )}
@@ -1057,6 +1251,9 @@ interface HeroCardProps {
   onSelect: (modId: string) => void;
   onToggleVariant: (modId: string) => void;
   onRequestDelete: (modIds: string[], name: string) => void;
+  includedSkinKeys: Set<string>;
+  onToggleShuffleIncluded: (skinKey: string) => void;
+  shuffleArmed: boolean;
   isFavorite: boolean;
   onToggleFavorite: () => void;
   hideNsfwPreviews: boolean;
@@ -1064,11 +1261,13 @@ interface HeroCardProps {
 
 interface HeroGalleryCardProps {
   hero: HeroCategory;
-  skinCount: number;
-  soundCount: number;
-  /** Whether a skin or sound mod is currently enabled for this hero. Drives the
-   *  indicator color: accent when active, muted when installed-but-disabled. */
-  isActive: boolean;
+  /** Per-axis customization state (skin/sound/card/effect) rendered as the
+   *  top-left indicator icons: accent when active, muted when installed but not
+   *  enabled. Absent keys render no icon. */
+  facets: HeroFacets;
+  /** True when the shuffle switch is armed AND this hero has a skin in the pool;
+   *  surfaces a shuffle badge so the rotation is visible at a glance. */
+  inShufflePool?: boolean;
   /** Issue #208: the active skin's chosen Locker image (data URL), shown as the
    *  card backdrop in place of the hero render. Undefined = use the render. */
   cardImage?: string;
@@ -1736,9 +1935,8 @@ function HeroGallerySkeleton() {
 
 function HeroGalleryCard({
   hero,
-  skinCount,
-  soundCount,
-  isActive,
+  facets,
+  inShufflePool,
   cardImage,
   hideHeroName,
   isFavorite,
@@ -1747,6 +1945,24 @@ function HeroGalleryCard({
   onToggleFavorite,
 }: HeroGalleryCardProps) {
   const { t } = useTranslation();
+  // The customization axes this hero actually has, in display order. Drives the
+  // top-left indicator icons. Empty = no pill.
+  const facetKeys = HERO_FACET_ORDER.filter((key) => facets[key]);
+  const facetLabel = (key: HeroFacetKey): string =>
+    key === 'skin'
+      ? t('locker.page.facetSkin')
+      : key === 'sound'
+        ? t('locker.page.facetSound')
+        : key === 'card'
+          ? t('locker.page.facetCard')
+          : t('locker.page.facetEffects');
+  const facetTitle = facetKeys
+    .map((key) =>
+      facets[key] === 'installed'
+        ? t('locker.page.facetInstalled', { label: facetLabel(key) })
+        : facetLabel(key)
+    )
+    .join(' • ');
   const renderLocal = getHeroRenderPath(hero.name);
   const wikiUrl = getHeroWikiUrl(hero.name);
   const namePath = getHeroNamePath(hero.name);
@@ -1868,32 +2084,41 @@ function HeroGalleryCard({
       >
         <Star className={`w-3 h-3 ${isFavorite ? 'fill-current' : ''}`} />
       </button>
-      {/* Modification indicator (top-left). The whole pill changes state so it
-          reads at a glance: a solid accent pill with a check = a skin/sound is
-          currently enabled; a dark pill with a hollow ring = mods are installed
-          but none active. No pill = no mods. Count = installed skin + sound. */}
-      {skinCount + soundCount > 0 && (
+      {/* Customization indicators (top-left): one icon per axis the hero has
+          something on (skin / sound / card art / ability effect). Active glyphs
+          are filled with a vertical sheen gradient and hardened with a thin dark
+          rim so they read as polished chips; installed-but-off stays a faint
+          outline. Filled vs outline reads at a glance without the accent color. */}
+      {(facetKeys.length > 0 || inShufflePool) && (
         <div
-          className={`absolute left-2 top-2 z-20 flex items-center gap-1 rounded-full bg-black/45 px-2 py-0.5 text-[10px] font-medium backdrop-blur-sm ${
-            isActive ? 'text-accent' : 'text-white/65'
-          }`}
-          title={
-            isActive
-              ? t('locker.page.modsActive', { count: skinCount + soundCount })
-              : t('locker.page.modsInstalled', { count: skinCount + soundCount })
-          }
-          aria-label={
-            isActive
-              ? t('locker.page.modsActive', { count: skinCount + soundCount })
-              : t('locker.page.modsInstalled', { count: skinCount + soundCount })
-          }
+          className="absolute left-2 top-2 z-20 flex items-center gap-1.5 rounded-full bg-black/55 px-2 py-1 ring-1 ring-inset ring-white/10 backdrop-blur-sm"
+          title={[facetTitle, inShufflePool ? t('locker.randomize.inPool') : ''].filter(Boolean).join(' • ')}
+          aria-label={[facetTitle, inShufflePool ? t('locker.randomize.inPool') : ''].filter(Boolean).join(' • ')}
         >
-          {isActive ? (
-            <span className="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden />
-          ) : (
-            <span className="h-1.5 w-1.5 rounded-full border border-white/45" aria-hidden />
+          {facetKeys.map((key) => {
+            const Icon = HERO_FACET_ICONS[key];
+            const active = facets[key] === 'active';
+            return (
+              <Icon
+                key={key}
+                className={`h-3.5 w-3.5 ${
+                  active
+                    ? 'text-[#3b4250] drop-shadow-[0_1px_1px_rgba(0,0,0,0.85)]'
+                    : 'fill-none text-white/40 drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]'
+                }`}
+                fill={active ? `url(#${FACET_SHEEN_ID})` : 'none'}
+                strokeWidth={active ? 1.5 : 2}
+                aria-hidden
+              />
+            );
+          })}
+          {inShufflePool && (
+            <Shuffle
+              className="h-3.5 w-3.5 text-accent drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]"
+              strokeWidth={2.25}
+              aria-hidden
+            />
           )}
-          {skinCount + soundCount}
         </div>
       )}
       {/* Issue #208: hide the name label when the active skin's image already
@@ -1934,6 +2159,9 @@ function HeroCard({
   onSelect,
   onToggleVariant,
   onRequestDelete,
+  includedSkinKeys,
+  onToggleShuffleIncluded,
+  shuffleArmed,
   isFavorite,
   onToggleFavorite,
   hideNsfwPreviews,
@@ -2099,6 +2327,9 @@ function HeroCard({
           onSelect={onSelect}
           onToggleVariant={onToggleVariant}
           onRequestDelete={onRequestDelete}
+          includedSkinKeys={activeSection === 'skins' ? includedSkinKeys : undefined}
+          onToggleShuffleIncluded={activeSection === 'skins' ? onToggleShuffleIncluded : undefined}
+          shuffleArmed={shuffleArmed}
           hideNsfwPreviews={hideNsfwPreviews}
           showDownloadable={activeSection === 'skins'}
           browseAction={

--- a/src/pages/LockerHero.tsx
+++ b/src/pages/LockerHero.tsx
@@ -54,6 +54,11 @@ interface LockerHeroViewProps {
    *  confirmation dialog and the actual delete. */
   onRequestDeleteSkin?: (modIds: string[], name: string) => void;
   hideNsfwPreviews?: boolean;
+  /** Launch-shuffle pool set + toggle, threaded to the skins panel cards. */
+  includedSkinKeys?: Set<string>;
+  onToggleShuffleIncluded?: (skinKey: string) => void;
+  /** Whether the master shuffle switch is armed (keeps per-skin toggles visible). */
+  shuffleArmed?: boolean;
 }
 
 type SectionId = 'skins' | 'sounds' | 'cards' | 'effects';
@@ -84,6 +89,9 @@ export function LockerHeroView({
   onReorderSkins,
   onRequestDeleteSkin,
   hideNsfwPreviews = false,
+  includedSkinKeys,
+  onToggleShuffleIncluded,
+  shuffleArmed,
 }: LockerHeroViewProps) {
   const { t } = useTranslation();
   // Issue #208: the backdrop reflects the active skin's chosen Locker image, if
@@ -248,6 +256,9 @@ export function LockerHeroView({
         heroName={hero.name}
         emptyMessage={t('locker.hero.downloadASkinForThisHero')}
         layout="cards"
+        includedSkinKeys={includedSkinKeys}
+        onToggleShuffleIncluded={onToggleShuffleIncluded}
+        shuffleArmed={shuffleArmed}
       />
     );
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -288,10 +288,9 @@ interface AppState {
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
   reorderMods: (orderedIds: string[]) => Promise<void>;
-  applyModToggleBatch: (enableIds: string[], disableIds: string[]) => Promise<boolean>;
   setShuffleOnLaunch: (enabled: boolean) => void;
   toggleShuffleIncluded: (skinKey: string) => void;
-  runLaunchShuffle: () => Promise<void>;
+  runLaunchShuffle: () => Promise<{ failures: number }>;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
   setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<void>;
@@ -671,25 +670,6 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  // Apply a batch of disables + enables as one atomic mutation (the launch skin
-  // shuffle). Serialized through enqueueToggle so it can't interleave with a
-  // manual toggle and operate on renamed ids. Returns false on failure so the
-  // caller can react (e.g. skip launch follow-up). Mirrors reorderMods' error
-  // handling + fresh-scan rollback.
-  applyModToggleBatch: (enableIds: string[], disableIds: string[]) => enqueueToggle(async () => {
-    if (enableIds.length === 0 && disableIds.length === 0) return true;
-    try {
-      const updated = await api.applyModToggleBatch(enableIds, disableIds);
-      set({ mods: updated });
-      return true;
-    } catch (err) {
-      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
-      else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
-      get().loadMods();
-      return false;
-    }
-  }),
-
   setShuffleOnLaunch: (enabled: boolean) => {
     try { localStorage.setItem(SHUFFLE_ON_LAUNCH_KEY, enabled ? 'true' : 'false'); } catch { /* ignore */ }
     set({ shuffleOnLaunch: enabled });
@@ -709,20 +689,42 @@ export const useAppStore = create<AppState>((set, get) => ({
   // least one skin is in the pool. Groups the live mod list by hero (cached
   // categories, the same grouping the Locker shows), picks one opted-in skin per
   // hero, and applies the whole swap as one atomic batch. Called from the
-  // Sidebar just before launchModded; failures are swallowed by
-  // applyModToggleBatch so a stuck shuffle never blocks the launch.
-  runLaunchShuffle: async () => {
-    const { shuffleOnLaunch, shuffleIncluded, mods } = get();
-    if (!shuffleOnLaunch || shuffleIncluded.size === 0) return;
+  // Sidebar just before launchModded. Returns the count of per-mod failures so
+  // the caller can warn that the shuffle only half-applied; a stuck shuffle
+  // never blocks the launch (the Sidebar swallows a thrown error).
+  runLaunchShuffle: async (): Promise<{ failures: number }> => {
+    const { shuffleOnLaunch, shuffleIncluded } = get();
+    if (!shuffleOnLaunch || shuffleIncluded.size === 0) return { failures: 0 };
     let heroList: { id: number; name: string }[] = [];
     try {
       heroList = buildHeroList(await api.getGamebananaCategories('ModCategory'));
     } catch {
-      // Offline / cache miss: grouping degrades to lockerHero + title inference.
+      // Cold category cache only (a fresh install that never opened Browse or
+      // the Locker): getGamebananaCategories is SQLite-backed, so it serves the
+      // warm cache even offline. With heroList=[] groupModsByCategory can route
+      // only mods carrying an author categoryId; lockerHero- and title-matched
+      // skins fall to `unassigned` and won't shuffle. Near-unreachable in
+      // practice since pooling a skin requires the Locker to have already
+      // grouped it from this same cache.
     }
-    const plan = planLaunchShuffle({ mods, heroList, included: shuffleIncluded });
-    if (plan.enableIds.length === 0 && plan.disableIds.length === 0) return;
-    await get().applyModToggleBatch(plan.enableIds, plan.disableIds);
+    // Build AND apply the plan inside the mutation queue so the plan's ids are
+    // derived from the mods state after any in-flight manual toggle has settled,
+    // not from a pre-launch snapshot that a concurrent rename could invalidate.
+    return enqueueToggle(async () => {
+      const { mods, shuffleIncluded: included } = get();
+      const plan = planLaunchShuffle({ mods, heroList, included });
+      if (plan.enableIds.length === 0 && plan.disableIds.length === 0) return { failures: 0 };
+      try {
+        const { mods: updated, failures } = await api.applyModToggleBatch(plan.enableIds, plan.disableIds);
+        set({ mods: updated });
+        return { failures: failures.length };
+      } catch (err) {
+        if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+        else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
+        get().loadMods();
+        return { failures: plan.enableIds.length + plan.disableIds.length };
+      }
+    });
   },
 
   editLocalMod: async (modId: string, args: EditLocalModArgs) => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -4,6 +4,14 @@ import { getActiveDeadlockPath } from '../lib/appSettings';
 import { setDateFormat } from '../lib/dateFormat';
 import { applyLanguagePreference } from '../i18n';
 import * as api from '../lib/api';
+import { buildHeroList } from '../lib/lockerUtils';
+import {
+  SHUFFLE_INCLUDED_KEY,
+  SHUFFLE_ON_LAUNCH_KEY,
+  planLaunchShuffle,
+  readStoredShuffleIncluded,
+  readStoredShuffleOnLaunch,
+} from '../lib/lockerRandomizer';
 
 // Cache entry with timestamp for TTL support
 interface CacheEntry<T> {
@@ -204,6 +212,14 @@ interface AppState {
   soundVolume: number;
   previewAudioPlaying: boolean;
 
+  // Skin shuffle: the user opts skins into a per-hero pool, then on each launch
+  // (via Grimoire) one chosen skin per hero is equipped at random. Master switch
+  // + the opted-in skin keys (shuffleSkinKey), both mirrored to localStorage so
+  // the Locker and the launch path share one source of truth. See
+  // src/lib/lockerRandomizer.ts.
+  shuffleOnLaunch: boolean;
+  shuffleIncluded: Set<string>;
+
   // Browse-page UI state (preserved across page nav)
   browseUi: BrowseUiState;
 
@@ -272,6 +288,10 @@ interface AppState {
   setModPriority: (modId: string, priority: number) => Promise<void>;
   swapModPriority: (modIdA: string, modIdB: string) => Promise<void>;
   reorderMods: (orderedIds: string[]) => Promise<void>;
+  applyModToggleBatch: (enableIds: string[], disableIds: string[]) => Promise<boolean>;
+  setShuffleOnLaunch: (enabled: boolean) => void;
+  toggleShuffleIncluded: (skinKey: string) => void;
+  runLaunchShuffle: () => Promise<void>;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
   setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<void>;
@@ -341,6 +361,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   downloadCountsCache: new Map(),
   soundVolume: readPersistedSoundVolume(),
   previewAudioPlaying: false,
+  shuffleOnLaunch: readStoredShuffleOnLaunch(),
+  shuffleIncluded: readStoredShuffleIncluded(),
   browseUi: { ...DEFAULT_BROWSE_UI },
   browseSession: null,
   installedScrollTop: 0,
@@ -647,6 +669,60 @@ export const useAppStore = create<AppState>((set, get) => ({
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
       get().loadMods();
     }
+  },
+
+  // Apply a batch of disables + enables as one atomic mutation (the launch skin
+  // shuffle). Serialized through enqueueToggle so it can't interleave with a
+  // manual toggle and operate on renamed ids. Returns false on failure so the
+  // caller can react (e.g. skip launch follow-up). Mirrors reorderMods' error
+  // handling + fresh-scan rollback.
+  applyModToggleBatch: (enableIds: string[], disableIds: string[]) => enqueueToggle(async () => {
+    if (enableIds.length === 0 && disableIds.length === 0) return true;
+    try {
+      const updated = await api.applyModToggleBatch(enableIds, disableIds);
+      set({ mods: updated });
+      return true;
+    } catch (err) {
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+      else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
+      get().loadMods();
+      return false;
+    }
+  }),
+
+  setShuffleOnLaunch: (enabled: boolean) => {
+    try { localStorage.setItem(SHUFFLE_ON_LAUNCH_KEY, enabled ? 'true' : 'false'); } catch { /* ignore */ }
+    set({ shuffleOnLaunch: enabled });
+  },
+
+  // Add/remove a skin from the launch-shuffle pool, keyed by shuffleSkinKey so
+  // the opt-in survives the id churn enable/disable causes for local imports.
+  toggleShuffleIncluded: (skinKey: string) => {
+    const next = new Set(get().shuffleIncluded);
+    if (next.has(skinKey)) next.delete(skinKey);
+    else next.add(skinKey);
+    try { localStorage.setItem(SHUFFLE_INCLUDED_KEY, JSON.stringify([...next])); } catch { /* ignore */ }
+    set({ shuffleIncluded: next });
+  },
+
+  // Re-roll skins for the launch. No-op unless the master switch is on and at
+  // least one skin is in the pool. Groups the live mod list by hero (cached
+  // categories, the same grouping the Locker shows), picks one opted-in skin per
+  // hero, and applies the whole swap as one atomic batch. Called from the
+  // Sidebar just before launchModded; failures are swallowed by
+  // applyModToggleBatch so a stuck shuffle never blocks the launch.
+  runLaunchShuffle: async () => {
+    const { shuffleOnLaunch, shuffleIncluded, mods } = get();
+    if (!shuffleOnLaunch || shuffleIncluded.size === 0) return;
+    let heroList: { id: number; name: string }[] = [];
+    try {
+      heroList = buildHeroList(await api.getGamebananaCategories('ModCategory'));
+    } catch {
+      // Offline / cache miss: grouping degrades to lockerHero + title inference.
+    }
+    const plan = planLaunchShuffle({ mods, heroList, included: shuffleIncluded });
+    if (plan.enableIds.length === 0 && plan.disableIds.length === 0) return;
+    await get().applyModToggleBatch(plan.enableIds, plan.disableIds);
   },
 
   editLocalMod: async (modId: string, args: EditLocalModArgs) => {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -643,6 +643,7 @@ export interface ElectronAPI {
     ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedIds: string[]) => Promise<Mod[]>;
+    applyModToggleBatch: (enableIds: string[], disableIds: string[]) => Promise<Mod[]>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     importSoulContainerGlb: (args: ImportSoulContainerGlbArgs) => Promise<Mod[]>;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -643,7 +643,10 @@ export interface ElectronAPI {
     ) => Promise<Mod>;
     setModPriority: (modId: string, priority: number) => Promise<Mod>;
     reorderMods: (orderedIds: string[]) => Promise<Mod[]>;
-    applyModToggleBatch: (enableIds: string[], disableIds: string[]) => Promise<Mod[]>;
+    applyModToggleBatch: (
+        enableIds: string[],
+        disableIds: string[]
+    ) => Promise<{ mods: Mod[]; failures: string[] }>;
     swapModPriority: (modIdA: string, modIdB: string) => Promise<Mod[]>;
     importCustomMod: (args: ImportCustomModArgs) => Promise<Mod[]>;
     importSoulContainerGlb: (args: ImportSoulContainerGlbArgs) => Promise<Mod[]>;


### PR DESCRIPTION
## What

Reworks the Locker skin **shuffle** from a one-shot button into a persistent mode that re-rolls your skins **each time you launch the game from Grimoire**.

### The model
- **Master toggle** "Shuffle on launch" in the Locker header (replaces the old one-shot split button + All/Favorites scope menu). Shows a count badge of how many skins are in the pool.
- **Per-skin opt-in, per hero**: each skin card/row has an add-to-shuffle toggle. Included skins get a highlight ring and the toggle stays lit. While the master switch is armed, the toggles are always visible (not hover-only) so the pool is easy to curate. This flips the previous opt-*out* into opt-*in*.
- **On launch** (`Launch Modded`): for each hero with at least one pooled skin, one is picked at random and equipped, biasing away from the currently-equipped skin so each launch actually differs. Heroes with nothing pooled are left alone, so scope is per-hero by construction.
- **Gallery badge**: heroes that have a pooled skin show an accent shuffle icon in the existing indicator pill, while the switch is armed.

### Caveat (surfaced in the toggle tooltip)
"Each time you play" only fires when you launch **through Grimoire**. Launching Deadlock straight from Steam can't be hooked before the game mounts its addons.

## How it's wired
- `src/lib/lockerRandomizer.ts` - pure plan logic (opt-in semantics + `planLaunchShuffle` that groups the live mod list by hero and shuffles each pooled hero). Unit-tested.
- `appStore` - `shuffleOnLaunch` + `shuffleIncluded` state (seeded from localStorage), `runLaunchShuffle()` computes and applies the plan via the existing `applyModToggleBatch`.
- `Sidebar` - `handleLaunchModded` runs `runLaunchShuffle()` before `launchModded()`; skipped when a vanilla stash is pending; guarded so a failed shuffle never blocks the launch.
- `setModsEnabledBatch` / `apply-mod-toggle-batch` IPC applies the disable+enable swap as one atomic mutation under the main-process mutation lock.
- Per-skin toggle anchors the top-right corner; hover-only image/delete controls extend leftward so the always-visible toggle is never orphaned.

## UI touches on the Locker page
- Header master toggle with pooled-skin count badge.
- Per-skin opt-in toggle + included highlight ring (cards and list rows).
- Gallery card shuffle indicator icon for pooled heroes.
- Removed the old `RandomizeMenu` split button and per-hero one-shot shuffle button.

## Tests / checks
- `pnpm exec vitest run` - 303 passed (incl. 13 new randomizer tests)
- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm i18n:check` OK + manifest regenerated