### PR TITLE
feat(profiles): add remove-crosshair button to profile cards

### DIFF
--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -8,6 +8,7 @@ import {
     applyProfile,
     deleteProfile,
     renameProfile,
+    removeProfileCrosshair,
     type Profile,
     type ProfileCrosshairSettings,
     type ApplyProfileResult,
@@ -104,6 +105,12 @@ ipcMain.handle('delete-profile', (_, profileId: string): void => {
 // rename-profile
 ipcMain.handle('rename-profile', (_, profileId: string, newName: string): Profile => {
     return renameProfile(profileId, newName);
+});
+
+// remove-profile-crosshair — drops the crosshair from a profile without
+// re-scanning/clobbering its mod list (unlike update-profile).
+ipcMain.handle('remove-profile-crosshair', (_, profileId: string): Profile => {
+    return removeProfileCrosshair(profileId);
 });
 
 // export-portable-profile

--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -107,7 +107,7 @@ ipcMain.handle('rename-profile', (_, profileId: string, newName: string): Profil
     return renameProfile(profileId, newName);
 });
 
-// remove-profile-crosshair — drops the crosshair from a profile without
+// remove-profile-crosshair: drops the crosshair from a profile without
 // re-scanning/clobbering its mod list (unlike update-profile).
 ipcMain.handle('remove-profile-crosshair', (_, profileId: string): Profile => {
     return removeProfileCrosshair(profileId);

--- a/electron/main/services/profiles.ts
+++ b/electron/main/services/profiles.ts
@@ -529,3 +529,23 @@ export function renameProfile(profileId: string, newName: string): Profile {
     saveProfiles(profiles);
     return profiles[index];
 }
+
+/**
+ * Remove the crosshair from a profile without touching its mods or autoexec.
+ * updateProfile() re-scans the live mod state, so it can't be used to just drop
+ * the crosshair. This is the targeted "forget the crosshair on this profile" op.
+ */
+export function removeProfileCrosshair(profileId: string): Profile {
+    const profiles = loadProfiles();
+    const index = profiles.findIndex(p => p.id === profileId);
+
+    if (index === -1) {
+        throw new Error(`Profile not found: ${profileId}`);
+    }
+
+    profiles[index].crosshair = undefined;
+    profiles[index].updatedAt = new Date().toISOString();
+
+    saveProfiles(profiles);
+    return profiles[index];
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -483,6 +483,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     applyProfile: (profileId: string) => ipcRenderer.invoke('apply-profile', profileId),
     deleteProfile: (profileId: string) => ipcRenderer.invoke('delete-profile', profileId),
     renameProfile: (profileId: string, newName: string) => ipcRenderer.invoke('rename-profile', profileId, newName),
+    removeProfileCrosshair: (profileId: string) => ipcRenderer.invoke('remove-profile-crosshair', profileId),
     exportPortableProfile: (profileId: string) => ipcRenderer.invoke('export-portable-profile', profileId),
     parsePortableProfile: (input: string) => ipcRenderer.invoke('parse-portable-profile', input),
     resolvePortableProfile: (profile: PortableProfile) => ipcRenderer.invoke('resolve-portable-profile', profile),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1055,6 +1055,10 @@ export async function renameProfile(profileId: string, newName: string): Promise
   return window.electronAPI.renameProfile(profileId, newName);
 }
 
+export async function removeProfileCrosshair(profileId: string): Promise<Profile> {
+  return window.electronAPI.removeProfileCrosshair(profileId);
+}
+
 // =====================
 // Portable Profile API
 // =====================

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1834,7 +1834,9 @@
     },
     "crosshair": {
       "summary": "Gap: {{gap}} | Height: {{height}} | Width: {{width}}",
-      "rgb": "RGB({{r}}, {{g}}, {{b}})"
+      "rgb": "RGB({{r}}, {{g}}, {{b}})",
+      "remove": "Remove",
+      "removeTitle": "Remove the crosshair from this profile"
     },
     "confirm": {
       "updateTitle": "Update Profile",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1746,7 +1746,8 @@
       "title": "Create New Profile",
       "placeholder": "Enter profile name, e.g. Competitive, Casual",
       "profileName": "Profile name",
-      "submit": "Create Profile"
+      "submit": "Create Profile",
+      "includeCrosshair": "Include current crosshair"
     },
     "import": {
       "title": "Import a portable profile from a share code or file"

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1970,
+  "totalKeys": 1971,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1970,
+      "translatedKeys": 1971,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1968,
+  "totalKeys": 1970,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1968,
+      "translatedKeys": 1970,
       "pct": 100
     },
     {

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -8,6 +8,7 @@ import {
   updateProfile,
   deleteProfile,
   renameProfile,
+  removeProfileCrosshair,
   getSettings,
   createSnapshot,
   listSnapshots,
@@ -109,6 +110,7 @@ export default function Profiles() {
   const [isCreating, setIsCreating] = useState(false);
   const [applyingId, setApplyingId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [removingCrosshairId, setRemovingCrosshairId] = useState<string | null>(null);
   // Profile id pending an "overwrite this profile?" confirmation. Gated on the
   // confirmProfileUpdate setting (on by default) so Update isn't a one-click,
   // no-undo overwrite sitting right next to Apply.
@@ -339,6 +341,21 @@ export default function Profiles() {
       setError(String(err));
     } finally {
       setUpdatingId(null);
+    }
+  };
+
+  // Drops the crosshair from a single profile without touching its mods. Needed
+  // because Update re-bakes the live crosshair back in whenever the experimental
+  // crosshair feature is on, so there'd otherwise be no way to forget it.
+  const handleRemoveCrosshair = async (profileId: string) => {
+    setRemovingCrosshairId(profileId);
+    try {
+      await removeProfileCrosshair(profileId);
+      await loadProfileList();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setRemovingCrosshairId(null);
     }
   };
 
@@ -909,8 +926,22 @@ export default function Profiles() {
                           {/* Crosshair Preview */}
                           {profile.crosshair && (
                             <div className="pt-3 border-t border-white/5">
-                              <div className="text-xs font-bold text-text-secondary mb-2 uppercase tracking-wider">
-                                <Tx k="nav.crosshair" fallback="Crosshair" />
+                              <div className="flex items-center justify-between mb-2">
+                                <div className="text-xs font-bold text-text-secondary uppercase tracking-wider">
+                                  <Tx k="nav.crosshair" fallback="Crosshair" />
+                                </div>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() => handleRemoveCrosshair(profile.id)}
+                                  disabled={isApplying || isUpdating || removingCrosshairId === profile.id}
+                                  icon={X}
+                                  title={t('profiles.crosshair.removeTitle')}
+                                  aria-label={t('profiles.crosshair.remove')}
+                                  className="px-1.5"
+                                >
+                                  <Tx k="profiles.crosshair.remove" fallback="Remove" />
+                                </Button>
                               </div>
                               <div className="flex items-center gap-4">
                                 <CrosshairPreview size={56} scale={1.3} settings={profile.crosshair} />

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -309,6 +309,7 @@ export default function Profiles() {
       const newProfile = await createProfile(newProfileName.trim(), crosshair as unknown as ProfileCrosshairSettings | undefined);
 
       setNewProfileName('');
+      setIncludeCrosshairOnCreate(false);
       setActiveProfileId(newProfile.id);
       await loadProfileList();
     } catch (err) {
@@ -363,9 +364,9 @@ export default function Profiles() {
     }
   };
 
-  // Drops the crosshair from a single profile without touching its mods. Needed
-  // because Update re-bakes the live crosshair back in whenever the experimental
-  // crosshair feature is on, so there'd otherwise be no way to forget it.
+  // Drops the crosshair from a single profile without touching its mods. Update
+  // preserves the profile's existing crosshair (it no longer re-bakes editor
+  // state), so clearing one needs this dedicated op.
   const handleRemoveCrosshair = async (profileId: string) => {
     setRemovingCrosshairId(profileId);
     try {

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -107,6 +107,10 @@ export default function Profiles() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newProfileName, setNewProfileName] = useState('');
+  // Opt-in: whether a newly created profile should bake in the currently applied
+  // crosshair. Off by default so a profile only carries a crosshair when the
+  // user explicitly asks for it (and only when one is actually set).
+  const [includeCrosshairOnCreate, setIncludeCrosshairOnCreate] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [applyingId, setApplyingId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
@@ -136,7 +140,7 @@ export default function Profiles() {
   const [bulkDeletingSnapshots, setBulkDeletingSnapshots] = useState(false);
 
   const { mods, loadMods } = useAppStore();
-  const { getSettings: getCrosshairSettings, loadSettingsFromPreset } = useCrosshairStore();
+  const { loadSettingsFromPreset, loadPresets, presets, activePresetId } = useCrosshairStore();
   const socialSignedIn = useSocialStore((s) => s.status.signedIn);
 
   const modByFileName = new Map(mods.map((m) => [m.fileName, m]));
@@ -175,7 +179,18 @@ export default function Profiles() {
   useEffect(() => {
     loadProfileList();
     void loadSnapshotList();
-  }, [loadSnapshotList]);
+    // Populate presets + activePresetId so we know whether a crosshair is
+    // actually applied (the store's editor settings aren't hydrated here).
+    void loadPresets();
+  }, [loadSnapshotList, loadPresets]);
+
+  // The crosshair currently applied to the game, as structured settings, or null
+  // if none is set. Sourced from the active preset (the persisted "applied"
+  // signal) rather than the editor store, which is often just defaults here.
+  const activeCrosshair =
+    crosshairEnabled
+      ? (presets.find((p) => p.id === activePresetId)?.settings ?? null)
+      : null;
 
   const handleRestoreSnapshot = useCallback(async (snapshotId: string) => {
     setRestoringSnapshotId(snapshotId);
@@ -287,8 +302,10 @@ export default function Profiles() {
 
     setIsCreating(true);
     try {
-      // Only include crosshair settings if the experimental crosshair feature is enabled
-      const crosshair = crosshairEnabled ? getCrosshairSettings() : undefined;
+      // Bake in the crosshair only when the user opted in AND one is actually
+      // applied. No crosshair set (or not opted in) means the profile carries
+      // no crosshair at all.
+      const crosshair = includeCrosshairOnCreate && activeCrosshair ? activeCrosshair : undefined;
       const newProfile = await createProfile(newProfileName.trim(), crosshair as unknown as ProfileCrosshairSettings | undefined);
 
       setNewProfileName('');
@@ -333,9 +350,11 @@ export default function Profiles() {
   const handleUpdateProfile = async (profileId: string) => {
     setUpdatingId(profileId);
     try {
-      // Only include crosshair settings if the experimental crosshair feature is enabled
-      const crosshair = crosshairEnabled ? getCrosshairSettings() : undefined;
-      await updateProfile(profileId, crosshair as unknown as ProfileCrosshairSettings | undefined);
+      // Preserve whatever crosshair the profile already has (set at creation or
+      // cleared via Remove). Update refreshes mods/autoexec but must not silently
+      // re-bake the editor's crosshair, which would undo a Remove.
+      const existingCrosshair = profiles.find((p) => p.id === profileId)?.crosshair;
+      await updateProfile(profileId, existingCrosshair);
       await loadProfileList();
     } catch (err) {
       setError(String(err));
@@ -447,6 +466,19 @@ export default function Profiles() {
                 <Tx k="profiles.actions.import" fallback="Import" />
               </Button>
             </div>
+            {/* Opt-in: only offered when a crosshair is actually applied. */}
+            {activeCrosshair && (
+              <label className="flex items-center gap-2 mt-3 cursor-pointer select-none text-sm text-text-secondary w-fit">
+                <input
+                  type="checkbox"
+                  checked={includeCrosshairOnCreate}
+                  onChange={(e) => setIncludeCrosshairOnCreate(e.target.checked)}
+                  className="peer sr-only"
+                />
+                <CheckboxMark checked={includeCrosshairOnCreate} />
+                <Tx k="profiles.create.includeCrosshair" fallback="Include current crosshair" />
+              </label>
+            )}
           </Card>
 
           {/* Snapshots — automatic recovery points captured before

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -856,6 +856,7 @@ export interface ElectronAPI {
     applyProfile: (profileId: string) => Promise<ApplyProfileResult>;
     deleteProfile: (profileId: string) => Promise<void>;
     renameProfile: (profileId: string, newName: string) => Promise<Profile>;
+    removeProfileCrosshair: (profileId: string) => Promise<Profile>;
     exportPortableProfile: (profileId: string) => Promise<import('./portableProfile').PortableExportResult>;
     parsePortableProfile: (input: string) => Promise<import('./portableProfile').PortableProfile>;
     resolvePortableProfile: (


### PR DESCRIPTION
## What

Two changes to how profiles handle the crosshair on the Profiles tab:

1. **Remove button** on each profile's crosshair panel, to strip the crosshair from just that profile (mods + autoexec untouched).
2. **Crosshair is opt-in at creation, and preserved on update**, so profiles no longer silently carry a crosshair.

## Why

Profiles baked in the editor crosshair whenever the experimental crosshair feature flag was on (even when the store was just defaults), and **Update** re-baked it on every run. There was no way to keep a crosshair out of a profile, or to remove one once attached.

## Changes

### Remove op (dedicated, non-clobbering)
`updateProfile` re-scans live mod state, so it can't be reused to just drop the crosshair without clobbering the profile's mods. Added a targeted `removeProfileCrosshair` through the full stack (mirrors `renameProfile`):

- `electron/main/services/profiles.ts` - clears `crosshair`, bumps `updatedAt`, touches nothing else.
- `electron/main/ipc/profiles.ts` - `remove-profile-crosshair` handler.
- `electron/preload/index.ts`, `src/types/electron.ts`, `src/lib/api.ts` - IPC/type/wrapper.
- `src/pages/Profiles.tsx` - ghost `X` Remove button in the crosshair panel.

### Opt-in at creation + preserve on update
- **Create** only bakes a crosshair when the user ticks **"Include current crosshair"**, and only when one is actually applied. The checkbox is sourced from the active preset (`activePresetId`, the persisted applied-crosshair signal, hydrated via `loadPresets()`) and is hidden when no crosshair is set. Off by default.
- **Update** now preserves the profile's existing crosshair instead of re-baking editor state, so it never silently re-adds a crosshair the user removed.

### i18n
`profiles.crosshair.remove` / `removeTitle`, `profiles.create.includeCrosshair`; manifest regenerated.

## Verification

`pnpm typecheck` (main/preload/renderer), `pnpm lint`, `pnpm i18n:check`, and `gen-locale-manifest --check` all pass (verified against the committed tree in an isolated worktree).
