### PR TITLE
fix(profiles): show real mod names on import when share hint is missing

### DIFF
--- a/electron/main/services/portableProfile.ts
+++ b/electron/main/services/portableProfile.ts
@@ -527,6 +527,7 @@ async function resolveOne(entry: PortableModEntry): Promise<PortableResolvedMod>
             status: 'exact',
             resolvedFileId: pinned.id,
             resolvedFileName: pinned.fileName,
+            resolvedName: details.name,
         };
     }
 
@@ -547,6 +548,7 @@ async function resolveOne(entry: PortableModEntry): Promise<PortableResolvedMod>
         status: 'upgraded',
         resolvedFileId: newest.id,
         resolvedFileName: newest.fileName,
+        resolvedName: details.name,
     };
 }
 

--- a/electron/main/services/resolvePortableProfile.test.ts
+++ b/electron/main/services/resolvePortableProfile.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Coverage for the import-resolution name carry (PR #295). resolvePortableProfile
+ * runs each entry through resolveOne, which fetches the GameBanana submission to
+ * pick the resolved file. Before the fix that live name was discarded, so
+ * hint-less profiles (e.g. DMM-origin exports whose metadata sidecar lacked a
+ * modName) collapsed every import row to "Submission #NNN". These tests pin the
+ * name onto PortableResolvedMod.resolvedName for BOTH resolvable paths (exact +
+ * upgraded) and assert unresolvable entries carry none. fetchModDetails is the
+ * only live dependency; everything else portableProfile imports is stubbed inert.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test' } }));
+vi.mock('./profiles', () => ({
+    addProfile: vi.fn(),
+    generateProfileId: vi.fn(),
+    loadProfiles: vi.fn(),
+}));
+vi.mock('./mods', () => ({ scanMods: vi.fn() }));
+vi.mock('./metadata', () => ({ getModMetadata: vi.fn() }));
+vi.mock('./lockerVpk', () => ({ isLockerManaged: vi.fn() }));
+
+const { fetchModDetails } = vi.hoisted(() => ({ fetchModDetails: vi.fn() }));
+vi.mock('./gamebanana', () => ({ fetchModDetails }));
+
+import { resolvePortableProfile } from './portableProfile';
+import {
+    PORTABLE_PROFILE_FORMAT,
+    PORTABLE_PROFILE_SCHEMA_VERSION,
+    type PortableModEntry,
+    type PortableProfile,
+} from '../../../src/types/portableProfile';
+
+type GbFile = { id: number; fileName: string; isArchived?: boolean; downloadCount?: number };
+
+function gbDetails(name: string, files: GbFile[]) {
+    return {
+        id: 1,
+        name,
+        description: '',
+        nsfw: false,
+        files: files.map((f) => ({
+            id: f.id,
+            fileName: f.fileName,
+            fileSize: 0,
+            downloadUrl: `https://gamebanana.example/dl/${f.id}`,
+            downloadCount: f.downloadCount ?? 0,
+            dateAdded: 0,
+            isArchived: f.isArchived ?? false,
+        })),
+    };
+}
+
+/** A hint-less GameBanana entry: the exact case the fix targets. */
+function entry(submissionId: number, fileId: number): PortableModEntry {
+    return {
+        source: 'gamebanana',
+        ref: { submissionId, fileId, section: 'Mod' },
+        enabled: true,
+        priority: 0,
+    };
+}
+
+function profileWith(mods: PortableModEntry[]): PortableProfile {
+    return {
+        format: PORTABLE_PROFILE_FORMAT,
+        schemaVersion: PORTABLE_PROFILE_SCHEMA_VERSION,
+        game: { steamAppId: 1422450, gameBananaGameId: 20948, name: 'Deadlock' },
+        exportedAt: '2026-01-01T00:00:00Z',
+        exportedBy: { tool: 'grimoire', version: '0.0.0-test' },
+        profile: { name: 'Test Profile' },
+        mods,
+    };
+}
+
+describe('resolvePortableProfile: resolvedName carry', () => {
+    beforeEach(() => {
+        fetchModDetails.mockReset();
+    });
+
+    it('carries the live name on an exact match (pinned file still live)', async () => {
+        fetchModDetails.mockResolvedValue(
+            gbDetails('Neon Vindicta', [{ id: 900, fileName: 'neon.vpk' }])
+        );
+
+        const report = await resolvePortableProfile(profileWith([entry(4242, 900)]));
+
+        expect(report.exactCount).toBe(1);
+        expect(report.resolved[0].status).toBe('exact');
+        expect(report.resolved[0].resolvedFileId).toBe(900);
+        expect(report.resolved[0].resolvedName).toBe('Neon Vindicta');
+    });
+
+    it('carries the live name on an upgraded match (pinned file archived)', async () => {
+        fetchModDetails.mockResolvedValue(
+            gbDetails('Spicy Skin', [
+                { id: 900, fileName: 'old.vpk', isArchived: true },
+                { id: 901, fileName: 'newest.vpk', downloadCount: 50 },
+            ])
+        );
+
+        const report = await resolvePortableProfile(profileWith([entry(4242, 900)]));
+
+        expect(report.upgradedCount).toBe(1);
+        expect(report.resolved[0].status).toBe('upgraded');
+        expect(report.resolved[0].resolvedFileId).toBe(901);
+        expect(report.resolved[0].resolvedName).toBe('Spicy Skin');
+    });
+
+    it('sets no resolvedName for an unresolvable entry (all files archived)', async () => {
+        fetchModDetails.mockResolvedValue(
+            gbDetails('Ghost Mod', [{ id: 900, fileName: 'old.vpk', isArchived: true }])
+        );
+
+        const report = await resolvePortableProfile(profileWith([entry(4242, 900)]));
+
+        expect(report.unresolvableCount).toBe(1);
+        expect(report.resolved[0].status).toBe('unresolvable');
+        expect(report.resolved[0].resolvedName).toBeUndefined();
+    });
+});

--- a/src/components/profiles/ImportProfileDialog.tsx
+++ b/src/components/profiles/ImportProfileDialog.tsx
@@ -559,7 +559,7 @@ export default function ImportProfileDialog({
           fileName,
           ref.section || 'Mod',
           undefined,
-          row.details?.name ?? row.mod.entry.hint?.name
+          row.details?.name ?? row.mod.entry.hint?.name ?? row.mod.resolvedName
         ).catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           setRows((prev) =>
@@ -954,6 +954,12 @@ export default function ImportProfileDialog({
                 {rows.map((r, idx) => {
                   const mod = r.mod;
                   const hint = mod.entry.hint;
+                  // Prefer the shared hint name; fall back to the live name the
+                  // resolver fetched from GameBanana so hint-less profiles (e.g.
+                  // DMM imports exported without a modName) still show real names
+                  // instead of "Submission #NNN".
+                  const displayName =
+                    hint?.name ?? mod.resolvedName ?? `Submission #${gbSubmissionId(mod) ?? '?'}`;
                   const isUnresolvable = mod.status === 'unresolvable';
                   const nsfwBlocked = skipNsfw && !!hint?.nsfw && !isUnresolvable;
                   const blocked = isRowBlocked(r);
@@ -998,20 +1004,20 @@ export default function ImportProfileDialog({
                             onChange={() => toggleRow(idx)}
                             disabled={blocked || importing}
                             className="peer sr-only"
-                            aria-label={`Toggle ${hint?.name ?? 'mod'}`}
+                            aria-label={`Toggle ${hint?.name ?? mod.resolvedName ?? 'mod'}`}
                           />
                           <CheckboxMark checked={r.selected && !blocked} disabled={blocked || importing} />
                         </label>
                         <ModThumbnail
                           src={hint?.thumbnailUrl}
-                          alt={hint?.name ?? 'Mod'}
+                          alt={hint?.name ?? mod.resolvedName ?? 'Mod'}
                           nsfw={hint?.nsfw}
                           hideNsfw={hideNsfwPreviews}
                           className="w-14 h-10 sm:w-20 sm:h-14 flex-shrink-0 rounded-sm bg-bg-tertiary"
                         />
                         <div className="min-w-0 flex-1">
                           <div className="text-sm font-medium text-text-primary truncate">
-                            {hint?.name ?? `Submission #${gbSubmissionId(mod) ?? '?'}`}
+                            {displayName}
                           </div>
                           <div className="text-xs text-text-secondary flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
                             {hint?.category && <span className="truncate max-w-[12rem]">{hint.category}</span>}

--- a/src/types/portableProfile.ts
+++ b/src/types/portableProfile.ts
@@ -131,6 +131,12 @@ export interface PortableResolvedMod {
   resolvedFileId?: number;
   /** Filename of the resolved file, used by the download pipeline. */
   resolvedFileName?: string;
+  /** Live mod name from the GameBanana lookup done during resolution. Used as
+   *  the display-name fallback when the shared profile carries no hint name
+   *  (e.g. profiles exported from installs whose metadata sidecar lacked a
+   *  modName, such as DMM imports resolved against an incomplete catalog).
+   *  Only set for resolvable entries. */
+  resolvedName?: string;
   /** Human-readable reason for unresolvable status (e.g. "submission 404"). */
   reason?: string;
   /** True when the resolved (submissionId, resolvedFileId) pair is already


### PR DESCRIPTION
## Problem

The import dialog derived each row's title solely from the `hint.name` baked into the share code at export time. Profiles exported from installs whose metadata sidecar lacked a `modName` (e.g. DMM imports resolved against an incomplete catalog) ship hint-less, so every row collapsed to "Submission #NNN" even though resolution had just fetched the real name from GameBanana and thrown it away.

## Fix

- Carry the live GameBanana name onto `PortableResolvedMod.resolvedName` during resolution (`resolveOne`, both the `exact` and `upgraded` paths).
- Fall back to it in the import UI for the row title, thumbnail `alt`, and toggle `aria-label`.
- Thread it into the download name hint so the download-queue indicator shows a real name while the mod installs.

Hint-present profiles are unaffected: `hint.name` still takes precedence.

## Files
- `electron/main/services/portableProfile.ts`
- `src/components/profiles/ImportProfileDialog.tsx`
- `src/types/portableProfile.ts`

## Testing
Ran the app locally on this branch and imported a hint-less (DMM-origin) profile: rows now show real GameBanana mod names instead of "Submission #NNN". Hint-carrying profiles render unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)