### PR TITLE
fix(installed): fall back to cached details when GameBanana is unreachable

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -24,6 +24,7 @@ import {
   Trash2,
   Coffee,
   Link2,
+  CloudOff,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type {
@@ -71,6 +72,10 @@ interface ModDetailsModalProps {
   hideNsfwPreviews: boolean;
   dateAdded?: number;
   dateModified?: number;
+  /** The mod object was rebuilt from the local catalog cache because the live
+   *  GameBanana fetch failed. Renders a banner explaining why description,
+   *  files, and previews may be missing. */
+  offline?: boolean;
   isNavigating?: boolean;
   navigationDirection?: ModDetailsNavigationDirection;
   navigationLabel?: string;
@@ -125,6 +130,7 @@ function ModDetailsModal({
   hideNsfwPreviews,
   dateAdded,
   dateModified,
+  offline = false,
   isNavigating = false,
   navigationDirection = 'next',
   navigationLabel,
@@ -250,6 +256,14 @@ function ModDetailsModal({
   }, [mod.id, installedFileIsArchived]);
 
   useEffect(() => {
+    // Offline fallback mods were built from the local cache; comments and
+    // updates would just re-fail against the same unreachable API.
+    if (offline) {
+      setComments([]);
+      setCommentsTotalCount(0);
+      setCommentsLoading(false);
+      return;
+    }
     let cancelled = false;
     setCommentsLoading(true);
     getModComments(mod.id, section)
@@ -268,9 +282,16 @@ function ModDetailsModal({
     return () => {
       cancelled = true;
     };
-  }, [mod.id, section]);
+  }, [mod.id, section, offline]);
 
   useEffect(() => {
+    if (offline) {
+      setUpdates([]);
+      setUpdatesTotalCount(0);
+      setUpdatesError(null);
+      setUpdatesLoading(false);
+      return;
+    }
     let cancelled = false;
     setUpdatesLoading(true);
     setUpdatesError(null);
@@ -300,7 +321,7 @@ function ModDetailsModal({
     return () => {
       cancelled = true;
     };
-  }, [mod.id, section]);
+  }, [mod.id, section, offline]);
 
   // Reset the image cursor when the mod changes so the sidebar carousel (and a
   // subsequently-opened lightbox) starts on the first preview rather than a
@@ -1085,6 +1106,13 @@ function ModDetailsModal({
                 </Button>
               </div>
             </div>
+          </div>
+        )}
+
+        {offline && (
+          <div className="flex items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-5 py-2 text-xs text-amber-300">
+            <CloudOff className="h-3.5 w-3.5 flex-shrink-0" />
+            {t('modDetails.offlineNotice')}
           </div>
         )}
 

--- a/src/lib/cachedModDetails.test.ts
+++ b/src/lib/cachedModDetails.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { CachedMod } from '../types/electron';
+import { buildCachedModDetails, canUseCachedModDetails } from './cachedModDetails';
+
+function cachedMod(overrides: Partial<CachedMod> = {}): CachedMod {
+  return {
+    id: 42,
+    name: 'Cached mod',
+    section: 'Mod',
+    categoryId: 7,
+    categoryName: 'Skins',
+    submitterName: 'Modder',
+    submitterId: 9,
+    likeCount: 0,
+    viewCount: 0,
+    downloadCount: 0,
+    dateAdded: 1,
+    dateModified: 2,
+    hasFiles: true,
+    isNsfw: true,
+    thumbnailUrl: 'https://images.gamebanana.com/img/ss/mods/preview.webp',
+    audioUrl: null,
+    profileUrl: 'https://gamebanana.com/mods/42',
+    cachedAt: 3,
+    ...overrides,
+  };
+}
+
+describe('canUseCachedModDetails', () => {
+  it.each([
+    new TypeError('fetch failed'),
+    new Error('GameBanana API request timed out after 30 seconds'),
+    new Error('connect ECONNRESET'),
+    new Error('GameBanana API error: 429 Too Many Requests'),
+    new Error('GameBanana API error: 503 Service Unavailable'),
+    new Error('GameBanana API returned empty response'),
+    new Error('GameBanana API returned invalid JSON: SyntaxError'),
+  ])('allows a cached fallback for a transient failure: %s', (error) => {
+    expect(canUseCachedModDetails(error)).toBe(true);
+  });
+
+  it.each([
+    new Error('GameBanana API error: 404 Not Found'),
+    new Error('GameBanana API error: 403 Forbidden'),
+    new Error('Unexpected mapping bug'),
+    new TypeError("Cannot read properties of undefined (reading '_idRow')"),
+  ])('keeps permanent or unexpected failures visible: %s', (error) => {
+    expect(canUseCachedModDetails(error)).toBe(false);
+  });
+});
+
+describe('buildCachedModDetails', () => {
+  it('maps catalog metadata into a degraded details object', () => {
+    expect(buildCachedModDetails(42, cachedMod())).toEqual({
+      id: 42,
+      name: 'Cached mod',
+      nsfw: true,
+      category: { id: 7, name: 'Skins' },
+      submitter: { id: 9, name: 'Modder' },
+      previewMedia: {
+        images: [{
+          baseUrl: 'https://images.gamebanana.com/img/ss/mods',
+          file: 'preview.webp',
+        }],
+      },
+    });
+  });
+
+  it('uses the installed name when the catalog has no row', () => {
+    expect(buildCachedModDetails(42, null, 'Installed mod')).toEqual({
+      id: 42,
+      name: 'Installed mod',
+      nsfw: false,
+      category: undefined,
+      submitter: undefined,
+      previewMedia: undefined,
+    });
+  });
+
+  it('cannot build linked-item details without a cached name', () => {
+    expect(buildCachedModDetails(42, null)).toBeNull();
+  });
+});

--- a/src/lib/cachedModDetails.ts
+++ b/src/lib/cachedModDetails.ts
@@ -1,0 +1,50 @@
+import type { CachedMod } from '../types/electron';
+import type { GameBananaModDetails } from '../types/gamebanana';
+
+/**
+ * Errors that mean live GameBanana details are temporarily unavailable and a
+ * local fallback is preferable. Permanent HTTP failures (notably 404) and
+ * unexpected renderer/main-process errors remain visible to the user.
+ */
+export function canUseCachedModDetails(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    /\bfetch failed\b/i.test(message) ||
+    /\bnetwork(?: request)? (?:error|failed)\b/i.test(message) ||
+    /\b(?:ENOTFOUND|EAI_AGAIN|ECONNABORTED|ECONNREFUSED|ECONNRESET|ENETUNREACH|ETIMEDOUT|UND_ERR_[A-Z_]+)\b/i.test(message) ||
+    /\b(?:request )?timed out\b/i.test(message) ||
+    /GameBanana API error:\s*(?:408|425|429|5\d\d)\b/i.test(message) ||
+    /GameBanana API returned (?:an )?(?:empty response|invalid JSON)/i.test(message)
+  );
+}
+
+/** Build the subset of details available from the local catalog mirror. */
+export function buildCachedModDetails(
+  gbId: number,
+  cached: CachedMod | null,
+  fallbackName?: string,
+): GameBananaModDetails | null {
+  const name = cached?.name ?? fallbackName;
+  if (!name) return null;
+
+  const thumbnailUrl = cached?.thumbnailUrl;
+  const slash = thumbnailUrl?.lastIndexOf('/') ?? -1;
+
+  return {
+    id: gbId,
+    name,
+    nsfw: cached?.isNsfw ?? false,
+    category: cached?.categoryName
+      ? { id: cached.categoryId ?? undefined, name: cached.categoryName }
+      : undefined,
+    submitter:
+      cached?.submitterName && cached.submitterId
+        ? { id: cached.submitterId, name: cached.submitterName }
+        : undefined,
+    previewMedia:
+      thumbnailUrl && slash > 0
+        ? { images: [{ baseUrl: thumbnailUrl.slice(0, slash), file: thumbnailUrl.slice(slash + 1) }] }
+        : undefined,
+  };
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2367,6 +2367,7 @@
     "viewOnGamebanana": "View on GameBanana",
     "copyLink": "Copy link",
     "linkCopied": "Link copied",
+    "offlineNotice": "GameBanana is unreachable. Showing cached info; description, files, and comments are unavailable.",
     "outdatedWarning": "This mod was last updated on {{date}} and may not be compatible with the current Deadlock version.",
     "deleteFile": {
       "title": "Delete installed file?",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2367,7 +2367,7 @@
     "viewOnGamebanana": "View on GameBanana",
     "copyLink": "Copy link",
     "linkCopied": "Link copied",
-    "offlineNotice": "GameBanana is unreachable. Showing cached info; description, files, and comments are unavailable.",
+    "offlineNotice": "Live GameBanana details are temporarily unavailable. Showing cached info; description, files, and comments are unavailable.",
     "outdatedWarning": "This mod was last updated on {{date}} and may not be compatible with the current Deadlock version.",
     "deleteFile": {
       "title": "Delete installed file?",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1968,
+  "totalKeys": 1969,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1968,
+      "translatedKeys": 1969,
       "pct": 100
     },
     {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -78,6 +78,7 @@ import type { UnmergeModResult, ImprintAllInstalledResult, ImprintInstalledProgr
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterGuess, MergedModSource, AssociateUnknownModArgs, ImprintAnomalousMod, ImprintSkippedMod, ImprintFailedMod } from '../types/mod';
 import type { GameBananaModDetails, GameBananaMod, GameBananaItemRef } from '../types/gamebanana';
+import type { CachedMod } from '../types/electron';
 import { getModThumbnail } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import ImageContextMenu from '../components/ImageContextMenu';
@@ -703,6 +704,35 @@ function getCardSizeGridStyle(multiplier: number): CSSProperties {
   } as CSSProperties;
 }
 
+// Degraded details built from the local catalog mirror (mods-cache.db) plus
+// the installed mod's own metadata, shown when the live GameBanana fetch
+// fails. Keeps the overlay usable offline instead of surfacing a raw fetch
+// error; the modal hides its files section when `files` is absent.
+function buildCachedModDetails(
+  gbId: number,
+  cached: CachedMod | null,
+  fallbackName?: string,
+): GameBananaModDetails | null {
+  const name = cached?.name ?? fallbackName;
+  if (!name) return null;
+  const thumbnailUrl = cached?.thumbnailUrl;
+  const slash = thumbnailUrl?.lastIndexOf('/') ?? -1;
+  return {
+    id: gbId,
+    name,
+    nsfw: cached?.isNsfw ?? false,
+    category: cached?.categoryName ? { id: cached.categoryId ?? undefined, name: cached.categoryName } : undefined,
+    submitter:
+      cached?.submitterName && cached.submitterId
+        ? { id: cached.submitterId, name: cached.submitterName }
+        : undefined,
+    previewMedia:
+      thumbnailUrl && slash > 0
+        ? { images: [{ baseUrl: thumbnailUrl.slice(0, slash), file: thumbnailUrl.slice(slash + 1) }] }
+        : undefined,
+  };
+}
+
 export default function Installed() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -1218,6 +1248,9 @@ export default function Installed() {
   const [detailsCategoryId, setDetailsCategoryId] = useState<number>(0);
   const [detailsLoading, setDetailsLoading] = useState(false);
   const [detailsError, setDetailsError] = useState<string | null>(null);
+  // True when the overlay is showing cached-catalog data because the live
+  // GameBanana fetch failed; drives the offline banner in the modal.
+  const [detailsOffline, setDetailsOffline] = useState(false);
   const [detailsUpdateAvailable, setDetailsUpdateAvailable] = useState(false);
   const [detailsIgnoreUpdates, setDetailsIgnoreUpdates] = useState(false);
   const [detailsInstalledFileIds, setDetailsInstalledFileIds] = useState<Set<number>>(new Set());
@@ -1325,19 +1358,32 @@ export default function Installed() {
     setDetailsUpdateAvailable(updatesAvailable.has(m.id));
     setDetailsIgnoreUpdates(!!m.ignoreUpdates);
     setDetailsDates(null);
+    setDetailsOffline(false);
+    const cachedPromise = window.electronAPI.getCachedMod(m.gameBananaId).catch(() => null);
     try {
-      const [details, cached] = await Promise.all([
-        getModDetails(m.gameBananaId, section, { includeSubmitter: true }),
-        window.electronAPI.getCachedMod(m.gameBananaId).catch(() => null),
-      ]);
+      const details = await getModDetails(m.gameBananaId, section, { includeSubmitter: true });
+      const cached = await cachedPromise;
       if (detailsRequestIdRef.current !== requestId) return;
       setDetailsMod(details);
       if (cached) {
         setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
       }
     } catch (err) {
+      const cached = await cachedPromise;
       if (detailsRequestIdRef.current !== requestId) return;
-      setDetailsError(String(err));
+      // GameBanana unreachable (or the page is gone): fall back to the local
+      // catalog record plus the installed mod's own name so the overlay still
+      // opens instead of dead-ending on a raw fetch error.
+      const fallback = buildCachedModDetails(m.gameBananaId, cached, m.name);
+      if (fallback) {
+        setDetailsMod(fallback);
+        setDetailsOffline(true);
+        if (cached) {
+          setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
+        }
+      } else {
+        setDetailsError(String(err));
+      }
     } finally {
       if (detailsRequestIdRef.current === requestId) {
         setDetailsLoading(false);
@@ -1348,6 +1394,7 @@ export default function Installed() {
   const closeModDetails = () => {
     setDetailsMod(null);
     setDetailsError(null);
+    setDetailsOffline(false);
     setDetailsUpdateAvailable(false);
     setDetailsIgnoreUpdates(false);
     setDetailsSourceModId(null);
@@ -1392,20 +1439,31 @@ export default function Installed() {
     setDetailsUpdateAvailable(updateAvailable);
     setDetailsDates(null);
 
+    const cachedPromise = window.electronAPI.getCachedMod(item.id).catch(() => null);
     try {
-      const [details, cached] = await Promise.all([
-        getModDetails(item.id, item.section, { includeSubmitter: true }),
-        window.electronAPI.getCachedMod(item.id).catch(() => null),
-      ]);
+      const details = await getModDetails(item.id, item.section, { includeSubmitter: true });
+      const cached = await cachedPromise;
       if (detailsRequestIdRef.current !== requestId) return;
       setDetailsMod(details);
+      setDetailsOffline(false);
       setDetailsSection(item.section);
       if (cached) {
         setDetailsDates({ dateAdded: cached.dateAdded, dateModified: cached.dateModified });
       }
     } catch (err) {
+      const cached = await cachedPromise;
       if (detailsRequestIdRef.current !== requestId) return;
-      setDetailsError(String(err));
+      // Linked items may not be installed, so the only offline fallback is the
+      // catalog cache; without a row there we still have to show the error.
+      const fallback = buildCachedModDetails(item.id, cached);
+      if (fallback) {
+        setDetailsMod(fallback);
+        setDetailsOffline(true);
+        setDetailsSection(item.section);
+        setDetailsDates({ dateAdded: cached!.dateAdded, dateModified: cached!.dateModified });
+      } else {
+        setDetailsError(String(err));
+      }
     }
   });
 
@@ -4378,6 +4436,7 @@ export default function Installed() {
           hideNsfwPreviews={installedHideNsfwPreviews}
           dateAdded={detailsDates?.dateAdded}
           dateModified={detailsDates?.dateModified}
+          offline={detailsOffline}
           updateAvailable={detailsUpdateAvailable}
           ignoreUpdates={detailsIgnoreUpdates}
           onToggleIgnoreUpdates={

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -78,7 +78,6 @@ import type { UnmergeModResult, ImprintAllInstalledResult, ImprintInstalledProgr
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterGuess, MergedModSource, AssociateUnknownModArgs, ImprintAnomalousMod, ImprintSkippedMod, ImprintFailedMod } from '../types/mod';
 import type { GameBananaModDetails, GameBananaMod, GameBananaItemRef } from '../types/gamebanana';
-import type { CachedMod } from '../types/electron';
 import { getModThumbnail } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
 import ImageContextMenu from '../components/ImageContextMenu';
@@ -96,6 +95,7 @@ import { formatBytes } from '../lib/formatBytes';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
 import { createEnabledVpkRestoreSnapshot, shouldRestoreVpkEnabled, type EnabledVpkRestoreSnapshot } from '../lib/vpkRestore';
 import { modRestoreKey } from '../lib/soloRestore';
+import { buildCachedModDetails, canUseCachedModDetails } from '../lib/cachedModDetails';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
 import { FormField, Input, Select } from '../components/common/forms';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -702,35 +702,6 @@ function getCardSizeGridStyle(multiplier: number): CSSProperties {
     '--card-size': getCardSizeCss(multiplier),
     gridTemplateColumns: 'repeat(auto-fill, minmax(var(--card-size), 1fr))',
   } as CSSProperties;
-}
-
-// Degraded details built from the local catalog mirror (mods-cache.db) plus
-// the installed mod's own metadata, shown when the live GameBanana fetch
-// fails. Keeps the overlay usable offline instead of surfacing a raw fetch
-// error; the modal hides its files section when `files` is absent.
-function buildCachedModDetails(
-  gbId: number,
-  cached: CachedMod | null,
-  fallbackName?: string,
-): GameBananaModDetails | null {
-  const name = cached?.name ?? fallbackName;
-  if (!name) return null;
-  const thumbnailUrl = cached?.thumbnailUrl;
-  const slash = thumbnailUrl?.lastIndexOf('/') ?? -1;
-  return {
-    id: gbId,
-    name,
-    nsfw: cached?.isNsfw ?? false,
-    category: cached?.categoryName ? { id: cached.categoryId ?? undefined, name: cached.categoryName } : undefined,
-    submitter:
-      cached?.submitterName && cached.submitterId
-        ? { id: cached.submitterId, name: cached.submitterName }
-        : undefined,
-    previewMedia:
-      thumbnailUrl && slash > 0
-        ? { images: [{ baseUrl: thumbnailUrl.slice(0, slash), file: thumbnailUrl.slice(slash + 1) }] }
-        : undefined,
-  };
 }
 
 export default function Installed() {
@@ -1371,10 +1342,12 @@ export default function Installed() {
     } catch (err) {
       const cached = await cachedPromise;
       if (detailsRequestIdRef.current !== requestId) return;
-      // GameBanana unreachable (or the page is gone): fall back to the local
-      // catalog record plus the installed mod's own name so the overlay still
-      // opens instead of dead-ending on a raw fetch error.
-      const fallback = buildCachedModDetails(m.gameBananaId, cached, m.name);
+      // For transient GameBanana failures, fall back to the local catalog
+      // record plus the installed mod's own name so the overlay still opens.
+      // Permanent and unexpected errors remain visible for diagnosis.
+      const fallback = canUseCachedModDetails(err)
+        ? buildCachedModDetails(m.gameBananaId, cached, m.name)
+        : null;
       if (fallback) {
         setDetailsMod(fallback);
         setDetailsOffline(true);
@@ -1455,13 +1428,20 @@ export default function Installed() {
       if (detailsRequestIdRef.current !== requestId) return;
       // Linked items may not be installed, so the only offline fallback is the
       // catalog cache; without a row there we still have to show the error.
-      const fallback = buildCachedModDetails(item.id, cached);
+      const fallback = canUseCachedModDetails(err)
+        ? buildCachedModDetails(item.id, cached)
+        : null;
       if (fallback) {
         setDetailsMod(fallback);
         setDetailsOffline(true);
         setDetailsSection(item.section);
         setDetailsDates({ dateAdded: cached!.dateAdded, dateModified: cached!.dateModified });
       } else {
+        // The previous item remains mounted while a linked item loads. Clear it
+        // before setting the error so the error dialog is not suppressed by its
+        // `!detailsMod` guard.
+        setDetailsMod(null);
+        setDetailsOffline(false);
         setDetailsError(String(err));
       }
     }


### PR DESCRIPTION
## Context

A user on Discord hit "Couldn't load mod details: TypeError: fetch failed" from the Installed page, intermittently ("half the time"). Their exported logs show every GameBanana request failing while the GitHub updater downloaded 80 MB in the same seconds: GB itself was unreachable for them, and the details overlay had no offline path.

## Changes

- **Installed details overlay falls back to local data.** When the live `getModDetails` fetch fails, the overlay now builds a degraded `GameBananaModDetails` from the local catalog mirror (mods-cache.db) plus the installed mod's own name, instead of showing the raw fetch error. For installed mods this always succeeds; GB-linked items fall back only when a cached row exists, otherwise the error dialog remains.
- **Offline banner in ModDetailsModal.** New optional `offline` prop renders a notice explaining why description, files, and comments are missing, and skips the comments/updates fetches that would just re-fail against the same unreachable API.
- **i18n:** added `modDetails.offlineNotice` to the en catalog, manifest regenerated.

## Not in scope

The Installed update-pulse check still re-fires ~1 doomed request per mod on every mount while GB is down, and a failed check is indistinguishable from "up to date". Follow-up candidate.

## Testing

- tsc (app + node), eslint, i18n:check all clean
- vitest: 563 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)