### PR TITLE
fix(dmm-import): consent gate, idempotency, staleness/catalog guards, pre-import recovery

### DIFF
--- a/electron/main/ipc/dmmMigrate.ts
+++ b/electron/main/ipc/dmmMigrate.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron';
 import { getActiveDeadlockPath } from '../services/settings';
 import { migrateDmmInstall } from '../services/dmmMigration';
+import { getModById, getModCount } from '../services/modDatabase';
+import { writeSnapshot } from '../services/snapshots';
 import type { DmmMigrationReport, DmmMigrationRequest } from '../../../src/lib/dmmMigration';
 
 function requireDeadlockPath(): string {
@@ -11,15 +13,53 @@ function requireDeadlockPath(): string {
     return deadlockPath;
 }
 
+// Submission-id validator backed by the local GameBanana catalog
+// (mods-cache.db). Returns undefined when the catalog is empty or unavailable
+// (fresh install, sync disabled): an empty catalog can't distinguish a wrong
+// id from an unsynced one, so the migration then skips the check rather than
+// rejecting everything.
+function catalogSubmissionLookup(): ((id: number) => boolean) | undefined {
+    try {
+        if (getModCount() === 0) return undefined;
+    } catch {
+        return undefined;
+    }
+    return (id: number) => {
+        try {
+            return getModById(id) !== null;
+        } catch {
+            // A lookup failure must not reject a legitimate mod: fail open.
+            return true;
+        }
+    };
+}
+
 // Non-mutating preview: build the adoption plan and return what WOULD be
 // adopted, without copying anything. Safe to run repeatedly against a real
-// DMM install.
+// DMM install. Runs the same already-managed + catalog filters as execute,
+// so the preview matches what execute will actually do.
 ipcMain.handle('dmm-migrate:scan', (_, req: DmmMigrationRequest): Promise<DmmMigrationReport> => {
-    return migrateDmmInstall({ ...req, deadlockPath: requireDeadlockPath(), planOnly: true });
+    return migrateDmmInstall({
+        ...req,
+        deadlockPath: requireDeadlockPath(),
+        planOnly: true,
+        isKnownSubmission: catalogSubmissionLookup(),
+    });
 });
 
 // Execute the migration: copy each VPK into Grimoire's layout and write its
-// metadata. Non-destructive (DMM's files are left in place).
-ipcMain.handle('dmm-migrate:execute', (_, req: DmmMigrationRequest): Promise<DmmMigrationReport> => {
-    return migrateDmmInstall({ ...req, deadlockPath: requireDeadlockPath() });
+// metadata. Non-destructive (DMM's files are left in place). A recovery
+// snapshot is taken first, like the update path; its failure is non-fatal.
+ipcMain.handle('dmm-migrate:execute', async (_, req: DmmMigrationRequest): Promise<DmmMigrationReport> => {
+    const deadlockPath = requireDeadlockPath();
+    try {
+        await writeSnapshot(deadlockPath, 'pre-dmm-import');
+    } catch (err) {
+        console.warn('[DMM] pre-import snapshot failed (continuing):', err);
+    }
+    return migrateDmmInstall({
+        ...req,
+        deadlockPath,
+        isKnownSubmission: catalogSubmissionLookup(),
+    });
 });

--- a/electron/main/services/dmmMigration.guards.test.ts
+++ b/electron/main/services/dmmMigration.guards.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Regression tests for the DMM-import corruption guards (the "everything is
+ * broken now" incident: a stale state.json + repeated Fix Unknown clicks
+ * tripled disabled mods and stamped wrong GameBanana identities onto real
+ * files). Four guards under test:
+ *  1. Idempotency: a re-run adopts nothing it adopted last time (no duplicate
+ *     pakNN slots, no duplicate .disabled copies).
+ *  2. Staleness: a DMM record older than the file it claims is a reused slot,
+ *     not that mod; it must be skipped, not identity-hijacked. Corroboration
+ *     by id-prefixed filename or matching name still adopts.
+ *  3. Catalog validation: a submission id missing from the local GameBanana
+ *     catalog is never stamped onto a file.
+ *  4. Recoverability: the metadata sidecar is backed up before the batch.
+ *
+ * Same electron-free harness as dmmMigration.nondestructive.test.ts: only
+ * app.getPath() is mocked; the real service runs against a temp sandbox.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createHash } from 'crypto';
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, utimesSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { migrateDmmInstall } from './dmmMigration';
+
+const h = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => h.userData } }));
+
+interface Sandbox {
+  dl: string;
+  addons: string;
+  disabled: string;
+  separate: string;
+  userData: string;
+  statePath: string;
+}
+
+function makeSandbox(): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), 'dmm-guards-'));
+  const dl = join(root, 'dl');
+  const addons = join(dl, 'game', 'citadel', 'addons');
+  const disabled = join(addons, '.disabled');
+  const separate = join(root, 'dmm-profile');
+  const userData = join(root, 'userdata');
+  for (const d of [addons, disabled, separate, userData]) mkdirSync(d, { recursive: true });
+  writeFileSync(join(dl, 'game', 'citadel', 'gameinfo.gi'), 'GameInfo {}\n');
+  return { dl, addons, disabled, separate, userData, statePath: join(root, 'state.json') };
+}
+
+interface StateModSpec {
+  id: number;
+  name: string;
+  enabled: boolean;
+  vpks: string[];
+}
+
+/** Write a DMM state.json (Tauri-store envelope, local-config as a STRING)
+ *  holding one default profile with the given mods. */
+function writeState(sb: Sandbox, mods: StateModSpec[]): void {
+  const enabledMods: Record<string, unknown> = {};
+  const stateMods: unknown[] = [];
+  mods.forEach((m, i) => {
+    enabledMods[String(m.id)] = { remoteId: String(m.id), enabled: m.enabled };
+    stateMods.push({
+      remoteId: String(m.id),
+      name: m.name,
+      category: 'Skins',
+      installOrder: i,
+      installedVpks: m.vpks,
+    });
+  });
+  const state = {
+    activeProfileId: 'default',
+    localMods: [],
+    profiles: {
+      default: {
+        id: 'default', name: 'Default', isDefault: true, folderName: null,
+        enabledMods, mods: stateMods,
+      },
+    },
+  };
+  writeFileSync(sb.statePath, JSON.stringify({ 'local-config': JSON.stringify({ state, version: 15 }) }));
+}
+
+function run(sb: Sandbox, extra: Partial<Parameters<typeof migrateDmmInstall>[0]> = {}) {
+  h.userData = sb.userData;
+  return migrateDmmInstall({ deadlockPath: sb.dl, dmmStatePath: sb.statePath, ...extra });
+}
+
+/** Push a file's mtime past the state.json that claims it, simulating a slot
+ *  Grimoire rewrote AFTER DMM last saved its bookkeeping. */
+function makeNewerThanState(path: string): void {
+  const future = new Date(Date.now() + 60_000);
+  utimesSync(path, future, future);
+}
+
+const fileNames = (dir: string) => (existsSync(dir) ? readdirSync(dir).sort() : []);
+
+describe('idempotency: a second run adopts nothing and mints no duplicates', () => {
+  it('re-run is a no-op for in-place and copy adoptions alike', async () => {
+    const sb = makeSandbox();
+    const liveSlot = join(sb.addons, 'pak50_dir.vpk');
+    const separateVpk = join(sb.separate, 'skin_c_dir.vpk');
+    writeFileSync(liveSlot, Buffer.from('ENABLED-MOD-111'));
+    writeFileSync(separateVpk, Buffer.from('DISABLED-MOD-333'));
+    writeState(sb, [
+      { id: 111, name: 'Enabled A', enabled: true, vpks: [liveSlot] },
+      { id: 333, name: 'Disabled C', enabled: false, vpks: [separateVpk] },
+    ]);
+
+    const first = await run(sb);
+    expect(first.adopted.map((a) => a.submissionId).sort()).toEqual([111, 333]);
+
+    const addonsAfterFirst = fileNames(sb.addons);
+    const disabledAfterFirst = fileNames(sb.disabled);
+    // The copy branch brought exactly one file into .disabled.
+    expect(disabledAfterFirst.length).toBe(1);
+
+    const second = await run(sb);
+    expect(second.adopted).toEqual([]);
+    expect(second.preview).toEqual([]);
+    expect(second.skipped.map((s) => s.submissionId).sort()).toEqual([111, 333]);
+    for (const s of second.skipped) expect(s.reason).toContain('already managed');
+    // THE regression: no third copy, no extra pakNN slot.
+    expect(fileNames(sb.addons)).toEqual(addonsAfterFirst);
+    expect(fileNames(sb.disabled)).toEqual(disabledAfterFirst);
+  });
+
+  it('an identical file already managed under another id is not copied again', async () => {
+    const sb = makeSandbox();
+    const content = Buffer.from('DISABLED-MOD-333');
+    const separateVpk = join(sb.separate, 'skin_c_dir.vpk');
+    writeFileSync(separateVpk, content);
+    // A prior import left a managed copy whose metadata lost the submission id
+    // (different gameBananaId), so the id filter alone would not catch it.
+    const managedCopy = join(sb.disabled, 'old_copy_dir.vpk');
+    writeFileSync(managedCopy, content);
+    const sha256 = createHash('sha256').update(content).digest('hex');
+    writeFileSync(
+      join(sb.userData, 'mod-metadata.json'),
+      JSON.stringify({ 'old_copy_dir.vpk': { gameBananaId: 999, sha256 } })
+    );
+    writeState(sb, [{ id: 333, name: 'Disabled C', enabled: false, vpks: [separateVpk] }]);
+
+    const preDisabled = fileNames(sb.disabled);
+    const report = await run(sb);
+    expect(report.adopted).toEqual([]);
+    expect(report.skipped[0].reason).toContain('identical file');
+    expect(fileNames(sb.disabled)).toEqual(preDisabled);
+  });
+});
+
+describe('staleness guard: stale DMM records cannot hijack reused slots', () => {
+  it('skips a bare pakNN slot that is newer than the record claiming it', async () => {
+    const sb = makeSandbox();
+    const liveSlot = join(sb.addons, 'pak50_dir.vpk');
+    writeFileSync(liveSlot, Buffer.from('SOME-OTHER-USERS-MOD'));
+    writeState(sb, [{ id: 111, name: 'Old DMM Mod', enabled: true, vpks: [liveSlot] }]);
+    makeNewerThanState(liveSlot);
+
+    const report = await run(sb);
+    expect(report.adopted).toEqual([]);
+    expect(report.skipped[0].submissionId).toBe(111);
+    expect(report.skipped[0].reason).toContain('newer than the DMM record');
+    // No identity was stamped onto the file.
+    const metaPath = join(sb.userData, 'mod-metadata.json');
+    if (existsSync(metaPath)) {
+      expect(JSON.parse(readFileSync(metaPath, 'utf-8'))['pak50_dir.vpk']).toBeUndefined();
+    }
+  });
+
+  it('still adopts when the filename matches the recorded mod name', async () => {
+    const sb = makeSandbox();
+    const vpk = join(sb.disabled, 'glamorous_geist_dir.vpk');
+    writeFileSync(vpk, Buffer.from('DISABLED-MOD-444'));
+    writeState(sb, [{ id: 444, name: 'Glamorous Geist', enabled: false, vpks: [vpk] }]);
+    makeNewerThanState(vpk);
+
+    const report = await run(sb);
+    expect(report.adopted.map((a) => a.submissionId)).toEqual([444]);
+  });
+
+  it('still adopts a file whose name carries the submission-id prefix', async () => {
+    const sb = makeSandbox();
+    const parked = join(sb.addons, '555_CoolSkin.vpk');
+    writeFileSync(parked, Buffer.from('PARKED-MOD-555'));
+    writeState(sb, [{ id: 555, name: 'Cool Skin', enabled: true, vpks: [parked] }]);
+    makeNewerThanState(parked);
+
+    const report = await run(sb);
+    expect(report.adopted.map((a) => a.submissionId)).toEqual([555]);
+    // Promoted into a real pakNN slot (a parked name is not engine-loadable).
+    expect(report.adopted[0].installedAs).toMatch(/^pak\d{2}_dir\.vpk$/);
+  });
+});
+
+describe('catalog validation: unknown submission ids are never stamped', () => {
+  it('skips ids the local GameBanana catalog does not know', async () => {
+    const sb = makeSandbox();
+    const knownVpk = join(sb.addons, 'pak50_dir.vpk');
+    const bogusVpk = join(sb.disabled, 'weird_thing_dir.vpk');
+    writeFileSync(knownVpk, Buffer.from('KNOWN-111'));
+    writeFileSync(bogusVpk, Buffer.from('BOGUS-76'));
+    writeState(sb, [
+      { id: 111, name: 'Known Mod', enabled: true, vpks: [knownVpk] },
+      { id: 76, name: 'Weird Thing', enabled: false, vpks: [bogusVpk] },
+    ]);
+
+    const report = await run(sb, { isKnownSubmission: (id) => id === 111 });
+    expect(report.adopted.map((a) => a.submissionId)).toEqual([111]);
+    expect(report.skipped[0].submissionId).toBe(76);
+    expect(report.skipped[0].reason).toContain('catalog');
+    expect(report.warnings.some((w) => w.includes('catalog'))).toBe(true);
+  });
+
+  it('scan preview reflects the same filters as execute', async () => {
+    const sb = makeSandbox();
+    const knownVpk = join(sb.addons, 'pak50_dir.vpk');
+    const bogusVpk = join(sb.disabled, 'weird_thing_dir.vpk');
+    writeFileSync(knownVpk, Buffer.from('KNOWN-111'));
+    writeFileSync(bogusVpk, Buffer.from('BOGUS-76'));
+    writeState(sb, [
+      { id: 111, name: 'Known Mod', enabled: true, vpks: [knownVpk] },
+      { id: 76, name: 'Weird Thing', enabled: false, vpks: [bogusVpk] },
+    ]);
+
+    const scan = await run(sb, { planOnly: true, isKnownSubmission: (id) => id === 111 });
+    expect(scan.preview.map((p) => p.submissionId)).toEqual([111]);
+    expect(scan.skipped.map((s) => s.submissionId)).toEqual([76]);
+    // Dry run: nothing written.
+    expect(existsSync(join(sb.userData, 'mod-metadata.json'))).toBe(false);
+  });
+});
+
+describe('recoverability: sidecar backup before the batch write', () => {
+  it('backs up the pre-import metadata and does not rotate it out on no-op re-runs', async () => {
+    const sb = makeSandbox();
+    const liveSlot = join(sb.addons, 'pak50_dir.vpk');
+    writeFileSync(liveSlot, Buffer.from('ENABLED-MOD-111'));
+    const seeded = JSON.stringify({ 'pak01_dir.vpk': { gameBananaId: 42, modName: 'Precious' } });
+    writeFileSync(join(sb.userData, 'mod-metadata.json'), seeded);
+    writeState(sb, [{ id: 111, name: 'Enabled A', enabled: true, vpks: [liveSlot] }]);
+
+    await run(sb);
+    const backupDir = join(sb.userData, 'mod-metadata.backups');
+    const backups = fileNames(backupDir);
+    expect(backups.length).toBe(1);
+    expect(readFileSync(join(backupDir, backups[0]), 'utf-8')).toBe(seeded);
+
+    // No-op re-runs (everything already managed) must not add backups.
+    await run(sb);
+    await run(sb);
+    expect(fileNames(backupDir)).toEqual(backups);
+  });
+
+  it('a re-run that only hits skips (perpetually stale entry) does not rotate the real backup', async () => {
+    const sb = makeSandbox();
+    const liveSlot = join(sb.addons, 'pak50_dir.vpk');
+    const staleVpk = join(sb.disabled, 'hijack_me_dir.vpk');
+    writeFileSync(liveSlot, Buffer.from('ENABLED-MOD-111'));
+    writeFileSync(staleVpk, Buffer.from('SOMEONE-ELSES-MOD'));
+    const seeded = JSON.stringify({ 'pak01_dir.vpk': { gameBananaId: 42 } });
+    writeFileSync(join(sb.userData, 'mod-metadata.json'), seeded);
+    writeState(sb, [
+      { id: 111, name: 'Enabled A', enabled: true, vpks: [liveSlot] },
+      { id: 222, name: 'Ugly Idol', enabled: false, vpks: [staleVpk] },
+    ]);
+    makeNewerThanState(staleVpk);
+
+    // First run adopts 111 (writes -> one backup of the seeded sidecar).
+    const first = await run(sb);
+    expect(first.adopted.map((a) => a.submissionId)).toEqual([111]);
+    const backupDir = join(sb.userData, 'mod-metadata.backups');
+    const backups = fileNames(backupDir);
+    expect(backups.length).toBe(1);
+    expect(readFileSync(join(backupDir, backups[0]), 'utf-8')).toBe(seeded);
+
+    // Entry 222 stays adoptable-but-stale forever; repeated clicks execute
+    // again but write nothing, so no new backup may appear (it would rotate
+    // the real pre-import backup out of the keep-N window).
+    for (let i = 0; i < 3; i++) {
+      const rerun = await run(sb);
+      expect(rerun.adopted).toEqual([]);
+    }
+    expect(fileNames(backupDir)).toEqual(backups);
+  });
+});

--- a/electron/main/services/dmmMigration.ts
+++ b/electron/main/services/dmmMigration.ts
@@ -30,6 +30,9 @@ import {
   setModMetadataWithHash,
   getModMetadata,
   removeModMetadata,
+  loadMetadata,
+  hashFileSha256,
+  backupMetadataSidecar,
   type ModMetadata,
 } from './metadata';
 import {
@@ -51,6 +54,70 @@ export interface DmmMigrationOptions extends DmmMigrationRequest {
   deadlockPath: string;
   /** Dry run: build the plan + preview without copying anything. */
   planOnly?: boolean;
+  /** Validates a submission id against Grimoire's local GameBanana catalog
+   *  (mods-cache.db). Injected by the IPC layer so this service stays free of
+   *  native sqlite imports (its tests run without Electron). Omitted = catalog
+   *  unavailable, check skipped. Guards against stamping a bogus id (e.g. a
+   *  digit-prefixed filename that isn't a GameBanana id) onto a real file:
+   *  such ids render as arbitrary submissions from unrelated games. */
+  isKnownSubmission?: (submissionId: number) => boolean;
+}
+
+/** Tolerance when comparing a VPK's mtime against the mtime of the DMM record
+ *  that claims it (filesystems and DMM's deploy-then-save ordering can put
+ *  them within the same second). */
+const STALE_CLAIM_SLACK_MS = 2000;
+
+/** Collapse a name to lowercase alphanumerics for fuzzy comparison. */
+function normalizeForMatch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/** Whether the on-disk filename resembles the DMM record's own name for the
+ *  mod (display name or source archive stem). Rescues legitimate adoptions
+ *  whose mtime corroboration fails because the files were copied to a new
+ *  drive or machine (copies refresh mtimes). */
+function nameCorroborates(fileName: string, entry: DmmAdoptionEntry): boolean {
+  let stem = fileName.replace(/_dir\.vpk$/i, '').replace(/\.vpk$/i, '');
+  stem = stem.replace(/^pak\d{2}_?/i, '');
+  const normalizedStem = normalizeForMatch(stem);
+  if (normalizedStem.length < 5) return false;
+  for (const candidate of [entry.modName, entry.sourceFileName]) {
+    if (!candidate) continue;
+    const normalized = normalizeForMatch(candidate);
+    if (normalized.length < 5) continue;
+    if (normalizedStem.includes(normalized) || normalized.includes(normalizedStem)) return true;
+  }
+  return false;
+}
+
+/**
+ * Staleness guard. DMM's records claim shared pakNN/.disabled slots by bare
+ * path, and Grimoire reuses those exact slots, so a record written long ago
+ * can now point at a completely different mod. Stamping DMM's identity onto
+ * such a file hijacks it (wrong name/thumbnail/GameBanana id on a real mod).
+ * A claim is trusted only when the file is provably the one DMM recorded:
+ *  - the filename carries the submission-id prefix DMM mints (`<id>_*.vpk`), or
+ *  - the file is not newer than the DMM record that claims it (a slot Grimoire
+ *    reused was rewritten AFTER DMM last saved its bookkeeping), or
+ *  - the filename matches the mod's recorded name.
+ */
+async function claimCorroborated(
+  src: string,
+  entry: DmmAdoptionEntry,
+  claimMtimeMs: number
+): Promise<boolean> {
+  const name = basename(src);
+  if (name.toLowerCase().startsWith(`${entry.submissionId}_`)) return true;
+  if (claimMtimeMs > 0) {
+    try {
+      const stat = await fs.stat(src);
+      if (stat.mtimeMs <= claimMtimeMs + STALE_CLAIM_SLACK_MS) return true;
+    } catch {
+      return false;
+    }
+  }
+  return nameCorroborates(name, entry);
 }
 
 /** Candidate on-disk locations of DMM's state.json. Tauri's store-plugin base
@@ -275,18 +342,81 @@ export async function migrateDmmInstall(opts: DmmMigrationOptions): Promise<DmmM
     profileName: plan.profileName,
     enrichment,
     mode,
-    preview: planToPreview(plan),
+    preview: [],
     adopted: [],
     skipped: [],
     warnings: [...plan.warnings],
   };
 
+  // Idempotency + validity filters run BEFORE the preview is built, so scan
+  // and execute agree on the same entry set and a re-run (another Fix Unknown
+  // click) is a true no-op for everything adopted last time, instead of
+  // minting duplicate slots/copies of it.
+  const allMetadata = loadMetadata();
+  const managedSubmissionIds = new Set<number>();
+  const managedHashes = new Set<string>();
+  for (const meta of Object.values(allMetadata)) {
+    if (meta.gameBananaId !== undefined) managedSubmissionIds.add(meta.gameBananaId);
+    if (meta.sha256) managedHashes.add(meta.sha256.toLowerCase());
+  }
+
+  const adoptableEntries: DmmAdoptionEntry[] = [];
+  let unknownToCatalog = 0;
+  for (const entry of plan.entries) {
+    if (managedSubmissionIds.has(entry.submissionId)) {
+      report.skipped.push({
+        submissionId: entry.submissionId,
+        reason: 'already managed by Grimoire (submission id present in metadata)',
+      });
+    } else if (opts.isKnownSubmission && !opts.isKnownSubmission(entry.submissionId)) {
+      unknownToCatalog++;
+      report.skipped.push({
+        submissionId: entry.submissionId,
+        reason:
+          'submission id not found in the local GameBanana catalog (wrong id or catalog out of date); left for manual identification',
+      });
+    } else {
+      adoptableEntries.push(entry);
+    }
+  }
+  if (unknownToCatalog > 0) {
+    report.warnings.push(
+      `${unknownToCatalog} mod(s) skipped: their DMM submission id is not in the local GameBanana catalog.`
+    );
+  }
+  report.preview = planToPreview({ ...plan, entries: adoptableEntries });
+
   if (opts.planOnly) return report;
+
+  // Staleness reference: a file claim is only as fresh as the DMM bookkeeping
+  // file that made it (the manifest when present, else state.json).
+  let claimMtimeMs = 0;
+  try {
+    const claimFile = manifestHit ? manifestHit.path : statePath;
+    claimMtimeMs = (await fs.stat(claimFile)).mtimeMs;
+  } catch {
+    claimMtimeMs = 0;
+  }
+
+  // Recoverability: back up the metadata sidecar before the first identity
+  // write (lazily, inside the batch), so a bad import can be rolled back by
+  // restoring one file. (The IPC layer additionally takes a mod snapshot.)
+  // Lazy on purpose: an execute whose every file is skipped (e.g. a
+  // perpetually stale entry re-clicked repeatedly) writes nothing and must
+  // not mint a backup, or it would rotate the REAL pre-import backup out of
+  // the pruned set. Non-fatal on failure.
+  let sidecarBackedUp = false;
+  const backupSidecarOnce = () => {
+    if (sidecarBackedUp) return;
+    sidecarBackedUp = true;
+    const backupPath = backupMetadataSidecar('pre-dmm-import');
+    if (backupPath) console.log(`[DMM] metadata sidecar backed up to ${backupPath}`);
+  };
 
   // Adopt enabled mods first (ascending priority so sequential slot allocation
   // -> pak01, pak02, ... preserves load order in copy mode; harmless in-place),
   // then disabled mods.
-  const ordered = [...plan.entries].sort((a, b) => {
+  const ordered = [...adoptableEntries].sort((a, b) => {
     if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
     return a.priority - b.priority;
   });
@@ -312,6 +442,31 @@ export async function migrateDmmInstall(opts: DmmMigrationOptions): Promise<DmmM
         const src = await locateVpk(dmmAddonsDir, [vpkName]);
         if (!src) {
           fileSkips.push(`${vpkName} (not found on disk)`);
+          continue;
+        }
+
+        // Staleness guard: only adopt a file the DMM record provably still
+        // describes; a shared slot Grimoire has since reused must stay
+        // untouched (see claimCorroborated).
+        if (!(await claimCorroborated(src, entry, claimMtimeMs))) {
+          fileSkips.push(
+            `${vpkName} (file is newer than the DMM record claiming it; possibly a reused slot, left for manual identification)`
+          );
+          continue;
+        }
+
+        // Content dedupe: if a byte-identical file is already managed (e.g. a
+        // copy minted by an earlier import run whose metadata lost the id),
+        // adopting another copy only duplicates the mod.
+        let srcHash: string;
+        try {
+          srcHash = (await hashFileSha256(src)).toLowerCase();
+        } catch (err) {
+          fileSkips.push(`${vpkName} (${err instanceof Error ? err.message : String(err)})`);
+          continue;
+        }
+        if (managedHashes.has(srcHash)) {
+          fileSkips.push(`${vpkName} (an identical file is already managed by Grimoire)`);
           continue;
         }
 
@@ -367,8 +522,10 @@ export async function migrateDmmInstall(opts: DmmMigrationOptions): Promise<DmmM
           // is only guaranteed free on disk, so a stale entry from a deleted mod
           // could otherwise bleed its fields (lockerHero, merged, thumbnail) into
           // this one via setModMetadata's shallow merge.
+          backupSidecarOnce();
           removeModMetadata(metaKey);
           await setModMetadataWithHash(metaKey, meta, destPath);
+          managedHashes.add(srcHash);
           adoptedKeys.push(metaKey);
         } catch (err) {
           fileSkips.push(`${vpkName} (${err instanceof Error ? err.message : String(err)})`);

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
-import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, statSync } from 'fs';
+import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, statSync, mkdirSync, copyFileSync, readdirSync } from 'fs';
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { getAddonFolderPaths, getDisabledPath, metaKeyFor } from './deadlock';
 import { getMetadataPath } from '../utils/paths';
 
@@ -261,7 +261,45 @@ function isValidSha256(value: string | undefined): boolean {
     return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value);
 }
 
-async function hashFileSha256(filePath: string): Promise<string> {
+/**
+ * Copy the metadata sidecar into mod-metadata.backups/<timestamp>_<tag>.json
+ * before a batch identity mutation (e.g. the DMM import), so a bad batch can
+ * be rolled back by restoring the file. Keeps the newest `keep` backups.
+ * Returns the backup path, or null when there is no sidecar yet. Never
+ * throws: a failed backup must not block the operation itself, so failures
+ * log a warning and return null.
+ */
+export function backupMetadataSidecar(tag: string, keep = 5): string | null {
+    const path = getMetadataPath();
+    if (!existsSync(path)) return null;
+
+    try {
+        const dir = join(dirname(path), 'mod-metadata.backups');
+        mkdirSync(dir, { recursive: true });
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const backupPath = join(dir, `${stamp}_${tag}.json`);
+        copyFileSync(path, backupPath);
+
+        // Prune old backups: ISO-stamped names sort chronologically, so a
+        // descending sort puts the newest first.
+        const stale = readdirSync(dir)
+            .filter((name) => name.endsWith('.json'))
+            .sort()
+            .reverse()
+            .slice(keep);
+        for (const name of stale) {
+            try {
+                unlinkSync(join(dir, name));
+            } catch { /* ignore prune failure */ }
+        }
+        return backupPath;
+    } catch (error) {
+        console.warn('[Metadata] Sidecar backup failed:', error);
+        return null;
+    }
+}
+
+export async function hashFileSha256(filePath: string): Promise<string> {
     const hash = createHash('sha256');
 
     await new Promise<void>((resolve, reject) => {

--- a/electron/main/services/snapshots.ts
+++ b/electron/main/services/snapshots.ts
@@ -117,6 +117,8 @@ export async function writeSnapshot(
     const profileName =
         trigger === 'pre-update'
             ? `Auto-snapshot (before update) ${friendlyTimestamp}`
+            : trigger === 'pre-dmm-import'
+            ? `Auto-snapshot (before DMM import) ${friendlyTimestamp}`
             : `Snapshot ${friendlyTimestamp}`;
 
     const { profile, warnings } = await buildPortableProfileFromInstalled(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -977,9 +977,14 @@
       "fixHiddenHint": "Fix unknown is hidden. Right-click to bring it back.",
       "fixButtonHint": "Find GameBanana matches or add custom metadata for unknown local mods. Right-click to hide this button.",
       "fixButton": "Fix unknown ({{count}})",
-      "dmmDetected": "Deadlock Mod Manager mods detected, importing...",
-      "dmmImported_one": "Detected and imported {{count}} mod from Deadlock Mod Manager",
-      "dmmImported_other": "Detected and imported {{count}} mods from Deadlock Mod Manager",
+      "dmmDetected": "Importing Deadlock Mod Manager mods...",
+      "dmmConfirmTitle": "Import Deadlock Mod Manager mods?",
+      "dmmConfirmMessage_one": "Grimoire found a Deadlock Mod Manager library (profile: {{profile}}) with {{count}} mod it doesn't manage yet. Import it? A snapshot and a metadata backup are taken first, and Deadlock Mod Manager's own files are never moved or deleted. Skipping goes straight to manual identification.",
+      "dmmConfirmMessage_other": "Grimoire found a Deadlock Mod Manager library (profile: {{profile}}) with {{count}} mods it doesn't manage yet. Import them? A snapshot and a metadata backup are taken first, and Deadlock Mod Manager's own files are never moved or deleted. Skipping goes straight to manual identification.",
+      "dmmConfirmImport": "Import",
+      "dmmConfirmSkip": "Skip",
+      "dmmImported_one": "Imported {{count}} mod from Deadlock Mod Manager",
+      "dmmImported_other": "Imported {{count}} mods from Deadlock Mod Manager",
       "dmmImportFailed": "Could not import Deadlock Mod Manager mods",
       "checkingCrcCache": "Checking local CRC cache...",
       "noCachedMatch": "No cached match found. Queued for online search.",
@@ -1695,11 +1700,13 @@
       "trigger": {
         "preUpdate": "Before mod update",
         "preApplyProfile": "Before applying profile",
+        "preDmmImport": "Before DMM import",
         "manual": "Manual snapshot"
       },
       "explanation": {
         "preUpdate": "Captured before a mod update changed your installed set.",
         "preApplyProfile": "Captured before applying a profile changed your installed set.",
+        "preDmmImport": "Captured before importing mods from Deadlock Mod Manager.",
         "manual": "Captured manually from the Profiles page."
       },
       "unselect": "Unselect snapshot",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,17 +1,17 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1870,
+  "totalKeys": 1877,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1621,
-      "pct": 87
+      "pct": 86
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1870,
+      "translatedKeys": 1877,
       "pct": 100
     },
     {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1025,6 +1025,13 @@ export default function Installed() {
   // state, so two clicks in the same tick can't both read a stale `false`.
   const dmmAutoImportInFlightRef = useRef(false);
   const [dmmAutoImporting, setDmmAutoImporting] = useState(false);
+  // Pending DMM-import consent dialog. Holds the promise resolver so
+  // autoImportDmmMods can await the user's answer; null = no dialog.
+  const [dmmConfirm, setDmmConfirm] = useState<{
+    count: number;
+    profileName: string;
+    resolve: (ok: boolean) => void;
+  } | null>(null);
   const [unknownFilterCache, setUnknownFilterCache] = useState<Record<string, UnknownModFilterGuess>>({});
   const [unknownFilterPendingIds, setUnknownFilterPendingIds] = useState<Set<string>>(new Set());
   const [unknownFilterErrors, setUnknownFilterErrors] = useState<Record<string, string>>({});
@@ -1496,6 +1503,14 @@ export default function Installed() {
     );
     const freshEntries = scan.preview.filter((p) => !managedGbIds.has(p.submissionId));
     if (freshEntries.length === 0) return currentUnknowns;
+
+    // Consent gate: importing writes mod identities in batch, so it never
+    // runs on a toast alone. The dialog says what was found; declining goes
+    // straight to manual identification.
+    const consent = await new Promise<boolean>((resolve) =>
+      setDmmConfirm({ count: freshEntries.length, profileName: scan.profileName, resolve })
+    );
+    if (!consent) return currentUnknowns;
 
     showToast(t('installed.unknown.dmmDetected'), { tone: 'info', duration: 4000 });
 
@@ -4090,6 +4105,26 @@ export default function Installed() {
           onClose={closeUnknownFix}
         />
       )}
+
+      {/* Consent gate for the DMM auto-import step of Fix Unknown Mods. */}
+      <ConfirmModal
+        isOpen={dmmConfirm !== null}
+        title={t('installed.unknown.dmmConfirmTitle')}
+        message={t('installed.unknown.dmmConfirmMessage', {
+          count: dmmConfirm?.count ?? 0,
+          profile: dmmConfirm?.profileName ?? '',
+        })}
+        confirmLabel={t('installed.unknown.dmmConfirmImport')}
+        cancelLabel={t('installed.unknown.dmmConfirmSkip')}
+        onConfirm={() => {
+          dmmConfirm?.resolve(true);
+          setDmmConfirm(null);
+        }}
+        onCancel={() => {
+          dmmConfirm?.resolve(false);
+          setDmmConfirm(null);
+        }}
+      />
 
       {customUnknownMod && (
         <ImportCustomModModal

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -569,12 +569,16 @@ export default function Profiles() {
                       ? t('profiles.snapshots.trigger.preUpdate')
                       : snap.trigger === 'pre-apply-profile'
                       ? t('profiles.snapshots.trigger.preApplyProfile')
+                      : snap.trigger === 'pre-dmm-import'
+                      ? t('profiles.snapshots.trigger.preDmmImport')
                       : t('profiles.snapshots.trigger.manual');
                   const triggerExplanation =
                     snap.trigger === 'pre-update'
                       ? t('profiles.snapshots.explanation.preUpdate')
                       : snap.trigger === 'pre-apply-profile'
                       ? t('profiles.snapshots.explanation.preApplyProfile')
+                      : snap.trigger === 'pre-dmm-import'
+                      ? t('profiles.snapshots.explanation.preDmmImport')
                       : t('profiles.snapshots.explanation.manual');
                   return (
                     <li

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -1,7 +1,8 @@
 /** Reason a snapshot was taken. Automatic triggers fire before destructive
  *  operations that overwrite installed mods (update from Browse,
- *  apply-profile swap). `manual` is the "Snapshot now" button. */
-export type SnapshotTrigger = 'pre-update' | 'pre-apply-profile' | 'manual';
+ *  apply-profile swap, the DMM import's batch identity write). `manual` is
+ *  the "Snapshot now" button. */
+export type SnapshotTrigger = 'pre-update' | 'pre-apply-profile' | 'pre-dmm-import' | 'manual';
 
 /** Summary used by the list view. Keeps the wire small when the user has
  *  accumulated many snapshots — the full PortableProfile only crosses the


### PR DESCRIPTION
## Why

A user report (Discord): clicking Fix Unknown Mods on a machine with a stale Deadlock Mod Manager `state.json` corrupted their install. Disabled mods tripled, their own unknown mods were re-labeled as mods they never downloaded (including CS 1.6-era GameBanana pages), and one skin's file list belonged to a different mod.

Root causes, all in the DMM auto-import that runs silently as the first step of Fix Unknown Mods:

1. **No idempotency.** Each execute re-ran the full plan. Any source that wasn't already a live slot (parked `<id>_*.vpk`, separate-folder copies) got a NEW pakNN slot or a NEW `.disabled` name per run; nothing marked the source as adopted. The renderer's "fresh entries" gate stays open forever if even one entry is perpetually skipped, so every click duplicated the same mods. Three clicks = tripled.
2. **Identity hijack via stale claims.** `state.json` records mods by absolute path in the shared `citadel/addons` + `.disabled` folders, and Grimoire reuses those exact slots. A stale record pointed at files that are now different mods; the only guard (`isGrimoireManaged`) doesn't protect unknown files, which are exactly what Fix Unknown targets.
3. **Unvalidated GameBanana ids.** `gameBananaId` was stamped straight from DMM's `remoteId` or a digit-prefixed filename. GB submission ids are global across games, so wrong ids render as arbitrary ancient submissions.
4. **No consent, no recovery.** The import ran on an info toast, took no snapshot, and had no metadata backup.

## What changed

- **Consent**: Fix Unknown now scans, then asks via ConfirmModal (profile name + count; "DMM's own files are never moved or deleted"). Skip goes straight to manual identification.
- **Idempotency (main process)**: already-managed submission ids are filtered before the preview is built, so scan and execute agree; byte-identical files (sha256 vs all managed hashes) are never copied again.
- **Staleness guard** (`claimCorroborated`): a claim is trusted only when the filename carries the `<id>_` prefix DMM mints, or the file is not newer than the DMM bookkeeping file claiming it (+2s slack), or the filename matches the recorded mod name. Otherwise: skipped, "left for manual identification".
- **Catalog validation**: the IPC layer injects an `isKnownSubmission` lookup backed by mods-cache.db into scan and execute. Fails open when the catalog is empty or errors, so a fresh install rejects nothing. The service stays sqlite-free (keeps the electron-free test harness).
- **Recovery**: execute takes a `pre-dmm-import` snapshot (new trigger, labeled on the Profiles page) and backs up `mod-metadata.json` to `userData/mod-metadata.backups/` (keeps 5). The backup is taken lazily right before the first actual write, so a skip-only re-run cannot rotate the real pre-import backup out of the keep-5 window.

## Verification

- **Unit**: `dmmMigration.guards.test.ts` (9 tests, electron-free, real temp FS): re-run mints no duplicate files; identical content under a different id is not re-copied; a bare pakNN slot newer than the record claiming it is skipped and gets no metadata; name-match and id-prefix corroboration still adopt; catalog filtering matches between scan preview and execute; the backup is created once and survives repeated skip-only executes. Full suite 364/364, `tsc -b`, eslint, `i18n:check` + manifest check all green on this branch's committed state.
- **End-to-end (CDP against a throwaway instance)**: fixture = fake Deadlock install with 3 unknown VPKs + a DMM `state.json` where two claims are legitimate and one is deliberately stale (file mtime newer than the record, name "Ugly Idol"). Observed: consent modal with correct copy and count; Skip changed nothing; Import adopted the 2 legitimate mods **in place** (no file created/moved anywhere), left the stale one unknown with the manual modal opening on it; `pre-dmm-import` snapshot + metadata backup written; two further Imports (the incident's repeat-click pattern) adopted 0 and created zero duplicate files; "Before DMM import" renders in the Profiles snapshot list.

## Notes

- The consent modal reappears on every Fix Unknown click while a perpetually-stale entry exists (count 1). Harmless (importing it is a no-op) but slightly noisy; a "don't ask again this session" flag could follow up.
- Snapshots of DMM-adopted mods without a recoverable GameBanana file id serialize as thin portable profiles (pre-existing portable-profile constraint). The metadata backup is the real rollback lever for this flow.
- Recovery recipe for already-affected installs (for the Discord thread): delete/rename DMM's `state.json`, remove duplicate byte-identical VPKs, delete the bogus `mod-metadata.json` entries (files return to unknown), re-identify via Fix Unknown.