### PR TITLE
Quick wins from Discord feature requests

### DIFF
--- a/electron/main/ipc/stats.ts
+++ b/electron/main/ipc/stats.ts
@@ -322,6 +322,16 @@ ipcMain.handle('stats:syncPlayerData', async (_, accountId: number) => {
         results.errors.push(`Match history: ${err}`)
     }
 
+    // Refresh cached Steam persona name + avatar
+    try {
+        const profiles = await statsApi.getPlayerSteamProfiles([accountId])
+        if (profiles.length > 0) {
+            statsDb.updatePlayerProfile(profiles[0])
+        }
+    } catch (err) {
+        results.errors.push(`Profile: ${err}`)
+    }
+
     return results
 })
 

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import {
@@ -26,8 +26,14 @@ import {
   Link2,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
-import type { GameBananaModDetails, GameBananaComment, GameBananaFile, GameBananaModUpdate } from '../types/gamebanana';
-import { isModOutdated, formatDate } from '../types/gamebanana';
+import type {
+  GameBananaModDetails,
+  GameBananaComment,
+  GameBananaFile,
+  GameBananaModUpdate,
+  GameBananaItemRef,
+} from '../types/gamebanana';
+import { isModOutdated, formatDate, parseGameBananaItemUrl } from '../types/gamebanana';
 import { getModComments, getModUpdates } from '../lib/api';
 import { useAppStore } from '../stores/appStore';
 import AudioPreviewPlayer from './AudioPreviewPlayer';
@@ -94,6 +100,14 @@ interface ModDetailsModalProps {
   /** When provided, clicking the artist opens "artist mode" (a grid of all the
    *  artist's mods) instead of their GameBanana profile. */
   onViewArtist?: (artist: { id: number; name: string; avatarUrl?: string; profileUrl?: string; kofiUrl?: string }) => void;
+  /**
+   * When provided, primary-clicks on GameBanana *item* links inside HTML bodies
+   * (description, changelog, comments) open that mod in-app instead of the
+   * system browser. Non-item GB URLs and every other host keep the default
+   * external open path. Modifier / middle clicks are left alone so users can
+   * still force an external browser.
+   */
+  onOpenGameBananaItem?: (item: GameBananaItemRef) => void;
 }
 
 function ModDetailsModal({
@@ -127,11 +141,40 @@ function ModDetailsModal({
   variant = 'modal',
   onChangeView,
   onViewArtist,
+  onOpenGameBananaItem,
 }: ModDetailsModalProps) {
   const { t } = useTranslation();
   // Canonical GameBanana page for this submission. WiPs live under /wips, Sounds
   // under /sounds, etc., which section.toLowerCase()+'s' already yields.
   const gbUrl = `https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`;
+
+  // Intercept description / changelog / comment links that point at another
+  // GameBanana item page so they open in this modal instead of the OS browser.
+  // Everything else (members, collections, Ko-fi, arbitrary sites) falls through
+  // to Electron's setWindowOpenHandler / will-navigate external open path.
+  const handleRichHtmlClick = (event: ReactMouseEvent<HTMLElement>) => {
+    if (!onOpenGameBananaItem) return;
+    if (event.defaultPrevented) return;
+    if (event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const anchor = (event.target as HTMLElement | null)?.closest?.('a');
+    if (!anchor || !(anchor instanceof HTMLAnchorElement)) return;
+
+    const href = anchor.getAttribute('href');
+    if (!href) return;
+
+    const item = parseGameBananaItemUrl(href);
+    if (!item) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Already viewing this item: nothing to load.
+    if (item.id === mod.id && item.section === section) return;
+
+    onOpenGameBananaItem(item);
+  };
   const copyGbLink = async () => {
     try {
       await navigator.clipboard.writeText(gbUrl);
@@ -1390,7 +1433,10 @@ function ModDetailsModal({
                   <h3 className="font-semibold text-xs uppercase tracking-wide text-text-secondary mb-2">
                     {t('modDetails.sections.about')}
                   </h3>
-                  <div className="text-sm text-text-primary/90 leading-relaxed [&_p]:mb-2 [&_a]:text-accent [&_a]:hover:underline [&_img]:rounded-md [&_img]:my-2 [&_img]:max-w-full">
+                  <div
+                    className="text-sm text-text-primary/90 leading-relaxed [&_p]:mb-2 [&_a]:text-accent [&_a]:hover:underline [&_img]:rounded-md [&_img]:my-2 [&_img]:max-w-full"
+                    onClick={handleRichHtmlClick}
+                  >
                     <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(mod.description) }} />
                   </div>
                 </section>
@@ -1500,6 +1546,7 @@ function ModDetailsModal({
                                 update.text && (
                                   <div
                                     className="text-sm text-text-primary/90 leading-relaxed [&_p]:mb-1 [&_a]:text-accent [&_a]:hover:underline"
+                                    onClick={handleRichHtmlClick}
                                     dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(update.text) }}
                                   />
                                 )
@@ -1588,6 +1635,7 @@ function ModDetailsModal({
                             </div>
                             <div
                               className="mod-comment-content mt-1"
+                              onClick={handleRichHtmlClick}
                               dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(comment.text) }}
                             />
                           </div>

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   AlertTriangle,
   ArrowUpCircle,
+  ArrowDownCircle,
   FileText,
   Terminal,
   ChevronDown,
@@ -1071,11 +1072,14 @@ export default function ImportProfileDialog({
                         </div>
                         <div className="text-sm flex-shrink-0 text-right sm:min-w-[100px]">
                           {r.status === 'pending' && !isUnresolvable && (
-                            <span className="text-text-tertiary text-xs">{t('servers.connect.status.ready')}</span>
+                            <span className="text-amber-300 inline-flex items-center gap-1.5 justify-end text-xs" title={t('servers.connect.status.ready')}>
+                              <ArrowDownCircle className="w-3.5 h-3.5 flex-shrink-0" />
+                              <span className="hidden sm:inline">{t('servers.connect.status.ready')}</span>
+                            </span>
                           )}
                           {r.status === 'already-installed' && (
                             <span
-                              className="text-text-secondary inline-flex items-center gap-1.5 justify-end text-xs"
+                              className="text-green-400 inline-flex items-center gap-1.5 justify-end text-xs"
                               title={t('importProfile.alreadyInstalled')}
                             >
                               <CheckCircle2 className="w-3.5 h-3.5 flex-shrink-0" />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -939,7 +939,8 @@
       "authorPageNotFound": "Couldn't find this mod's author page",
       "copyEnabled": "Copy enabled mods",
       "copyEnabledHint": "Copy the names of all enabled mods to the clipboard",
-      "copyEnabledToast": "Enabled mods copied ({{count}})"
+      "copyEnabledToast": "Enabled mods copied ({{count}})",
+      "copyFailed": "Couldn't copy: {{error}}"
     },
     "filters": {
       "searchPlaceholder": "Search installed...",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -936,7 +936,10 @@
       "selectMultipleHint": "Select multiple mods for bulk delete, enable, or disable",
       "lockerOverrides": "Locker overrides",
       "lockerOverridesHint": "Locker overrides: review and remove applied hero cards, ability sounds, and ability colors",
-      "authorPageNotFound": "Couldn't find this mod's author page"
+      "authorPageNotFound": "Couldn't find this mod's author page",
+      "copyEnabled": "Copy enabled mods",
+      "copyEnabledHint": "Copy the names of all enabled mods to the clipboard",
+      "copyEnabledToast": "Enabled mods copied ({{count}})"
     },
     "filters": {
       "searchPlaceholder": "Search installed...",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,17 +1,17 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1873,
+  "totalKeys": 1874,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1621,
-      "pct": 87
+      "pct": 86
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1873,
+      "translatedKeys": 1874,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1870,
+  "totalKeys": 1873,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1870,
+      "translatedKeys": 1873,
       "pct": 100
     },
     {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -77,6 +77,7 @@ import type {
   GameBananaSection,
   GameBananaCategoryNode,
   GameBananaArtistLink,
+  GameBananaItemRef,
 } from '../types/gamebanana';
 import { getModThumbnail, getSoundPreviewUrl, getPrimaryFile, formatDate, isModOutdated } from '../types/gamebanana';
 import {
@@ -1155,6 +1156,10 @@ export default function Browse() {
   // current section's category tree has no Skins parent.
   const [modCategories, setModCategories] = useState<GameBananaCategoryNode[]>([]);
   const [selectedMod, setSelectedMod] = useState<GameBananaModDetails | null>(null);
+  // Section of the open details item. Usually matches the browse tab, but
+  // description/changelog links can jump to a Sound/Wip/Mod from another tab;
+  // downloads and comments must use this, not the grid's current section.
+  const [selectedDetailsSection, setSelectedDetailsSection] = useState(section);
   const [selectedModDates, setSelectedModDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   const [modalNavigation, setModalNavigation] = useState<{ direction: ModDetailsNavigationDirection; label: string } | null>(null);
   const modalNavigationRequestRef = useRef(0);
@@ -2273,8 +2278,13 @@ export default function Browse() {
     setRefreshKey((k) => k + 1);
   }, []);
 
-  const applyLoadedModDetails = async (mod: GameBananaMod, details: GameBananaModDetails) => {
+  const applyLoadedModDetails = async (
+    mod: GameBananaMod,
+    details: GameBananaModDetails,
+    detailsSection: string = section,
+  ) => {
     setSelectedMod(details);
+    setSelectedDetailsSection(detailsSection);
     setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
 
     // Update the mods array with the correct nsfw flag from details
@@ -2310,7 +2320,7 @@ export default function Browse() {
   const handleModClick = async (mod: GameBananaMod) => {
     try {
       const details = await getModDetails(mod.id, section, { includeSubmitter: true });
-      await applyLoadedModDetails(mod, details);
+      await applyLoadedModDetails(mod, details, section);
     } catch (err) {
       setError(String(err));
     }
@@ -2326,7 +2336,7 @@ export default function Browse() {
     try {
       const details = await getModDetails(mod.id, section, { includeSubmitter: true });
       if (modalNavigationRequestRef.current !== requestId) return;
-      await applyLoadedModDetails(mod, details);
+      await applyLoadedModDetails(mod, details, section);
     } catch (err) {
       if (modalNavigationRequestRef.current === requestId) {
         setError(String(err));
@@ -2337,6 +2347,49 @@ export default function Browse() {
       }
     }
   };
+
+  // Open a GameBanana item linked from description/changelog/comments in the
+  // same details surface (no external browser). Uses the URL's section so a
+  // Sound link works even while the Mods tab is selected.
+  const handleOpenGameBananaItem = useStableCallback(async (item: GameBananaItemRef) => {
+    if (selectedMod && item.id === selectedMod.id && item.section === selectedDetailsSection) {
+      return;
+    }
+
+    const requestId = modalNavigationRequestRef.current + 1;
+    modalNavigationRequestRef.current = requestId;
+    setModalNavigation({ direction: 'next', label: t('modDetails.aria.loadingDetails') });
+
+    try {
+      const details = await getModDetails(item.id, item.section, { includeSubmitter: true });
+      if (modalNavigationRequestRef.current !== requestId) return;
+
+      setSelectedMod(details);
+      setSelectedDetailsSection(item.section);
+      // Dates may not be in the current grid (cross-section / off-page link).
+      // Prefer cache when present so the meta row still has something useful.
+      try {
+        const cached = await window.electronAPI.getCachedMod(item.id);
+        if (modalNavigationRequestRef.current !== requestId) return;
+        setSelectedModDates(
+          cached
+            ? { dateAdded: cached.dateAdded, dateModified: cached.dateModified }
+            : null,
+        );
+      } catch {
+        if (modalNavigationRequestRef.current !== requestId) return;
+        setSelectedModDates(null);
+      }
+    } catch (err) {
+      if (modalNavigationRequestRef.current === requestId) {
+        setError(String(err));
+      }
+    } finally {
+      if (modalNavigationRequestRef.current === requestId) {
+        setModalNavigation(null);
+      }
+    }
+  });
 
   // Stable identity (useStableCallback) so the memoized ModDetailsModal does
   // not re-render every time this large component does (e.g. on every
@@ -2354,7 +2407,7 @@ export default function Browse() {
     }
 
     try {
-      await downloadMod(selectedMod.id, fileId, fileName, section, effectiveCategoryId);
+      await downloadMod(selectedMod.id, fileId, fileName, selectedDetailsSection, effectiveCategoryId);
     } catch (err) {
       setError(String(err));
       // Reset the active UI only if the file that failed is the active one.
@@ -2418,6 +2471,7 @@ export default function Browse() {
           setFilePicker({ details, files: installable, anchor, dates: { dateAdded: mod.dateAdded, dateModified: mod.dateModified } });
         } else {
           setSelectedMod(details);
+          setSelectedDetailsSection(section);
           setSelectedModDates({ dateAdded: mod.dateAdded, dateModified: mod.dateModified });
         }
         return;
@@ -2821,7 +2875,7 @@ export default function Browse() {
         variant={variant}
         onChangeView={setBrowseDetailsView}
         mod={selectedMod}
-        section={section}
+        section={selectedDetailsSection}
         installed={installedIds.has(selectedMod.id)}
         installedFileIds={installedFileIds}
         installedFileStates={installedFileStates}
@@ -2844,6 +2898,7 @@ export default function Browse() {
         nextLabel={nextSelectedMod?.name}
         onDeleteFile={deleteMod}
         onViewArtist={viewArtist}
+        onOpenGameBananaItem={handleOpenGameBananaItem}
       />
     ) : null;
 
@@ -3598,6 +3653,7 @@ export default function Browse() {
           }}
           onViewAll={() => {
             setSelectedMod(filePicker.details);
+            setSelectedDetailsSection(section);
             setSelectedModDates(filePicker.dates);
             setFilePicker(null);
           }}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -73,7 +73,7 @@ import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModD
 import type { UnmergeModResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterGuess, MergedModSource, AssociateUnknownModArgs } from '../types/mod';
-import type { GameBananaModDetails, GameBananaMod } from '../types/gamebanana';
+import type { GameBananaModDetails, GameBananaMod, GameBananaItemRef } from '../types/gamebanana';
 import { getModThumbnail } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import ImageContextMenu from '../components/ImageContextMenu';
@@ -1149,6 +1149,8 @@ export default function Installed() {
   // delete this entry first so Update/Reinstall replaces the old VPK instead
   // of installing a second copy alongside it.
   const [detailsSourceModId, setDetailsSourceModId] = useState<string | null>(null);
+  // Monotonic guard so a slower linked-item fetch can't clobber a newer one.
+  const detailsRequestIdRef = useRef(0);
 
   // Map of mod id → true if a newer version exists on GameBanana.
   const [updatesAvailable, setUpdatesAvailable] = useState<Set<string>>(new Set());
@@ -1216,6 +1218,8 @@ export default function Installed() {
     if (!m.gameBananaId) return;
     const section = m.sourceSection ?? 'Mod';
     const categoryId = m.categoryId ?? 0;
+    const requestId = detailsRequestIdRef.current + 1;
+    detailsRequestIdRef.current = requestId;
     setDetailsLoading(true);
     setDetailsMod(null);
     setDetailsError(null);
@@ -1246,14 +1250,18 @@ export default function Installed() {
         getModDetails(m.gameBananaId, section, { includeSubmitter: true }),
         window.electronAPI.getCachedMod(m.gameBananaId).catch(() => null),
       ]);
+      if (detailsRequestIdRef.current !== requestId) return;
       setDetailsMod(details);
       if (cached) {
         setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
       }
     } catch (err) {
+      if (detailsRequestIdRef.current !== requestId) return;
       setDetailsError(String(err));
     } finally {
-      setDetailsLoading(false);
+      if (detailsRequestIdRef.current === requestId) {
+        setDetailsLoading(false);
+      }
     }
   };
 
@@ -1266,6 +1274,60 @@ export default function Installed() {
     setDetailsActiveFileIds(new Set());
     setDetailsDates(null);
   };
+
+  // Open a GameBanana item linked from description/changelog/comments inside
+  // the same details modal (in-app), rather than the OS browser. Works for
+  // mods that are not installed too.
+  const openLinkedGameBananaItem = useStableCallback(async (item: GameBananaItemRef) => {
+    if (detailsMod && item.id === detailsMod.id && item.section === detailsSection) {
+      return;
+    }
+
+    const requestId = detailsRequestIdRef.current + 1;
+    detailsRequestIdRef.current = requestId;
+
+    // Keep the current modal open while loading so we don't flash-close.
+    setDetailsError(null);
+    setDetailsSection(item.section);
+    setDetailsCategoryId(0);
+
+    const siblingFileIds = new Set<number>();
+    const activeFileIds = new Set<number>();
+    let sourceModId: string | null = null;
+    let ignoreUpdates = false;
+    let updateAvailable = false;
+    for (const candidate of mods) {
+      if (candidate.gameBananaId !== item.id) continue;
+      if (!sourceModId) sourceModId = candidate.id;
+      if (candidate.ignoreUpdates) ignoreUpdates = true;
+      if (updatesAvailable.has(candidate.id)) updateAvailable = true;
+      if (typeof candidate.gameBananaFileId !== 'number') continue;
+      siblingFileIds.add(candidate.gameBananaFileId);
+      if (candidate.enabled) activeFileIds.add(candidate.gameBananaFileId);
+    }
+    setDetailsInstalledFileIds(siblingFileIds);
+    setDetailsActiveFileIds(activeFileIds);
+    setDetailsSourceModId(sourceModId);
+    setDetailsIgnoreUpdates(ignoreUpdates);
+    setDetailsUpdateAvailable(updateAvailable);
+    setDetailsDates(null);
+
+    try {
+      const [details, cached] = await Promise.all([
+        getModDetails(item.id, item.section, { includeSubmitter: true }),
+        window.electronAPI.getCachedMod(item.id).catch(() => null),
+      ]);
+      if (detailsRequestIdRef.current !== requestId) return;
+      setDetailsMod(details);
+      setDetailsSection(item.section);
+      if (cached) {
+        setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
+      }
+    } catch (err) {
+      if (detailsRequestIdRef.current !== requestId) return;
+      setDetailsError(String(err));
+    }
+  });
 
   const getUnknownCache = (mod: Mod) => unknownFilterCache[unknownModCacheKey(mod)];
 
@@ -2368,7 +2430,12 @@ export default function Installed() {
       showToast(t('installed.merge.shareCodeCopiedToast'), { tone: 'success', duration: 2200 });
     } catch (err) {
       console.error('[Installed] clipboard write failed:', err);
-      showToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`, { tone: 'error' });
+      showToast(
+        t('installed.actions.copyFailed', {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+        { tone: 'error' },
+      );
     }
   };
 
@@ -2925,10 +2992,9 @@ export default function Installed() {
   const loadPositionById = new Map(enabledByLoadOrder.map((m, i) => [m.id, i + 1] as const));
 
   const handleCopyEnabledMods = async () => {
-    const names = mods
-      .filter((m) => m.enabled)
-      .sort((a, b) => modLoadOrder(a) - modLoadOrder(b))
-      .map((m) => m.name);
+    // Use the same enabled list the UI shows (visibleMods / load order), not the
+    // raw store: that includes Locker-managed VPKs the Installed grid hides.
+    const names = enabledByLoadOrder.map((m) => m.name);
     if (names.length === 0) return;
     try {
       await navigator.clipboard.writeText(names.join('\n'));
@@ -2937,9 +3003,12 @@ export default function Installed() {
         duration: 2200,
       });
     } catch (err) {
-      showToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`, {
-        tone: 'error',
-      });
+      showToast(
+        t('installed.actions.copyFailed', {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+        { tone: 'error' },
+      );
     }
   };
 
@@ -3367,21 +3436,33 @@ export default function Installed() {
         ))}
     </div>
   ) : null;
-  const topStatusActions = hasStatusButtons || viewIsReorderable ? (
-    <div className="flex flex-wrap items-center gap-2">
-      {statusButtons}
-      {viewIsReorderable && (
-        <Button
-          variant="secondary"
-          onClick={fixOrder}
-          icon={Wrench}
-          className="!px-2.5"
-          aria-label={t('installed.actions.fixOrder')}
-          title={t('installed.actions.fixOrderHint')}
-        />
-      )}
-    </div>
-  ) : null;
+  const topStatusActions =
+    hasStatusButtons || viewIsReorderable || enabledModCount > 0 ? (
+      <div className="flex flex-wrap items-center gap-2">
+        {statusButtons}
+        {/* After Fix Unknown (last status button): copy enabled names in load order. */}
+        {enabledModCount > 0 && (
+          <Button
+            variant="secondary"
+            onClick={handleCopyEnabledMods}
+            icon={ClipboardList}
+            className="!px-2.5"
+            aria-label={t('installed.actions.copyEnabled')}
+            title={t('installed.actions.copyEnabledHint')}
+          />
+        )}
+        {viewIsReorderable && (
+          <Button
+            variant="secondary"
+            onClick={fixOrder}
+            icon={Wrench}
+            className="!px-2.5"
+            aria-label={t('installed.actions.fixOrder')}
+            title={t('installed.actions.fixOrderHint')}
+          />
+        )}
+      </div>
+    ) : null;
 
   return (
     <div ref={installedScrollRef} className="h-full overflow-y-auto px-4 pb-5 sm:px-6">
@@ -3411,19 +3492,10 @@ export default function Installed() {
             )}
           </div>
           <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
-            {mods.some((m) => m.enabled) && (
-              <Button
-                variant="secondary"
-                onClick={handleCopyEnabledMods}
-                icon={ClipboardList}
-                className="!px-2.5"
-                aria-label={t('installed.actions.copyEnabled')}
-                title={t('installed.actions.copyEnabledHint')}
-              />
-            )}
             {/* Contextual status + reorder actions ride the same row as the
                 view controls (wrapping together when cramped) instead of
-                claiming a second strip below the search. */}
+                claiming a second strip below the search. Copy-enabled sits
+                inside topStatusActions, immediately after Fix Unknown. */}
             {topStatusActions}
             {/* Sort + filter: load order / recent / name, GameBanana vs local
                 import, hero, and metadata tags. The badge counts active
@@ -4056,7 +4128,7 @@ export default function Installed() {
         <ModDetailsModal
           mod={detailsMod}
           section={detailsSection}
-          installed={true}
+          installed={detailsInstalledFileIds.size > 0}
           installedFileIds={detailsInstalledFileIds}
           activeFileIds={detailsActiveFileIds}
           downloadingFileId={null}
@@ -4067,7 +4139,9 @@ export default function Installed() {
           dateModified={detailsDates?.dateModified}
           updateAvailable={detailsUpdateAvailable}
           ignoreUpdates={detailsIgnoreUpdates}
-          onToggleIgnoreUpdates={handleToggleIgnoreUpdates}
+          onToggleIgnoreUpdates={
+            detailsSourceModId ? handleToggleIgnoreUpdates : undefined
+          }
           onClose={closeModDetails}
           onViewArtist={openArtistPage}
           onDownload={handleDetailsDownload}
@@ -4079,6 +4153,7 @@ export default function Installed() {
           }
           previousLabel={previousDetailsEntry ? entryName(previousDetailsEntry) : undefined}
           nextLabel={nextDetailsEntry ? entryName(nextDetailsEntry) : undefined}
+          onOpenGameBananaItem={openLinkedGameBananaItem}
         />
       )}
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -62,6 +62,7 @@ import {
   Banana,
   HelpCircle,
   GripVertical,
+  ClipboardList,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/common/menu';
@@ -2923,6 +2924,25 @@ export default function Installed() {
   const enabledModCount = enabledByLoadOrder.length;
   const loadPositionById = new Map(enabledByLoadOrder.map((m, i) => [m.id, i + 1] as const));
 
+  const handleCopyEnabledMods = async () => {
+    const names = mods
+      .filter((m) => m.enabled)
+      .sort((a, b) => modLoadOrder(a) - modLoadOrder(b))
+      .map((m) => m.name);
+    if (names.length === 0) return;
+    try {
+      await navigator.clipboard.writeText(names.join('\n'));
+      showToast(t('installed.actions.copyEnabledToast', { count: names.length }), {
+        tone: 'success',
+        duration: 2200,
+      });
+    } catch (err) {
+      showToast(`Couldn't copy: ${err instanceof Error ? err.message : String(err)}`, {
+        tone: 'error',
+      });
+    }
+  };
+
   // Filter by search query (substring on name), source (GameBanana vs local
   // import), hero, and tags, then optionally re-sort. Status (enabled/disabled)
   // is applied per-section below. Drag-and-drop reorder is disabled whenever any
@@ -3391,6 +3411,16 @@ export default function Installed() {
             )}
           </div>
           <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+            {mods.some((m) => m.enabled) && (
+              <Button
+                variant="secondary"
+                onClick={handleCopyEnabledMods}
+                icon={ClipboardList}
+                className="!px-2.5"
+                aria-label={t('installed.actions.copyEnabled')}
+                title={t('installed.actions.copyEnabledHint')}
+              />
+            )}
             {/* Contextual status + reorder actions ride the same row as the
                 view controls (wrapping together when cramped) instead of
                 claiming a second strip below the search. */}

--- a/src/stores/stats/playerStore.ts
+++ b/src/stores/stats/playerStore.ts
@@ -163,6 +163,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
         try {
             await window.electronAPI.stats.syncPlayerData(accountId)
             await get().loadPlayerData(accountId)
+            await get().loadTrackedPlayers()
         } catch (err) {
             if (get().selectedAccountId !== accountId) return
             set((s) => ({

--- a/src/types/gamebanana.parseItemUrl.test.ts
+++ b/src/types/gamebanana.parseItemUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseGameBananaItemUrl } from './gamebanana';
+
+describe('parseGameBananaItemUrl', () => {
+  it('parses standard mod / sound / wip item pages', () => {
+    expect(parseGameBananaItemUrl('https://gamebanana.com/mods/610813')).toEqual({
+      id: 610813,
+      section: 'Mod',
+    });
+    expect(parseGameBananaItemUrl('https://www.gamebanana.com/sounds/12345')).toEqual({
+      id: 12345,
+      section: 'Sound',
+    });
+    expect(parseGameBananaItemUrl('http://gamebanana.com/wips/99')).toEqual({
+      id: 99,
+      section: 'Wip',
+    });
+  });
+
+  it('accepts protocol-relative URLs and ignores query/hash', () => {
+    expect(parseGameBananaItemUrl('//gamebanana.com/mods/690548?ref=desc#top')).toEqual({
+      id: 690548,
+      section: 'Mod',
+    });
+  });
+
+  it('rejects non-item GameBanana paths (open externally)', () => {
+    expect(parseGameBananaItemUrl('https://gamebanana.com/members/123')).toBeNull();
+    expect(parseGameBananaItemUrl('https://gamebanana.com/collections/164637')).toBeNull();
+    expect(parseGameBananaItemUrl('https://gamebanana.com/dl/1392011')).toBeNull();
+    expect(parseGameBananaItemUrl('https://gamebanana.com/mods/download/690548')).toBeNull();
+    expect(parseGameBananaItemUrl('https://gamebanana.com/mods/cats/33295')).toBeNull();
+    expect(parseGameBananaItemUrl('https://gamebanana.com/tools/1')).toBeNull();
+  });
+
+  it('rejects non-GameBanana hosts and empty input', () => {
+    expect(parseGameBananaItemUrl('https://example.com/mods/1')).toBeNull();
+    expect(parseGameBananaItemUrl('https://evilgamebanana.com/mods/1')).toBeNull();
+    expect(parseGameBananaItemUrl('')).toBeNull();
+    expect(parseGameBananaItemUrl('not a url')).toBeNull();
+  });
+});

--- a/src/types/gamebanana.ts
+++ b/src/types/gamebanana.ts
@@ -213,6 +213,60 @@ export function parseCollectionId(input: string): number | null {
   }
 }
 
+/**
+ * GameBanana content item pages Grimoire can open in the details modal.
+ * Path segment (plural) -> API model name used by getModDetails / fetchModDetails.
+ * Keep this aligned with Browse SECTION_WHITELIST (Mod / Sound / Wip).
+ * Members, collections, download pages, category pages, etc. stay external.
+ */
+const GAMEBANANA_ITEM_PATH_TO_SECTION: Record<string, string> = {
+  mods: 'Mod',
+  sounds: 'Sound',
+  wips: 'Wip',
+};
+
+export type GameBananaItemRef = {
+  id: number;
+  /** API section / model name, e.g. "Mod", "Sound", "Wip". */
+  section: string;
+};
+
+/**
+ * Parse a GameBanana *item* page URL into { id, section }.
+ * Accepts absolute and protocol-relative URLs. Returns null for non-GB hosts,
+ * non-item paths (/members, /collections, /dl, /mods/download, /mods/cats, ...),
+ * and item types we do not open in-app.
+ */
+export function parseGameBananaItemUrl(input: string): GameBananaItemRef | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  try {
+    // Protocol-relative and bare paths: resolve against gamebanana.com so
+    // `//gamebanana.com/mods/1` and accidental root-relative paths still parse.
+    const url = new URL(trimmed, 'https://gamebanana.com');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    // Exact host or real subdomain (www.gamebanana.com). Reject lookalikes
+    // like evilgamebanana.com that merely end with the same suffix.
+    const host = url.hostname.toLowerCase();
+    if (host !== 'gamebanana.com' && !host.endsWith('.gamebanana.com')) return null;
+
+    // Strict: /{type}/{id} only. Reject /mods/download/123, /mods/cats/..., trailing junk.
+    const match = url.pathname.match(/^\/(mods|sounds|wips)\/(\d+)\/?$/i);
+    if (!match) return null;
+
+    const section = GAMEBANANA_ITEM_PATH_TO_SECTION[match[1].toLowerCase()];
+    if (!section) return null;
+
+    const id = Number(match[2]);
+    if (!Number.isFinite(id) || id <= 0) return null;
+
+    return { id, section };
+  } catch {
+    return null;
+  }
+}
+
 export function getModThumbnail(mod: GameBananaMod): string | undefined {
   const images = mod.previewMedia?.images;
   if (!images || images.length === 0) return undefined;


### PR DESCRIPTION
Three small, self-contained wins pulled from #feature-requests and #general on Discord.

## Changes

**1. Copy enabled mods to clipboard** (macchiako)
New "Copy enabled mods" button in the Installed toolbar (shows only when at least one mod is enabled). Copies a flat, newline-separated list of enabled mod names in load order.

**2. Color-differentiate "Ready" vs "On disk"** (justnikocat)
In the profile import dialog these two states both rendered near-identical grey. "Ready" (pending download) is now amber with a down-arrow icon; "On disk" (already installed) is now green with its check. Styling only, states unchanged.

**3. Persist fresh Steam name/avatar on Stats sync** (macchiako)
The Stats page showed a stale persona name/avatar because the cached profile in `stats.db` was written once and never refreshed. `stats:syncPlayerData` now re-fetches the Steam profile and calls the previously-unused `updatePlayerProfile()` write-back; the renderer reloads tracked players after a sync so the UI updates. No schema change (columns already existed).

## Not included (deliberately)
- justnikocat's "view in explorer" request: already shipped as **Reveal in folder** in the card's overflow menu, so no code needed.

## Verification
- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm test` 355/355 pass
- `pnpm i18n:check` OK, manifest regenerated

UI/IPC changes have no direct unit-test surface; the suite covers regressions. Worth a manual smoke of the three surfaces before merge.