### PR TITLE
test(profiles): unit-test the vpkIndex resolver + restore logic

### DIFF
--- a/electron/main/services/profileResolver.test.ts
+++ b/electron/main/services/profileResolver.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type { Mod } from '../../../src/types/mod';
+import type { ProfileMod } from '../../../src/types/electron';
+import {
+  normalizeVpkIndex,
+  inferMissingVpkIndexes,
+  dedupeEnabledForProfile,
+  buildProfileModResolver,
+  type VpkIndexMeta,
+} from './profileResolver';
+
+// dedupe logs a warning per dropped duplicate; keep the suite output clean.
+beforeAll(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+/** Minimal Mod. metaKey defaults to `<id>.vpk`; meta maps below key on that. */
+function mod(over: Partial<Mod> & { id: string }): Mod {
+  return {
+    name: over.id,
+    fileName: `${over.id}.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    metaKey: `${over.id}.vpk`,
+    enabled: true,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+/** getMeta driven by a metaKey -> metadata map (what getModMetadata provides). */
+function metaLookup(map: Record<string, VpkIndexMeta>) {
+  return (metaKey: string): VpkIndexMeta | undefined => map[metaKey];
+}
+
+function pm(over: Partial<ProfileMod> & { fileName: string }): ProfileMod {
+  return { enabled: true, priority: 1, ...over };
+}
+
+describe('normalizeVpkIndex', () => {
+  it('accepts non-negative integers, rejects the rest', () => {
+    expect(normalizeVpkIndex(0)).toBe(0);
+    expect(normalizeVpkIndex(2)).toBe(2);
+    expect(normalizeVpkIndex(-1)).toBeUndefined();
+    expect(normalizeVpkIndex(1.5)).toBeUndefined();
+    expect(normalizeVpkIndex('3')).toBeUndefined();
+    expect(normalizeVpkIndex(undefined)).toBeUndefined();
+  });
+});
+
+describe('inferMissingVpkIndexes', () => {
+  it('assigns indexes by ascending size within a GameBanana file group', () => {
+    const mods = [mod({ id: 'big', size: 200 }), mod({ id: 'small', size: 100 })];
+    const inferred = inferMissingVpkIndexes(
+      mods,
+      metaLookup({
+        'big.vpk': { gameBananaId: 100, gameBananaFileId: 5 },
+        'small.vpk': { gameBananaId: 100, gameBananaFileId: 5 },
+      })
+    );
+    expect(inferred.get('small.vpk')).toBe(0);
+    expect(inferred.get('big.vpk')).toBe(1);
+  });
+
+  it('skips single-VPK groups', () => {
+    const inferred = inferMissingVpkIndexes(
+      [mod({ id: 'a', size: 10 })],
+      metaLookup({ 'a.vpk': { gameBananaId: 1, gameBananaFileId: 1 } })
+    );
+    expect(inferred.size).toBe(0);
+  });
+
+  it('refuses to guess when the sibling sizes are all equal', () => {
+    const mods = [mod({ id: 'a', size: 100 }), mod({ id: 'b', size: 100 })];
+    const inferred = inferMissingVpkIndexes(
+      mods,
+      metaLookup({
+        'a.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+        'b.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+      })
+    );
+    expect(inferred.size).toBe(0);
+  });
+
+  it('never overwrites an index that was actually stamped', () => {
+    const mods = [mod({ id: 'a', size: 100 }), mod({ id: 'b', size: 200 })];
+    const inferred = inferMissingVpkIndexes(
+      mods,
+      metaLookup({
+        'a.vpk': { gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 5 },
+        'b.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+      })
+    );
+    expect(inferred.has('a.vpk')).toBe(false);
+    expect(inferred.get('b.vpk')).toBe(1);
+  });
+
+  it('ignores mods without GameBanana ids', () => {
+    const inferred = inferMissingVpkIndexes(
+      [mod({ id: 'a', size: 1 }), mod({ id: 'b', size: 2 })],
+      metaLookup({})
+    );
+    expect(inferred.size).toBe(0);
+  });
+});
+
+describe('dedupeEnabledForProfile', () => {
+  it('keeps distinct multi-VPK siblings (different indexes)', () => {
+    const mods = [mod({ id: 'a', size: 100, priority: 1 }), mod({ id: 'b', size: 200, priority: 2 })];
+    const out = dedupeEnabledForProfile(
+      mods,
+      metaLookup({
+        'a.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+        'b.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+      })
+    );
+    expect(out.map((m) => m.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('drops a duplicate of the same file/index, keeping the higher load order (lower priority)', () => {
+    // Both stamped index 0 -> same stable key -> duplicate. Feed the low-priority
+    // copy second to exercise the swap-in-place branch.
+    const mods = [mod({ id: 'hi', priority: 5 }), mod({ id: 'lo', priority: 1 })];
+    const out = dedupeEnabledForProfile(
+      mods,
+      metaLookup({
+        'hi.vpk': { gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 0 },
+        'lo.vpk': { gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 0 },
+      })
+    );
+    expect(out.map((m) => m.id)).toEqual(['lo']);
+  });
+
+  it('passes non-GameBanana mods through untouched', () => {
+    const mods = [mod({ id: 'x', priority: 1 }), mod({ id: 'y', priority: 2 })];
+    const out = dedupeEnabledForProfile(mods, metaLookup({}));
+    expect(out.map((m) => m.id)).toEqual(['x', 'y']);
+  });
+});
+
+describe('buildProfileModResolver', () => {
+  it('matches a multi-VPK sibling by gbId+fileId+vpkIndex even after a fileName change', () => {
+    const current = [mod({ id: 'm0' }), mod({ id: 'm1' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({
+        'm0.vpk': { gameBananaId: 10, gameBananaFileId: 20, vpkIndex: 0 },
+        'm1.vpk': { gameBananaId: 10, gameBananaFileId: 20, vpkIndex: 1 },
+      })
+    );
+    const r0 = resolve(pm({ fileName: 'renamed0.vpk', gameBananaId: 10, gameBananaFileId: 20, vpkIndex: 0 }));
+    const r1 = resolve(pm({ fileName: 'renamed1.vpk', gameBananaId: 10, gameBananaFileId: 20, vpkIndex: 1 }));
+    expect(r0).toMatchObject({ via: 'stable' });
+    expect(r0.mod?.id).toBe('m0');
+    expect(r1.mod?.id).toBe('m1');
+  });
+
+  it('resolves a legacy single-VPK profile entry (no vpkIndex) even when renamed', () => {
+    const current = [mod({ id: 'm', fileName: 'pak01_dir.vpk' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({ 'm.vpk': { gameBananaId: 10, gameBananaFileId: 20 } })
+    );
+    const r = resolve(pm({ fileName: 'DIFFERENT.vpk', gameBananaId: 10, gameBananaFileId: 20 }));
+    expect(r.mod?.id).toBe('m');
+    expect(r.via).toBe('stable');
+  });
+
+  it('resolves a legacy multi-VPK profile positionally without double-claiming', () => {
+    // Old profile: two entries, same gb file, NO vpkIndex, fileNames that no
+    // longer match. The installed siblings got inferred indexes (distinct
+    // sizes). Each entry claims a distinct sibling; neither is double-assigned.
+    const current = [
+      mod({ id: 'm0', fileName: 'pak01_dir.vpk', size: 100 }),
+      mod({ id: 'm1', fileName: 'pak02_dir.vpk', size: 200 }),
+    ];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({
+        'm0.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+        'm1.vpk': { gameBananaId: 1, gameBananaFileId: 1 },
+      })
+    );
+    const a = resolve(pm({ fileName: 'oldA.vpk', gameBananaId: 1, gameBananaFileId: 1 }));
+    const b = resolve(pm({ fileName: 'oldB.vpk', gameBananaId: 1, gameBananaFileId: 1 }));
+    expect(a.mod?.id).toBe('m0');
+    expect(b.mod?.id).toBe('m1');
+  });
+
+  it('never assigns one installed mod to two profile entries', () => {
+    const current = [mod({ id: 'm0' }), mod({ id: 'm1' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({
+        'm0.vpk': { gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 0 },
+        'm1.vpk': { gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 1 },
+      })
+    );
+    const a = resolve(pm({ fileName: 'x', gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 0 }));
+    const b = resolve(pm({ fileName: 'y', gameBananaId: 1, gameBananaFileId: 1, vpkIndex: 0 }));
+    expect(a.mod?.id).toBe('m0');
+    expect(b.mod).toBeUndefined();
+    expect(b.via).toBe('miss');
+  });
+
+  it('survives a file-id change by matching gbId + vpkIndex (update-tolerant)', () => {
+    const current = [mod({ id: 'm0' }), mod({ id: 'm1' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({
+        'm0.vpk': { gameBananaId: 10, gameBananaFileId: 999, vpkIndex: 0 },
+        'm1.vpk': { gameBananaId: 10, gameBananaFileId: 999, vpkIndex: 1 },
+      })
+    );
+    // profile saved against the OLD file id 20
+    const r = resolve(pm({ fileName: 'x', gameBananaId: 10, gameBananaFileId: 20, vpkIndex: 0 }));
+    expect(r.mod?.id).toBe('m0');
+    expect(r.via).toBe('stable');
+  });
+
+  it('survives a file-id change for a lone single-VPK install', () => {
+    const current = [mod({ id: 'm' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({ 'm.vpk': { gameBananaId: 10, gameBananaFileId: 999 } })
+    );
+    const r = resolve(pm({ fileName: 'x', gameBananaId: 10, gameBananaFileId: 20 }));
+    expect(r.mod?.id).toBe('m');
+    expect(r.via).toBe('stable');
+  });
+
+  it('refuses a fileName collision when ids cannot be reconciled', () => {
+    const current = [mod({ id: 'other', fileName: 'pak01.vpk' })];
+    const resolve = buildProfileModResolver(
+      current,
+      metaLookup({ 'other.vpk': { gameBananaId: 777, gameBananaFileId: 888 } })
+    );
+    const r = resolve(pm({ fileName: 'pak01.vpk', gameBananaId: 10, gameBananaFileId: 20 }));
+    expect(r.mod).toBeUndefined();
+    expect(r.via).toBe('refused-crossmatch');
+    expect(r.via === 'refused-crossmatch' && r.candidateFileName).toBe('pak01.vpk');
+  });
+
+  it('falls back to fileName for local-to-local (no ids on either side)', () => {
+    const current = [mod({ id: 'local', fileName: 'my_mod.vpk' })];
+    const resolve = buildProfileModResolver(current, metaLookup({}));
+    const r = resolve(pm({ fileName: 'my_mod.vpk' }));
+    expect(r.mod?.id).toBe('local');
+    expect(r.via).toBe('fileName');
+  });
+
+  it('misses cleanly when nothing matches', () => {
+    const current = [mod({ id: 'a', fileName: 'a.vpk' })];
+    const resolve = buildProfileModResolver(current, metaLookup({}));
+    const r = resolve(pm({ fileName: 'nonexistent.vpk' }));
+    expect(r.mod).toBeUndefined();
+    expect(r.via).toBe('miss');
+  });
+});

--- a/electron/main/services/profileResolver.ts
+++ b/electron/main/services/profileResolver.ts
@@ -1,0 +1,257 @@
+import type { Mod } from '../../../src/types/mod';
+import type { ProfileMod } from '../../../src/types/electron';
+
+/**
+ * Pure profile <-> installed-mod matching logic, split out of profiles.ts so it
+ * can be unit-tested without dragging in the main-process (fs / sqlite / IPC)
+ * graph. The single dependency on the metadata sidecar is injected as `getMeta`
+ * (profiles.ts binds the real getModMetadata; tests pass a plain map lookup).
+ */
+
+/** The subset of mod metadata the resolver reads. getModMetadata's ModMetadata
+ *  is assignable to this (it carries these fields plus more), so callers pass it
+ *  directly. */
+export type VpkIndexMeta = {
+    gameBananaId?: number;
+    gameBananaFileId?: number;
+    vpkIndex?: number;
+};
+export type MetaLookup = (metaKey: string) => VpkIndexMeta | undefined;
+
+export function normalizeVpkIndex(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+/**
+ * For multi-VPK GameBanana files whose siblings never got a `vpkIndex` stamped
+ * (installed before the field existed), reconstruct one by size-sorting the
+ * group. Bails on a group of one, and on a group whose VPKs are all the same
+ * size (the size tiebreak can't order them reliably once filenames are the
+ * uninformative `pakNN_dir.vpk`), leaving those to fileName/positional matching.
+ * Never overwrites an index that was actually stamped.
+ */
+export function inferMissingVpkIndexes<T extends { metaKey: string; fileName: string; size: number }>(
+    mods: T[],
+    getMeta: MetaLookup
+): Map<string, number> {
+    const groups = new Map<string, T[]>();
+    for (const mod of mods) {
+        const meta = getMeta(mod.metaKey);
+        if (typeof meta?.gameBananaId !== 'number' || typeof meta?.gameBananaFileId !== 'number') continue;
+        const key = `${meta.gameBananaId}:${meta.gameBananaFileId}`;
+        const group = groups.get(key) ?? [];
+        group.push(mod);
+        groups.set(key, group);
+    }
+
+    const inferred = new Map<string, number>();
+    for (const group of groups.values()) {
+        if (group.length <= 1) continue;
+        if (new Set(group.map((mod) => mod.size)).size <= 1) continue;
+        [...group]
+            .sort((a, b) => a.size - b.size || a.fileName.localeCompare(b.fileName))
+            .forEach((mod, index) => {
+                if (normalizeVpkIndex(getMeta(mod.metaKey)?.vpkIndex) === undefined) {
+                    inferred.set(mod.metaKey, index);
+                }
+            });
+    }
+    return inferred;
+}
+
+function profileStableKey(gbId: number, fileId: number, vpkIndex: number | undefined): string {
+    return vpkIndex === undefined ? `${gbId}:${fileId}` : `${gbId}:${fileId}:${vpkIndex}`;
+}
+
+/** Drop duplicate physical VPKs before they're written into a profile. */
+export function dedupeEnabledForProfile<T extends { metaKey: string; fileName: string; priority: number; size: number }>(
+    mods: T[],
+    getMeta: MetaLookup
+): T[] {
+    const inferredVpkIndexes = inferMissingVpkIndexes(mods, getMeta);
+    const byStableKey = new Map<string, T>();
+    const out: T[] = [];
+    for (const mod of mods) {
+        const meta = getMeta(mod.metaKey);
+        const gbId = meta?.gameBananaId;
+        const fileId = meta?.gameBananaFileId;
+        if (typeof gbId !== 'number' || typeof fileId !== 'number') {
+            out.push(mod);
+            continue;
+        }
+        const vpkIndex = normalizeVpkIndex(meta?.vpkIndex) ?? inferredVpkIndexes.get(mod.metaKey);
+        const key = profileStableKey(gbId, fileId, vpkIndex);
+        const existing = byStableKey.get(key);
+        if (!existing) {
+            byStableKey.set(key, mod);
+            out.push(mod);
+        } else if (mod.priority < existing.priority) {
+            // Prefer the higher-load-order copy; swap it in place.
+            const idx = out.indexOf(existing);
+            if (idx !== -1) out[idx] = mod;
+            byStableKey.set(key, mod);
+            console.warn(
+                `[profiles] dedupe: dropping duplicate VPK ${existing.fileName} ` +
+                `(same GameBanana file/index as ${mod.fileName})`
+            );
+        } else {
+            console.warn(
+                `[profiles] dedupe: dropping duplicate VPK ${mod.fileName} ` +
+                `(same GameBanana file/index as ${existing.fileName})`
+            );
+        }
+    }
+    return out;
+}
+
+/** Outcome of resolving one ProfileMod against the current scan. The `via`
+ *  field lets callers (and the diagnostic log) distinguish a real stable-id
+ *  match from a best-effort fileName fallback, and surfaces the refused
+ *  fileName cross-match case that was the cause of the
+ *  "Profile apply misrecognizing mods to turn on" bug. */
+export type ResolvedMatch =
+    | { mod: Mod; via: 'stable' | 'fileName' }
+    | { mod: undefined; via: 'miss' | 'refused-crossmatch'; candidateFileName?: string };
+
+/**
+ * Build a resolver that maps a ProfileMod to one of the current scanned mods.
+ *
+ * Tries stable id first (`gameBananaId` + `gameBananaFileId` + optional
+ * `vpkIndex`) so a mod can be found after a fileName change. Multi-VPK
+ * siblings use the size-sorted index assigned at download time instead of a
+ * content hash, so profile apply can still survive a redownload/update that
+ * changes the VPK bytes but keeps the archive's relative VPK shape. Falls back
+ * to fileName ONLY when neither the profile entry nor the candidate currentMod carry ids: this keeps
+ * local-to-local fileName matching working for custom mods, while refusing to
+ * cross-match a legacy stable-id-less profile entry to an unrelated
+ * GameBanana mod that just happens to occupy the same pakNN_ slot today. The
+ * unconditional fileName fallback used to silently enable the wrong mod after
+ * any reorder rotated pakNN_ prefixes (Discord #bugs:
+ * "Profile apply misrecognizing mods to turn on", 1.11.2).
+ *
+ * Matches are deduped on a first-come basis so duplicate profile entries can't
+ * double-assign the same file.
+ */
+export function buildProfileModResolver(
+    currentMods: Array<Mod>,
+    getMeta: MetaLookup
+): (pm: ProfileMod) => ResolvedMatch {
+    const byFileName = new Map<string, typeof currentMods[number]>();
+    const byGbFile = new Map<string, Array<typeof currentMods[number]>>();
+    const byGbMod = new Map<number, Array<typeof currentMods[number]>>();
+    const vpkIndexByModId = new Map<string, number | undefined>();
+    const metaByFileName = new Map<string, VpkIndexMeta | undefined>();
+    const inferredVpkIndexes = inferMissingVpkIndexes(currentMods, getMeta);
+    for (const mod of currentMods) {
+        byFileName.set(mod.fileName, mod);
+        const meta = getMeta(mod.metaKey);
+        metaByFileName.set(mod.fileName, meta);
+        const gbId = meta?.gameBananaId;
+        const fileId = meta?.gameBananaFileId;
+        const vpkIndex = normalizeVpkIndex(meta?.vpkIndex) ?? inferredVpkIndexes.get(mod.metaKey);
+        vpkIndexByModId.set(mod.id, vpkIndex);
+        if (typeof gbId === 'number') {
+            const modMatches = byGbMod.get(gbId);
+            if (modMatches) {
+                modMatches.push(mod);
+            } else {
+                byGbMod.set(gbId, [mod]);
+            }
+        }
+        if (typeof gbId === 'number' && typeof fileId === 'number') {
+            const key = `${gbId}:${fileId}`;
+            const matches = byGbFile.get(key);
+            if (matches) {
+                matches.push(mod);
+            } else {
+                byGbFile.set(key, [mod]);
+            }
+        }
+    }
+    const claimed = new Set<string>();
+    const take = (
+        mod: typeof currentMods[number] | undefined,
+        via: 'stable' | 'fileName'
+    ): ResolvedMatch | undefined => {
+        if (!mod || claimed.has(mod.id)) return undefined;
+        claimed.add(mod.id);
+        return { mod, via };
+    };
+    return (pm: ProfileMod): ResolvedMatch => {
+        const profileGameBananaId = typeof pm.gameBananaId === 'number' ? pm.gameBananaId : undefined;
+        const profileFileId = typeof pm.gameBananaFileId === 'number' ? pm.gameBananaFileId : undefined;
+        const profileHasStableIds = profileGameBananaId !== undefined && profileFileId !== undefined;
+        const profileVpkIndex = normalizeVpkIndex(pm.vpkIndex);
+        const stableCandidates = profileHasStableIds
+            ? byGbFile.get(`${profileGameBananaId}:${profileFileId}`) ?? []
+            : [];
+        if (profileHasStableIds) {
+            const stable =
+                profileVpkIndex !== undefined
+                    ? stableCandidates.find(
+                        (mod) => vpkIndexByModId.get(mod.id) === profileVpkIndex && !claimed.has(mod.id)
+                    ) ??
+                    stableCandidates.find(
+                        (mod) =>
+                            mod.fileName === pm.fileName &&
+                            vpkIndexByModId.get(mod.id) === undefined &&
+                            !claimed.has(mod.id)
+                    )
+                    : stableCandidates.find((mod) => mod.fileName === pm.fileName && !claimed.has(mod.id)) ??
+                    stableCandidates.find(
+                        (mod) => vpkIndexByModId.get(mod.id) === undefined && !claimed.has(mod.id)
+                    ) ??
+                    stableCandidates.find((mod) => !claimed.has(mod.id));
+            const stableMatch = take(stable, 'stable');
+            if (stableMatch) return stableMatch;
+
+            // Update-tolerant fallback: the GameBanana file id may change when
+            // an author replaces an upload. Use the VPK index only when it
+            // points to one unclaimed installed candidate; otherwise a single
+            // installed mod from the same page is safe for one-VPK archives.
+            const modCandidates = profileGameBananaId !== undefined
+                ? byGbMod.get(profileGameBananaId) ?? []
+                : [];
+            if (profileVpkIndex !== undefined) {
+                const indexedCandidates = modCandidates.filter(
+                    (mod) => vpkIndexByModId.get(mod.id) === profileVpkIndex && !claimed.has(mod.id)
+                );
+                if (indexedCandidates.length === 1) {
+                    const indexedMatch = take(indexedCandidates[0], 'stable');
+                    if (indexedMatch) return indexedMatch;
+                }
+            } else if (stableCandidates.length === 0) {
+                const unclaimedCandidates = modCandidates.filter((mod) => !claimed.has(mod.id));
+                if (unclaimedCandidates.length === 1) {
+                    const modMatch = take(unclaimedCandidates[0], 'stable');
+                    if (modMatch) return modMatch;
+                }
+            }
+        }
+
+        const fallback = byFileName.get(pm.fileName);
+        if (!fallback || claimed.has(fallback.id)) {
+            return { mod: undefined, via: 'miss' };
+        }
+
+        // Refuse the fileName fallback whenever either side carries GameBanana
+        // ids that the stable-id lookup couldn't reconcile. If both sides have
+        // ids that disagree (or the profile entry has ids but the candidate
+        // doesn't, or vice versa), the fileName collision is almost certainly
+        // a slot reuse after a reorder, not the same mod. Returning the
+        // candidate anyway is the bug we're fixing.
+        const candidateMeta = metaByFileName.get(fallback.fileName);
+        const candidateHasStableIds =
+            typeof candidateMeta?.gameBananaId === 'number' &&
+            typeof candidateMeta?.gameBananaFileId === 'number';
+        if (profileHasStableIds || candidateHasStableIds) {
+            return {
+                mod: undefined,
+                via: 'refused-crossmatch',
+                candidateFileName: fallback.fileName,
+            };
+        }
+
+        return take(fallback, 'fileName') ?? { mod: undefined, via: 'miss' };
+    };
+}

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -9,6 +9,13 @@ import {
     reorderModsUnlocked,
 } from './mods';
 import { getModMetadata } from './metadata';
+import {
+    normalizeVpkIndex,
+    inferMissingVpkIndexes as resolverInferMissingVpkIndexes,
+    dedupeEnabledForProfile as resolverDedupeEnabledForProfile,
+    buildProfileModResolver as resolverBuildProfileModResolver,
+    type ResolvedMatch,
+} from './profileResolver';
 import { isLockerManaged, pinLockerVpksToFront } from './lockerVpk';
 import { readAutoexec, writeAutoexec } from './autoexec';
 import {
@@ -91,80 +98,20 @@ function saveProfiles(profiles: Profile[]): void {
     }
 }
 
-function normalizeVpkIndex(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
-}
-
+// The profile <-> installed-mod matching logic (index inference, dedupe, the
+// resolver) lives in profileResolver.ts so it can be unit-tested without the
+// main-process graph. These binders inject the real metadata sidecar reader so
+// the call sites in this file stay unchanged.
 function inferMissingVpkIndexes<T extends { metaKey: string; fileName: string; size: number }>(
     mods: T[]
 ): Map<string, number> {
-    const groups = new Map<string, T[]>();
-    for (const mod of mods) {
-        const meta = getModMetadata(mod.metaKey);
-        if (typeof meta?.gameBananaId !== 'number' || typeof meta?.gameBananaFileId !== 'number') continue;
-        const key = `${meta.gameBananaId}:${meta.gameBananaFileId}`;
-        const group = groups.get(key) ?? [];
-        group.push(mod);
-        groups.set(key, group);
-    }
-
-    const inferred = new Map<string, number>();
-    for (const group of groups.values()) {
-        if (group.length <= 1) continue;
-        if (new Set(group.map((mod) => mod.size)).size <= 1) continue;
-        [...group]
-            .sort((a, b) => a.size - b.size || a.fileName.localeCompare(b.fileName))
-            .forEach((mod, index) => {
-                if (normalizeVpkIndex(getModMetadata(mod.metaKey)?.vpkIndex) === undefined) {
-                    inferred.set(mod.metaKey, index);
-                }
-            });
-    }
-    return inferred;
+    return resolverInferMissingVpkIndexes(mods, getModMetadata);
 }
 
-function profileStableKey(gbId: number, fileId: number, vpkIndex: number | undefined): string {
-    return vpkIndex === undefined ? `${gbId}:${fileId}` : `${gbId}:${fileId}:${vpkIndex}`;
-}
-
-/** Drop duplicate physical VPKs before they're written into a profile. */
 function dedupeEnabledForProfile<T extends { metaKey: string; fileName: string; priority: number; size: number }>(
     mods: T[]
 ): T[] {
-    const inferredVpkIndexes = inferMissingVpkIndexes(mods);
-    const byStableKey = new Map<string, T>();
-    const out: T[] = [];
-    for (const mod of mods) {
-        const meta = getModMetadata(mod.metaKey);
-        const gbId = meta?.gameBananaId;
-        const fileId = meta?.gameBananaFileId;
-        if (typeof gbId !== 'number' || typeof fileId !== 'number') {
-            out.push(mod);
-            continue;
-        }
-        const vpkIndex = normalizeVpkIndex(meta?.vpkIndex) ?? inferredVpkIndexes.get(mod.metaKey);
-        const key = profileStableKey(gbId, fileId, vpkIndex);
-        const existing = byStableKey.get(key);
-        if (!existing) {
-            byStableKey.set(key, mod);
-            out.push(mod);
-        } else if (mod.priority < existing.priority) {
-            // Prefer the higher-load-order copy; swap it in place.
-            const idx = out.indexOf(existing);
-            if (idx !== -1) out[idx] = mod;
-            byStableKey.set(key, mod);
-            console.warn(
-                `[profiles] dedupe: dropping duplicate VPK ${existing.fileName} ` +
-                `(same GameBanana file/index as ${mod.fileName})`
-            );
-        } else {
-            console.warn(
-                `[profiles] dedupe: dropping duplicate VPK ${mod.fileName} ` +
-                `(same GameBanana file/index as ${existing.fileName})`
-            );
-        }
-    }
-    return out;
+    return resolverDedupeEnabledForProfile(mods, getModMetadata);
 }
 
 /**
@@ -312,155 +259,12 @@ export async function updateProfile(deadlockPath: string, profileId: string, cro
     return profiles[index];
 }
 
-/** Outcome of resolving one ProfileMod against the current scan. The `via`
- *  field lets callers (and the diagnostic log) distinguish a real stable-id
- *  match from a best-effort fileName fallback, and surfaces the refused
- *  fileName cross-match case that was the cause of the
- *  "Profile apply misrecognizing mods to turn on" bug. */
-type ResolvedMatch =
-    | { mod: import('../../../src/types/mod').Mod; via: 'stable' | 'fileName' }
-    | { mod: undefined; via: 'miss' | 'refused-crossmatch'; candidateFileName?: string };
-
-/**
- * Build a resolver that maps a ProfileMod to one of the current scanned mods.
- *
- * Tries stable id first (`gameBananaId` + `gameBananaFileId` + optional
- * `vpkIndex`) so a mod can be found after a fileName change. Multi-VPK
- * siblings use the size-sorted index assigned at download time instead of a
- * content hash, so profile apply can still survive a redownload/update that
- * changes the VPK bytes but keeps the archive's relative VPK shape. Falls back
- * to fileName ONLY when neither the profile entry nor the candidate currentMod carry ids: this keeps
- * local-to-local fileName matching working for custom mods, while refusing to
- * cross-match a legacy stable-id-less profile entry to an unrelated
- * GameBanana mod that just happens to occupy the same pakNN_ slot today. The
- * unconditional fileName fallback used to silently enable the wrong mod after
- * any reorder rotated pakNN_ prefixes (Discord #bugs:
- * "Profile apply misrecognizing mods to turn on", 1.11.2).
- *
- * Matches are deduped on a first-come basis so duplicate profile entries can't
- * double-assign the same file.
- */
+/** Binds the pure resolver (profileResolver.ts) to the real metadata sidecar so
+ *  applyProfile resolves each ProfileMod against the current scan. */
 function buildProfileModResolver(
     currentMods: Array<import('../../../src/types/mod').Mod>
 ): (pm: ProfileMod) => ResolvedMatch {
-    const byFileName = new Map<string, typeof currentMods[number]>();
-    const byGbFile = new Map<string, Array<typeof currentMods[number]>>();
-    const byGbMod = new Map<number, Array<typeof currentMods[number]>>();
-    const vpkIndexByModId = new Map<string, number | undefined>();
-    const metaByFileName = new Map<string, ReturnType<typeof getModMetadata>>();
-    const inferredVpkIndexes = inferMissingVpkIndexes(currentMods);
-    for (const mod of currentMods) {
-        byFileName.set(mod.fileName, mod);
-        const meta = getModMetadata(mod.metaKey);
-        metaByFileName.set(mod.fileName, meta);
-        const gbId = meta?.gameBananaId;
-        const fileId = meta?.gameBananaFileId;
-        const vpkIndex = normalizeVpkIndex(meta?.vpkIndex) ?? inferredVpkIndexes.get(mod.metaKey);
-        vpkIndexByModId.set(mod.id, vpkIndex);
-        if (typeof gbId === 'number') {
-            const modMatches = byGbMod.get(gbId);
-            if (modMatches) {
-                modMatches.push(mod);
-            } else {
-                byGbMod.set(gbId, [mod]);
-            }
-        }
-        if (typeof gbId === 'number' && typeof fileId === 'number') {
-            const key = `${gbId}:${fileId}`;
-            const matches = byGbFile.get(key);
-            if (matches) {
-                matches.push(mod);
-            } else {
-                byGbFile.set(key, [mod]);
-            }
-        }
-    }
-    const claimed = new Set<string>();
-    const take = (
-        mod: typeof currentMods[number] | undefined,
-        via: 'stable' | 'fileName'
-    ): ResolvedMatch | undefined => {
-        if (!mod || claimed.has(mod.id)) return undefined;
-        claimed.add(mod.id);
-        return { mod, via };
-    };
-    return (pm: ProfileMod): ResolvedMatch => {
-        const profileGameBananaId = typeof pm.gameBananaId === 'number' ? pm.gameBananaId : undefined;
-        const profileFileId = typeof pm.gameBananaFileId === 'number' ? pm.gameBananaFileId : undefined;
-        const profileHasStableIds = profileGameBananaId !== undefined && profileFileId !== undefined;
-        const profileVpkIndex = normalizeVpkIndex(pm.vpkIndex);
-        const stableCandidates = profileHasStableIds
-            ? byGbFile.get(`${profileGameBananaId}:${profileFileId}`) ?? []
-            : [];
-        if (profileHasStableIds) {
-            const stable =
-                profileVpkIndex !== undefined
-                    ? stableCandidates.find(
-                        (mod) => vpkIndexByModId.get(mod.id) === profileVpkIndex && !claimed.has(mod.id)
-                    ) ??
-                    stableCandidates.find(
-                        (mod) =>
-                            mod.fileName === pm.fileName &&
-                            vpkIndexByModId.get(mod.id) === undefined &&
-                            !claimed.has(mod.id)
-                    )
-                    : stableCandidates.find((mod) => mod.fileName === pm.fileName && !claimed.has(mod.id)) ??
-                    stableCandidates.find(
-                        (mod) => vpkIndexByModId.get(mod.id) === undefined && !claimed.has(mod.id)
-                    ) ??
-                    stableCandidates.find((mod) => !claimed.has(mod.id));
-            const stableMatch = take(stable, 'stable');
-            if (stableMatch) return stableMatch;
-
-            // Update-tolerant fallback: the GameBanana file id may change when
-            // an author replaces an upload. Use the VPK index only when it
-            // points to one unclaimed installed candidate; otherwise a single
-            // installed mod from the same page is safe for one-VPK archives.
-            const modCandidates = profileGameBananaId !== undefined
-                ? byGbMod.get(profileGameBananaId) ?? []
-                : [];
-            if (profileVpkIndex !== undefined) {
-                const indexedCandidates = modCandidates.filter(
-                    (mod) => vpkIndexByModId.get(mod.id) === profileVpkIndex && !claimed.has(mod.id)
-                );
-                if (indexedCandidates.length === 1) {
-                    const indexedMatch = take(indexedCandidates[0], 'stable');
-                    if (indexedMatch) return indexedMatch;
-                }
-            } else if (stableCandidates.length === 0) {
-                const unclaimedCandidates = modCandidates.filter((mod) => !claimed.has(mod.id));
-                if (unclaimedCandidates.length === 1) {
-                    const modMatch = take(unclaimedCandidates[0], 'stable');
-                    if (modMatch) return modMatch;
-                }
-            }
-        }
-
-        const fallback = byFileName.get(pm.fileName);
-        if (!fallback || claimed.has(fallback.id)) {
-            return { mod: undefined, via: 'miss' };
-        }
-
-        // Refuse the fileName fallback whenever either side carries GameBanana
-        // ids that the stable-id lookup couldn't reconcile. If both sides have
-        // ids that disagree (or the profile entry has ids but the candidate
-        // doesn't, or vice versa), the fileName collision is almost certainly
-        // a slot reuse after a reorder, not the same mod. Returning the
-        // candidate anyway is the bug we're fixing.
-        const candidateMeta = metaByFileName.get(fallback.fileName);
-        const candidateHasStableIds =
-            typeof candidateMeta?.gameBananaId === 'number' &&
-            typeof candidateMeta?.gameBananaFileId === 'number';
-        if (profileHasStableIds || candidateHasStableIds) {
-            return {
-                mod: undefined,
-                via: 'refused-crossmatch',
-                candidateFileName: fallback.fileName,
-            };
-        }
-
-        return take(fallback, 'fileName') ?? { mod: undefined, via: 'miss' };
-    };
+    return resolverBuildProfileModResolver(currentMods, getModMetadata);
 }
 
 /** One-line tag for a profile entry in diagnostic logs. We keep it compact so

--- a/src/lib/vpkRestore.test.ts
+++ b/src/lib/vpkRestore.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import type { Mod } from '../types/mod';
+import {
+  getVpkIndex,
+  createEnabledVpkRestoreSnapshot,
+  shouldRestoreVpkEnabled,
+} from './vpkRestore';
+
+/** Minimal Mod; the restore logic only reads `vpkIndex` (via getVpkIndex). */
+function mod(over: Partial<Mod> & { id: string }): Mod {
+  return {
+    name: over.id,
+    fileName: `${over.id}.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    metaKey: `${over.id}.vpk`,
+    enabled: false,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('getVpkIndex', () => {
+  it('accepts non-negative integers (incl. 0)', () => {
+    expect(getVpkIndex({ vpkIndex: 0 })).toBe(0);
+    expect(getVpkIndex({ vpkIndex: 3 })).toBe(3);
+  });
+  it('rejects negatives, non-integers, and absent values', () => {
+    expect(getVpkIndex({ vpkIndex: -1 })).toBeUndefined();
+    expect(getVpkIndex({ vpkIndex: 1.5 })).toBeUndefined();
+    expect(getVpkIndex({})).toBeUndefined();
+  });
+});
+
+describe('createEnabledVpkRestoreSnapshot', () => {
+  it('reports no enabled state when nothing is enabled', () => {
+    const snap = createEnabledVpkRestoreSnapshot([
+      { enabled: false, vpkIndex: 0 },
+      { enabled: false, vpkIndex: 1 },
+    ]);
+    expect(snap).toEqual({ hadEnabled: false, enabledIndexes: new Set(), enabledUnindexed: false });
+  });
+
+  it('records the indexes of the enabled, indexed VPKs', () => {
+    const snap = createEnabledVpkRestoreSnapshot([
+      { enabled: true, vpkIndex: 0 },
+      { enabled: false, vpkIndex: 1 },
+      { enabled: true, vpkIndex: 2 },
+    ]);
+    expect(snap.hadEnabled).toBe(true);
+    expect([...snap.enabledIndexes].sort()).toEqual([0, 2]);
+    expect(snap.enabledUnindexed).toBe(false);
+  });
+
+  it('flags enabled-but-unindexed VPKs (pre-vpkIndex installs)', () => {
+    const snap = createEnabledVpkRestoreSnapshot([
+      { enabled: true },
+      { enabled: false, vpkIndex: 1 },
+    ]);
+    expect(snap).toEqual({ hadEnabled: true, enabledIndexes: new Set(), enabledUnindexed: true });
+  });
+});
+
+describe('shouldRestoreVpkEnabled', () => {
+  it('restores nothing when the old install had nothing enabled', () => {
+    const snap = createEnabledVpkRestoreSnapshot([{ enabled: false, vpkIndex: 0 }]);
+    expect(shouldRestoreVpkEnabled(mod({ id: 'a', vpkIndex: 0 }), [mod({ id: 'a', vpkIndex: 0 })], snap)).toBe(false);
+  });
+
+  it('restores only the sibling whose index was enabled', () => {
+    const snap = createEnabledVpkRestoreSnapshot([
+      { enabled: true, vpkIndex: 0 },
+      { enabled: false, vpkIndex: 1 },
+    ]);
+    const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
+    expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(true);
+    expect(shouldRestoreVpkEnabled(fresh[1], fresh, snap)).toBe(false);
+  });
+
+  // The regression this suite exists to lock in: a multi-VPK mod installed
+  // BEFORE vpkIndex existed has an all-unindexed snapshot, but the redownload
+  // stamps indexes. Every fresh VPK must be restored (coarse "something was on")
+  // instead of the mod silently landing fully disabled.
+  it('restores every fresh VPK when the snapshot predates vpkIndex', () => {
+    const snap = createEnabledVpkRestoreSnapshot([{ enabled: true }, { enabled: true }]);
+    expect(snap.enabledIndexes.size).toBe(0);
+    expect(snap.enabledUnindexed).toBe(true);
+    const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
+    expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(true);
+    expect(shouldRestoreVpkEnabled(fresh[1], fresh, snap)).toBe(true);
+  });
+
+  it('restores a single-VPK mod (no indexes on either side)', () => {
+    const snap = createEnabledVpkRestoreSnapshot([{ enabled: true }]);
+    const fresh = [mod({ id: 'n' })];
+    expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(true);
+  });
+
+  it('does not restore an indexed sibling that was off, even when another was on', () => {
+    const snap = createEnabledVpkRestoreSnapshot([
+      { enabled: true, vpkIndex: 1 },
+      { enabled: false, vpkIndex: 0 },
+    ]);
+    const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
+    expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(false);
+    expect(shouldRestoreVpkEnabled(fresh[1], fresh, snap)).toBe(true);
+  });
+});

--- a/src/lib/vpkRestore.ts
+++ b/src/lib/vpkRestore.ts
@@ -1,0 +1,61 @@
+import type { Mod } from '../types/mod';
+
+/**
+ * Preserving per-VPK enabled state across a redownload/update. A replacement
+ * download lands every VPK disabled, so before deleting the old install we
+ * snapshot which VPKs were enabled (by their size-sorted `vpkIndex`), then
+ * re-enable the matching siblings on the fresh install. Split out of Installed
+ * so the matching rules are unit-tested.
+ */
+export type EnabledVpkRestoreSnapshot = {
+  hadEnabled: boolean;
+  enabledIndexes: Set<number>;
+  enabledUnindexed: boolean;
+};
+
+export function getVpkIndex(mod: Pick<Mod, 'vpkIndex'>): number | undefined {
+  return typeof mod.vpkIndex === 'number' && Number.isInteger(mod.vpkIndex) && mod.vpkIndex >= 0
+    ? mod.vpkIndex
+    : undefined;
+}
+
+export function createEnabledVpkRestoreSnapshot(
+  targets: Array<{ enabled: boolean; vpkIndex?: number }>
+): EnabledVpkRestoreSnapshot {
+  const enabledIndexes = new Set<number>();
+  let enabledUnindexed = false;
+  for (const target of targets) {
+    if (!target.enabled) continue;
+    const index = getVpkIndex(target);
+    if (index === undefined) {
+      enabledUnindexed = true;
+    } else {
+      enabledIndexes.add(index);
+    }
+  }
+  return {
+    hadEnabled: enabledUnindexed || enabledIndexes.size > 0,
+    enabledIndexes,
+    enabledUnindexed,
+  };
+}
+
+export function shouldRestoreVpkEnabled(
+  mod: Mod,
+  candidates: Mod[],
+  snapshot: EnabledVpkRestoreSnapshot
+): boolean {
+  if (!snapshot.hadEnabled) return false;
+  const hasIndexedCandidates = candidates.some((candidate) => getVpkIndex(candidate) !== undefined);
+  const index = getVpkIndex(mod);
+  if (hasIndexedCandidates) {
+    // Snapshot carries no per-VPK index (the old install predates vpkIndex), but
+    // the redownload assigned indexes. We can't map which sibling was on, so
+    // honor the coarse "something was enabled" and restore every VPK, matching
+    // the pre-index behavior. Without this, a multi-VPK mod installed before
+    // vpkIndex existed silently lands fully disabled after an update.
+    if (snapshot.enabledIndexes.size === 0) return snapshot.enabledUnindexed;
+    return index === undefined ? snapshot.enabledUnindexed : snapshot.enabledIndexes.has(index);
+  }
+  return snapshot.enabledIndexes.size === 0 && snapshot.enabledUnindexed;
+}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -88,6 +88,7 @@ import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
+import { createEnabledVpkRestoreSnapshot, shouldRestoreVpkEnabled, type EnabledVpkRestoreSnapshot } from '../lib/vpkRestore';
 import { Button, CheckboxMark, IconButton, Tag } from '../components/common/ui';
 import { FormField, Input, Select } from '../components/common/forms';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -171,60 +172,6 @@ function modEntryKey(mod: Mod): string {
   }
   return `single:local:${mod.name}:${mod.size}`;
 }
-
-type EnabledVpkRestoreSnapshot = {
-  hadEnabled: boolean;
-  enabledIndexes: Set<number>;
-  enabledUnindexed: boolean;
-};
-
-function getVpkIndex(mod: Pick<Mod, 'vpkIndex'>): number | undefined {
-  return typeof mod.vpkIndex === 'number' && Number.isInteger(mod.vpkIndex) && mod.vpkIndex >= 0
-    ? mod.vpkIndex
-    : undefined;
-}
-
-function createEnabledVpkRestoreSnapshot(
-  targets: Array<{ enabled: boolean; vpkIndex?: number }>
-): EnabledVpkRestoreSnapshot {
-  const enabledIndexes = new Set<number>();
-  let enabledUnindexed = false;
-  for (const target of targets) {
-    if (!target.enabled) continue;
-    const index = getVpkIndex(target);
-    if (index === undefined) {
-      enabledUnindexed = true;
-    } else {
-      enabledIndexes.add(index);
-    }
-  }
-  return {
-    hadEnabled: enabledUnindexed || enabledIndexes.size > 0,
-    enabledIndexes,
-    enabledUnindexed,
-  };
-}
-
-function shouldRestoreVpkEnabled(
-  mod: Mod,
-  candidates: Mod[],
-  snapshot: EnabledVpkRestoreSnapshot
-): boolean {
-  if (!snapshot.hadEnabled) return false;
-  const hasIndexedCandidates = candidates.some((candidate) => getVpkIndex(candidate) !== undefined);
-  const index = getVpkIndex(mod);
-  if (hasIndexedCandidates) {
-    // Snapshot carries no per-VPK index (the old install predates vpkIndex), but
-    // the redownload assigned indexes. We can't map which sibling was on, so
-    // honor the coarse "something was enabled" and restore every VPK, matching
-    // the pre-index behavior. Without this, a multi-VPK mod installed before
-    // vpkIndex existed silently lands fully disabled after an update.
-    if (snapshot.enabledIndexes.size === 0) return snapshot.enabledUnindexed;
-    return index === undefined ? snapshot.enabledUnindexed : snapshot.enabledIndexes.has(index);
-  }
-  return snapshot.enabledIndexes.size === 0 && snapshot.enabledUnindexed;
-}
-
 
 function buildModEntries(mods: Mod[]): ModEntry[] {
   const byGb = new Map<number, Mod[]>();


### PR DESCRIPTION
## Why

#277 reworked multi-VPK profile identity (size-sorted `vpkIndex` replacing the sha256 tiebreaker) and the redownload enable-restore, but that format-sensitive logic shipped with **zero test coverage**. This adds it, and pins the `shouldRestoreVpkEnabled` fix from #277 so it can't regress.

## What

Pure refactor + tests, **no behavior change**:

- **`electron/main/services/profileResolver.ts`** (new) - the profile<->installed-mod matching (index inference, dedupe, resolver) split out of `profiles.ts` with the metadata sidecar reader injected (`getMeta`), so it's testable without the fs/sqlite/IPC graph. `profiles.ts` keeps thin binders that pass the real `getModMetadata`; its call sites are unchanged.
- **`src/lib/vpkRestore.ts`** (new) - `createEnabledVpkRestoreSnapshot` / `shouldRestoreVpkEnabled` / `getVpkIndex` lifted out of `Installed.tsx` (pure, renderer-graph-free).
- **28 new tests** across the two:
  - `inferMissingVpkIndexes`: size-sort ordering, single-VPK skip, **equal-size skip** (can't order reliably), never overwriting a stamped index, non-GB ignored.
  - `dedupeEnabledForProfile`: distinct siblings kept, same-index dup dropped keeping the higher load order (swap-in-place path), non-GB pass-through.
  - `buildProfileModResolver`: stable match by gbId+fileId+vpkIndex across a rename; **legacy no-index back-compat** (single-VPK + positional multi-VPK without double-claim); update-tolerant file-id fallback (indexed + lone single-VPK); no-double-claim; refused-crossmatch; local-to-local fileName; clean miss.
  - `shouldRestoreVpkEnabled`: per-index restore, single-VPK, off-sibling stays off, and the **regression fix** - a multi-VPK mod installed before `vpkIndex` existed restores all fresh VPKs instead of silently landing disabled after an update.

## Checks

`pnpm typecheck` clean, `pnpm lint` clean, `pnpm exec vitest run` **333 passed** (+28 new).