### PR TITLE
feat(installed): premium glass mod cards + fix hover highlight

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1366,6 +1366,104 @@ body {
   background: var(--color-bg-secondary);
 }
 
+/* ============================================================================
+   Premium UI Card System Enhancements
+   ========================================================================== */
+
+/* Refined Glassmorphism Cards */
+.premium-glass-card {
+  background: linear-gradient(
+    135deg,
+    rgba(20, 20, 20, 0.45) 0%,
+    rgba(12, 12, 12, 0.75) 100%
+  );
+  backdrop-filter: blur(14px) saturate(125%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 4px 20px rgba(0, 0, 0, 0.35);
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.premium-glass-card:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(25, 25, 25, 0.55) 0%,
+    rgba(18, 18, 18, 0.8) 100%
+  );
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 12px 32px rgba(0, 0, 0, 0.5);
+  /* Lift only, no scale(): this card has backdrop-filter, and scaling a
+     backdrop-filtered element upscales its whole rasterized surface, softening
+     the thumbnail + text. The lift + glow already read as "pop" without blur. */
+  transform: translateY(-3px);
+}
+
+/* Premium Card Hover Glow and Transitions */
+.premium-card-glow {
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.premium-card-glow:hover {
+  /* No scale() here either, see .premium-glass-card:hover. */
+  transform: translateY(-3px);
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.55);
+}
+
+/* Accent Glow for Enabled cards */
+.premium-card-glow-active:hover {
+  box-shadow: 
+    0 0 25px rgba(249, 115, 22, 0.12),
+    0 12px 30px rgba(0, 0, 0, 0.55);
+  border-color: rgba(249, 115, 22, 0.45);
+}
+
+/* Warning Glow for Conflict cards */
+.premium-card-glow-warning:hover {
+  box-shadow: 
+    0 0 25px rgba(250, 204, 21, 0.12),
+    0 12px 30px rgba(0, 0, 0, 0.55);
+  border-color: rgba(250, 204, 21, 0.45);
+}
+
+/* Glassmorphic Overlay Badges */
+.premium-overlay-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  backdrop-filter: blur(8px);
+  background-color: rgba(10, 12, 16, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* Seamless Title Inline Renaming */
+.premium-inline-rename-input {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+  background: rgba(0, 0, 0, 0.3);
+  border: none;
+  border-bottom: 2px solid var(--color-accent);
+  padding: 0 4px;
+  border-radius: 2px;
+  outline: none;
+  width: 100%;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-slide-in-left,
   .animate-hero-zoom-in,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -398,29 +398,33 @@ const SortableEntryCard = memo(function SortableEntryCard({
     isDragging,
   } = useSortable({ id: cardProps.entry.key, disabled: sortableDisabled });
 
+  const isList = cardProps.viewMode === 'list';
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.32 : undefined,
     position: 'relative',
     zIndex: isDragging ? 1 : undefined,
-    // Skip layout + paint for offscreen cards. This is most of the cost of
-    // mounting a large library: only the ~15 visible cards pay full price up
-    // front. The `auto` keyword keeps the real size once a card has been
-    // rendered; the estimate only stands in before first view. dnd-kit drag
-    // measurement is unaffected: offscreen items still have placeholder boxes.
-    contentVisibility: 'auto',
-    containIntrinsicSize: cardProps.viewMode === 'list' ? 'auto 72px' : 'auto 280px',
+    // Sizing estimate for the content-visibility skip. The property itself lives
+    // in className (not here) so a :hover variant can lift it, see below. The
+    // `auto` keyword keeps the real size once a card has been rendered; the
+    // estimate only stands in before first view. dnd-kit drag measurement is
+    // unaffected: offscreen items still have placeholder boxes.
+    containIntrinsicSize: isList ? 'auto 72px' : 'auto 280px',
   };
 
   return (
     <div
       ref={setNodeRef}
-      // Each card carries a transform (its own stacking context), so a card's
-      // open action menu can only paint within that card. When the menu opens
-      // downward it would land behind the next card; lift this wrapper above its
-      // siblings whenever it contains an open menu so the dropdown stays on top.
-      className={`flex flex-col has-[[data-card-menu-open]]:z-20 ${sortableDisabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
+      // content-visibility:auto skips layout + paint for offscreen cards (most of
+      // the cost of mounting a large library) but implies contain:paint, which
+      // clips whatever the card paints outside its box AND traps it in its own
+      // stacking context. On grid/compact the enabled-card :hover lifts + scales
+      // the card: that expansion would be cropped and stuck behind neighbors. So
+      // on hover we lift containment (-> visible) and raise z so the expanded card
+      // renders whole and on top. The has-menu-open lift does the same for an open
+      // action menu that would otherwise paint behind the next card.
+      className={`flex flex-col has-[[data-card-menu-open]]:z-20 [content-visibility:auto] ${isList ? '' : 'hover:[content-visibility:visible] hover:z-10'} ${sortableDisabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       style={style}
       {...attributes}
       {...listeners}
@@ -6056,7 +6060,7 @@ function EditableModTitle({
       }}
       onBlur={() => void commit()}
       data-card-action="true"
-      className={`${className} w-full rounded-[4px] border border-accent/70 bg-bg-primary/90 px-1 outline-none focus:border-accent disabled:opacity-60`}
+      className={`${className} premium-inline-rename-input disabled:opacity-60`}
     />
   );
 }
@@ -6119,7 +6123,7 @@ function ModListRowContent({
           onOpenDetails?.();
         }}
         disabled={!canOpen}
-        className={`group relative h-10 w-14 flex-shrink-0 overflow-hidden rounded-md bg-bg-tertiary border border-white/[0.08] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default enabled:cursor-pointer transition-[filter,opacity] duration-200 ${
+        className={`group relative h-10 w-14 flex-shrink-0 overflow-hidden rounded-lg bg-bg-tertiary border border-white/[0.08] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 disabled:cursor-default enabled:cursor-pointer transition-[filter,opacity] duration-200 ${
           mod.enabled ? '' : 'grayscale-[0.6] opacity-[0.7]'
         }`}
         aria-label={canOpen ? (isGroupCard ? t('installed.card.chooseFilesFor', { name: mod.name }) : t('installed.card.viewDetailsFor', { name: mod.name })) : undefined}
@@ -6376,10 +6380,10 @@ function ModCard({
   // blurred copy of the cover art (see glassBackdropUrl) bleeds, so the card
   // is tinted by its own thumbnail. List view keeps the solid stateClasses.
   const glassStateClasses = hasConflicts
-    ? 'border-state-warning/45 bg-state-warning/[0.07]'
+    ? 'border-state-warning/45 bg-state-warning/[0.07] premium-card-glow premium-card-glow-warning'
     : mod.enabled
-      ? 'border-white/[0.12] bg-bg-sunken/65 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)] hover:border-white/[0.2]'
-      : 'border-white/[0.08] bg-bg-sunken/55 text-text-primary/75 hover:border-white/[0.16] hover:text-text-primary';
+      ? 'premium-glass-card premium-card-glow-active'
+      : 'premium-glass-card opacity-85';
 
   // Merged mods get a "stacked card" silhouette via two offset box-shadows
   // that read as cards-behind-the-card. Uses only neutral surface/border
@@ -6759,7 +6763,7 @@ function ModCard({
       <MenuTrigger asChild disabled={selectMode}>
     <div
       data-mod-entry-key={entryKey}
-      className={`group/card relative rounded-[10px] border transform-gpu transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ${isList ? stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
+      className={`group/card relative rounded-xl border transform-gpu ${isList ? 'transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ' + stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
     >
       <div className={isList ? 'contents' : ''}>
         {selectMode && (
@@ -6812,7 +6816,7 @@ function ModCard({
         ) : (
         <>
         {glassBackdropUrl && (
-          <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[10px]">
+          <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-xl">
             <img
               src={glassBackdropUrl}
               alt=""


### PR DESCRIPTION
## What

Restyles the Installed mod cards with the `premium-glass-card` system (glassmorphism, accent hover glow, seamless inline rename) and fixes two hover-highlight bugs that surfaced with it.

## The two bugs (both rooted in `content-visibility: auto`)

`SortableEntryCard`'s wrapper uses `content-visibility: auto` for the offscreen render-skip (Installed nav-lag optimization). That always also applies `contain: paint`, which bit the new hover treatment two ways:

**1. Hovered card clipped and stuck behind neighbors**
`contain: paint` clips whatever the card paints outside its box and traps it in its own stacking context, so the lifted/glowing hovered card got cropped and rendered *under* adjacent cards instead of on top.

Fix: on `:hover` (grid/compact only, list rows do not lift) drop containment to `visible` and raise `z`, so the highlighted card paints whole and on top. Same trick the existing `has-[[data-card-menu-open]]:z-20` already uses for open action menus. `content-visibility` had to move from the inline `style` object into `className` first, since an inline style can't be overridden by a `:hover` variant.

**2. Hover made the card blurry**
The hover scaled the card (`transform: scale(1.015)`), and scaling a `backdrop-filter`ed element upscales its whole rasterized surface, softening the thumbnail and text. Isolated in a repro matrix: `scale + backdrop-filter` blurs; either one alone stays crisp.

Fix: drop `scale()` from `.premium-glass-card:hover` and `.premium-card-glow:hover`, keep the `translateY(-3px)` lift. The lift plus glow still read as a pop, and stay crisp.

## Verification

- Production build succeeds; emitted CSS confirmed to contain the new arbitrary-property/hover classes and `scale(1.015)` count is 0.
- ESLint clean.
- Behavior reproduced in standalone Chromium: hovered card renders whole, lifted, glowing, on top of neighbors, and crisp.

## Scope

Only the premium-card work (`src/index.css` + `src/pages/Installed.tsx`). The unrelated multi-VPK / profiles / download changes in the working tree are intentionally left out for a separate PR.

## Note

The hover highlight is now a lift, not a size increase. A crisp size-increase is not achievable while these cards keep `backdrop-filter`; it would mean dropping the glass blur or restructuring so the backdrop layer does not scale.
