### PR TITLE
feat(installed): "start with only this mod enabled" solo launch

### DIFF
--- a/src/lib/soloRestore.test.ts
+++ b/src/lib/soloRestore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Mod } from '../types/mod';
-import { modRestoreKey, planSolo, planRestore } from './soloRestore';
+import { modRestoreKey, planSoloByKeys, planRestore } from './soloRestore';
 
 function mod(over: Partial<Mod> & { id: string }): Mod {
   return {
@@ -35,33 +35,51 @@ describe('modRestoreKey', () => {
   });
 });
 
-describe('planSolo', () => {
+describe('planSoloByKeys', () => {
   it('disables every other enabled mod and enables the target if off', () => {
     const mods = [
-      mod({ id: 'a', enabled: true }),
-      mod({ id: 'b', enabled: true }),
-      mod({ id: 'c', enabled: false }),
+      mod({ id: 'a', enabled: true, sha256: 'aa' }),
+      mod({ id: 'b', enabled: true, sha256: 'bb' }),
+      mod({ id: 'c', enabled: false, sha256: 'cc' }),
     ];
-    expect(planSolo(mods, ['c'])).toEqual({ enable: ['c'], disable: ['a', 'b'] });
+    expect(planSoloByKeys(mods, ['sha:cc'])).toEqual({ enable: ['c'], disable: ['a', 'b'] });
   });
 
   it('is a no-op when the target is already the only thing enabled', () => {
-    const mods = [mod({ id: 'a', enabled: true }), mod({ id: 'b', enabled: false })];
-    expect(planSolo(mods, ['a'])).toEqual({ enable: [], disable: [] });
+    const mods = [mod({ id: 'a', enabled: true, sha256: 'aa' }), mod({ id: 'b', enabled: false, sha256: 'bb' })];
+    expect(planSoloByKeys(mods, ['sha:aa'])).toEqual({ enable: [], disable: [] });
   });
 
-  it('keeps multiple target ids enabled (group variants)', () => {
+  it('keeps multiple target keys enabled (group variants)', () => {
     const mods = [
-      mod({ id: 'v1', enabled: true }),
-      mod({ id: 'v2', enabled: false }),
-      mod({ id: 'other', enabled: true }),
+      mod({ id: 'v1', enabled: true, gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 0 }),
+      mod({ id: 'v2', enabled: false, gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 1 }),
+      mod({ id: 'other', enabled: true, gameBananaId: 6, gameBananaFileId: 10 }),
     ];
-    expect(planSolo(mods, ['v1', 'v2'])).toEqual({ enable: ['v2'], disable: ['other'] });
+    expect(planSoloByKeys(mods, ['gb:5:9:0', 'gb:5:9:1'])).toEqual({ enable: ['v2'], disable: ['other'] });
   });
 
-  it('ignores unknown ids', () => {
-    const mods = [mod({ id: 'a', enabled: true })];
-    expect(planSolo(mods, ['ghost'])).toEqual({ enable: [], disable: ['a'] });
+  it('aborts when no target keys resolve', () => {
+    const mods = [mod({ id: 'a', enabled: true, sha256: 'aa' })];
+    expect(planSoloByKeys(mods, ['sha:ghost'])).toBeNull();
+  });
+
+  it('resolves a target after id churn', () => {
+    const targetKey = modRestoreKey(mod({ id: 'before-disable', gameBananaId: 5, gameBananaFileId: 9 }));
+    const mods = [
+      mod({ id: 'renamed-after-toggle', enabled: false, gameBananaId: 5, gameBananaFileId: 9 }),
+      mod({ id: 'other', enabled: true, sha256: 'other' }),
+    ];
+    expect(planSoloByKeys(mods, [targetKey])).toEqual({ enable: ['renamed-after-toggle'], disable: ['other'] });
+  });
+
+  it('targets every local import that shares the name+size fallback key', () => {
+    const mods = [
+      mod({ id: 'local-a', name: 'Same Local', size: 42, enabled: false }),
+      mod({ id: 'local-b', name: 'Same Local', size: 42, enabled: false }),
+      mod({ id: 'other', name: 'Other', size: 42, enabled: true }),
+    ];
+    expect(planSoloByKeys(mods, ['nm:Same Local:42'])).toEqual({ enable: ['local-a', 'local-b'], disable: ['other'] });
   });
 });
 
@@ -97,5 +115,14 @@ describe('planRestore', () => {
     ];
     const mods = [mod({ id: 'A', enabled: false, sha256: 'aa' })];
     expect(planRestore(mods, snapshot)).toEqual({ enable: ['A'], disable: [] });
+  });
+
+  it('enables every current local import that shares a snapshotted name+size fallback key', () => {
+    const snapshot = ['nm:Same Local:42'];
+    const mods = [
+      mod({ id: 'local-a', name: 'Same Local', size: 42, enabled: false }),
+      mod({ id: 'local-b', name: 'Same Local', size: 42, enabled: false }),
+    ];
+    expect(planRestore(mods, snapshot)).toEqual({ enable: ['local-a', 'local-b'], disable: [] });
   });
 });

--- a/src/lib/soloRestore.test.ts
+++ b/src/lib/soloRestore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import type { Mod } from '../types/mod';
+import { modRestoreKey, planSolo, planRestore } from './soloRestore';
+
+function mod(over: Partial<Mod> & { id: string }): Mod {
+  return {
+    name: over.id,
+    fileName: `${over.id}.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    metaKey: `${over.id}.vpk`,
+    enabled: false,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('modRestoreKey', () => {
+  it('prefers GameBanana file identity, keyed with vpkIndex for siblings', () => {
+    expect(modRestoreKey(mod({ id: 'a', gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 0 }))).toBe('gb:5:9:0');
+    expect(modRestoreKey(mod({ id: 'a', gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 1 }))).toBe('gb:5:9:1');
+  });
+
+  it('falls back to content hash, then name+size', () => {
+    expect(modRestoreKey(mod({ id: 'a', sha256: 'deadbeef' }))).toBe('sha:deadbeef');
+    expect(modRestoreKey(mod({ id: 'a', name: 'Cool Skin', size: 42 }))).toBe('nm:Cool Skin:42');
+  });
+
+  it('is stable across the id/fileName churn that disabling causes', () => {
+    // Same GameBanana file, different local id/fileName after a disable rename.
+    const enabled = mod({ id: 'id-enabled', fileName: 'pak01_dir.vpk', enabled: true, gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 0 });
+    const disabled = mod({ id: 'id-disabled', fileName: 'cool_skin_a1b2_dir.vpk', gameBananaId: 5, gameBananaFileId: 9, vpkIndex: 0 });
+    expect(modRestoreKey(enabled)).toBe(modRestoreKey(disabled));
+  });
+});
+
+describe('planSolo', () => {
+  it('disables every other enabled mod and enables the target if off', () => {
+    const mods = [
+      mod({ id: 'a', enabled: true }),
+      mod({ id: 'b', enabled: true }),
+      mod({ id: 'c', enabled: false }),
+    ];
+    expect(planSolo(mods, ['c'])).toEqual({ enable: ['c'], disable: ['a', 'b'] });
+  });
+
+  it('is a no-op when the target is already the only thing enabled', () => {
+    const mods = [mod({ id: 'a', enabled: true }), mod({ id: 'b', enabled: false })];
+    expect(planSolo(mods, ['a'])).toEqual({ enable: [], disable: [] });
+  });
+
+  it('keeps multiple target ids enabled (group variants)', () => {
+    const mods = [
+      mod({ id: 'v1', enabled: true }),
+      mod({ id: 'v2', enabled: false }),
+      mod({ id: 'other', enabled: true }),
+    ];
+    expect(planSolo(mods, ['v1', 'v2'])).toEqual({ enable: ['v2'], disable: ['other'] });
+  });
+
+  it('ignores unknown ids', () => {
+    const mods = [mod({ id: 'a', enabled: true })];
+    expect(planSolo(mods, ['ghost'])).toEqual({ enable: [], disable: ['a'] });
+  });
+});
+
+describe('planRestore', () => {
+  it('restores the snapshotted enabled set across id churn', () => {
+    // Pre-solo A and B were enabled (GameBanana files 1 and 2). Solo A disabled
+    // B, which renamed it to a new id. Restore must re-enable B by its new id.
+    const snapshot = [
+      modRestoreKey(mod({ id: 'A', gameBananaId: 5, gameBananaFileId: 1 })),
+      modRestoreKey(mod({ id: 'B', gameBananaId: 5, gameBananaFileId: 2 })),
+    ];
+    const postSolo = [
+      mod({ id: 'A', enabled: true, gameBananaId: 5, gameBananaFileId: 1 }),
+      mod({ id: 'B-renamed', enabled: false, gameBananaId: 5, gameBananaFileId: 2 }),
+      mod({ id: 'C', enabled: false, gameBananaId: 5, gameBananaFileId: 3 }),
+    ];
+    expect(planRestore(postSolo, snapshot)).toEqual({ enable: ['B-renamed'], disable: [] });
+  });
+
+  it('disables mods enabled after the snapshot that are not part of it', () => {
+    const snapshot = [modRestoreKey(mod({ id: 'A', sha256: 'aa' }))];
+    const mods = [
+      mod({ id: 'A', enabled: true, sha256: 'aa' }),
+      mod({ id: 'B', enabled: true, sha256: 'bb' }),
+    ];
+    expect(planRestore(mods, snapshot)).toEqual({ enable: [], disable: ['B'] });
+  });
+
+  it('skips snapshot keys with no matching mod (deleted mid-test)', () => {
+    const snapshot = [
+      modRestoreKey(mod({ id: 'A', sha256: 'aa' })),
+      modRestoreKey(mod({ id: 'gone', sha256: 'zz' })),
+    ];
+    const mods = [mod({ id: 'A', enabled: false, sha256: 'aa' })];
+    expect(planRestore(mods, snapshot)).toEqual({ enable: ['A'], disable: [] });
+  });
+});

--- a/src/lib/soloRestore.ts
+++ b/src/lib/soloRestore.ts
@@ -1,0 +1,67 @@
+import type { Mod } from '../types/mod';
+
+/**
+ * "Start with only this mod enabled" solo testing. Soloing disables every other
+ * mod; restoring brings the previous enabled set back. The catch is that
+ * disabling a mod renames its VPK into `.disabled/`, which changes its metaKey
+ * and therefore its `id`, so a restore snapshot can't hold ids. We snapshot a
+ * stable identity key instead and re-match it against the current (post-solo)
+ * mod list. Split out of the store so the matching rules are unit-tested.
+ */
+
+export interface TogglePlan {
+  /** Mod ids to enable. */
+  enable: string[];
+  /** Mod ids to disable. */
+  disable: string[];
+}
+
+type IdentityFields = Pick<
+  Mod,
+  'gameBananaId' | 'gameBananaFileId' | 'vpkIndex' | 'sha256' | 'name' | 'size'
+>;
+
+/**
+ * Stable identity for a mod across the id churn that enable/disable causes.
+ * Prefer GameBanana file identity (survives the rename), then content hash,
+ * then name+size for local imports that carry neither.
+ */
+export function modRestoreKey(m: IdentityFields): string {
+  if (typeof m.gameBananaFileId === 'number') {
+    return `gb:${m.gameBananaId ?? ''}:${m.gameBananaFileId}:${m.vpkIndex ?? ''}`;
+  }
+  if (m.sha256) return `sha:${m.sha256}`;
+  return `nm:${m.name}:${m.size}`;
+}
+
+/**
+ * Enable exactly `enableIds` and disable every other currently-enabled mod.
+ * Ids in `enableIds` that are already enabled (or unknown) contribute nothing.
+ */
+export function planSolo(mods: Mod[], enableIds: string[]): TogglePlan {
+  const enableSet = new Set(enableIds);
+  const byId = new Map(mods.map((m) => [m.id, m]));
+  const disable = mods.filter((m) => m.enabled && !enableSet.has(m.id)).map((m) => m.id);
+  const enable = enableIds.filter((id) => {
+    const m = byId.get(id);
+    return !!m && !m.enabled;
+  });
+  return { enable, disable };
+}
+
+/**
+ * Bring the enabled set back to the snapshot identified by `keys`: enable any
+ * currently-disabled mod whose key is in the snapshot, disable any currently-
+ * enabled mod whose key is not. Keys with no matching mod (e.g. a mod deleted
+ * mid-test) are simply skipped.
+ */
+export function planRestore(mods: Mod[], keys: string[]): TogglePlan {
+  const keySet = new Set(keys);
+  const enable = mods
+    .filter((m) => !m.enabled && keySet.has(modRestoreKey(m)))
+    .map((m) => m.id);
+  const disable = mods
+    .filter((m) => m.enabled && !keySet.has(modRestoreKey(m)))
+    .map((m) => m.id);
+  return { enable, disable };
+}

--- a/src/lib/soloRestore.ts
+++ b/src/lib/soloRestore.ts
@@ -24,7 +24,9 @@ type IdentityFields = Pick<
 /**
  * Stable identity for a mod across the id churn that enable/disable causes.
  * Prefer GameBanana file identity (survives the rename), then content hash,
- * then name+size for local imports that carry neither.
+ * then name+size for local imports that carry neither. The name+size fallback
+ * can collide for distinct local imports; callers intentionally treat every
+ * matching mod as the same logical target in that rare case.
  */
 export function modRestoreKey(m: IdentityFields): string {
   if (typeof m.gameBananaFileId === 'number') {
@@ -35,17 +37,19 @@ export function modRestoreKey(m: IdentityFields): string {
 }
 
 /**
- * Enable exactly `enableIds` and disable every other currently-enabled mod.
- * Ids in `enableIds` that are already enabled (or unknown) contribute nothing.
+ * Enable exactly the mods matching `enableKeys` and disable every other
+ * currently-enabled mod. Returns null when no key resolves against the live mod
+ * list, so a stale click cannot disable the whole library and launch with
+ * nothing enabled.
  */
-export function planSolo(mods: Mod[], enableIds: string[]): TogglePlan {
-  const enableSet = new Set(enableIds);
-  const byId = new Map(mods.map((m) => [m.id, m]));
-  const disable = mods.filter((m) => m.enabled && !enableSet.has(m.id)).map((m) => m.id);
-  const enable = enableIds.filter((id) => {
-    const m = byId.get(id);
-    return !!m && !m.enabled;
-  });
+export function planSoloByKeys(mods: Mod[], enableKeys: string[]): TogglePlan | null {
+  const keySet = new Set(enableKeys);
+  const targets = mods.filter((m) => keySet.has(modRestoreKey(m)));
+  if (targets.length === 0) return null;
+
+  const keep = new Set(targets.map((m) => m.id));
+  const enable = targets.filter((m) => !m.enabled).map((m) => m.id);
+  const disable = mods.filter((m) => m.enabled && !keep.has(m.id)).map((m) => m.id);
   return { enable, disable };
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1248,8 +1248,11 @@
     "solo": {
       "banner": "Testing {{name}} solo: every other mod is disabled.",
       "restore": "Restore mods",
-      "partial": "{{count}} mod could not be toggled; launching anyway.",
-      "partial_other": "{{count}} mods could not be toggled; launching anyway."
+      "partial_one": "{{count}} mod could not be toggled; launching anyway.",
+      "partial_other": "{{count}} mods could not be toggled; launching anyway.",
+      "restorePartial_one": "{{count}} mod could not be restored; try again.",
+      "restorePartial_other": "{{count}} mods could not be restored; try again.",
+      "targetMissing": "Couldn't find that mod to solo. It may have been toggled or removed."
     },
     "edit": {
       "title": "Edit mod",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1242,7 +1242,14 @@
       "mergedBadge": "Merged · {{count}}",
       "noFilesEnabled": "No files enabled",
       "variantStatusTitle": "{{labels}} - click card to choose files",
-      "revealInFolder": "Reveal in folder"
+      "revealInFolder": "Reveal in folder",
+      "soloLaunch": "Start with only this enabled"
+    },
+    "solo": {
+      "banner": "Testing {{name}} solo: every other mod is disabled.",
+      "restore": "Restore mods",
+      "partial": "{{count}} mod could not be toggled; launching anyway.",
+      "partial_other": "{{count}} mods could not be toggled; launching anyway."
     },
     "edit": {
       "title": "Edit mod",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1961,
+  "totalKeys": 1964,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1961,
+      "translatedKeys": 1964,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1956,
+  "totalKeys": 1961,
   "languages": [
     {
       "code": "bg",
@@ -11,14 +11,14 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1956,
+      "translatedKeys": 1961,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1870,
-      "pct": 96
+      "pct": 95
     },
     {
       "code": "ru",

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -93,6 +93,7 @@ import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
 import { createEnabledVpkRestoreSnapshot, shouldRestoreVpkEnabled, type EnabledVpkRestoreSnapshot } from '../lib/vpkRestore';
+import { modRestoreKey } from '../lib/soloRestore';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
 import { FormField, Input, Select } from '../components/common/forms';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -466,6 +467,7 @@ interface InstalledEntryCardProps {
   loadCount: number;
   selectMode: boolean;
   selected: boolean;
+  soloBusy: boolean;
   onOpenDetails: (mod: Mod) => void;
   onViewAuthor: (mod: Mod) => void;
   onOpenPicker: (gameBananaId: number) => void;
@@ -509,6 +511,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
   loadCount,
   selectMode,
   selected,
+  soloBusy,
   onOpenDetails,
   onViewAuthor,
   onOpenPicker,
@@ -543,6 +546,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
         onViewAuthor={mod.gameBananaId ? () => onViewAuthor(mod) : undefined}
         onToggle={() => onToggle(entry)}
         onSoloLaunch={() => onSoloLaunch(entry)}
+        soloBusy={soloBusy}
         onDelete={() => onDelete(entry)}
         onEditLocal={!mod.gameBananaId ? () => onEditLocal(mod) : undefined}
         onRenameLocal={!mod.gameBananaId ? (newName) => onRenameLocal(mod, newName) : undefined}
@@ -596,6 +600,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
       onViewImprint={entry.primary.imprinted ? () => onViewImprint(entry.primary) : undefined}
       onToggle={() => onToggle(entry)}
       onSoloLaunch={() => onSoloLaunch(entry)}
+      soloBusy={soloBusy}
       onDelete={() => onDelete(entry)}
       onTagLocker={(heroName) => onTagLocker(entry, heroName)}
       onTagGlobal={(globalType) => onTagGlobal(entry, globalType)}
@@ -1091,6 +1096,8 @@ export default function Installed() {
   // state, so two clicks in the same tick can't both read a stale `false`.
   const dmmAutoImportInFlightRef = useRef(false);
   const [dmmAutoImporting, setDmmAutoImporting] = useState(false);
+  const soloBusyRef = useRef(false);
+  const [soloBusy, setSoloBusy] = useState(false);
   // Pending DMM-import consent dialog. Holds the promise resolver so
   // autoImportDmmMods can await the user's answer; null = no dialog.
   const [dmmConfirm, setDmmConfirm] = useState<{
@@ -2906,24 +2913,52 @@ export default function Installed() {
     else void toggleMod(entry.mod.id);
   });
   // "Start with only this mod enabled": solo the entry (disable everything else)
-  // then launch. For a group we keep its already-enabled variants, or fall back
-  // to the primary when the whole group is currently off. The prior enabled set
+  // then launch. For a group we keep its already-enabled variants, or enable
+  // every variant when the whole group is currently off. The prior enabled set
   // is snapshotted by soloMod for the restore banner.
   const soloLaunchEntry = useStableCallback(async (entry: ModEntry) => {
-    const targetIds =
-      entry.kind === 'group'
-        ? (entry.enabledVariants.length > 0 ? entry.enabledVariants : [entry.primary]).map((m) => m.id)
-        : [entry.mod.id];
-    const label = entry.kind === 'group' ? entry.primary.name : entry.mod.name;
-    const { applied, failures } = await soloMod(targetIds, label);
-    if (!applied) return;
-    if (failures > 0) {
-      showToast(t('installed.solo.partial', { count: failures }), { tone: 'warning' });
-    }
+    if (soloBusyRef.current) return;
+    soloBusyRef.current = true;
+    setSoloBusy(true);
     try {
-      await launchModded();
-    } catch (err) {
-      showToast(String(err).replace(/^Error:\s*/, ''), { tone: 'error' });
+      const targetMods =
+        entry.kind === 'group'
+          ? (entry.enabledVariants.length > 0 ? entry.enabledVariants : entry.variants)
+          : [entry.mod];
+      const targetKeys = targetMods.map(modRestoreKey);
+      const label = entry.kind === 'group' ? entry.primary.name : entry.mod.name;
+      const { applied, failures, reason } = await soloMod(targetKeys, label);
+      if (!applied) {
+        if (reason === 'missing') {
+          showToast(t('installed.solo.targetMissing'), { tone: 'error' });
+        }
+        return;
+      }
+      if (failures > 0) {
+        showToast(t('installed.solo.partial', { count: failures }), { tone: 'warning' });
+      }
+      try {
+        await launchModded();
+      } catch (err) {
+        showToast(String(err).replace(/^Error:\s*/, ''), { tone: 'error' });
+      }
+    } finally {
+      soloBusyRef.current = false;
+      setSoloBusy(false);
+    }
+  });
+  const restoreSolo = useStableCallback(async () => {
+    if (soloBusyRef.current) return;
+    soloBusyRef.current = true;
+    setSoloBusy(true);
+    try {
+      const { failures } = await restoreSoloMods();
+      if (failures > 0) {
+        showToast(t('installed.solo.restorePartial', { count: failures }), { tone: 'warning' });
+      }
+    } finally {
+      soloBusyRef.current = false;
+      setSoloBusy(false);
     }
   });
   const deleteEntry = useStableCallback((entry: ModEntry) => {
@@ -3340,6 +3375,7 @@ export default function Installed() {
     loadCount: enabledModCount,
     selectMode,
     selected: isEntrySelected(entry),
+    soloBusy,
     onOpenDetails: openEntryDetails,
     onViewAuthor: viewEntryAuthor,
     onOpenPicker: openEntryPicker,
@@ -3905,15 +3941,16 @@ export default function Installed() {
           <span className="flex-1 text-sm text-text-primary">
             {t('installed.solo.banner', { name: soloRestore.label })}
           </span>
-          <Button variant="secondary" size="sm" onClick={() => void restoreSoloMods()}>
+          <Button variant="secondary" size="sm" disabled={soloBusy} onClick={() => void restoreSolo()}>
             {t('installed.solo.restore')}
           </Button>
           <button
             type="button"
+            disabled={soloBusy}
             onClick={() => clearSoloRestore()}
             title={t('common.actions.dismiss')}
             aria-label={t('common.actions.dismiss')}
-            className="rounded-md p-1 text-text-secondary hover:bg-white/5 hover:text-text-primary"
+            className="rounded-md p-1 text-text-secondary hover:bg-white/5 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             <X className="h-4 w-4" />
           </button>
@@ -6478,6 +6515,7 @@ interface ModCardProps {
   /** Disable every other mod, enable only this one, and launch the game. Used
    *  for A/B testing a single skin. */
   onSoloLaunch?: () => void;
+  soloBusy?: boolean;
   onDelete: () => void;
   onEditLocal?: () => void;
   /** Inline rename of a local mod's name (double-click the title). Undefined
@@ -7110,6 +7148,7 @@ function ModCard({
   onViewAuthor,
   onToggle,
   onSoloLaunch,
+  soloBusy = false,
   onDelete,
   onEditLocal,
   onRenameLocal,
@@ -7458,6 +7497,7 @@ function ModCard({
               <button
                 type="button"
                 role="menuitem"
+                disabled={soloBusy}
                 onClick={(e) => {
                   e.stopPropagation();
                   setMenuOpen(false);

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -72,7 +72,7 @@ import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { isImprintPending } from '../lib/imprintPending';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder, dmmMigrateScan, dmmMigrateExecute, imprintAllInstalled, onImprintAllInstalledProgress, imprintPreflight, readImprintDetails, peekImprint } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder, dmmMigrateScan, dmmMigrateExecute, imprintAllInstalled, onImprintAllInstalledProgress, imprintPreflight, readImprintDetails, peekImprint, launchModded } from '../lib/api';
 import type { UnmergeModResult, ImprintAllInstalledResult, ImprintInstalledProgress, ImprintPreflightResult, ImprintDetails, PeekImprintResult } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterGuess, MergedModSource, AssociateUnknownModArgs, ImprintAnomalousMod, ImprintSkippedMod, ImprintFailedMod } from '../types/mod';
@@ -470,6 +470,7 @@ interface InstalledEntryCardProps {
   onViewAuthor: (mod: Mod) => void;
   onOpenPicker: (gameBananaId: number) => void;
   onToggle: (entry: ModEntry) => void;
+  onSoloLaunch: (entry: ModEntry) => void;
   onDelete: (entry: ModEntry) => void;
   onEditLocal: (mod: Mod) => void;
   onRenameLocal: (mod: Mod, newName: string) => Promise<void>;
@@ -512,6 +513,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
   onViewAuthor,
   onOpenPicker,
   onToggle,
+  onSoloLaunch,
   onDelete,
   onEditLocal,
   onRenameLocal,
@@ -540,6 +542,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
         }
         onViewAuthor={mod.gameBananaId ? () => onViewAuthor(mod) : undefined}
         onToggle={() => onToggle(entry)}
+        onSoloLaunch={() => onSoloLaunch(entry)}
         onDelete={() => onDelete(entry)}
         onEditLocal={!mod.gameBananaId ? () => onEditLocal(mod) : undefined}
         onRenameLocal={!mod.gameBananaId ? (newName) => onRenameLocal(mod, newName) : undefined}
@@ -592,6 +595,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
       // Imprints are per file; a group card shows the primary's imprint.
       onViewImprint={entry.primary.imprinted ? () => onViewImprint(entry.primary) : undefined}
       onToggle={() => onToggle(entry)}
+      onSoloLaunch={() => onSoloLaunch(entry)}
       onDelete={() => onDelete(entry)}
       onTagLocker={(heroName) => onTagLocker(entry, heroName)}
       onTagGlobal={(globalType) => onTagGlobal(entry, globalType)}
@@ -703,6 +707,10 @@ export default function Installed() {
     modsError,
     modsNotice,
     clearModsNotice,
+    soloRestore,
+    soloMod,
+    restoreSoloMods,
+    clearSoloRestore,
     loadSettings,
     loadMods,
     toggleMod,
@@ -2897,6 +2905,27 @@ export default function Installed() {
     if (entry.kind === 'group') void handleGroupToggle(entry);
     else void toggleMod(entry.mod.id);
   });
+  // "Start with only this mod enabled": solo the entry (disable everything else)
+  // then launch. For a group we keep its already-enabled variants, or fall back
+  // to the primary when the whole group is currently off. The prior enabled set
+  // is snapshotted by soloMod for the restore banner.
+  const soloLaunchEntry = useStableCallback(async (entry: ModEntry) => {
+    const targetIds =
+      entry.kind === 'group'
+        ? (entry.enabledVariants.length > 0 ? entry.enabledVariants : [entry.primary]).map((m) => m.id)
+        : [entry.mod.id];
+    const label = entry.kind === 'group' ? entry.primary.name : entry.mod.name;
+    const { applied, failures } = await soloMod(targetIds, label);
+    if (!applied) return;
+    if (failures > 0) {
+      showToast(t('installed.solo.partial', { count: failures }), { tone: 'warning' });
+    }
+    try {
+      await launchModded();
+    } catch (err) {
+      showToast(String(err).replace(/^Error:\s*/, ''), { tone: 'error' });
+    }
+  });
   const deleteEntry = useStableCallback((entry: ModEntry) => {
     if (entry.kind === 'group') {
       setModToDelete({
@@ -3315,6 +3344,7 @@ export default function Installed() {
     onViewAuthor: viewEntryAuthor,
     onOpenPicker: openEntryPicker,
     onToggle: toggleEntry,
+    onSoloLaunch: soloLaunchEntry,
     onDelete: deleteEntry,
     onEditLocal: editLocalEntry,
     onRenameLocal: renameLocalMod,
@@ -3868,6 +3898,27 @@ export default function Installed() {
           </div>
         </div>
       </div>
+
+      {soloRestore && (
+        <div className="mb-4 flex items-center gap-3 rounded-lg border border-accent/30 bg-accent/10 px-4 py-2.5">
+          <Beaker className="h-4 w-4 flex-shrink-0 text-accent" />
+          <span className="flex-1 text-sm text-text-primary">
+            {t('installed.solo.banner', { name: soloRestore.label })}
+          </span>
+          <Button variant="secondary" size="sm" onClick={() => void restoreSoloMods()}>
+            {t('installed.solo.restore')}
+          </Button>
+          <button
+            type="button"
+            onClick={() => clearSoloRestore()}
+            title={t('common.actions.dismiss')}
+            aria-label={t('common.actions.dismiss')}
+            className="rounded-md p-1 text-text-secondary hover:bg-white/5 hover:text-text-primary"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       {lockerOverridesOpen && (
         <LockerOverridesModal
@@ -6424,6 +6475,9 @@ interface ModCardProps {
    *  local mods with no GameBanana source. */
   onViewAuthor?: () => void;
   onToggle: () => void;
+  /** Disable every other mod, enable only this one, and launch the game. Used
+   *  for A/B testing a single skin. */
+  onSoloLaunch?: () => void;
   onDelete: () => void;
   onEditLocal?: () => void;
   /** Inline rename of a local mod's name (double-click the title). Undefined
@@ -7055,6 +7109,7 @@ function ModCard({
   onOpenDetails,
   onViewAuthor,
   onToggle,
+  onSoloLaunch,
   onDelete,
   onEditLocal,
   onRenameLocal,
@@ -7397,6 +7452,21 @@ function ModCard({
               >
                 <Banana className="w-3.5 h-3.5" />
                 {t('installed.card.viewAuthorPage')}
+              </button>
+            )}
+            {onSoloLaunch && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  onSoloLaunch();
+                }}
+                className={menuItemClasses}
+              >
+                <Beaker className="w-3.5 h-3.5" />
+                {t('installed.card.soloLaunch')}
               </button>
             )}
             {(onTagLocker || onTagGlobal) && (

--- a/src/stores/appStore.solo.test.ts
+++ b/src/stores/appStore.solo.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mod } from '../types/mod';
+import * as api from '../lib/api';
+import { modRestoreKey } from '../lib/soloRestore';
+import { useAppStore } from './appStore';
+
+vi.mock('../i18n', () => ({
+  applyLanguagePreference: vi.fn(),
+}));
+
+vi.mock('../lib/api', () => ({
+  applyModToggleBatch: vi.fn(),
+}));
+
+function mod(over: Partial<Mod> & { id: string }): Mod {
+  return {
+    name: over.id,
+    fileName: `${over.id}.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    metaKey: `${over.id}.vpk`,
+    enabled: false,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+const applyModToggleBatch = vi.mocked(api.applyModToggleBatch);
+
+describe('appStore solo restore', () => {
+  beforeEach(() => {
+    applyModToggleBatch.mockReset();
+    useAppStore.setState({
+      mods: [],
+      modsError: null,
+      modsNotice: null,
+      soloRestore: null,
+    });
+  });
+
+  it('keeps the restore snapshot when restore partially fails', async () => {
+    const a = mod({ id: 'a', enabled: true, sha256: 'aa' });
+    const b = mod({ id: 'b-renamed', enabled: false, sha256: 'bb' });
+    const snap = { keys: [modRestoreKey(a), modRestoreKey(b)], label: 'A' };
+    useAppStore.setState({ mods: [a, b], soloRestore: snap });
+    applyModToggleBatch.mockResolvedValueOnce({ mods: [a, b], failures: ['enable b failed'] });
+
+    const result = await useAppStore.getState().restoreSoloMods();
+
+    expect(result).toEqual({ failures: 1 });
+    expect(applyModToggleBatch).toHaveBeenCalledWith(['b-renamed'], []);
+    expect(useAppStore.getState().soloRestore).toBe(snap);
+  });
+
+  it('clears the restore snapshot when restore fully succeeds', async () => {
+    const a = mod({ id: 'a', enabled: true, sha256: 'aa' });
+    const b = mod({ id: 'b-renamed', enabled: false, sha256: 'bb' });
+    useAppStore.setState({
+      mods: [a, b],
+      soloRestore: { keys: [modRestoreKey(a), modRestoreKey(b)], label: 'A' },
+    });
+    applyModToggleBatch.mockResolvedValueOnce({
+      mods: [a, { ...b, enabled: true }],
+      failures: [],
+    });
+
+    const result = await useAppStore.getState().restoreSoloMods();
+
+    expect(result).toEqual({ failures: 0 });
+    expect(useAppStore.getState().soloRestore).toBeNull();
+  });
+
+  it('preserves the first restore snapshot across nested solos', async () => {
+    const a = mod({ id: 'a', enabled: true, sha256: 'aa' });
+    const b = mod({ id: 'b', enabled: true, sha256: 'bb' });
+    const c = mod({ id: 'c', enabled: false, sha256: 'cc' });
+    const originalKeys = [modRestoreKey(a), modRestoreKey(b)];
+    useAppStore.setState({ mods: [a, b, c] });
+    applyModToggleBatch
+      .mockResolvedValueOnce({
+        mods: [a, { ...b, enabled: false }, c],
+        failures: [],
+      })
+      .mockResolvedValueOnce({
+        mods: [{ ...a, enabled: false }, { ...b, enabled: false }, { ...c, enabled: true }],
+        failures: [],
+      });
+
+    await useAppStore.getState().soloMod([modRestoreKey(a)], 'A');
+    await useAppStore.getState().soloMod([modRestoreKey(c)], 'C');
+
+    expect(useAppStore.getState().soloRestore).toEqual({ keys: originalKeys, label: 'C' });
+  });
+
+  it('aborts solo when no target key resolves', async () => {
+    useAppStore.setState({ mods: [mod({ id: 'a', enabled: true, sha256: 'aa' })] });
+
+    const result = await useAppStore.getState().soloMod(['sha:ghost'], 'Ghost');
+
+    expect(result).toEqual({ applied: false, failures: 0, reason: 'missing' });
+    expect(applyModToggleBatch).not.toHaveBeenCalled();
+    expect(useAppStore.getState().mods.map((m) => m.id)).toEqual(['a']);
+  });
+});

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -5,6 +5,7 @@ import { setDateFormat } from '../lib/dateFormat';
 import { applyLanguagePreference } from '../i18n';
 import * as api from '../lib/api';
 import { buildHeroList } from '../lib/lockerUtils';
+import { modRestoreKey, planSolo, planRestore } from '../lib/soloRestore';
 import {
   SHUFFLE_INCLUDED_KEY,
   SHUFFLE_ON_LAUNCH_KEY,
@@ -205,6 +206,12 @@ interface AppState {
   // toast rather than replacing the page the way modsError does.
   modsNotice: string | null;
 
+  // "Start with only this mod" solo test: identity keys of the mods that were
+  // enabled before the last soloMod swap, so the Installed page can offer a
+  // one-click restore. Kept as stable keys (not ids) because disabling renames
+  // a VPK and churns its id. Null when no solo swap is outstanding.
+  soloRestore: { keys: string[]; label: string } | null;
+
   // Download counts cache (mod id -> { downloadCount, timestamp })
   downloadCountsCache: Map<number, CacheEntry<number>>;
 
@@ -291,6 +298,15 @@ interface AppState {
   setShuffleOnLaunch: (enabled: boolean) => void;
   toggleShuffleIncluded: (skinKey: string) => void;
   runLaunchShuffle: () => Promise<{ failures: number }>;
+  /** Disable every other mod and enable only `enableIds` (one card's file(s)),
+   *  snapshotting the prior enabled set for one-click restore. `applied` is
+   *  false only when the whole batch was rejected (e.g. game running), so the
+   *  caller knows whether it's safe to launch. */
+  soloMod: (enableIds: string[], label: string) => Promise<{ applied: boolean; failures: number }>;
+  /** Re-apply the enabled set captured by the last soloMod call. */
+  restoreSoloMods: () => Promise<void>;
+  /** Drop the solo-restore snapshot without touching enablement. */
+  clearSoloRestore: () => void;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
   setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<void>;
@@ -357,6 +373,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   modsLoading: false,
   modsError: null,
   modsNotice: null,
+  soloRestore: null,
   downloadCountsCache: new Map(),
   soundVolume: readPersistedSoundVolume(),
   previewAudioPlaying: false,
@@ -726,6 +743,47 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     });
   },
+
+  // "Start with only this mod enabled." Disables every currently-enabled mod
+  // except the target file(s) and enables the target, as one atomic batch, then
+  // snapshots the prior enabled set (by stable key) so the page can restore it.
+  // Runs inside enqueueToggle so the plan is derived after any in-flight toggle.
+  soloMod: (enableIds, label) => enqueueToggle(async () => {
+    const mods = get().mods;
+    const { enable, disable } = planSolo(mods, enableIds);
+    // Already solo (target is the only thing enabled): nothing to swap, and no
+    // meaningful state to restore to, so skip the snapshot but let the caller
+    // launch.
+    if (enable.length === 0 && disable.length === 0) return { applied: true, failures: 0 };
+    const keys = mods.filter((m) => m.enabled).map(modRestoreKey);
+    try {
+      const { mods: updated, failures } = await api.applyModToggleBatch(enable, disable);
+      set({ mods: updated, soloRestore: { keys, label } });
+      return { applied: true, failures: failures.length };
+    } catch (err) {
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+      else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
+      get().loadMods();
+      return { applied: false, failures: 0 };
+    }
+  }),
+
+  restoreSoloMods: () => enqueueToggle(async () => {
+    const snap = get().soloRestore;
+    if (!snap) return;
+    const { enable, disable } = planRestore(get().mods, snap.keys);
+    if (enable.length === 0 && disable.length === 0) { set({ soloRestore: null }); return; }
+    try {
+      const { mods: updated } = await api.applyModToggleBatch(enable, disable);
+      set({ mods: updated, soloRestore: null });
+    } catch (err) {
+      if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
+      else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
+      get().loadMods();
+    }
+  }),
+
+  clearSoloRestore: () => set({ soloRestore: null }),
 
   editLocalMod: async (modId: string, args: EditLocalModArgs) => {
     const updated = await api.editLocalMod(modId, args);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -5,7 +5,7 @@ import { setDateFormat } from '../lib/dateFormat';
 import { applyLanguagePreference } from '../i18n';
 import * as api from '../lib/api';
 import { buildHeroList } from '../lib/lockerUtils';
-import { modRestoreKey, planSolo, planRestore } from '../lib/soloRestore';
+import { modRestoreKey, planSoloByKeys, planRestore } from '../lib/soloRestore';
 import {
   SHUFFLE_INCLUDED_KEY,
   SHUFFLE_ON_LAUNCH_KEY,
@@ -298,13 +298,13 @@ interface AppState {
   setShuffleOnLaunch: (enabled: boolean) => void;
   toggleShuffleIncluded: (skinKey: string) => void;
   runLaunchShuffle: () => Promise<{ failures: number }>;
-  /** Disable every other mod and enable only `enableIds` (one card's file(s)),
+  /** Disable every other mod and enable only `enableKeys` (one card's file(s)),
    *  snapshotting the prior enabled set for one-click restore. `applied` is
-   *  false only when the whole batch was rejected (e.g. game running), so the
-   *  caller knows whether it's safe to launch. */
-  soloMod: (enableIds: string[], label: string) => Promise<{ applied: boolean; failures: number }>;
+   *  false when the target no longer resolves or the whole batch was rejected
+   *  (e.g. game running), so the caller knows whether it's safe to launch. */
+  soloMod: (enableKeys: string[], label: string) => Promise<{ applied: boolean; failures: number; reason?: 'missing' | 'blocked' }>;
   /** Re-apply the enabled set captured by the last soloMod call. */
-  restoreSoloMods: () => Promise<void>;
+  restoreSoloMods: () => Promise<{ failures: number }>;
   /** Drop the solo-restore snapshot without touching enablement. */
   clearSoloRestore: () => void;
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
@@ -744,18 +744,19 @@ export const useAppStore = create<AppState>((set, get) => ({
     });
   },
 
-  // "Start with only this mod enabled." Disables every currently-enabled mod
-  // except the target file(s) and enables the target, as one atomic batch, then
-  // snapshots the prior enabled set (by stable key) so the page can restore it.
-  // Runs inside enqueueToggle so the plan is derived after any in-flight toggle.
-  soloMod: (enableIds, label) => enqueueToggle(async () => {
+  // "Start with only this mod enabled." The UI passes stable keys, not current
+  // ids, because queued toggles may rename the target before this plan runs.
+  // The plan is resolved inside enqueueToggle against the post-toggle mod list.
+  soloMod: (enableKeys, label) => enqueueToggle(async () => {
     const mods = get().mods;
-    const { enable, disable } = planSolo(mods, enableIds);
+    const plan = planSoloByKeys(mods, enableKeys);
+    if (!plan) return { applied: false, failures: 0, reason: 'missing' };
+    const { enable, disable } = plan;
     // Already solo (target is the only thing enabled): nothing to swap, and no
     // meaningful state to restore to, so skip the snapshot but let the caller
     // launch.
     if (enable.length === 0 && disable.length === 0) return { applied: true, failures: 0 };
-    const keys = mods.filter((m) => m.enabled).map(modRestoreKey);
+    const keys = get().soloRestore?.keys ?? mods.filter((m) => m.enabled).map(modRestoreKey);
     try {
       const { mods: updated, failures } = await api.applyModToggleBatch(enable, disable);
       set({ mods: updated, soloRestore: { keys, label } });
@@ -764,22 +765,27 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
       get().loadMods();
-      return { applied: false, failures: 0 };
+      return { applied: false, failures: 0, reason: 'blocked' };
     }
   }),
 
   restoreSoloMods: () => enqueueToggle(async () => {
     const snap = get().soloRestore;
-    if (!snap) return;
+    if (!snap) return { failures: 0 };
     const { enable, disable } = planRestore(get().mods, snap.keys);
-    if (enable.length === 0 && disable.length === 0) { set({ soloRestore: null }); return; }
+    if (enable.length === 0 && disable.length === 0) {
+      set({ soloRestore: null });
+      return { failures: 0 };
+    }
     try {
-      const { mods: updated } = await api.applyModToggleBatch(enable, disable);
-      set({ mods: updated, soloRestore: null });
+      const { mods: updated, failures } = await api.applyModToggleBatch(enable, disable);
+      set({ mods: updated, soloRestore: failures.length === 0 ? null : snap });
+      return { failures: failures.length };
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
       get().loadMods();
+      return { failures: enable.length + disable.length };
     }
   }),
 


### PR DESCRIPTION
## What

Adds a per-card action **"Start with only this enabled"** (beaker icon, in the card's actions menu). It disables every other mod, enables just that one, and launches Deadlock: the A/B skin-testing flow requested on Discord (macchiako). A dismissable banner then offers one-click **Restore mods** to bring the previous enabled set back.

Works for single mods and for grouped variants (keeps the group's enabled variants, or falls back to the primary when the whole group is off).

## Why restore is non-trivial

Disabling a mod renames its VPK into `.disabled/`, which changes its `metaKey` and therefore its `id`. So a restore snapshot can't hold ids. Instead it snapshots a **stable identity key** per previously-enabled mod (GameBanana `fileId` + `vpkIndex`, then `sha256`, then `name`+`size`) and re-matches against the current list on restore. Same approach profiles use to survive id churn.

## Implementation

- `src/lib/soloRestore.ts` (new) - pure `modRestoreKey` / `planSolo` / `planRestore`, unit-tested (`soloRestore.test.ts`, 10 cases incl. the id-churn restore).
- `appStore.ts` - `soloMod` / `restoreSoloMods` / `clearSoloRestore` actions + `soloRestore` snapshot state. Both apply via the existing atomic `applyModToggleBatch`, inside `enqueueToggle`, mirroring `runLaunchShuffle`'s error handling (enable-cap notice, game-running lock).
- `Installed.tsx` - menu item, page handler (`soloLaunchEntry`, launches after the swap without re-running the launch shuffle), and the restore banner.
- Solo does **not** trigger the launch shuffle (that would re-randomize and defeat the point).

## Notes / scope

- The restore snapshot is in-memory (session-scoped): it survives tab navigation but not an app restart. Reasonable for a "test this now" flow; can persist later if wanted.
- If the game is already running the toggle batch is rejected (lock) and launch is skipped; no snapshot is written.

## Testing

- `pnpm build` (with placeholder `GRIMOIRE_SOCIAL_BASE_URL`), `tsc`, `eslint`, `pnpm i18n:check`, manifest check: all clean.
- `vitest run`: 550 passed (was 540; +10 new).
- Not yet manually exercised end-to-end in the running app (no game/Steam here) - worth a quick smoke test: solo a skin, launch, restore.