### PR TITLE
fix: post-merge follow-ups for vpk imprinting (#287)

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -31,7 +31,7 @@ import {
     type UnknownModFilterGuess,
 } from '../services/unknownModDetection';
 import { downloadMod } from '../services/download';
-import { fetchModDetails } from '../services/gamebanana';
+import { fetchAdoptedThumbnail, type AdoptedThumbnailTarget } from '../services/adoptedThumbnail';
 import { extractArchive, isArchive, type ExtractedVpk } from '../services/extract';
 import { mergeMods, unmergeMod, extractMergeSource } from '../services/modMerger';
 import {
@@ -1044,7 +1044,7 @@ ipcMain.handle(
         // has no thumbnail yet, collected during the copy loop so the
         // best-effort background thumbnail fetch (fired after the lock/import
         // fully completes) knows which slots to enrich.
-        const thumbnailFetchTargets: Array<{ metaKey: string; gameBananaId: number; section: string }> = [];
+        const thumbnailFetchTargets: AdoptedThumbnailTarget[] = [];
 
         try {
             // Imports install ENABLED, so reserve a slot via the overflow-aware
@@ -1119,6 +1119,9 @@ ipcMain.handle(
                         metaKey: destMetaKey,
                         gameBananaId: adoptedGbId,
                         section: finalMeta?.sourceSection || 'Mod',
+                        // The hash setModMetadataWithHash just stamped: pins the
+                        // fetch to THIS file, so a recycled slot is never stamped.
+                        expectedSha256: finalMeta?.sha256,
                     });
                 }
             }
@@ -1132,46 +1135,16 @@ ipcMain.handle(
         const result = mods.map(enrichMod);
 
         // Fire-and-forget: never await, never let a network failure affect the
-        // import result already being returned to the renderer.
+        // import result already being returned to the renderer. The fetch
+        // itself re-verifies slot identity before writing (see
+        // services/adoptedThumbnail.ts).
         for (const target of thumbnailFetchTargets) {
-            void fetchAdoptedThumbnail(target.metaKey, target.gameBananaId, target.section);
+            void fetchAdoptedThumbnail(target);
         }
 
         return result;
     }
 );
-
-/**
- * Best-effort background fetch of a thumbnail (and audio preview, for Sound
- * mods) for a mod whose gamebananaId was just ADOPTED from its own embed at
- * import time, but whose sidecar has no thumbnailUrl (the user imported a
- * bare VPK, not an archive with art, or the embed predates thumbnails).
- * Mirrors download.ts's own field mapping (thumbnail = file530 falling back to
- * file; audioUrl from previewMedia.metadata). Never throws: offline or a
- * revoked/renamed GameBanana submission just leaves the mod without a
- * thumbnail, exactly as if adoption had never found the id.
- */
-async function fetchAdoptedThumbnail(metaKey: string, gameBananaId: number, section: string): Promise<void> {
-    try {
-        const details = await fetchModDetails(gameBananaId, section);
-        const thumbnail = details.previewMedia?.images?.[0];
-        const thumbnailUrl = thumbnail
-            ? `${thumbnail.baseUrl}/${thumbnail.file530 || thumbnail.file}`
-            : undefined;
-        const audioUrl = details.previewMedia?.metadata?.audioUrl;
-        if (!thumbnailUrl && !audioUrl) return;
-        // Re-check under the current sidecar: don't clobber a thumbnail the
-        // user set (or another path fetched) while this request was in flight.
-        const current = getModMetadata(metaKey);
-        if (current?.thumbnailUrl) return;
-        setModMetadata(metaKey, {
-            ...(thumbnailUrl ? { thumbnailUrl } : {}),
-            ...(audioUrl ? { audioUrl } : {}),
-        });
-    } catch (err) {
-        console.warn(`[import-custom-mod] Best-effort thumbnail fetch failed for ${metaKey}:`, err);
-    }
-}
 
 // foundry:swapSound
 // Build a hero sound-swap addon VPK (drop your own MP3 onto a hero gameplay

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -573,11 +573,19 @@ ipcMain.handle(
 async function refreshEmbedAfterMetadataChange(
     deadlockPath: string,
     modId: string,
-    metaKey: string
+    metaKey: string,
+    modPath: string
 ): Promise<void> {
     try {
         if (!loadSettings().experimentalVpkImprinting) return;
-        if (!getModMetadata(metaKey)?.imprinted) return;
+        // The sidecar flag alone misses a VPK dropped into addons mid-session:
+        // the startup backfill has not seen it, so `imprinted` is unset even
+        // though the file carries an embed, and bailing here would silently
+        // leave the wrong embed in the file after the user just corrected the
+        // identity. Consult the file itself too (the same predicate the
+        // backfill and the import handler use). A foreign embed surviving to
+        // imprintOneMod fails soft into the warn below, unchanged.
+        if (!getModMetadata(metaKey)?.imprinted && !hasAnyImprint(modPath)) return;
         await imprintOneMod(deadlockPath, modId);
     } catch (err) {
         console.warn(`[mods] Post-associate embed refresh failed for ${metaKey}:`, err);
@@ -608,7 +616,7 @@ ipcMain.handle(
             nsfw: !!args.nsfw,
         }, target.path);
 
-        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey);
+        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey, target.path);
         return enrichMod(target);
     }
 );
@@ -661,7 +669,7 @@ ipcMain.handle(
             sourceSection: args.sourceSection,
         }, target.path);
 
-        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey);
+        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey, target.path);
         return enrichMod(target);
     }
 );
@@ -696,7 +704,7 @@ ipcMain.handle(
             nsfw: !!args.nsfw,
         }, target.path);
 
-        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey);
+        await refreshEmbedAfterMetadataChange(deadlockPath, target.id, target.metaKey, target.path);
         return enrichMod(target);
     }
 );

--- a/electron/main/services/adoptedThumbnail.test.ts
+++ b/electron/main/services/adoptedThumbnail.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Coverage for the adopted-thumbnail slot-identity guards: the fetch is
+ * fire-and-forget, and metaKeys are just pakNN file names, so by the time the
+ * network resolves the slot may hold a different mod (deleted + reimported),
+ * point at a different submission, or already have art. None of those may be
+ * stamped with the old occupant's thumbnail (same failure class as the
+ * pose-cache bug).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { fetchModDetails } = vi.hoisted(() => ({
+    fetchModDetails: vi.fn<(id: number, section: string) => Promise<unknown>>(),
+}));
+vi.mock('./gamebanana', () => ({ fetchModDetails }));
+
+const metadataStore = vi.hoisted(() => new Map<string, Record<string, unknown>>());
+const { setModMetadata } = vi.hoisted(() => ({
+    setModMetadata: vi.fn((key: string, patch: Record<string, unknown>) => {
+        metadataStore.set(key, { ...(metadataStore.get(key) ?? {}), ...patch });
+    }),
+}));
+vi.mock('./metadata', () => ({
+    getModMetadata: vi.fn((key: string) => metadataStore.get(key)),
+    setModMetadata,
+}));
+
+import { fetchAdoptedThumbnail } from './adoptedThumbnail';
+
+const SHA = 'a'.repeat(64);
+const TARGET = {
+    metaKey: 'pak05_dir.vpk',
+    gameBananaId: 4242,
+    section: 'Sound',
+    expectedSha256: SHA,
+};
+
+function gbDetails(overrides: Record<string, unknown> = {}) {
+    return {
+        previewMedia: {
+            images: [{ baseUrl: 'https://images.gb', file530: 'thumb_530.jpg', file: 'thumb.jpg' }],
+            metadata: { audioUrl: 'https://files.gb/preview.mp3' },
+        },
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    metadataStore.clear();
+});
+
+describe('fetchAdoptedThumbnail', () => {
+    it('stamps thumbnail and audio on the still-matching row (happy path)', async () => {
+        metadataStore.set('pak05_dir.vpk', { gameBananaId: 4242, sha256: SHA });
+        fetchModDetails.mockResolvedValue(gbDetails());
+
+        await fetchAdoptedThumbnail(TARGET);
+
+        expect(setModMetadata).toHaveBeenCalledWith('pak05_dir.vpk', {
+            thumbnailUrl: 'https://images.gb/thumb_530.jpg',
+            audioUrl: 'https://files.gb/preview.mp3',
+        });
+    });
+
+    it('does not write when the metadata row was deleted mid-fetch', async () => {
+        fetchModDetails.mockResolvedValue(gbDetails());
+
+        await fetchAdoptedThumbnail(TARGET);
+
+        expect(setModMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not write when a different mod recycled the pakNN slot (sha mismatch)', async () => {
+        metadataStore.set('pak05_dir.vpk', { gameBananaId: 4242, sha256: 'b'.repeat(64) });
+        fetchModDetails.mockResolvedValue(gbDetails());
+
+        await fetchAdoptedThumbnail(TARGET);
+
+        expect(setModMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not write when the mod was re-associated to another submission mid-flight', async () => {
+        metadataStore.set('pak05_dir.vpk', { gameBananaId: 9999, sha256: SHA });
+        fetchModDetails.mockResolvedValue(gbDetails());
+
+        await fetchAdoptedThumbnail(TARGET);
+
+        expect(setModMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not clobber a thumbnail that appeared while in flight', async () => {
+        metadataStore.set('pak05_dir.vpk', {
+            gameBananaId: 4242,
+            sha256: SHA,
+            thumbnailUrl: 'https://user.set/art.png',
+        });
+        fetchModDetails.mockResolvedValue(gbDetails());
+
+        await fetchAdoptedThumbnail(TARGET);
+
+        expect(setModMetadata).not.toHaveBeenCalled();
+    });
+
+    it('swallows a fetch rejection without writing', async () => {
+        metadataStore.set('pak05_dir.vpk', { gameBananaId: 4242, sha256: SHA });
+        fetchModDetails.mockRejectedValue(new Error('offline'));
+
+        await expect(fetchAdoptedThumbnail(TARGET)).resolves.toBeUndefined();
+        expect(setModMetadata).not.toHaveBeenCalled();
+    });
+});

--- a/electron/main/services/adoptedThumbnail.ts
+++ b/electron/main/services/adoptedThumbnail.ts
@@ -1,0 +1,62 @@
+import { fetchModDetails } from './gamebanana';
+import { getModMetadata, setModMetadata } from './metadata';
+
+/**
+ * One queued best-effort thumbnail fetch for a mod whose gamebananaId was just
+ * ADOPTED from its own embed at import time. Captured at queue time, while the
+ * import handler still knows exactly which file occupies the slot.
+ */
+export interface AdoptedThumbnailTarget {
+    metaKey: string;
+    gameBananaId: number;
+    section: string;
+    /** The sha256 stamped on the metadata row at queue time. metaKeys are just
+     *  file names (pakNN slots), so this is what identifies THIS file: a slot
+     *  recycled by a different mod while the fetch was in flight must never be
+     *  stamped with the old occupant's art. */
+    expectedSha256?: string;
+}
+
+/**
+ * Best-effort background fetch of a thumbnail (and audio preview, for Sound
+ * mods) for a mod whose gamebananaId was just adopted from its own embed at
+ * import time, but whose sidecar has no thumbnailUrl (the user imported a
+ * bare VPK, not an archive with art, or the embed predates thumbnails).
+ * Mirrors download.ts's own field mapping (thumbnail = file530 falling back to
+ * file; audioUrl from previewMedia.metadata). Never throws: offline or a
+ * revoked/renamed GameBanana submission just leaves the mod without a
+ * thumbnail, exactly as if adoption had never found the id.
+ *
+ * Fire-and-forget by design, so every write is re-checked against the CURRENT
+ * sidecar: the row must still exist (mod not deleted mid-fetch), still carry
+ * the queue-time sha256 (pakNN slot not recycled by a different mod), still
+ * point at the same submission (not re-associated mid-flight), and still have
+ * no thumbnail (never clobber one the user set or another path fetched).
+ */
+export async function fetchAdoptedThumbnail(target: AdoptedThumbnailTarget): Promise<void> {
+    try {
+        const details = await fetchModDetails(target.gameBananaId, target.section);
+        const thumbnail = details.previewMedia?.images?.[0];
+        const thumbnailUrl = thumbnail
+            ? `${thumbnail.baseUrl}/${thumbnail.file530 || thumbnail.file}`
+            : undefined;
+        const audioUrl = details.previewMedia?.metadata?.audioUrl;
+        if (!thumbnailUrl && !audioUrl) return;
+
+        const current = getModMetadata(target.metaKey);
+        if (!current) return;
+        if (target.expectedSha256 && current.sha256 !== target.expectedSha256) return;
+        if (current.gameBananaId !== target.gameBananaId) return;
+        if (current.thumbnailUrl) return;
+
+        setModMetadata(target.metaKey, {
+            ...(thumbnailUrl ? { thumbnailUrl } : {}),
+            ...(audioUrl ? { audioUrl } : {}),
+        });
+    } catch (err) {
+        console.warn(
+            `[adoptedThumbnail] Best-effort thumbnail fetch failed for ${target.metaKey}:`,
+            err
+        );
+    }
+}

--- a/electron/main/services/imprintEligibility.test.ts
+++ b/electron/main/services/imprintEligibility.test.ts
@@ -178,3 +178,29 @@ describe('never-identified VPKs and bulk imprint', () => {
         expect(result.counts.alreadyImprinted + result.counts.eligible).toBe(1);
     });
 });
+describe('preflight cost contract', () => {
+    it('never whole-file-hashes during the read-only preflight', async () => {
+        // An identified, non-embedded mod with a stored sha256: exactly the
+        // shape the old preflight hashed serially inside the mutation lock.
+        metadataStore.set('pak10_dir.vpk', { modName: 'Known Mod', sha256: 'c'.repeat(64) });
+        scanMods.mockResolvedValue([makeMod()]);
+
+        await imprintPreflight('C:/deadlock');
+
+        expect(computeOriginalIdentity).not.toHaveBeenCalled();
+    });
+
+    it('still hash-checks at write time in the bulk run (KEYSTONE drift refusal)', async () => {
+        metadataStore.set('pak10_dir.vpk', { modName: 'Known Mod', sha256: 'c'.repeat(64) });
+        scanMods.mockResolvedValue([makeMod()]);
+        computeOriginalIdentity.mockResolvedValue({ sha256: 'd'.repeat(64) });
+
+        const result = await imprintAllInstalled('C:/deadlock');
+
+        expect(computeOriginalIdentity).toHaveBeenCalled();
+        expect(result.failed).toEqual([
+            { fileName: 'pak10_dir.vpk', modName: 'Known Mod', reason: 'hash-drift' },
+        ]);
+        expect(runVpkmerge).not.toHaveBeenCalled();
+    });
+});

--- a/electron/main/services/imprintEligibility.test.ts
+++ b/electron/main/services/imprintEligibility.test.ts
@@ -77,11 +77,11 @@ vi.mock('./modinfoFormat', () => ({
     MODINFO_SCHEMA_VERSION: 1,
 }));
 
-const { runVpkmerge } = vi.hoisted(() => ({
-    runVpkmerge: vi.fn<(args: string[]) => Promise<void>>(),
+const { repackWithEmbeddedEntries } = vi.hoisted(() => ({
+    repackWithEmbeddedEntries: vi.fn<(...args: unknown[]) => Promise<void>>(),
 }));
 vi.mock('./modMerger', () => ({
-    runVpkmerge,
+    repackWithEmbeddedEntries,
     embedMergeIdentity: vi.fn(),
     buildPortableForMergeSources: vi.fn(),
 }));
@@ -138,7 +138,7 @@ describe('never-identified VPKs and bulk imprint', () => {
 
         const result = await imprintAllInstalled('C:/deadlock');
 
-        expect(runVpkmerge).not.toHaveBeenCalled();
+        expect(repackWithEmbeddedEntries).not.toHaveBeenCalled();
         expect(result.imprinted).toBe(0);
         expect(result.failed).toEqual([
             { fileName: 'pak10_dir.vpk', modName: 'pak10', reason: 'unidentified' },
@@ -200,6 +200,6 @@ describe('preflight cost contract', () => {
         expect(result.failed).toEqual([
             { fileName: 'pak10_dir.vpk', modName: 'Known Mod', reason: 'hash-drift' },
         ]);
-        expect(runVpkmerge).not.toHaveBeenCalled();
+        expect(repackWithEmbeddedEntries).not.toHaveBeenCalled();
     });
 });

--- a/electron/main/services/imprintEligibility.test.ts
+++ b/electron/main/services/imprintEligibility.test.ts
@@ -13,7 +13,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ModinfoRecord } from '../../../src/types/modinfo';
 import type { ParsedAddonInfo } from './vpkIdentity';
 import type { Mod } from './mods';
-import type { ModMetadata } from './metadata';
 
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test' } }));
 vi.mock('fs', () => ({

--- a/electron/main/services/imprintEligibility.test.ts
+++ b/electron/main/services/imprintEligibility.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Coverage for bulk-imprint eligibility of never-identified VPKs: a mod with
+ * no metadata row and no embed must be refused ('unidentified'), because the
+ * repack permanently changes the live size/CRC the GameBanana archive
+ * matchers key on, with nothing in the embed to compensate. A meta-less mod
+ * that already carries a valid embed stays eligible (its identity anchor is
+ * the embedded original). Also pins the preflight cost contract: the
+ * read-only preflight never whole-file-hashes a candidate, while the bulk
+ * run's write-time drift guard still does. imprintStaleness stays REAL, same
+ * pattern as imprintAdoption.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ModinfoRecord } from '../../../src/types/modinfo';
+import type { ParsedAddonInfo } from './vpkIdentity';
+import type { Mod } from './mods';
+import type { ModMetadata } from './metadata';
+
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test' } }));
+vi.mock('fs', () => ({
+    promises: {
+        stat: vi.fn(async () => ({ size: 1024 })),
+        readdir: vi.fn(async () => []),
+    },
+}));
+
+const { scanMods } = vi.hoisted(() => ({
+    scanMods: vi.fn<(deadlockPath: string) => Promise<Mod[]>>(),
+}));
+vi.mock('./mods', () => ({
+    scanMods,
+    runExclusiveModMutation: vi.fn(<T,>(fn: () => Promise<T>) => fn()),
+}));
+
+const metadataStore = vi.hoisted(() => new Map<string, Record<string, unknown>>());
+vi.mock('./metadata', () => ({
+    getModMetadata: vi.fn((key: string) => metadataStore.get(key)),
+    setModMetadata: vi.fn((key: string, patch: Record<string, unknown>) => {
+        metadataStore.set(key, { ...(metadataStore.get(key) ?? {}), ...patch });
+    }),
+}));
+
+const { readEmbeddedAddonInfo, carryForwardOriginalIdentity } = vi.hoisted(() => ({
+    readEmbeddedAddonInfo: vi.fn<(path: string) => ParsedAddonInfo | null>(),
+    carryForwardOriginalIdentity:
+        vi.fn<(embed: unknown, legacy?: unknown) => { sha256: string } | null>(),
+}));
+vi.mock('./vpkIdentity', () => ({
+    readEmbeddedAddonInfo,
+    carryForwardOriginalIdentity,
+}));
+
+vi.mock('./vpk', () => ({
+    parseVpkDirectoryCached: vi.fn(() => ['materials/foo.txt']),
+    parseVpkEntryStats: vi.fn(() => []),
+    findChunkSiblingNames: vi.fn(() => []),
+}));
+
+const { readEmbeddedModinfo, computeOriginalIdentity } = vi.hoisted(() => ({
+    readEmbeddedModinfo: vi.fn<(path: string) => ModinfoRecord | null>(),
+    computeOriginalIdentity:
+        vi.fn<(path: string, opts?: unknown) => Promise<{ sha256: string }>>(),
+}));
+vi.mock('./modinfoFormat', () => ({
+    computeOriginalIdentity,
+    serializeAddonInfo: vi.fn(() => 'addoninfo'),
+    serializeModinfo: vi.fn(() => 'modinfo'),
+    readEmbeddedModinfo,
+    readLegacyGrimoireMergeMeta: vi.fn(() => null),
+    hasLegacyGrimoireMergeMetaEntry: vi.fn(() => false),
+    findImprintRepackMismatch: vi.fn(() => null),
+    reconstructMergedModInfoFromEmbed: vi.fn(() => null),
+    reconstructMergedModInfoFromLegacy: vi.fn(() => null),
+    ADDONINFO_ENTRY: 'addoninfo.txt',
+    MODINFO_ENTRY: 'modinfo.json',
+    LEGACY_GRIMOIRE_META_ENTRY: 'grimoire_meta.json',
+    MODINFO_FORMAT: 'vpk-modinfo',
+    MODINFO_GAME: { name: 'Deadlock', steamAppId: 1422450, gameBananaGameId: 20948 },
+    MODINFO_SCHEMA_VERSION: 1,
+}));
+
+const { runVpkmerge } = vi.hoisted(() => ({
+    runVpkmerge: vi.fn<(args: string[]) => Promise<void>>(),
+}));
+vi.mock('./modMerger', () => ({
+    runVpkmerge,
+    embedMergeIdentity: vi.fn(),
+    buildPortableForMergeSources: vi.fn(),
+}));
+
+vi.mock('./gameSessionMods', () => ({
+    assertCanMoveLoadedGameMod: vi.fn(),
+    isLoadedGameModLocked: vi.fn(() => false),
+    syncRunningGameModSnapshotFromMods: vi.fn(),
+}));
+
+vi.mock('./profileResolver', () => ({ inferMissingVpkIndexes: vi.fn(() => new Map()) }));
+
+import { imprintAllInstalled, imprintPreflight } from './imprintMods';
+
+function makeMod(overrides: Partial<Mod> = {}): Mod {
+    return {
+        id: 'pak10_dir.vpk',
+        name: 'pak10',
+        fileName: 'pak10_dir.vpk',
+        metaKey: 'pak10_dir.vpk',
+        path: 'C:/addons/pak10_dir.vpk',
+        enabled: true,
+        ...overrides,
+    } as Mod;
+}
+
+function modRecord(): ModinfoRecord {
+    return {
+        format: 'vpk-modinfo',
+        schemaVersion: 1,
+        kind: 'mod',
+        writtenBy: { tool: 'grimoire', version: '0.0.0-test' },
+        writtenAt: '2026-01-01T00:00:00.000Z',
+        firstImprintedAt: '2025-06-01T00:00:00.000Z',
+        game: { name: 'Deadlock', steamAppId: 1422450, gameBananaGameId: 20948 },
+        identity: { sha256: 'a'.repeat(64) },
+        title: 'Imprinted Import',
+        source: { gamebananaId: 4242, gamebananaFileId: 9001, section: 'Mod' },
+    } as ModinfoRecord;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    metadataStore.clear();
+    readEmbeddedAddonInfo.mockReturnValue(null);
+    carryForwardOriginalIdentity.mockReturnValue(null);
+    readEmbeddedModinfo.mockReturnValue(null);
+    computeOriginalIdentity.mockResolvedValue({ sha256: 'b'.repeat(64) });
+});
+
+describe('never-identified VPKs and bulk imprint', () => {
+    it('bulk run refuses a meta-less, embed-less mod without repacking it', async () => {
+        scanMods.mockResolvedValue([makeMod()]);
+
+        const result = await imprintAllInstalled('C:/deadlock');
+
+        expect(runVpkmerge).not.toHaveBeenCalled();
+        expect(result.imprinted).toBe(0);
+        expect(result.failed).toEqual([
+            { fileName: 'pak10_dir.vpk', modName: 'pak10', reason: 'unidentified' },
+        ]);
+    });
+
+    it('preflight buckets it as anomalous with the same reason, counts summing to total', async () => {
+        scanMods.mockResolvedValue([makeMod()]);
+
+        const result = await imprintPreflight('C:/deadlock');
+
+        expect(result.counts.eligible).toBe(0);
+        expect(result.counts.anomalous).toBe(1);
+        expect(result.anomalous).toEqual([
+            { fileName: 'pak10_dir.vpk', modName: 'pak10', reason: 'unidentified' },
+        ]);
+        const summed = Object.values(result.counts).reduce((a, b) => a + b, 0);
+        expect(summed).toBe(result.total);
+    });
+
+    it('keeps a meta-less mod WITH a valid embed eligible (identity anchored by the embed)', async () => {
+        scanMods.mockResolvedValue([makeMod()]);
+        readEmbeddedAddonInfo.mockReturnValue({
+            originalSha256: 'a'.repeat(64),
+            gamebananaId: '4242',
+            raw: {},
+        });
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(modRecord());
+
+        const result = await imprintPreflight('C:/deadlock');
+
+        expect(result.counts.anomalous).toBe(0);
+        // Wherever it lands (already-imprinted when fresh, eligible when the
+        // sidecar drifted), it is never refused as unidentified.
+        expect(result.counts.alreadyImprinted + result.counts.eligible).toBe(1);
+    });
+});

--- a/electron/main/services/imprintMods.ts
+++ b/electron/main/services/imprintMods.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { join, dirname } from 'path';
-import os, { tmpdir } from 'os';
+import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
 import { scanMods, runExclusiveModMutation, type Mod } from './mods';
@@ -33,6 +33,7 @@ import {
     type ReconstructedMergeManifest,
 } from './modinfoFormat';
 import { runVpkmerge, embedMergeIdentity, buildPortableForMergeSources } from './modMerger';
+import { DEFAULT_WORKER_CONCURRENCY } from './workers';
 import { encodeShareCode } from './portableProfile';
 import {
     evaluateEmbedStaleness,
@@ -369,7 +370,11 @@ export function hasAnyImprint(vpkPath: string): boolean {
  *    on. Files that already carry a valid embed are exempt: their canonical
  *    identity is the embedded original, and the live bytes legitimately differ.
  */
-async function checkImprintAnomaly(mod: Mod): Promise<ImprintAnomalousMod['reason'] | null> {
+async function checkImprintAnomaly(
+    mod: Mod,
+    opts: { checkHashDrift?: boolean } = {}
+): Promise<ImprintAnomalousMod['reason'] | null> {
+    const { checkHashDrift = true } = opts;
     // Zero-byte / truncated file.
     try {
         const st = await fs.stat(mod.path);
@@ -415,8 +420,10 @@ async function checkImprintAnomaly(mod: Mod): Promise<ImprintAnomalousMod['reaso
 
     // Non-embedded file: the live whole-file hash must still match the stored
     // canonical identity. Drift means the bytes changed out of band; refuse and
-    // report, but NEVER re-record (KEYSTONE).
-    if (meta?.sha256 && SHA256_RE.test(meta.sha256)) {
+    // report, but NEVER re-record (KEYSTONE). The whole-file read is the only
+    // expensive check here, so read-only callers (preflight) opt out and the
+    // refusal happens at write time in the bulk run instead.
+    if (checkHashDrift && meta?.sha256 && SHA256_RE.test(meta.sha256)) {
         try {
             const live = await computeOriginalIdentity(mod.path, { includeCrc: false });
             if (live.sha256 !== meta.sha256.toLowerCase()) return 'hash-drift';
@@ -734,7 +741,7 @@ export async function imprintAllInstalled(
         // read-then-write of shared state. Each worker pulls the next candidate via a
         // synchronous index bump (nextIndex++). `done` is incremented once per mod as
         // it COMPLETES (all classifications land there), keeping done/total monotonic.
-        const poolSize = Math.min(8, Math.max(1, os.cpus().length));
+        const poolSize = DEFAULT_WORKER_CONCURRENCY;
         let nextIndex = 0;
 
         const processOne = (mod: Mod): Promise<void> => {
@@ -975,7 +982,13 @@ export async function imprintPreflight(deadlockPath: string): Promise<ImprintPre
             }
 
             // 4. Anomaly guard (skip + report, never re-stamp: KEYSTONE).
-            const anomaly = await checkImprintAnomaly(mod);
+            //    checkHashDrift: false keeps the modal-open path free of
+            //    whole-file reads (preflight runs inside the exclusive
+            //    mutation lock, so every other mutation queues behind it). A
+            //    hash-drifted file therefore previews as eligible and is
+            //    refused at write time by the bulk run's own guard, landing
+            //    in failed[] with the same localized 'hash-drift' reason.
+            const anomaly = await checkImprintAnomaly(mod, { checkHashDrift: false });
             if (anomaly) {
                 result.counts.anomalous++;
                 result.anomalous.push({ fileName: mod.fileName, modName, reason: anomaly });

--- a/electron/main/services/imprintMods.ts
+++ b/electron/main/services/imprintMods.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
-import { join, dirname } from 'path';
-import { tmpdir } from 'os';
+import { dirname } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
 import { scanMods, runExclusiveModMutation, type Mod } from './mods';
@@ -10,20 +9,16 @@ import {
     carryForwardOriginalIdentity,
     type OriginalIdentity,
 } from './vpkIdentity';
-import { parseVpkDirectoryCached, parseVpkEntryStats, findChunkSiblingNames } from './vpk';
+import { parseVpkDirectoryCached, findChunkSiblingNames } from './vpk';
 import {
     computeOriginalIdentity,
     serializeAddonInfo,
     serializeModinfo,
     readEmbeddedModinfo,
     readLegacyGrimoireMergeMeta,
-    findImprintRepackMismatch,
     hasLegacyGrimoireMergeMetaEntry,
     reconstructMergedModInfoFromEmbed,
     reconstructMergedModInfoFromLegacy,
-    ADDONINFO_ENTRY,
-    MODINFO_ENTRY,
-    LEGACY_GRIMOIRE_META_ENTRY,
     MODINFO_FORMAT,
     MODINFO_GAME,
     MODINFO_SCHEMA_VERSION,
@@ -32,7 +27,7 @@ import {
     type ModinfoMergeSource,
     type ReconstructedMergeManifest,
 } from './modinfoFormat';
-import { runVpkmerge, embedMergeIdentity, buildPortableForMergeSources } from './modMerger';
+import { embedMergeIdentity, buildPortableForMergeSources, repackWithEmbeddedEntries } from './modMerger';
 import { DEFAULT_WORKER_CONCURRENCY } from './workers';
 import { encodeShareCode } from './portableProfile';
 import {
@@ -436,75 +431,6 @@ async function checkImprintAnomaly(
 }
 
 /**
- * Re-pack `modPath` in place with BOTH imprint entries (`addoninfo.txt` +
- * `modinfo.json`) embedded at its root in one pass, then atomically swap it
- * over the original. Uses the single-input `vpkmerge metadata` subcommand
- * (which preserves every existing entry and refuses output == input); no typed
- * --title/--author is passed, so Grimoire's own serialized blobs ride in
- * purely via the two --extra-file args. The temp output is a dotfile in the
- * mod's OWN folder (a non-`_dir.vpk` name, so it is neither scanned as a mod
- * nor counted as a slot) so the rename stays on one volume; on any failure the
- * original VPK is left untouched.
- *
- * Before the swap the repacked output must pass a real parity check against
- * the input's entry tree (findImprintRepackMismatch): every carried entry
- * present with an unchanged logical size (except an expected `--drop-entry`
- * removal), nothing added beyond the two imprint entries. A magic-bytes check
- * alone (verifyVpkOutput) would accept a structurally valid VPK that silently
- * dropped or corrupted game content. Any mismatch throws (landing in the
- * caller's fail-soft per-mod handling) and the original VPK keeps its slot.
- *
- * A single-mod imprint record fully supersedes the old grimoire-branded merge
- * companion (kind:"mod" never had one to begin with, but a file that started
- * life as a legacy MERGE and is being handled as a plain mod here should not
- * happen post-never-flatten; the check is defensive residue cleanup either
- * way): when the input still carries a legacy grimoire_meta.json entry, it is
- * passed to vpkmerge's `--drop-entry` so the residue is retired in the same
- * repack that writes its replacement.
- */
-async function embedImprintInPlace(modPath: string, addonText: string, modinfoText: string): Promise<void> {
-    const inputEntries = parseVpkEntryStats(modPath);
-    if (!inputEntries) {
-        throw new Error('Cannot verify the repack: the input VPK entry tree is unreadable.');
-    }
-    const addonTmp = join(tmpdir(), `grimoire-imprint-addoninfo-${randomUUID()}.txt`);
-    const modinfoTmp = join(tmpdir(), `grimoire-imprint-modinfo-${randomUUID()}.json`);
-    const embedOut = join(dirname(modPath), `.imprint-embed-${randomUUID()}.vpk`);
-    const droppedEntries = hasLegacyGrimoireMergeMetaEntry(modPath) ? [LEGACY_GRIMOIRE_META_ENTRY] : [];
-    try {
-        await fs.writeFile(addonTmp, addonText);
-        await fs.writeFile(modinfoTmp, modinfoText);
-        await runVpkmerge([
-            'metadata',
-            '--vpk',
-            modPath,
-            '--output',
-            embedOut,
-            '--extra-file',
-            `${ADDONINFO_ENTRY}=${addonTmp}`,
-            '--extra-file',
-            `${MODINFO_ENTRY}=${modinfoTmp}`,
-            ...droppedEntries.flatMap((entry) => ['--drop-entry', entry]),
-        ]);
-        const outputEntries = parseVpkEntryStats(embedOut);
-        if (!outputEntries) {
-            throw new Error('Imprint repack produced an unreadable VPK; the original was left untouched.');
-        }
-        const mismatch = findImprintRepackMismatch(inputEntries, outputEntries, droppedEntries);
-        if (mismatch) {
-            throw new Error(`Imprint repack parity check failed: ${mismatch}. The original was left untouched.`);
-        }
-        await fs.rename(embedOut, modPath);
-    } catch (err) {
-        try { await fs.unlink(embedOut); } catch { /* ignore partial-output cleanup */ }
-        throw err;
-    } finally {
-        try { await fs.unlink(addonTmp); } catch { /* best-effort temp cleanup */ }
-        try { await fs.unlink(modinfoTmp); } catch { /* best-effort temp cleanup */ }
-    }
-}
-
-/**
  * Imprint one mod in place (the shared core; caller already holds the mutation lock
  * and has verified the mod is not loaded). Carries an existing embed's original
  * hash forward when present (current keys or the legacy shim), else computes it
@@ -533,7 +459,7 @@ async function imprintModCore(mod: Mod): Promise<void> {
     const modinfoText = serializeModinfo(
         buildModinfoRecord(mod, meta, original, writtenAt, firstImprintedAt)
     );
-    await embedImprintInPlace(mod.path, addonText, modinfoText);
+    await repackWithEmbeddedEntries(mod.path, addonText, modinfoText);
     const hasValidStoredHash = !!meta?.sha256 && SHA256_RE.test(meta.sha256);
     setModMetadata(mod.metaKey, {
         imprinted: true,
@@ -733,7 +659,7 @@ export async function imprintAllInstalled(
         let done = 0;
 
         // Bounded worker pool: the dominant per-mod cost is the vpkmerge repack
-        // subprocess in embedImprintInPlace, so overlapping several across cores
+        // subprocess in repackWithEmbeddedEntries, so overlapping several across cores
         // shrinks a bulk run wall-clock. The per-mod work is fully independent, and
         // JS is single-threaded: every shared-state mutation below (result.*, the
         // `done` counter + its onProgress emit, setModMetadata inside imprintModCore)

--- a/electron/main/services/imprintMods.ts
+++ b/electron/main/services/imprintMods.ts
@@ -358,6 +358,10 @@ export function hasAnyImprint(vpkPath: string): boolean {
  *  - 'foreign-embed': carries an addoninfo.txt but no recoverable original
  *    identity, current keys or legacy shim (a non-Grimoire addon block, or one
  *    written by an incompatible tool).
+ *  - 'unidentified': a NON-embedded file with no metadata row at all. The
+ *    repack would permanently change the live size/CRC the GameBanana archive
+ *    matchers key on, with nothing in the embed to compensate; refuse so the
+ *    file stays identifiable (identify first, imprint after).
  *  - 'hash-drift': a NON-embedded file whose live whole-file hash no longer
  *    matches the stored canonical metadata.sha256 (someone edited the bytes out
  *    of band). We report it and refuse; we do NOT re-record the drifted hash,
@@ -401,10 +405,17 @@ async function checkImprintAnomaly(mod: Mod): Promise<ImprintAnomalousMod['reaso
         return null;
     }
 
+    // Non-embedded file with no metadata row: never identified. The repack
+    // permanently changes the live size/CRC the GameBanana archive matchers
+    // key on, and with no GameBanana source to write into the embed, the file
+    // could never be identified again, offline or online. Refuse: identify
+    // first (Fix Unknown / Link), imprint after.
+    const meta = getModMetadata(mod.metaKey);
+    if (!meta) return 'unidentified';
+
     // Non-embedded file: the live whole-file hash must still match the stored
     // canonical identity. Drift means the bytes changed out of band; refuse and
     // report, but NEVER re-record (KEYSTONE).
-    const meta = getModMetadata(mod.metaKey);
     if (meta?.sha256 && SHA256_RE.test(meta.sha256)) {
         try {
             const live = await computeOriginalIdentity(mod.path, { includeCrc: false });

--- a/electron/main/services/mergeEmbedParity.test.ts
+++ b/electron/main/services/mergeEmbedParity.test.ts
@@ -10,9 +10,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 
 const fsMocks = vi.hoisted(() => ({
-    writeFile: vi.fn(async () => undefined),
-    rename: vi.fn(async () => undefined),
-    unlink: vi.fn(async () => undefined),
+    writeFile: vi.fn(async (..._args: unknown[]) => undefined),
+    rename: vi.fn(async (..._args: unknown[]) => undefined),
+    unlink: vi.fn(async (..._args: unknown[]) => undefined),
 }));
 vi.mock('fs', () => ({
     promises: fsMocks,

--- a/electron/main/services/mergeEmbedParity.test.ts
+++ b/electron/main/services/mergeEmbedParity.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Coverage for the unified embed writer: embedMergeIdentity now routes
+ * through repackWithEmbeddedEntries, so the merge embed pass gains the same
+ * repack parity check the single-mod imprint always had. A parity mismatch
+ * must reject, unlink the temp output, and never rename over the original; a
+ * clean parity must atomically rename the temp output into place. vpkmerge
+ * itself is stubbed at the child_process boundary.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+const fsMocks = vi.hoisted(() => ({
+    writeFile: vi.fn(async () => undefined),
+    rename: vi.fn(async () => undefined),
+    unlink: vi.fn(async () => undefined),
+}));
+vi.mock('fs', () => ({
+    promises: fsMocks,
+    existsSync: vi.fn(() => true),
+}));
+
+vi.mock('child_process', () => ({
+    spawn: vi.fn(() => {
+        const proc = new EventEmitter() as EventEmitter & {
+            stdout: EventEmitter;
+            stderr: EventEmitter;
+            kill: () => void;
+            killed: boolean;
+        };
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = () => undefined;
+        proc.killed = false;
+        setImmediate(() => proc.emit('close', 0));
+        return proc;
+    }),
+}));
+
+vi.mock('electron', () => ({
+    app: {
+        getVersion: () => '0.0.0-test',
+        getAppPath: () => '/fake/app',
+        isPackaged: false,
+    },
+}));
+vi.mock('./deadlock', () => ({ metaKeyFor: vi.fn((p: string) => p) }));
+vi.mock('./settings', () => ({ loadSettings: vi.fn(() => ({})) }));
+vi.mock('./mods', () => ({
+    scanMods: vi.fn(),
+    disableModUnlocked: vi.fn(),
+    enableModUnlocked: vi.fn(),
+    allocateEnabledVpkPath: vi.fn(),
+    runExclusiveModMutation: vi.fn(),
+}));
+vi.mock('./metadata', () => ({
+    getModMetadata: vi.fn(),
+    setModMetadata: vi.fn(),
+    removeModMetadata: vi.fn(),
+}));
+vi.mock('./vpkIdentity', () => ({ resolveVpkIdentity: vi.fn() }));
+
+const { parseVpkEntryStats } = vi.hoisted(() => ({
+    parseVpkEntryStats: vi.fn<(path: string) => Array<{ path: string; size: number }> | null>(),
+}));
+vi.mock('./vpk', () => ({ parseVpkEntryStats }));
+
+const { findImprintRepackMismatch } = vi.hoisted(() => ({
+    findImprintRepackMismatch: vi.fn<(...args: unknown[]) => string | null>(),
+}));
+vi.mock('./modinfoFormat', () => ({
+    computeOriginalIdentity: vi.fn(),
+    serializeAddonInfo: vi.fn(() => 'addoninfo-text'),
+    serializeModinfo: vi.fn(() => 'modinfo-text'),
+    hasLegacyGrimoireMergeMetaEntry: vi.fn(() => false),
+    findImprintRepackMismatch,
+    ADDONINFO_ENTRY: 'addoninfo.txt',
+    MODINFO_ENTRY: 'modinfo.json',
+    LEGACY_GRIMOIRE_META_ENTRY: 'grimoire_meta.json',
+    MODINFO_FORMAT: 'vpk-modinfo',
+    MODINFO_GAME: { name: 'Deadlock', steamAppId: 1422450, gameBananaGameId: 20948 },
+    MODINFO_SCHEMA_VERSION: 1,
+}));
+vi.mock('./gameSessionMods', () => ({
+    assertCanMoveLoadedGameMod: vi.fn(),
+    assertCanMoveLoadedGameMods: vi.fn(),
+    syncRunningGameModSnapshotFromMods: vi.fn(),
+}));
+
+import { embedMergeIdentity } from './modMerger';
+
+const MERGED_PATH = '/fake/addons/pak09_dir.vpk';
+const ORIGINAL = { sha256: 'a'.repeat(64), size: 1234, crc32: 'deadbeef' };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    parseVpkEntryStats.mockReturnValue([{ path: 'materials/foo.txt', size: 10 }]);
+});
+
+describe('embedMergeIdentity repack parity', () => {
+    it('renames the verified temp output over the merged VPK on clean parity', async () => {
+        findImprintRepackMismatch.mockReturnValue(null);
+
+        await embedMergeIdentity(MERGED_PATH, 'My Merge', '2026-01-01T00:00:00.000Z', ORIGINAL, []);
+
+        expect(findImprintRepackMismatch).toHaveBeenCalledTimes(1);
+        expect(fsMocks.rename).toHaveBeenCalledTimes(1);
+        const [from, to] = fsMocks.rename.mock.calls[0] as unknown as [string, string];
+        expect(from).toMatch(/\.imprint-embed-.*\.vpk$/);
+        expect(to).toBe(MERGED_PATH);
+    });
+
+    it('rejects, unlinks the temp output, and never renames on a parity mismatch', async () => {
+        findImprintRepackMismatch.mockReturnValue('materials/foo.txt missing from output');
+
+        await expect(
+            embedMergeIdentity(MERGED_PATH, 'My Merge', '2026-01-01T00:00:00.000Z', ORIGINAL, [])
+        ).rejects.toThrow(/parity check failed/);
+
+        expect(fsMocks.rename).not.toHaveBeenCalled();
+        const unlinked = fsMocks.unlink.mock.calls.map((c) => c[0] as unknown as string);
+        expect(unlinked.some((p) => /\.imprint-embed-.*\.vpk$/.test(p))).toBe(true);
+    });
+
+    it('rejects without renaming when the repacked output is unreadable', async () => {
+        parseVpkEntryStats
+            .mockReturnValueOnce([{ path: 'materials/foo.txt', size: 10 }])
+            .mockReturnValueOnce(null);
+
+        await expect(
+            embedMergeIdentity(MERGED_PATH, 'My Merge', '2026-01-01T00:00:00.000Z', ORIGINAL, [])
+        ).rejects.toThrow(/unreadable/);
+
+        expect(fsMocks.rename).not.toHaveBeenCalled();
+    });
+});

--- a/electron/main/services/mergePortableHints.test.ts
+++ b/electron/main/services/mergePortableHints.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Coverage for the merge share-code hint payload: an NSFW source inside a
+ * shared merge must carry hint.nsfw (ImportProfileDialog's skip filter and
+ * thumbnail blur key off it), along with the category/fileLabel/
+ * originalFileName/isArchived hints a plain export carries. Bare snapshots
+ * (the DB-wipe reconstruction path) still project without the extras. Every
+ * heavy modMerger dependency is stubbed inert; portableProfile stays REAL
+ * (encodeShareCode is pure and unused here).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test' } }));
+vi.mock('./deadlock', () => ({ metaKeyFor: vi.fn((p: string) => p) }));
+vi.mock('./settings', () => ({ loadSettings: vi.fn(() => ({})) }));
+vi.mock('./mods', () => ({
+    scanMods: vi.fn(),
+    disableModUnlocked: vi.fn(),
+    enableModUnlocked: vi.fn(),
+    allocateEnabledVpkPath: vi.fn(),
+    runExclusiveModMutation: vi.fn(),
+}));
+vi.mock('./metadata', () => ({
+    getModMetadata: vi.fn(),
+    setModMetadata: vi.fn(),
+    removeModMetadata: vi.fn(),
+}));
+vi.mock('./vpkIdentity', () => ({ resolveVpkIdentity: vi.fn() }));
+vi.mock('./modinfoFormat', () => ({
+    computeOriginalIdentity: vi.fn(),
+    serializeAddonInfo: vi.fn(),
+    serializeModinfo: vi.fn(),
+    hasLegacyGrimoireMergeMetaEntry: vi.fn(),
+    findImprintRepackMismatch: vi.fn(),
+    ADDONINFO_ENTRY: 'addoninfo.txt',
+    MODINFO_ENTRY: 'modinfo.json',
+    LEGACY_GRIMOIRE_META_ENTRY: 'grimoire_meta.json',
+    MODINFO_FORMAT: 'vpk-modinfo',
+    MODINFO_GAME: { name: 'Deadlock', steamAppId: 1422450, gameBananaGameId: 20948 },
+    MODINFO_SCHEMA_VERSION: 1,
+}));
+vi.mock('./gameSessionMods', () => ({
+    assertCanMoveLoadedGameMod: vi.fn(),
+    assertCanMoveLoadedGameMods: vi.fn(),
+    syncRunningGameModSnapshotFromMods: vi.fn(),
+}));
+vi.mock('./vpk', () => ({
+    parseVpkDirectory: vi.fn(),
+    parseVpkDirectoryCached: vi.fn(),
+    parseVpkEntryStats: vi.fn(),
+}));
+
+import { buildPortableForMergeSources, type PortableMergeSourceEntry } from './modMerger';
+
+const BASE: PortableMergeSourceEntry = {
+    fileName: 'pak05_dir.vpk',
+    modName: 'Spicy Skin',
+    gameBananaId: 4242,
+    gameBananaFileId: 9001,
+    section: 'Mod',
+    enabledAtMergeTime: true,
+    priorityAtMergeTime: 5,
+};
+
+describe('buildPortableForMergeSources', () => {
+    it('carries the full hint fields when the entry is enriched', () => {
+        const portable = buildPortableForMergeSources(
+            [
+                {
+                    ...BASE,
+                    thumbnailUrl: 'https://images.example/thumb.jpg',
+                    nsfw: true,
+                    categoryName: 'Vindicta',
+                    fileLabel: 'gold variant',
+                    originalFileName: 'spicy_skin.zip',
+                    isArchived: true,
+                },
+            ],
+            'My Merge'
+        );
+
+        expect(portable.mods).toHaveLength(1);
+        expect(portable.mods[0].hint).toEqual({
+            name: 'Spicy Skin',
+            category: 'Vindicta',
+            fileLabel: 'gold variant',
+            originalFileName: 'spicy_skin.zip',
+            thumbnailUrl: 'https://images.example/thumb.jpg',
+            nsfw: true,
+            isArchived: true,
+        });
+    });
+
+    it('projects a bare snapshot (DB-wipe reconstruction) with the extras simply absent', () => {
+        const portable = buildPortableForMergeSources([BASE], 'My Merge');
+
+        expect(portable.mods).toHaveLength(1);
+        expect(portable.mods[0].ref).toEqual({ submissionId: 4242, fileId: 9001, section: 'Mod' });
+        expect(portable.mods[0].hint?.name).toBe('Spicy Skin');
+        expect(portable.mods[0].hint?.nsfw).toBeUndefined();
+    });
+
+    it('still omits local sources (no GameBanana ref)', () => {
+        const portable = buildPortableForMergeSources(
+            [{ ...BASE, gameBananaId: undefined, gameBananaFileId: undefined }],
+            'My Merge'
+        );
+        expect(portable.mods).toHaveLength(0);
+    });
+});

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -636,7 +636,7 @@ async function mergeModsLocked(
 }
 
 function buildPortableForSources(sources: Mod[], profileName: string): PortableProfile {
-    const entries: MergedModSource[] = sources.map((src) => {
+    const entries: PortableMergeSourceEntry[] = sources.map((src) => {
         const meta = getModMetadata(src.metaKey);
         return {
             fileName: src.fileName,
@@ -647,24 +647,48 @@ function buildPortableForSources(sources: Mod[], profileName: string): PortableP
             section: meta?.sourceSection,
             enabledAtMergeTime: true,
             priorityAtMergeTime: src.priority,
+            // Hint extras the snapshot shape cannot carry: the merge-time
+            // caller has full metadata, so the share code keeps the same hint
+            // a plain (non-merge) export would. nsfw in particular drives the
+            // import dialog's skip filter and thumbnail blur.
+            nsfw: meta?.nsfw,
+            categoryName: meta?.categoryName,
+            fileLabel: meta?.variantLabel || meta?.fileDescription || meta?.sourceFileName,
+            originalFileName: meta?.sourceFileName,
+            isArchived: meta?.isArchived,
         };
     });
     return buildPortableForMergeSources(entries, profileName);
 }
 
 /**
+ * A merge-source snapshot, optionally enriched with the hint-only fields a
+ * live metadata lookup can supply (nsfw / category / file labels). The
+ * snapshot shape itself stays lean: these extras exist only to round-trip
+ * into PortableModHint when the caller has them.
+ */
+export type PortableMergeSourceEntry = MergedModSource & {
+    nsfw?: boolean;
+    categoryName?: string;
+    fileLabel?: string;
+    originalFileName?: string;
+    isArchived?: boolean;
+};
+
+/**
  * Build a portable profile (the unmerge-fallback share code payload) straight
  * from a merge's own source snapshots, with no live Mod/metadata lookup. Pure
- * projection of MergedModSource -> PortableModEntry: every field this reads
- * already lives on the snapshot, which is what lets it double as the DB-wipe
+ * projection of the snapshot -> PortableModEntry: every field this reads
+ * already lives on the entry, which is what lets it double as the DB-wipe
  * reconstruction path (see reconstructMergedModInfo/imprintMods.ts) where the
  * sources come from an embedded modinfo.json or legacy grimoire_meta.json
- * record, not a live scan. Local sources (no GameBanana id) are omitted, same
- * as buildPortableForSources: the share code is best-effort, not authoritative
+ * record, not a live scan (those bare snapshots simply omit the hint extras).
+ * Local sources (no GameBanana id) are omitted, same as
+ * buildPortableForSources: the share code is best-effort, not authoritative
  * (the merge's own metadata.merged manifest is authoritative for unmerge).
  */
 export function buildPortableForMergeSources(
-    sources: MergedModSource[],
+    sources: PortableMergeSourceEntry[],
     profileName: string
 ): PortableProfile {
     const mods: PortableModEntry[] = [];
@@ -681,7 +705,12 @@ export function buildPortableForMergeSources(
             priority: src.priorityAtMergeTime,
             hint: {
                 name: src.modName,
+                category: src.categoryName,
+                fileLabel: src.fileLabel,
+                originalFileName: src.originalFileName,
                 thumbnailUrl: src.thumbnailUrl,
+                nsfw: src.nsfw,
+                isArchived: src.isArchived,
             },
         });
     }

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -16,11 +16,13 @@ import {
 } from './mods';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
 import { resolveVpkIdentity, type OriginalIdentity } from './vpkIdentity';
+import { parseVpkEntryStats } from './vpk';
 import {
     computeOriginalIdentity,
     serializeAddonInfo,
     serializeModinfo,
     hasLegacyGrimoireMergeMetaEntry,
+    findImprintRepackMismatch,
     ADDONINFO_ENTRY,
     MODINFO_ENTRY,
     LEGACY_GRIMOIRE_META_ENTRY,
@@ -312,47 +314,80 @@ export async function embedMergeIdentity(
         sources,
     };
     const metaText = serializeModinfo(record);
+    await repackWithEmbeddedEntries(mergedPath, addonText, metaText);
+}
 
-    const addonTmp = join(tmpdir(), `grimoire-addoninfo-${randomUUID()}.txt`);
-    const metaTmp = join(tmpdir(), `grimoire-modinfo-${randomUUID()}.json`);
-    // Build the embed output as a dotfile in the merged mod's OWN folder (a
-    // non-`_dir.vpk` name, so it is neither scanned as a mod nor counted as a
-    // slot), then swap it over the original. Same-folder keeps the rename on one
-    // volume (no cross-device EXDEV), exactly like extractMergeSource's rebuild.
-    const embedOut = join(dirname(mergedPath), `.merge-embed-${randomUUID()}.vpk`);
-
+/**
+ * Re-pack `vpkPath` in place with BOTH imprint entries (`addoninfo.txt` +
+ * `modinfo.json`) embedded at its root in one `vpkmerge metadata` pass, then
+ * atomically swap it over the original. The single shared embed writer: the
+ * merge pass (embedMergeIdentity above) and the single-mod imprint
+ * (imprintMods.ts) both go through here, so the parity check and the legacy
+ * residue retirement cannot drift between them.
+ *
+ * The temp output is a dotfile in the VPK's OWN folder (a non-`_dir.vpk`
+ * name, so it is neither scanned as a mod nor counted as a slot), keeping the
+ * rename on one volume; on any failure the original VPK is left untouched.
+ *
+ * Before the swap the repacked output must pass a real parity check against
+ * the input's entry tree (findImprintRepackMismatch): every carried entry
+ * present with an unchanged logical size (except an expected `--drop-entry`
+ * removal), nothing added beyond the two imprint entries. A magic-bytes check
+ * alone (verifyVpkOutput) would accept a structurally valid VPK that silently
+ * dropped or corrupted game content. Any mismatch throws (landing in the
+ * caller's fail-soft handling) and the original VPK keeps its slot.
+ *
+ * When the input still carries a legacy grimoire_meta.json companion, it is
+ * passed to vpkmerge's `--drop-entry` so the residue is retired in the same
+ * repack that writes its replacement (the new record fully supersedes it).
+ */
+export async function repackWithEmbeddedEntries(
+    vpkPath: string,
+    addonText: string,
+    modinfoText: string
+): Promise<void> {
+    const inputEntries = parseVpkEntryStats(vpkPath);
+    if (!inputEntries) {
+        throw new Error('Cannot verify the repack: the input VPK entry tree is unreadable.');
+    }
+    const addonTmp = join(tmpdir(), `grimoire-imprint-addoninfo-${randomUUID()}.txt`);
+    const modinfoTmp = join(tmpdir(), `grimoire-imprint-modinfo-${randomUUID()}.json`);
+    const embedOut = join(dirname(vpkPath), `.imprint-embed-${randomUUID()}.vpk`);
+    const droppedEntries = hasLegacyGrimoireMergeMetaEntry(vpkPath) ? [LEGACY_GRIMOIRE_META_ENTRY] : [];
     try {
         await fs.writeFile(addonTmp, addonText);
-        await fs.writeFile(metaTmp, metaText);
-        // The new merge record lives entirely in modinfo.json, so a legacy
-        // grimoire_meta.json companion (pre-redo files) is superseded, not
-        // merely shadowed: drop it in the same repack rather than leaving
-        // residue an old reader might still trust.
-        const dropLegacyMeta = hasLegacyGrimoireMergeMetaEntry(mergedPath);
+        await fs.writeFile(modinfoTmp, modinfoText);
         await runVpkmerge([
             'metadata',
             '--vpk',
-            mergedPath,
+            vpkPath,
             '--output',
             embedOut,
             '--extra-file',
             `${ADDONINFO_ENTRY}=${addonTmp}`,
             '--extra-file',
-            `${MODINFO_ENTRY}=${metaTmp}`,
-            ...(dropLegacyMeta ? ['--drop-entry', LEGACY_GRIMOIRE_META_ENTRY] : []),
+            `${MODINFO_ENTRY}=${modinfoTmp}`,
+            ...droppedEntries.flatMap((entry) => ['--drop-entry', entry]),
         ]);
-        await verifyVpkOutput(embedOut);
+        const outputEntries = parseVpkEntryStats(embedOut);
+        if (!outputEntries) {
+            throw new Error('Imprint repack produced an unreadable VPK; the original was left untouched.');
+        }
+        const mismatch = findImprintRepackMismatch(inputEntries, outputEntries, droppedEntries);
+        if (mismatch) {
+            throw new Error(`Imprint repack parity check failed: ${mismatch}. The original was left untouched.`);
+        }
         // Atomic replace (rename over the existing file, the metadata.ts write
         // idiom): either the embedded VPK fully takes the slot or, if the rename
-        // fails, the original un-embedded merged VPK is left untouched. Avoids a
-        // window where the merged slot is missing on disk.
-        await fs.rename(embedOut, mergedPath);
+        // fails, the original un-embedded VPK is left untouched. Avoids a
+        // window where the slot is missing on disk.
+        await fs.rename(embedOut, vpkPath);
     } catch (err) {
         try { await fs.unlink(embedOut); } catch { /* ignore partial-output cleanup */ }
         throw err;
     } finally {
         try { await fs.unlink(addonTmp); } catch { /* best-effort temp cleanup */ }
-        try { await fs.unlink(metaTmp); } catch { /* best-effort temp cleanup */ }
+        try { await fs.unlink(modinfoTmp); } catch { /* best-effort temp cleanup */ }
     }
 }
 

--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -8,7 +8,7 @@ import {
     type GameBananaModsResponse,
 } from './gamebanana';
 import { parseVpkDirectory, parseVpkDirectoryCached } from './vpk';
-import { resolveVpkIdentity } from './vpkIdentity';
+import { carryForwardOriginalIdentity, readEmbeddedAddonInfo } from './vpkIdentity';
 import { readEmbeddedModinfo } from './modinfoFormat';
 import { fingerprintFilesInWorkers, type FileFingerprintResult } from './workers';
 import {
@@ -296,11 +296,18 @@ async function detectFromEmbed(
     vpkPath: string,
     signal?: AbortSignal
 ): Promise<UnknownModFilterGuess | null> {
+    if (signal?.aborted) return null;
+    // Cheap presence probe: the cached directory parse detects an embed
+    // without reading the whole file. The same validity rule as
+    // resolveVpkIdentity's embed arm (a parseable addoninfo.txt carrying the
+    // original-identity anchor), but without its live fallback, which used to
+    // whole-file-hash every non-imprinted VPK here only for the result to be
+    // discarded.
     let embedded;
     try {
-        const identity = await resolveVpkIdentity(vpkPath, signal);
-        if (identity.source !== 'embed' || !identity.embedded) return null;
-        embedded = identity.embedded;
+        const parsed = readEmbeddedAddonInfo(vpkPath);
+        if (!parsed || !carryForwardOriginalIdentity(parsed)) return null;
+        embedded = parsed;
     } catch {
         return null;
     }
@@ -329,10 +336,39 @@ async function detectFromEmbed(
         };
     }
 
-    // A single tagged mod carrying its GameBanana submission id.
+    // A single tagged mod carrying its GameBanana submission id. Prefer the
+    // machine record (modinfo.json): GameBanana sections are separate id
+    // namespaces (Mod/<id> vs Sound/<id>), so section and file id must ride
+    // along or a Sound mod resolves against the wrong submission.
+    if (modinfo?.kind === 'mod' && modinfo.source?.gamebananaId) {
+        return {
+            ...base,
+            crcMatch: {
+                ...emptyCrcMatch('found'),
+                status: 'found',
+                provenance: 'embedded-metadata',
+                modId: modinfo.source.gamebananaId,
+                modName: modinfo.title ?? base.search ?? undefined,
+                fileId: modinfo.source.gamebananaFileId,
+                fileName,
+                section: modinfo.source.section === 'Sound' ? 'Sound' : 'Mod',
+                categoryName: modinfo.source.categoryName,
+                confidence: 'exact',
+                reason: 'Identified from embedded Grimoire metadata (no network).',
+            },
+        };
+    }
+
+    // Legacy fallback: pre-modinfo imprints carry only the addoninfo keys.
+    // The section is recoverable from the source URL's path (the inverse of
+    // gameBananaPageUrl's mapping); left undefined when not derivable.
     if (embedded.gamebananaId) {
         const gbId = Number(embedded.gamebananaId);
         if (Number.isFinite(gbId) && gbId > 0) {
+            const legacyFileId = Number(embedded.gamebananaFileId);
+            let section: 'Mod' | 'Sound' | undefined;
+            if (embedded.sourceUrl?.includes('/sounds/')) section = 'Sound';
+            else if (embedded.sourceUrl?.includes('/mods/')) section = 'Mod';
             return {
                 ...base,
                 crcMatch: {
@@ -341,7 +377,12 @@ async function detectFromEmbed(
                     provenance: 'embedded-metadata',
                     modId: gbId,
                     modName: embedded.title ?? base.search ?? undefined,
+                    fileId:
+                        Number.isFinite(legacyFileId) && legacyFileId > 0
+                            ? legacyFileId
+                            : undefined,
                     fileName,
+                    section,
                     confidence: 'exact',
                     reason: 'Identified from embedded Grimoire metadata (no network).',
                 },

--- a/electron/main/services/unknownModEmbedDetect.test.ts
+++ b/electron/main/services/unknownModEmbedDetect.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Coverage for detectFromEmbed (via detectUnknownModCacheMatches): the embed
+ * consult must carry the GameBanana section and file id through (sections are
+ * separate id namespaces, so a Sound mod without them resolves against the
+ * wrong submission), must probe embeds cheaply (no whole-file hashing), and
+ * must route only embed-less inputs into the worker fingerprint pass. Every
+ * fs/electron/network dependency is stubbed inert, same pattern as
+ * imprintAdoption.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ModinfoRecord } from '../../../src/types/modinfo';
+import type { ParsedAddonInfo } from './vpkIdentity';
+
+vi.mock('./archiveCrc', () => ({
+    crc32File: vi.fn(),
+    fetchGameBananaArchiveVpkCrcEntries: vi.fn(),
+}));
+vi.mock('./gamebanana', () => ({
+    fetchModsFilesMetadata: vi.fn(),
+    fetchSubmissions: vi.fn(),
+}));
+vi.mock('./vpk', () => ({
+    parseVpkDirectory: vi.fn(() => []),
+    parseVpkDirectoryCached: vi.fn(() => []),
+}));
+
+const { readEmbeddedAddonInfo, carryForwardOriginalIdentity } = vi.hoisted(() => ({
+    readEmbeddedAddonInfo: vi.fn<(path: string) => ParsedAddonInfo | null>(),
+    carryForwardOriginalIdentity: vi.fn<(embed: unknown) => { sha256: string } | null>(),
+}));
+vi.mock('./vpkIdentity', () => ({
+    readEmbeddedAddonInfo,
+    carryForwardOriginalIdentity,
+}));
+
+const { readEmbeddedModinfo } = vi.hoisted(() => ({
+    readEmbeddedModinfo: vi.fn<(path: string) => ModinfoRecord | null>(),
+}));
+vi.mock('./modinfoFormat', () => ({ readEmbeddedModinfo }));
+
+const { fingerprintFilesInWorkers } = vi.hoisted(() => ({
+    fingerprintFilesInWorkers:
+        vi.fn<
+            (
+                files: Array<{ id: string; filePath: string }>,
+                opts?: unknown
+            ) => Promise<Array<{ id: string; crc32: string; size: number; error?: string }>>
+        >(),
+}));
+vi.mock('./workers', () => ({ fingerprintFilesInWorkers }));
+
+vi.mock('./unknownCrcCache', () => ({
+    getUnknownCrcEntryCount: vi.fn(() => 0),
+    getUnknownCrcFilesForMods: vi.fn(() => []),
+    lookupUnknownCrcMatch: vi.fn(() => null),
+    lookupUnknownCrcMatches: vi.fn(() => new Map()),
+    replaceUnknownCrcEntries: vi.fn(),
+    updateUnknownCrcFileStatus: vi.fn(),
+    upsertUnknownCrcFiles: vi.fn(),
+    UNKNOWN_CRC_PARSER_VERSION: 1,
+}));
+
+import { detectUnknownModCacheMatches } from './unknownModDetection';
+
+const IMPRINTED = 'C:/addons/pak01_dir.vpk';
+const PLAIN = 'C:/addons/pak02_dir.vpk';
+
+function addonInfo(overrides: Partial<ParsedAddonInfo> = {}): ParsedAddonInfo {
+    return {
+        originalSha256: 'a'.repeat(64),
+        gamebananaId: '4242',
+        title: 'Neon Vindicta',
+        raw: {},
+        ...overrides,
+    };
+}
+
+function modRecord(overrides: Partial<ModinfoRecord> = {}): ModinfoRecord {
+    return {
+        format: 'vpk-modinfo',
+        schemaVersion: 1,
+        kind: 'mod',
+        writtenBy: { tool: 'grimoire', version: '0.0.0-test' },
+        writtenAt: '2026-01-01T00:00:00.000Z',
+        firstImprintedAt: '2025-06-01T00:00:00.000Z',
+        game: { name: 'Deadlock', steamAppId: 1422450, gameBananaGameId: 20948 },
+        identity: { sha256: 'a'.repeat(64) },
+        title: 'Boom Melee',
+        author: 'someauthor',
+        source: {
+            gamebananaId: 4242,
+            gamebananaFileId: 9001,
+            section: 'Sound',
+            categoryId: 77,
+            categoryName: 'Hero Sounds',
+        },
+        packaging: { vpkIndex: 1 },
+        ...overrides,
+    } as ModinfoRecord;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    fingerprintFilesInWorkers.mockResolvedValue([]);
+});
+
+describe('detectUnknownModCacheMatches embed consult', () => {
+    it('carries section and file id from a kind:"mod" modinfo record (Sound namespace)', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(addonInfo());
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(modRecord());
+
+        const [result] = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        expect(result.crcMatch).toMatchObject({
+            status: 'found',
+            provenance: 'embedded-metadata',
+            modId: 4242,
+            modName: 'Boom Melee',
+            fileId: 9001,
+            section: 'Sound',
+            categoryName: 'Hero Sounds',
+        });
+    });
+
+    it('derives the Sound section and file id from legacy addoninfo keys', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(
+            addonInfo({
+                gamebananaId: '1234',
+                gamebananaFileId: '5678',
+                sourceUrl: 'https://gamebanana.com/sounds/1234',
+                title: 'Legacy Sound',
+            })
+        );
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(null);
+
+        const [result] = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        expect(result.crcMatch).toMatchObject({
+            status: 'found',
+            provenance: 'embedded-metadata',
+            modId: 1234,
+            fileId: 5678,
+            section: 'Sound',
+        });
+    });
+
+    it('leaves the section undefined when a legacy embed cannot say', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(
+            addonInfo({ gamebananaId: '1234', sourceUrl: undefined })
+        );
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(null);
+
+        const [result] = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        expect(result.crcMatch.status).toBe('found');
+        expect(result.crcMatch.section).toBeUndefined();
+        expect(result.crcMatch.fileId).toBeUndefined();
+    });
+
+    it('still reconstructs merge sources from a kind:"merge" record', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(addonInfo({ gamebananaId: undefined }));
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(
+            modRecord({
+                kind: 'merge',
+                title: 'My Merge',
+                source: undefined,
+                merge: { title: 'My Merge' },
+                sources: [
+                    {
+                        title: 'Mod A',
+                        gamebananaId: 11,
+                        gamebananaFileId: 22,
+                        section: 'Mod',
+                        fileNameAtMergeTime: 'a_dir.vpk',
+                    },
+                ],
+            } as Partial<ModinfoRecord>)
+        );
+
+        const [result] = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        expect(result.crcMatch).toMatchObject({
+            status: 'found',
+            provenance: 'embedded-merge',
+            modName: 'My Merge',
+        });
+        expect(result.crcMatch.mergeSources).toEqual([
+            {
+                modName: 'Mod A',
+                gameBananaId: 11,
+                gameBananaFileId: 22,
+                section: 'Mod',
+                fileName: 'a_dir.vpk',
+            },
+        ]);
+    });
+
+    it('never hashes an embed-carrying input and fingerprints only the rest', async () => {
+        readEmbeddedAddonInfo.mockImplementation((path) =>
+            path === IMPRINTED ? addonInfo() : null
+        );
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockImplementation((path) =>
+            path === IMPRINTED ? modRecord() : null
+        );
+        fingerprintFilesInWorkers.mockResolvedValue([{ id: 'm2', crc32: 'deadbeef', size: 100 }]);
+
+        const results = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+            { modId: 'm2', fileName: 'pak02_dir.vpk', vpkPath: PLAIN },
+        ]);
+
+        expect(results).toHaveLength(2);
+        // Only the embed-less input reaches the worker fingerprint pass; the
+        // imprinted one was answered by the cheap directory-parse probe.
+        expect(fingerprintFilesInWorkers).toHaveBeenCalledTimes(1);
+        expect(fingerprintFilesInWorkers.mock.calls[0][0]).toEqual([
+            { id: 'm2', filePath: PLAIN },
+        ]);
+    });
+
+    it('falls through to fingerprinting when the embed lacks an identity anchor', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(addonInfo());
+        carryForwardOriginalIdentity.mockReturnValue(null);
+        readEmbeddedModinfo.mockReturnValue(modRecord());
+
+        await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        expect(fingerprintFilesInWorkers).toHaveBeenCalledTimes(1);
+        expect(fingerprintFilesInWorkers.mock.calls[0][0]).toEqual([
+            { id: 'm1', filePath: IMPRINTED },
+        ]);
+    });
+});

--- a/electron/main/services/workers.ts
+++ b/electron/main/services/workers.ts
@@ -21,7 +21,11 @@ export interface FileFingerprintWorkerOptions {
     onResult?: (result: FileFingerprintResult) => void;
 }
 
-const DEFAULT_WORKER_CONCURRENCY = Math.max(1, Math.min(8, availableParallelism() - 1));
+/** House default for bounded per-file work pools (worker threads or
+ *  subprocess fan-out): cores minus one, capped at 8. Exported so callers
+ *  running their own pools (e.g. the bulk imprint's vpkmerge subprocesses)
+ *  share the same number instead of hardcoding a copy. */
+export const DEFAULT_WORKER_CONCURRENCY = Math.max(1, Math.min(8, availableParallelism() - 1));
 
 // Long-lived worker: waits for task messages and fingerprints one file per
 // message, so the pool reuses threads across a batch instead of paying worker

--- a/scripts/fetch-vpkmerge.mjs
+++ b/scripts/fetch-vpkmerge.mjs
@@ -16,12 +16,12 @@ import { fileURLToPath } from 'node:url';
 import { get as httpsGet } from 'node:https';
 import { pipeline } from 'node:stream/promises';
 
-const VPKMERGE_VERSION = 'v0.18.0';
+const VPKMERGE_VERSION = 'v0.19.0';
 
 const ASSETS = {
-    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'e77066c57f16c16727031856f3270288d531912db57e5983110a13c05eaceb28' },
-    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: 'b21e321a1dd5ab5686b4bbd3f232c2a669b6bbab3487a954d6f8daf43b87d348' },
-    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '0ef859ca889507e878fd701beb88dc24ac6e808285d9a9805a8d6847c3002377' },
+    'linux-x64':  { name: 'vpkmerge-linux-x86_64',      sha256: 'fc33ee3ea6ea551fb5866e0077effb725da16e935eab07c1a2a407f10028a92c' },
+    'darwin-arm64': { name: 'vpkmerge-macos-aarch64',    sha256: '418f650dd6afff9228d8fa9c289bb1a4a01488191bb54636b69aaca0c4f8be28' },
+    'win32-x64':  { name: 'vpkmerge-windows-x86_64.exe', sha256: '7c85e2e5830621e4a6cd4dea848cb23b57fa0272b87e044e59a571424e9d52d0' },
 };
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/src/lib/imprintPending.test.ts
+++ b/src/lib/imprintPending.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isImprintPending } from './imprintPending';
+
+describe('isImprintPending', () => {
+    it('counts a pre-feature merge (no embed, backfill skipped, both flags unset)', () => {
+        // The old merged-only predicate (m.merged ? m.imprintStale : ...)
+        // returned undefined here, hiding the toolbar button for a library
+        // whose only pending work is old merges.
+        expect(isImprintPending({ imprinted: undefined, imprintStale: undefined })).toBe(true);
+    });
+
+    it('does not count a freshly imprinted mod', () => {
+        expect(isImprintPending({ imprinted: true, imprintStale: false })).toBe(false);
+    });
+
+    it('counts a stale re-imprint', () => {
+        expect(isImprintPending({ imprinted: true, imprintStale: true })).toBe(true);
+    });
+
+    it('counts a plain never-imprinted mod', () => {
+        expect(isImprintPending({ imprinted: false, imprintStale: undefined })).toBe(true);
+    });
+
+    it('does not count an imprinted mod whose stale flag is simply unset', () => {
+        expect(isImprintPending({ imprinted: true, imprintStale: undefined })).toBe(false);
+    });
+});

--- a/src/lib/imprintPending.ts
+++ b/src/lib/imprintPending.ts
@@ -1,0 +1,16 @@
+import type { Mod } from '../types/mod';
+
+/**
+ * Whether a visible mod is plausible pending work for the bulk imprint: not
+ * yet imprinted, or carrying a stale embed (legacy format / sidecar drift).
+ *
+ * One uniform rule for merged and single mods. Merged mods used to require
+ * imprintStale === true, but a pre-feature merge has no embed at all, so the
+ * startup backfill skips it and the flag stays undefined: exactly the library
+ * where the toolbar button (the flow's only entry point) must show. The bulk
+ * run handles a never-imprinted merge fine (it routes through the merge
+ * refresh path), so "never imprinted" counts as pending for merges too.
+ */
+export function isImprintPending(mod: Pick<Mod, 'imprinted' | 'imprintStale'>): boolean {
+    return !mod.imprinted || !!mod.imprintStale;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -974,6 +974,7 @@
       "anomalyHashDrift": "File changed since it was recorded",
       "anomalyForeignEmbed": "Carries a non-Grimoire addon block",
       "anomalyOrphanMerge": "Merged mod record couldn't be recovered",
+      "anomalyUnidentified": "Not identified yet: link it to its source first",
       "empty": "Nothing to imprint.",
       "error": "Imprinting failed: {{error}}"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1121,10 +1121,7 @@
       "modIdTag": "Mod #{{id}}",
       "fileIdTag": "File #{{id}}",
       "viewMod": "View Mod",
-      "embeddedBadge": "Embedded metadata",
-      "embeddedMetadataBadge": "Identified via embedded Grimoire metadata",
       "embeddedMetadataDesc": "This VPK carries embedded Grimoire metadata identifying it. No network needed.",
-      "embeddedMergeBadge": "Grimoire merge (embedded metadata)",
       "embeddedMergeDesc_one": "This is a Grimoire merge of {{count}} mod, reconstructed from embedded metadata.",
       "embeddedMergeDesc_other": "This is a Grimoire merge of {{count}} mods, reconstructed from embedded metadata.",
       "linkInPlace": "Link in place"

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1958,
+  "totalKeys": 1959,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1958,
+      "translatedKeys": 1959,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1870,
-      "pct": 96
+      "pct": 95
     },
     {
       "code": "ru",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1959,
+  "totalKeys": 1956,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1959,
+      "translatedKeys": 1956,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1870,
-      "pct": 95
+      "pct": 96
     },
     {
       "code": "ru",

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -6211,6 +6211,7 @@ function UnknownEmbeddedCard({
       await onAssociate(mod, {
         gameBananaId: match.modId,
         modName: match.modName ?? mod.name,
+        gameBananaFileId: match.fileId,
         thumbnailUrl: match.thumbnailUrl,
         nsfw: match.nsfw,
         categoryName: match.categoryName,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -5758,6 +5758,7 @@ function ImprintModal({ state, onConfirm, onClose }: {
       case 'hash-drift': return t('installed.imprintAll.anomalyHashDrift');
       case 'foreign-embed': return t('installed.imprintAll.anomalyForeignEmbed');
       case 'orphan-merge': return t('installed.imprintAll.anomalyOrphanMerge');
+      case 'unidentified': return t('installed.imprintAll.anomalyUnidentified');
     }
   };
   // The bulk run reports anomalies as their raw reason tokens (they flow into
@@ -5765,7 +5766,8 @@ function ImprintModal({ state, onConfirm, onClose }: {
   // the result list reads the same as the preflight list.
   const isAnomalyReason = (reason: string): reason is ImprintAnomalousMod['reason'] =>
     reason === 'unparseable' || reason === 'empty' || reason === 'chunked' ||
-    reason === 'hash-drift' || reason === 'foreign-embed' || reason === 'orphan-merge';
+    reason === 'hash-drift' || reason === 'foreign-embed' || reason === 'orphan-merge' ||
+    reason === 'unidentified';
 
   let body: ReactNode;
   let footer: ReactNode;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -71,6 +71,7 @@ import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/comm
 import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
+import { isImprintPending } from '../lib/imprintPending';
 import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder, dmmMigrateScan, dmmMigrateExecute, imprintAllInstalled, onImprintAllInstalledProgress, imprintPreflight, readImprintDetails, peekImprint } from '../lib/api';
 import type { UnmergeModResult, ImprintAllInstalledResult, ImprintInstalledProgress, ImprintPreflightResult, ImprintDetails, PeekImprintResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
@@ -769,13 +770,14 @@ export default function Installed() {
   // Mods the bulk imprint could plausibly act on: visible (locker artifacts and
   // absorbed sources already excluded above) that are not yet imprinted OR
   // carry a stale embed (legacy format / sidecar drift, pending re-imprint).
-  // Merged mods count too: the bulk run refreshes stale merges. Drives the
-  // toolbar button's hide-when-done visibility. Deliberately optimistic:
+  // Merged mods count under the same uniform rule (see isImprintPending: a
+  // pre-feature merge has no embed and no flags, and IS pending work). Drives
+  // the toolbar button's hide-when-done visibility. Deliberately optimistic:
   // files the backend would classify as loaded or anomalous still count (they
   // need attention, so the entry point stays up); the preflight modal is the
   // source of truth for what actually happens.
   const pendingImprintCount = useMemo(
-    () => visibleMods.filter((m) => (m.merged ? m.imprintStale : !m.imprinted || m.imprintStale)).length,
+    () => visibleMods.filter(isImprintPending).length,
     [visibleMods]
   );
   // Layout = the user's structural choice (cards grid vs horizontal list).

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -877,7 +877,10 @@ export interface ImprintAnomalousMod {
   // entry, but the file's own embed/legacy companion is a merge whose source
   // list could not be read cleanly (NEVER FLATTEN: refused rather than
   // re-imprinted as a plain kind:"mod", which would destroy the source list).
-  reason: 'unparseable' | 'empty' | 'chunked' | 'hash-drift' | 'foreign-embed' | 'orphan-merge';
+  // 'unidentified': no metadata row and no embed. Repacking would permanently
+  // change the live size/CRC the GameBanana archive matchers key on, with no
+  // GameBanana source in the embed to compensate: identify first, imprint after.
+  reason: 'unparseable' | 'empty' | 'chunked' | 'hash-drift' | 'foreign-embed' | 'orphan-merge' | 'unidentified';
 }
 
 // Per-bucket counts from imprintPreflight. Every scanMods() candidate lands in


### PR DESCRIPTION
Post-merge fix pass for the review findings on #287, plus the vpkmerge pin bump the feature needs. Every behavioral fix landed with vitest coverage first (new suites: unknownModEmbedDetect, imprintEligibility, mergePortableHints, adoptedThumbnail, mergeEmbedParity, imprintPending).

## Pin
- vpkmerge pin bumped to v0.19.0 (published release carrying #40 plus its hardening pass Slush97/vpkmerge#41). The imprint repack shells out to the metadata subcommand's --extra-file/--drop-entry, which v0.18.0 does not have; the stale-residue retirement also depends on v0.19.0's ./x drop matching. Verified: fetch + hash check pass, and the exact repack invocation shape (two extra files + legacy drop) runs clean against the pinned binary.

## Fixes
1. **Bulk imprint no longer destroys CRC identifiability of never-identified VPKs**: a meta-less, embed-less file is refused with a new 'unidentified' anomaly reason (identify first, imprint after). Meta-less files that already carry a valid embed stay eligible.
2. **Merge share codes carry the full hint fields** (nsfw/category/fileLabel/originalFileName/isArchived), so NSFW mods inside shared merges blur and can be skipped on import again.
3. **Embed detection carries section + fileId** (GameBanana sections are separate id namespaces), so View on an imprinted Sound mod opens the right submission and Link-in-place persists sourceSection + gameBananaFileId.
4. **Toolbar imprint button shows for pre-feature merges** (uniform isImprintPending predicate; the old merged-only gate hid the button exactly when old merges were the pending work).
5. **Mid-session embed refresh** also consults hasAnyImprint(path), so a VPK dropped into addons mid-session gets its wrong embed corrected on associate instead of silently kept.
6. **Preflight does zero whole-file reads** (it runs inside the exclusive mutation lock); hash-drift refusal moves to write time in the bulk run with the same localized reason. Bulk pool uses the exported DEFAULT_WORKER_CONCURRENCY.
7. **Embed probe is the cached directory parse**, not resolveVpkIdentity, whose live fallback whole-file-hashed every non-imprinted unknown VPK just to discard the result.
8. **Adopted-thumbnail fetch verifies slot identity** (row exists, queue-time sha256, same submission) before writing, closing the recycled-pakNN cross-stamp.
9. **One embed writer** (repackWithEmbeddedEntries): the merge embed pass gains the repack parity check the single-mod imprint had.
10. **Three dead i18n keys removed** (embeddedBadge / embeddedMetadataBadge / embeddedMergeBadge), manifest regenerated.

Gate run locally: vitest 540 passing, typecheck, lint, i18n:check + manifest check, pnpm fetch-vpkmerge.