### PR TITLE
chore(release): v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.21.5",
+  "version": "1.22.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump to `1.22.0` for the next release.

Release notes drafted in `release/RELEASE_NOTES_v1.22.0.md` (applied to the GitHub Release after the tag push).

Local gates green: typecheck, lint, vitest (355), i18n:check, locale manifest. AppImage built + smoke-tested (bundled vpkmerge v0.18.0).