### PR TITLE
chore(release): v1.23.0

### DIFF
--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -351,7 +351,17 @@ async function detectFromEmbed(
                 modName: modinfo.title ?? base.search ?? undefined,
                 fileId: modinfo.source.gamebananaFileId,
                 fileName,
-                section: modinfo.source.section === 'Sound' ? 'Sound' : 'Mod',
+                // GameBanana ids are per-section namespaces, so only carry a
+                // section we can map to the two the match result models. An
+                // unrecognized section (notably 'Wip') falls to undefined
+                // rather than coercing to 'Mod', which would query the wrong
+                // namespace. Mirrors the legacy addoninfo branch below.
+                section:
+                    modinfo.source.section === 'Sound'
+                        ? 'Sound'
+                        : modinfo.source.section === 'Mod'
+                          ? 'Mod'
+                          : undefined,
                 categoryName: modinfo.source.categoryName,
                 confidence: 'exact',
                 reason: 'Identified from embedded Grimoire metadata (no network).',

--- a/electron/main/services/unknownModEmbedDetect.test.ts
+++ b/electron/main/services/unknownModEmbedDetect.test.ts
@@ -125,6 +125,32 @@ describe('detectUnknownModCacheMatches embed consult', () => {
         });
     });
 
+    it('leaves the section undefined for a non-Mod/Sound modinfo section instead of coercing to Mod', async () => {
+        readEmbeddedAddonInfo.mockReturnValue(addonInfo());
+        carryForwardOriginalIdentity.mockReturnValue({ sha256: 'a'.repeat(64) });
+        readEmbeddedModinfo.mockReturnValue(
+            modRecord({
+                source: {
+                    gamebananaId: 4242,
+                    gamebananaFileId: 9001,
+                    section: 'Wip',
+                    categoryName: 'Works in Progress',
+                },
+            })
+        );
+
+        const [result] = await detectUnknownModCacheMatches([
+            { modId: 'm1', fileName: 'pak01_dir.vpk', vpkPath: IMPRINTED },
+        ]);
+
+        // GameBanana ids are per-section namespaces; coercing 'Wip' -> 'Mod'
+        // would query the wrong submission. It must fall to undefined.
+        expect(result.crcMatch.status).toBe('found');
+        expect(result.crcMatch.section).toBeUndefined();
+        expect(result.crcMatch.modId).toBe(4242);
+        expect(result.crcMatch.fileId).toBe(9001);
+    });
+
     it('derives the Sound section and file id from legacy addoninfo keys', async () => {
         readEmbeddedAddonInfo.mockReturnValue(
             addonInfo({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2999,6 +2999,8 @@ export default function Installed() {
       if (!applied) {
         if (reason === 'missing') {
           showToast(t('installed.solo.targetMissing'), { tone: 'error' });
+        } else if (reason === 'gameRunning') {
+          showToast(t('common.gameRunningWarning'), { tone: 'warning' });
         }
         return;
       }

--- a/src/stores/appStore.solo.test.ts
+++ b/src/stores/appStore.solo.test.ts
@@ -10,6 +10,9 @@ vi.mock('../i18n', () => ({
 
 vi.mock('../lib/api', () => ({
   applyModToggleBatch: vi.fn(),
+  // soloMod's error path re-scans via loadMods; keep it a no-op so the catch
+  // branch under test isn't derailed by an unmocked api call.
+  getMods: vi.fn(async () => []),
 }));
 
 function mod(over: Partial<Mod> & { id: string }): Mod {
@@ -101,5 +104,18 @@ describe('appStore solo restore', () => {
     expect(result).toEqual({ applied: false, failures: 0, reason: 'missing' });
     expect(applyModToggleBatch).not.toHaveBeenCalled();
     expect(useAppStore.getState().mods.map((m) => m.id)).toEqual(['a']);
+  });
+
+  it('reports the game-running lock as a distinct reason so the caller can warn', async () => {
+    const a = mod({ id: 'a', enabled: true, sha256: 'aa' });
+    const b = mod({ id: 'b', enabled: true, sha256: 'bb' });
+    useAppStore.setState({ mods: [a, b] });
+    applyModToggleBatch.mockRejectedValueOnce(new Error('Game is running; refusing to modify mods.'));
+
+    const result = await useAppStore.getState().soloMod([modRestoreKey(a)], 'A');
+
+    expect(result).toEqual({ applied: false, failures: 0, reason: 'gameRunning' });
+    // Expected, recoverable lock: it must not snapshot a restore set (nothing changed).
+    expect(useAppStore.getState().soloRestore).toBeNull();
   });
 });

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -302,7 +302,7 @@ interface AppState {
    *  snapshotting the prior enabled set for one-click restore. `applied` is
    *  false when the target no longer resolves or the whole batch was rejected
    *  (e.g. game running), so the caller knows whether it's safe to launch. */
-  soloMod: (enableKeys: string[], label: string) => Promise<{ applied: boolean; failures: number; reason?: 'missing' | 'blocked' }>;
+  soloMod: (enableKeys: string[], label: string) => Promise<{ applied: boolean; failures: number; reason?: 'missing' | 'blocked' | 'gameRunning' }>;
   /** Re-apply the enabled set captured by the last soloMod call. */
   restoreSoloMods: () => Promise<{ failures: number }>;
   /** Drop the solo-restore snapshot without touching enablement. */
@@ -765,7 +765,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
       get().loadMods();
-      return { applied: false, failures: 0, reason: 'blocked' };
+      // The game-running lock is swallowed silently everywhere else (background
+      // toggles), but a solo *launch* that does nothing needs a reason, so the
+      // caller can surface it. Enable-cap already auto-toasts via modsNotice and
+      // a generic error drops the full-page modsError screen, so both stay 'blocked'.
+      return {
+        applied: false,
+        failures: 0,
+        reason: isGameRunningModLockError(err) ? 'gameRunning' : 'blocked',
+      };
     }
   }),
 


### PR DESCRIPTION
Release cut for **v1.23.0**. Version bumped in \`package.json\`; this PR also carries two small pre-release review fixes (with regression tests).

## What's in v1.23.0 (already on main)
- feat: self-identifying VPKs / vpk-modinfo v1 imprinting (#287, @oldreceipt) + follow-ups (#288). Experimental, off by default.
- feat: "start with only this mod enabled" solo launch (#290)
- Quick wins: in-app GameBanana links, copy enabled mods, import state colors, persona persistence (#289)

## Fixes in this PR
- **fix(unknown):** stop coercing a non-Mod/Sound imprint section to \`Mod\`. A WiP-sourced imprinted mod resolved against the wrong GameBanana id namespace; it now falls to \`undefined\`, matching the legacy branch.
- **fix(installed):** solo launch blocked by a running game was a silent no-op. \`soloMod\` now returns a distinct \`gameRunning\` reason and the caller shows the localized warning.

## Validation
- Gates green: \`tsc -b\`, \`eslint\`, vitest **563 passed**, \`i18n:check\`, manifest \`--check\`.
- vpkmerge pin \`v0.19.0\` published; pinned SHA256 matches the release binary.
- Local \`Grimoire-1.23.0.AppImage\` + \`.deb\` packaged and launch-verified (logger reports version=1.23.0).
- No new deps; \`experimentalVpkImprinting\` defaults off.

Kept the 3 \`PRE-RELEASE SHIM\` markers deliberately (they're wired into live never-flatten + merge-repack paths); removal is a post-1.23.0 follow-up.