### PR TITLE
Add hidden creator controls to Browse

### DIFF
--- a/electron/main/services/searchService.hiddenCreators.test.ts
+++ b/electron/main/services/searchService.hiddenCreators.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp/grimoire-search-test' } }));
+
+import { normalizeHiddenCreatorIds } from './searchService';
+
+describe('normalizeHiddenCreatorIds', () => {
+  it('keeps unique positive safe integers in user-defined order', () => {
+    expect(normalizeHiddenCreatorIds([42, 7, 42, 9])).toEqual([42, 7, 9]);
+  });
+
+  it('drops values that cannot be safe GameBanana submitter ids', () => {
+    expect(normalizeHiddenCreatorIds([0, -1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 1, 12]))
+      .toEqual([12]);
+  });
+
+  it('caps the exclusion list to a bounded number of SQL parameters', () => {
+    const ids = Array.from({ length: 1200 }, (_, index) => index + 1);
+    const normalized = normalizeHiddenCreatorIds(ids);
+
+    expect(normalized).toHaveLength(1000);
+    expect(normalized[0]).toBe(1);
+    expect(normalized[999]).toBe(1000);
+  });
+});

--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -82,6 +82,32 @@ function applyContentFilters(
     }
 }
 
+/** Exclude hidden GameBanana submitters at query time so counts and pagination
+ *  describe the visible catalog. Null submitter ids remain visible because
+ *  there is no stable creator identity to compare against. */
+export function normalizeHiddenCreatorIds(hiddenCreatorIds: SearchOptions['hiddenCreatorIds']): number[] {
+    if (!hiddenCreatorIds?.length) return [];
+    return [...new Set(hiddenCreatorIds)]
+        .filter((id) => Number.isSafeInteger(id) && id > 0)
+        .slice(0, 1000);
+}
+
+function applyHiddenCreatorFilter(
+    conditions: string[],
+    params: Record<string, unknown>,
+    hiddenCreatorIds: SearchOptions['hiddenCreatorIds']
+): void {
+    const ids = normalizeHiddenCreatorIds(hiddenCreatorIds);
+    if (ids.length === 0) return;
+
+    const placeholders = ids.map((id, index) => {
+        const key = `hidden_creator_${index}`;
+        params[key] = id;
+        return `@${key}`;
+    });
+    conditions.push(`(mods.submitter_id IS NULL OR mods.submitter_id NOT IN (${placeholders.join(', ')}))`);
+}
+
 /**
  * Fallback search used when the FTS5 path returns zero results. FTS5 is
  * tokenized and prefix-only, so creative names ("MìnaMod-v2", typos, partial
@@ -101,6 +127,7 @@ function runFallbackSubstringSearch(
     addedWithin: SearchOptions['addedWithin'],
     addedFrom: number | undefined,
     addedTo: number | undefined,
+    hiddenCreatorIds: SearchOptions['hiddenCreatorIds'],
     limit: number,
     offset: number
 ): SearchResult {
@@ -137,6 +164,7 @@ function runFallbackSubstringSearch(
     }
 
     applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
+    applyHiddenCreatorFilter(conditions, params, hiddenCreatorIds);
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const orderBy = buildOrderBy(sortBy, false); // no FTS rank in fallback
@@ -178,6 +206,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         addedWithin = 'all',
         addedFrom,
         addedTo,
+        hiddenCreatorIds,
     } = options;
 
     // Validate and cap pagination values
@@ -235,6 +264,7 @@ export function searchMods(options: SearchOptions): SearchResult {
     }
 
     applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
+    applyHiddenCreatorFilter(conditions, params, hiddenCreatorIds);
 
     // Build WHERE clause
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -274,6 +304,7 @@ export function searchMods(options: SearchOptions): SearchResult {
             addedWithin,
             addedFrom,
             addedTo,
+            hiddenCreatorIds,
             limit,
             offset
         );

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     browseNsfwContentMode: 'blur',
     installedHideNsfwPreviews: true,
     hideOutdatedMods: false,
+    hiddenCreators: [],
     lockerCardsExpandedByDefault: false,
     autoDisableSiblingVariants: true,
     autoEnableDownloads: false,
@@ -44,6 +45,25 @@ const DEFAULT_SETTINGS: AppSettings = {
     verboseModTrace: false,
 };
 
+/** Normalize user-editable settings.json data into a small, deterministic
+ *  creator list. Invalid ids are ignored and duplicate ids keep the most
+ *  recently listed display name. */
+function normalizeHiddenCreators(value: unknown): AppSettings['hiddenCreators'] {
+    if (!Array.isArray(value)) return [];
+
+    const byId = new Map<number, string>();
+    for (const candidate of value) {
+        if (!candidate || typeof candidate !== 'object') continue;
+        const { id, name } = candidate as { id?: unknown; name?: unknown };
+        if (!Number.isSafeInteger(id) || (id as number) <= 0 || typeof name !== 'string') continue;
+        const trimmedName = name.trim();
+        if (!trimmedName) continue;
+        byId.set(id as number, trimmedName.slice(0, 200));
+    }
+
+    return [...byId.entries()].map(([id, name]) => ({ id, name }));
+}
+
 /**
  * Load settings from disk
  * If settings are corrupted, resets to defaults and logs warning (P2 fix #21)
@@ -61,6 +81,7 @@ export function loadSettings(): AppSettings {
         return {
             ...DEFAULT_SETTINGS,
             ...settings,
+            hiddenCreators: normalizeHiddenCreators(settings.hiddenCreators),
             browseNsfwContentMode:
                 settings.browseNsfwContentMode ??
                 (settings.hideNsfwPreviews === false ? 'show' : DEFAULT_SETTINGS.browseNsfwContentMode),

--- a/electron/main/services/settingsMigration.test.ts
+++ b/electron/main/services/settingsMigration.test.ts
@@ -51,3 +51,47 @@ describe('loadSettings legacy experimentalVpkTagging migration', () => {
     expect(loadSettings().experimentalVpkImprinting).toBe(true);
   });
 });
+
+describe('loadSettings hidden creator normalization', () => {
+  it('defaults hidden creators to an empty list for existing settings', () => {
+    writeFileSync(settingsPath(), JSON.stringify({}));
+    expect(loadSettings().hiddenCreators).toEqual([]);
+  });
+
+  it('keeps valid ids, trims names, and deduplicates by stable id', () => {
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        hiddenCreators: [
+          { id: 42, name: ' First name ' },
+          { id: 7, name: 'Another creator' },
+          { id: 42, name: 'Renamed creator' },
+        ],
+      })
+    );
+
+    expect(loadSettings().hiddenCreators).toEqual([
+      { id: 42, name: 'Renamed creator' },
+      { id: 7, name: 'Another creator' },
+    ]);
+  });
+
+  it('drops malformed entries from hand-edited settings', () => {
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        hiddenCreators: [
+          null,
+          { id: 0, name: 'Zero' },
+          { id: -1, name: 'Negative' },
+          { id: 1.5, name: 'Fractional' },
+          { id: 9, name: '   ' },
+          { id: '12', name: 'String id' },
+          { id: 12, name: 'Valid' },
+        ],
+      })
+    );
+
+    expect(loadSettings().hiddenCreators).toEqual([{ id: 12, name: 'Valid' }]);
+  });
+});

--- a/src/components/HiddenCreatorsManager.tsx
+++ b/src/components/HiddenCreatorsManager.tsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { HiddenCreator } from '../types/mod';
+import { Modal } from './common/Modal';
+import { Button, ModalHeader } from './common/ui';
+
+interface HiddenCreatorsManagerProps {
+  creators: HiddenCreator[];
+  onRemove: (creator: HiddenCreator) => void | Promise<void>;
+  className?: string;
+}
+
+/** Shared hidden-creator list used by both Settings and Browse's management
+ *  dialog. Keeping removal in one component prevents the two entry points from
+ *  drifting in behavior or accessibility. */
+export function HiddenCreatorsManager({ creators, onRemove, className = '' }: HiddenCreatorsManagerProps) {
+  const { t } = useTranslation();
+  const [pendingId, setPendingId] = useState<number | null>(null);
+  const sortedCreators = useMemo(
+    () => [...creators].sort((a, b) => a.name.localeCompare(b.name)),
+    [creators]
+  );
+
+  if (sortedCreators.length === 0) {
+    return (
+      <div className={`flex flex-col items-center justify-center rounded-lg border border-dashed border-border px-5 py-8 text-center ${className}`}>
+        <EyeOff className="mb-3 h-8 w-8 text-text-tertiary" aria-hidden />
+        <p className="text-sm font-medium text-text-primary">{t('hiddenCreators.emptyTitle')}</p>
+        <p className="mt-1 max-w-sm text-xs text-text-secondary">{t('hiddenCreators.emptyDescription')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {sortedCreators.map((creator) => (
+        <div
+          key={creator.id}
+          className="flex items-center gap-3 rounded-lg border border-border bg-bg-tertiary/45 px-3 py-2.5"
+        >
+          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-accent/25 bg-accent/10 font-semibold uppercase text-accent">
+            {creator.name.charAt(0)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-text-primary">{creator.name}</div>
+            <div className="text-[11px] text-text-tertiary">
+              {t('hiddenCreators.gamebananaId', { id: creator.id })}
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            icon={Eye}
+            isLoading={pendingId === creator.id}
+            disabled={pendingId !== null}
+            onClick={async () => {
+              setPendingId(creator.id);
+              try {
+                await onRemove(creator);
+              } finally {
+                setPendingId(null);
+              }
+            }}
+          >
+            {t('hiddenCreators.showCreator')}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface HiddenCreatorsModalProps extends HiddenCreatorsManagerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function HiddenCreatorsModal({ open, onClose, creators, onRemove }: HiddenCreatorsModalProps) {
+  const { t } = useTranslation();
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      labelledBy="hidden-creators-modal-title"
+      size="md"
+      panelClassName="flex max-h-[min(680px,calc(100vh-2rem))] flex-col overflow-hidden"
+    >
+      <ModalHeader
+        titleId="hidden-creators-modal-title"
+        title={t('hiddenCreators.title')}
+        subtitle={t('hiddenCreators.description')}
+        onClose={onClose}
+      />
+      <div className="min-h-0 overflow-y-auto p-5">
+        <HiddenCreatorsManager creators={creators} onRemove={onRemove} />
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/HiddenCreatorsManager.tsx
+++ b/src/components/HiddenCreatorsManager.tsx
@@ -24,7 +24,7 @@ export function HiddenCreatorsManager({ creators, onRemove, className = '' }: Hi
 
   if (sortedCreators.length === 0) {
     return (
-      <div className={`flex flex-col items-center justify-center rounded-lg border border-dashed border-border px-5 py-8 text-center ${className}`}>
+      <div className={`flex flex-col items-center justify-center rounded-sm border border-dashed border-border px-5 py-8 text-center ${className}`}>
         <EyeOff className="mb-3 h-8 w-8 text-text-tertiary" aria-hidden />
         <p className="text-sm font-medium text-text-primary">{t('hiddenCreators.emptyTitle')}</p>
         <p className="mt-1 max-w-sm text-xs text-text-secondary">{t('hiddenCreators.emptyDescription')}</p>
@@ -37,7 +37,7 @@ export function HiddenCreatorsManager({ creators, onRemove, className = '' }: Hi
       {sortedCreators.map((creator) => (
         <div
           key={creator.id}
-          className="flex items-center gap-3 rounded-lg border border-border bg-bg-tertiary/45 px-3 py-2.5"
+          className="flex items-center gap-3 rounded-sm border border-border bg-bg-tertiary/45 px-3 py-2.5"
         >
           <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-accent/25 bg-accent/10 font-semibold uppercase text-accent">
             {creator.name.charAt(0)}

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -25,6 +25,7 @@ import {
   Coffee,
   Link2,
   CloudOff,
+  EyeOff,
 } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import type {
@@ -105,6 +106,9 @@ interface ModDetailsModalProps {
   /** When provided, clicking the artist opens "artist mode" (a grid of all the
    *  artist's mods) instead of their GameBanana profile. */
   onViewArtist?: (artist: { id: number; name: string; avatarUrl?: string; profileUrl?: string; kofiUrl?: string }) => void;
+  /** Browse-only visibility action. Installed details intentionally omit it so
+   *  hiding a creator never implies hiding content the user already owns. */
+  onHideArtist?: (artist: { id: number; name: string }) => void;
   /**
    * When provided, primary-clicks on GameBanana *item* links inside HTML bodies
    * (description, changelog, comments) open that mod in-app instead of the
@@ -147,6 +151,7 @@ function ModDetailsModal({
   variant = 'modal',
   onChangeView,
   onViewArtist,
+  onHideArtist,
   onOpenGameBananaItem,
 }: ModDetailsModalProps) {
   const { t } = useTranslation();
@@ -466,6 +471,10 @@ function ModDetailsModal({
             profileUrl: submitterProfileUrl,
             kofiUrl: submitterKofiUrl,
           })
+      : undefined;
+  const hideArtist =
+    submitter && submitter.id > 0 && onHideArtist
+      ? () => onHideArtist({ id: submitter.id, name: submitter.name })
       : undefined;
   const avatarVisual = submitter ? (
     submitter.avatarUrl && !avatarFailed ? (
@@ -1451,6 +1460,18 @@ function ModDetailsModal({
                         <Coffee className="h-4 w-4" />
                         {t('modDetails.meta.koFi')}
                       </a>
+                    )}
+                    {hideArtist && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        icon={EyeOff}
+                        onClick={hideArtist}
+                        className="flex-shrink-0"
+                      >
+                        {t('hiddenCreators.hideCreator')}
+                      </Button>
                     )}
                   </div>
                 </section>

--- a/src/components/common/ToastStack.tsx
+++ b/src/components/common/ToastStack.tsx
@@ -59,6 +59,18 @@ function ToastItem({ toast }: { toast: Toast }) {
     >
       {icon}
       <span className="min-w-0 flex-1">{toast.message}</span>
+      {toast.actionLabel && toast.onAction && (
+        <button
+          type="button"
+          onClick={() => {
+            toast.onAction?.();
+            dismissToast(toast.id);
+          }}
+          className="flex-shrink-0 cursor-pointer font-semibold underline decoration-current/50 underline-offset-2 transition-opacity hover:opacity-80"
+        >
+          {toast.actionLabel}
+        </button>
+      )}
       {toast.dismissable && (
         <button
           type="button"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -663,7 +663,7 @@
       "appearance": "Appearance",
       "grimoireSocial": "Grimoire Social",
       "preferences": "Preferences",
-      "browseContent": "Browse Content",
+      "hiddenCreators": "Hidden creators",
       "experimentalFeatures": "Experimental Features",
       "support": "Support",
       "maintenance": "Maintenance",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -18,6 +18,7 @@
       "reset": "Reset",
       "retry": "Retry",
       "save": "Save",
+      "undo": "Undo",
       "collapseDetails": "Collapse details",
       "expandDetails": "Expand details",
       "tryAgain": "Try again"
@@ -637,6 +638,21 @@
       "list": "List view"
     }
   },
+  "hiddenCreators": {
+    "title": "Hidden creators",
+    "description": "Hide uploads from selected GameBanana creators in Browse. Installed mods remain visible.",
+    "manage": "Manage hidden creators",
+    "emptyTitle": "No hidden creators",
+    "emptyDescription": "Use Hide creator from a mod's artist details or artist page to add someone here.",
+    "gamebananaId": "GameBanana member #{{id}}",
+    "showCreator": "Show creator",
+    "hideCreator": "Hide creator",
+    "hideNamedCreator": "Hide {{name}} from Browse",
+    "confirmTitle": "Hide this creator?",
+    "confirmMessage": "Hide all Mods, Sounds, and WiPs uploaded by {{name}} from Browse? Installed content will not be affected.",
+    "hiddenToast": "Uploads from {{name}} are now hidden.",
+    "shownToast": "Uploads from {{name}} are visible again."
+  },
   "settings": {
     "header": {
       "description": "Game paths, preferences, and maintenance"
@@ -647,6 +663,7 @@
       "appearance": "Appearance",
       "grimoireSocial": "Grimoire Social",
       "preferences": "Preferences",
+      "browseContent": "Browse Content",
       "experimentalFeatures": "Experimental Features",
       "support": "Support",
       "maintenance": "Maintenance",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 1972,
+  "totalKeys": 1987,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1972,
-      "pct": 100
+      "pct": 99
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 1972,
+      "translatedKeys": 1987,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1870,
-      "pct": 95
+      "pct": 94
     },
     {
       "code": "ru",

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -84,7 +84,7 @@ import {
   useAppStore,
 } from '../stores/appStore';
 import type { BrowseNsfwFilter, BrowseTimeRange, BrowseLayout, BrowseArtistRef } from '../stores/appStore';
-import type { BrowseNsfwContentMode } from '../types/mod';
+import type { BrowseNsfwContentMode, HiddenCreator } from '../types/mod';
 import ModThumbnail from '../components/ModThumbnail';
 import BrowseFileQuickPicker from '../components/BrowseFileQuickPicker';
 import ImageContextMenu from '../components/ImageContextMenu';
@@ -94,12 +94,14 @@ import { HeroSelect } from '../components/common/HeroSelect';
 import { Button, IconButton, Tag } from '../components/common/ui';
 import { Select } from '../components/common/forms';
 import { IconText } from '../components/common/IconText';
-import { EmptyState } from '../components/common/PageComponents';
+import { ConfirmModal, EmptyState } from '../components/common/PageComponents';
 import ModDetailsModal from '../components/ModDetailsModal';
+import { HiddenCreatorsModal } from '../components/HiddenCreatorsManager';
 import ImportCollectionModal from '../components/ImportCollectionModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, findCategoryByName } from '../lib/lockerUtils';
 import { formatAbsoluteDate, formatRelativeDate } from '../lib/dates';
+import { showToast } from '../stores/toastStore';
 
 const DEFAULT_PER_PAGE = 36;
 type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
@@ -133,6 +135,10 @@ const BROWSE_SIDEBAR_GRID_RESERVE = 360;
 // slide-out can play, then unmount it (no reflow: the grid already widened at
 // close-start).
 const BROWSE_DOCK_ANIM_MS = 220;
+
+function hiddenCreatorIdsStamp(creators: readonly HiddenCreator[]): string {
+  return creators.map((creator) => creator.id).sort((a, b) => a - b).join(',');
+}
 
 // Filled brand glyphs (see common/BrandIcons). Platform keys come from
 // GameBanana's contact icon classes, lowercased by normalizeContactPlatform
@@ -1089,6 +1095,10 @@ export default function Browse() {
   const browseSession = useAppStore((s) => s.browseSession);
   const setBrowseSession = useAppStore((s) => s.setBrowseSession);
   const activeDeadlockPath = getActiveDeadlockPath(settings);
+  const hiddenCreators = useMemo(() => settings?.hiddenCreators ?? [], [settings?.hiddenCreators]);
+  const hiddenCreatorIds = useMemo(() => hiddenCreators.map((creator) => creator.id), [hiddenCreators]);
+  const hiddenCreatorIdSet = useMemo(() => new Set(hiddenCreatorIds), [hiddenCreatorIds]);
+  const hiddenCreatorsStamp = useMemo(() => hiddenCreatorIdsStamp(hiddenCreators), [hiddenCreators]);
   // Filter inputs are mirrored from the store so they survive page nav.
   // `setBrowseUi({...})` is the write path; reads come straight from `browseUi`.
   const { search, layout, sort, section, nsfw, addedWithin, addedFrom, addedTo, heroCategoryId, categoryId, submitter } = browseUi;
@@ -1136,7 +1146,7 @@ export default function Browse() {
   // wipe loaded results or scroll position. The cache stamp encodes current
   // filters; if filters changed in between (impossible today since they only
   // change on Browse, but defensive) we ignore the stale cache.
-  const initialFilterStamp = `${browseUi.section}|${browseUi.search}|${browseUi.sort}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}`;
+  const initialFilterStamp = `${browseUi.section}|${browseUi.search}|${browseUi.sort}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
   const initialCache = browseSession && browseSession.stamp === initialFilterStamp
     ? browseSession
     : null;
@@ -1186,7 +1196,7 @@ export default function Browse() {
   // double effect run in dev — the second setup compares stamps and short-
   // circuits, instead of consuming a one-shot skip flag.
   const lastFetchedStampRef = useRef<string | null>(
-    initialCache ? `${initialCache.page}|${browseUi.search}|${browseUi.sort}|${browseUi.section}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}` : null
+    initialCache ? `${initialCache.page}|${browseUi.search}|${browseUi.sort}|${browseUi.section}|${browseUi.categoryId}|${browseUi.heroCategoryId}|${browseUi.nsfw}|${browseUi.addedWithin}|${browseUi.addedFrom}|${browseUi.addedTo}|${browseUi.submitter?.id ?? ''}|${hiddenCreatorsStamp}` : null
   );
   // Monotonic guard for browse/search requests. Filter changes and newer
   // requests invalidate older responses so they cannot append stale pages into
@@ -1240,6 +1250,8 @@ export default function Browse() {
   const importMenuRef = useRef<HTMLDivElement>(null);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
   const viewMenuRef = useRef<HTMLDivElement>(null);
+  const [hiddenCreatorsOpen, setHiddenCreatorsOpen] = useState(false);
+  const [creatorToHide, setCreatorToHide] = useState<HiddenCreator | null>(null);
   const [browseCardDesign, setBrowseCardDesignState] = useState<BrowseCardDesign>(() => {
     if (typeof window === 'undefined') return 'readable';
     return window.localStorage.getItem(BROWSE_CARD_DESIGN_STORAGE_KEY) === 'classic' ? 'classic' : 'readable';
@@ -1463,7 +1475,7 @@ export default function Browse() {
     return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
   }, [addedWithin, addedTo]);
 
-  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}`;
+  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
   const browseResultsCacheRef = useRef<Map<string, BrowseResultCacheEntry>>(new Map());
   const browseScrollCacheRef = useRef<Map<string, number>>(new Map());
   const activeFetchFilterStampRef = useRef(fetchFilterStamp);
@@ -1624,7 +1636,8 @@ export default function Browse() {
   useEffect(() => {
     return () => {
       const ui = useAppStore.getState().browseUi;
-      const stamp = `${ui.section}|${ui.search}|${ui.sort}|${ui.categoryId}|${ui.heroCategoryId}|${ui.nsfw}|${ui.addedWithin}|${ui.addedFrom}|${ui.addedTo}|${ui.submitter?.id ?? ''}`;
+      const liveHiddenCreators = useAppStore.getState().settings?.hiddenCreators ?? [];
+      const stamp = `${ui.section}|${ui.search}|${ui.sort}|${ui.categoryId}|${ui.heroCategoryId}|${ui.nsfw}|${ui.addedWithin}|${ui.addedFrom}|${ui.addedTo}|${ui.submitter?.id ?? ''}|${hiddenCreatorIdsStamp(liveHiddenCreators)}`;
       const cachedMods = modsRef.current;
       // Don't cache an empty state — would just bypass the next fetch
       // unhelpfully. Clear instead so the next mount starts fresh.
@@ -1659,18 +1672,18 @@ export default function Browse() {
     // NSFW and recency filters only the local catalog mirror can satisfy: the
     // live API enriches NSFW after the fact and doesn't window by date, so route
     // those through local search (the cache is a full mirror of the index).
-    const hasContentFilter = nsfw !== 'all' || addedWithin !== 'all';
+    const hasContentFilter = nsfw !== 'all' || addedWithin !== 'all' || hiddenCreatorIds.length > 0;
     // The v11 API has no alphabetical sort token, so name ordering also has to
     // come from the local mirror (which sorts name COLLATE NOCASE ASC).
     const needsLocalSort = sort === 'name';
     return (hasSearchQuery || hasHeroFilter || hasContentFilter || needsLocalSort) && hasLocalCache && !localSearchFailed;
-  }, [submitter, debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hasLocalCache, localSearchFailed]);
+  }, [submitter, debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hiddenCreatorIds.length, hasLocalCache, localSearchFailed]);
 
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
   useEffect(() => {
     setLocalSearchFailed(false);
-  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section, sort]);
+  }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section, sort, hiddenCreatorsStamp]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
@@ -1739,6 +1752,13 @@ export default function Browse() {
         }
       }
 
+      // Remote fallback paths cannot express a negative submitter filter in
+      // GameBanana's API. Filter defensively here; normal browsing routes to
+      // the local catalog above so pagination remains full and accurate.
+      enrichedRecords = enrichedRecords.filter(
+        (mod) => !mod.submitter?.id || !hiddenCreatorIdSet.has(mod.submitter.id)
+      );
+
       if (requestGeneration !== requestGenerationRef.current || lastFetchedStampRef.current !== stamp) {
         return;
       }
@@ -1796,6 +1816,7 @@ export default function Browse() {
     fetchFilterStamp,
     useLocalSearch,
     submitter,
+    hiddenCreatorIdSet,
   ]);
 
   // Local search function using SQLite cache
@@ -1860,6 +1881,7 @@ export default function Browse() {
         addedWithin,
         addedFrom: customAddedFrom,
         addedTo: customAddedTo,
+        hiddenCreatorIds,
         limit: perPage,
         offset: (page - 1) * perPage,
       });
@@ -1934,7 +1956,7 @@ export default function Browse() {
         setLoadingMore(false);
       }
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, modCategories, fetchFilterStamp]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, hiddenCreatorIds, modCategories, fetchFilterStamp]);
 
   // Value-compare gate for the filter-reset: remember what filters last
   // triggered a reset; only reset when the new combination is actually
@@ -2682,9 +2704,12 @@ export default function Browse() {
   // Just use all loaded mods - infinite scroll handles pagination.
   // Hide outdated mods if the user has opted in.
   const displayMods = useMemo(() => {
-    let nextMods = settings?.hideOutdatedMods
-      ? mods.filter((m) => !m.dateModified || !isModOutdated(m.dateModified))
+    let nextMods = hiddenCreatorIdSet.size > 0
+      ? mods.filter((mod) => !mod.submitter?.id || !hiddenCreatorIdSet.has(mod.submitter.id))
       : mods;
+    if (settings?.hideOutdatedMods) {
+      nextMods = nextMods.filter((m) => !m.dateModified || !isModOutdated(m.dateModified));
+    }
     // "(No hero)" Sound filter: GameBanana Sound categories don't carry hero
     // metadata, so hero association is inferred from the title.
     if (section === 'Sound' && heroCategoryId === 'none') {
@@ -2704,7 +2729,7 @@ export default function Browse() {
     }
 
     return nextMods;
-  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId, browseNsfwContentMode, nsfw]);
+  }, [mods, settings?.hideOutdatedMods, section, heroCategoryId, browseNsfwContentMode, nsfw, hiddenCreatorIdSet]);
   const selectedModIndex = selectedMod
     ? displayMods.findIndex((mod) => mod.id === selectedMod.id)
     : -1;
@@ -2782,6 +2807,58 @@ export default function Browse() {
     scrollContainerRef.current?.scrollTo({ top: 0 });
   });
   const clearArtist = () => setBrowseUi({ submitter: undefined });
+
+  const updateHiddenCreators = useStableCallback(async (
+    updater: (current: HiddenCreator[]) => HiddenCreator[]
+  ) => {
+    const currentSettings = useAppStore.getState().settings;
+    if (!currentSettings) return;
+    await saveSettings({
+      ...currentSettings,
+      hiddenCreators: updater(currentSettings.hiddenCreators ?? []),
+    });
+  });
+
+  const requestHideCreator = useStableCallback((creator: HiddenCreator) => {
+    if (!creator.id || hiddenCreatorIdSet.has(creator.id)) return;
+    setCreatorToHide(creator);
+  });
+
+  const confirmHideCreator = useStableCallback(async () => {
+    const creator = creatorToHide;
+    if (!creator) return;
+    setCreatorToHide(null);
+
+    await updateHiddenCreators((current) => [
+      ...current.filter((entry) => entry.id !== creator.id),
+      creator,
+    ]);
+    if (selectedMod?.submitter?.id === creator.id) closeSelectedMod();
+    if (submitter?.id === creator.id) clearArtist();
+
+    showToast(t('hiddenCreators.hiddenToast', { name: creator.name }), {
+      tone: 'success',
+      duration: 8000,
+      actionLabel: t('common.actions.undo'),
+      onAction: () => {
+        void updateHiddenCreators((current) => current.filter((entry) => entry.id !== creator.id));
+      },
+    });
+  });
+
+  const showHiddenCreator = useStableCallback(async (creator: HiddenCreator) => {
+    await updateHiddenCreators((current) => current.filter((entry) => entry.id !== creator.id));
+    showToast(t('hiddenCreators.shownToast', { name: creator.name }), { tone: 'success' });
+  });
+
+  // Artist mode can be entered from Installed as well as Browse. If that
+  // submitter is already hidden, return to the normal catalog instead of
+  // presenting an empty artist page that cannot explain why it is empty.
+  useEffect(() => {
+    if (submitter?.id && hiddenCreatorIdSet.has(submitter.id)) {
+      setBrowseUi({ submitter: undefined });
+    }
+  }, [submitter?.id, hiddenCreatorIdSet, setBrowseUi]);
 
   const readableCardTargetWidth = getReadableCardTargetWidth(browseCardSize);
   const gridGap =
@@ -2898,6 +2975,7 @@ export default function Browse() {
         nextLabel={nextSelectedMod?.name}
         onDeleteFile={deleteMod}
         onViewArtist={viewArtist}
+        onHideArtist={requestHideCreator}
         onOpenGameBananaItem={handleOpenGameBananaItem}
       />
     ) : null;
@@ -2991,6 +3069,11 @@ export default function Browse() {
                   {t('browse.artist.kofi')}
                 </a>
               )}
+              <IconButton
+                icon={EyeOff}
+                label={t('hiddenCreators.hideNamedCreator', { name: submitter.name })}
+                onClick={() => requestHideCreator({ id: submitter.id, name: submitter.name })}
+              />
             </div>
             <div className="hidden flex-shrink-0 items-center gap-1 rounded-lg border border-border bg-bg-secondary p-0.5 sm:flex">
               {(['Mod', 'Sound', 'Wip'] as const).map((s) => (
@@ -3233,6 +3316,23 @@ export default function Browse() {
                           { value: 'hide', label: t('browse.viewOptions.hide'), icon: EyeOff },
                         ]}
                       />
+                    </div>
+
+                    <div className="border-t border-border pt-3">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setViewMenuOpen(false);
+                          setHiddenCreatorsOpen(true);
+                        }}
+                        className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                      >
+                        <EyeOff className="h-4 w-4 flex-shrink-0 text-text-secondary" />
+                        <span className="min-w-0 flex-1 truncate">{t('hiddenCreators.manage')}</span>
+                        <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] font-semibold text-text-secondary">
+                          {hiddenCreators.length}
+                        </span>
+                      </button>
                     </div>
 
                   </div>
@@ -3679,6 +3779,23 @@ export default function Browse() {
           onImported={() => { void loadMods(); }}
         />
       )}
+
+      <HiddenCreatorsModal
+        open={hiddenCreatorsOpen}
+        onClose={() => setHiddenCreatorsOpen(false)}
+        creators={hiddenCreators}
+        onRemove={showHiddenCreator}
+      />
+
+      <ConfirmModal
+        isOpen={creatorToHide !== null}
+        title={t('hiddenCreators.confirmTitle')}
+        message={t('hiddenCreators.confirmMessage', { name: creatorToHide?.name ?? '' })}
+        confirmLabel={t('hiddenCreators.hideCreator')}
+        variant="danger"
+        onConfirm={() => { void confirmHideCreator(); }}
+        onCancel={() => setCreatorToHide(null)}
+      />
       </div>
 
       {/* Docked details sidebar. While OPEN it's an in-flow flex child, so the

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3319,20 +3319,21 @@ export default function Browse() {
                     </div>
 
                     <div className="border-t border-border pt-3">
-                      <button
+                      <Button
                         type="button"
+                        variant="ghost"
+                        icon={EyeOff}
                         onClick={() => {
                           setViewMenuOpen(false);
                           setHiddenCreatorsOpen(true);
                         }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        className="w-full justify-start px-2 text-text-primary"
                       >
-                        <EyeOff className="h-4 w-4 flex-shrink-0 text-text-secondary" />
-                        <span className="min-w-0 flex-1 truncate">{t('hiddenCreators.manage')}</span>
+                        <span className="min-w-0 flex-1 truncate text-left">{t('hiddenCreators.manage')}</span>
                         <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] font-semibold text-text-secondary">
                           {hiddenCreators.length}
                         </span>
-                      </button>
+                      </Button>
                     </div>
 
                   </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation, Trans } from 'react-i18next';
-import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy } from 'lucide-react';
+import { FolderOpen, Check, X, Loader2, RefreshCw, Database, Trash2, Shield, Wrench, HardDrive, Beaker, Download, Sparkles, ArrowDownCircle, Palette, Pipette, LifeBuoy, Github, Globe, FileText, Bug, Copy, EyeOff } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import DOMPurify from 'dompurify';
 import { useAppStore } from '../stores/appStore';
@@ -30,6 +30,8 @@ import SocialAccountSection from '../components/social/SocialAccountSection';
 import PerformanceConfigCard from '../components/performance/PerformanceConfigCard';
 import KofiSupportButton from '../components/KofiSupportButton';
 import type { SaltIngestStatus } from '../types/electron';
+import type { HiddenCreator } from '../types/mod';
+import { HiddenCreatorsManager } from '../components/HiddenCreatorsManager';
 
 // GitHub Releases is the source of truth for changelogs. When we have local
 // release notes (an update is pending) we show them in-app; otherwise we link
@@ -284,6 +286,15 @@ export default function Settings() {
     if (settings) {
       await saveSettings({ ...settings, installedHideNsfwPreviews: checked });
     }
+  };
+
+  const handleShowCreator = async (creator: HiddenCreator) => {
+    if (!settings) return;
+    await saveSettings({
+      ...settings,
+      hiddenCreators: (settings.hiddenCreators ?? []).filter((entry) => entry.id !== creator.id),
+    });
+    showToast(t('hiddenCreators.shownToast', { name: creator.name }), { tone: 'success' });
   };
 
   const handleAutoDisableSiblingsChange = async (checked: boolean) => {
@@ -1179,6 +1190,17 @@ export default function Settings() {
               onChange={handleLanguageChange}
             />
           </div>
+        </Card>
+
+        <Card
+          title={<Tx k="settings.sections.browseContent" fallback="Browse Content" />}
+          description={<Tx k="hiddenCreators.description" fallback="Hide uploads from selected GameBanana creators in Browse." />}
+          icon={EyeOff}
+        >
+          <HiddenCreatorsManager
+            creators={settings?.hiddenCreators ?? []}
+            onRemove={handleShowCreator}
+          />
         </Card>
 
         {/* Experimental Features */}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,7 +31,7 @@ import PerformanceConfigCard from '../components/performance/PerformanceConfigCa
 import KofiSupportButton from '../components/KofiSupportButton';
 import type { SaltIngestStatus } from '../types/electron';
 import type { HiddenCreator } from '../types/mod';
-import { HiddenCreatorsManager } from '../components/HiddenCreatorsManager';
+import { HiddenCreatorsManager, HiddenCreatorsModal } from '../components/HiddenCreatorsManager';
 
 // GitHub Releases is the source of truth for changelogs. When we have local
 // release notes (an update is pending) we show them in-app; otherwise we link
@@ -94,6 +94,7 @@ export default function Settings() {
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [resetResult, setResetResult] = useState<string | null>(null);
   const [saltIngestStatus, setSaltIngestStatus] = useState<SaltIngestStatus | null>(null);
+  const [hiddenCreatorsOpen, setHiddenCreatorsOpen] = useState(false);
 
   // Updater state
   const [appVersion, setAppVersion] = useState<string>('');
@@ -1060,6 +1061,32 @@ export default function Settings() {
 
             <div className="h-px bg-white/5" />
 
+            <div>
+              <label className="text-sm font-medium text-text-primary block">
+                <Tx k="hiddenCreators.title" fallback="Hidden creators" />
+              </label>
+              <p className="text-xs text-text-secondary mt-0.5 mb-2">
+                <Tx
+                  k="hiddenCreators.description"
+                  fallback="Hide uploads from selected GameBanana creators in Browse. Installed mods remain visible."
+                />
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  icon={EyeOff}
+                  onClick={() => setHiddenCreatorsOpen(true)}
+                >
+                  <Tx k="hiddenCreators.manage" fallback="Manage hidden creators" />
+                </Button>
+                <Badge>{settings?.hiddenCreators?.length ?? 0}</Badge>
+              </div>
+            </div>
+
+            <div className="h-px bg-white/5" />
+
             <Toggle
               checked={settings?.lockerCardsExpandedByDefault ?? false}
               onChange={handleLockerCardsExpandedByDefaultChange}
@@ -1192,17 +1219,6 @@ export default function Settings() {
           </div>
         </Card>
 
-        <Card
-          title={<Tx k="settings.sections.browseContent" fallback="Browse Content" />}
-          description={<Tx k="hiddenCreators.description" fallback="Hide uploads from selected GameBanana creators in Browse." />}
-          icon={EyeOff}
-        >
-          <HiddenCreatorsManager
-            creators={settings?.hiddenCreators ?? []}
-            onRemove={handleShowCreator}
-          />
-        </Card>
-
         {/* Experimental Features */}
         <Card title={<Tx k="settings.sections.experimentalFeatures" fallback="Experimental Features" />} icon={Beaker}>
           <div className="space-y-6">
@@ -1283,6 +1299,22 @@ export default function Settings() {
             />
           </div>
         </Card>
+
+        {/* Hidden creators. Only rendered once there is a list to show: the
+            always-available entry point is the Manage button in Preferences. */}
+        {(settings?.hiddenCreators?.length ?? 0) > 0 && (
+          <Card
+            title={<Tx k="settings.sections.hiddenCreators" fallback="Hidden creators" />}
+            description={<Tx k="hiddenCreators.description" fallback="Hide uploads from selected GameBanana creators in Browse. Installed mods remain visible." />}
+            icon={EyeOff}
+            className="lg:col-span-2"
+          >
+            <HiddenCreatorsManager
+              creators={settings?.hiddenCreators ?? []}
+              onRemove={handleShowCreator}
+            />
+          </Card>
+        )}
 
         {settings?.experimentalPerformanceConfig && <PerformanceConfigCard />}
 
@@ -1682,6 +1714,13 @@ export default function Settings() {
           </div>
         </div>
       )}
+
+      <HiddenCreatorsModal
+        open={hiddenCreatorsOpen}
+        onClose={() => setHiddenCreatorsOpen(false)}
+        creators={settings?.hiddenCreators ?? []}
+        onRemove={handleShowCreator}
+      />
 
       <ConfirmModal
         isOpen={wipeConfirmOpen}

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -14,12 +14,17 @@ export interface Toast {
   duration: number;
   /** show an explicit Dismiss button (sticky warnings) */
   dismissable?: boolean;
+  /** Optional one-shot action such as restoring a just-hidden creator. */
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 interface ToastOptions {
   tone?: ToastTone;
   duration?: number;
   dismissable?: boolean;
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 interface ToastState {
@@ -40,6 +45,8 @@ export const useToastStore = create<ToastState>((set) => ({
       tone: opts.tone ?? 'info',
       duration: opts.duration ?? 5000,
       dismissable: opts.dismissable,
+      actionLabel: opts.actionLabel,
+      onAction: opts.onAction,
     };
     set((s) => ({ toasts: [...s.toasts, toast] }));
     return id;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -367,6 +367,9 @@ export interface SearchLocalModsOptions {
     addedWithin?: 'all' | 'today' | 'week' | 'month' | 'custom';
     addedFrom?: number;
     addedTo?: number;
+    /** GameBanana submitter ids to exclude before count/limit/offset are
+     *  applied, keeping hidden creators from producing sparse result pages. */
+    hiddenCreatorIds?: number[];
     limit?: number;
     offset?: number;
 }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -992,6 +992,14 @@ export interface AppearanceBg {
   hero?: string | null;
 }
 
+/** A GameBanana submitter whose uploads the user has hidden from Browse.
+ *  The numeric id is the durable identity; name is retained only so Settings
+ *  can render a useful management list if the submitter later renames. */
+export interface HiddenCreator {
+  id: number;
+  name: string;
+}
+
 export interface AppSettings {
   deadlockPath: string | null;
   devMode: boolean;
@@ -1010,6 +1018,9 @@ export interface AppSettings {
   installedHideNsfwPreviews: boolean;
   /** Hide GameBanana mods flagged as outdated in Browse. */
   hideOutdatedMods: boolean;
+  /** GameBanana submitters whose Mods, Sounds, and WiPs are excluded from
+   *  Browse. This does not hide or disable content already installed. */
+  hiddenCreators: HiddenCreator[];
   /** Open Locker list-view hero cards expanded on first load. */
   lockerCardsExpandedByDefault: boolean;
   /** Installing a different file of an already-enabled mod disables the


### PR DESCRIPTION
## Summary

- persist hidden GameBanana creators by stable submitter ID with defensive settings migration
- add Hide creator actions to mod artist details and artist pages, including confirmation and one-click undo
- add a reusable hidden-creator manager in Settings and a shortcut from Browse View options
- exclude hidden creators before local catalog counts and pagination, with defensive filtering for live API fallback results
- keep installed mods visible and manageable

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (45 files, 583 tests)
- `pnpm i18n:check`
- `GRIMOIRE_SOCIAL_BASE_URL=https://example.invalid pnpm build`