### PR TITLE
Pre-release cleanup: 7 confirmed bugs plus a CI test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
         working-directory: grimoire
         run: pnpm exec tsc -b --noEmit
 
+      # Vitest covers the FeModel parser, cloth fit math + solver stability,
+      # Source 2 / NPR material reconstruction, the dynamic-scalar evaluator and
+      # the profiles vpkIndex resolver. Nothing gated these until now, so a PR
+      # could break every one of them and still go green.
+      - name: Test
+        working-directory: grimoire
+        run: pnpm exec vitest run
+
       # Every referenced t()/Tx key must exist in the English catalog, and the
       # committed locale manifest (what the app fetches from `main` to populate
       # the language picker) must match the catalogs on disk.

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -33,7 +33,13 @@ import {
 import { downloadMod } from '../services/download';
 import { fetchAdoptedThumbnail, type AdoptedThumbnailTarget } from '../services/adoptedThumbnail';
 import { extractArchive, isArchive, type ExtractedVpk } from '../services/extract';
-import { mergeMods, unmergeMod, extractMergeSource, addMergeSources } from '../services/modMerger';
+import {
+    mergeMods,
+    unmergeMod,
+    extractMergeSource,
+    addMergeSources,
+    reserveOutputSlot,
+} from '../services/modMerger';
 import {
     imprintOneMod,
     imprintAllInstalled,
@@ -60,6 +66,38 @@ const unknownDetectionControllers = new Map<string, AbortController>();
 interface UnknownCacheBulkRequest {
     modId: string;
     requestId?: string;
+}
+
+/**
+ * Copy a built or extracted VPK into an ENABLED slot.
+ *
+ * `allocateEnabledVpkPath` reserves nothing on disk, so between the allocate and
+ * the copy a concurrent enable or download scans the folder, sees the same pakNN
+ * as free, and renames its own VPK in: the copy then overwrites it and that mod
+ * silently loses its file. Claiming the slot exclusively first closes that
+ * window, the same way mergeMods does via reserveOutputSlot. A failed copy
+ * removes the reservation so no 0-byte VPK is left for scanMods to pick up.
+ *
+ * `freshlyAllocated` is false when replacing one of our own earlier imports
+ * (resolveModVpk returned an existing path), where the slot is already ours and
+ * an exclusive create would fail with EEXIST.
+ */
+async function copyIntoModSlot(
+    sourcePath: string,
+    destPath: string,
+    freshlyAllocated: boolean
+): Promise<void> {
+    if (!freshlyAllocated) {
+        await fs.copyFile(sourcePath, destPath);
+        return;
+    }
+    await reserveOutputSlot(destPath);
+    try {
+        await fs.copyFile(sourcePath, destPath);
+    } catch (err) {
+        try { await fs.unlink(destPath); } catch { /* ignore partial-output cleanup */ }
+        throw err;
+    }
 }
 
 /**
@@ -1058,7 +1096,7 @@ ipcMain.handle(
                 const destPath = await allocateEnabledVpkPath(deadlockPath);
                 const destMetaKey = metaKeyFor(destPath);
 
-                await fs.copyFile(sourceVpks[i].path, destPath);
+                await copyIntoModSlot(sourceVpks[i].path, destPath, true);
 
                 // Scrub any orphan metadata at this slot before writing.
                 // setModMetadata merges into the existing entry, so stale fields
@@ -1208,7 +1246,7 @@ ipcMain.handle(
             const destPath = await allocateEnabledVpkPath(deadlockPath);
             const destMetaKey = metaKeyFor(destPath);
 
-            await fs.copyFile(built.vpkPath, destPath);
+            await copyIntoModSlot(built.vpkPath, destPath, true);
 
             const soundSwap: SoundSwapInfo = {
                 heroCodename: built.soundCodename,
@@ -1327,12 +1365,14 @@ ipcMain.handle(
                 destPath = await resolveModVpk(deadlockPath, replaceMetaKey);
                 if (destPath) destMetaKey = replaceMetaKey;
             }
+            let freshSlot = false;
             if (!destPath) {
                 destPath = await allocateEnabledVpkPath(deadlockPath);
                 destMetaKey = metaKeyFor(destPath);
+                freshSlot = true;
             }
 
-            await fs.copyFile(built.vpkPath, destPath);
+            await copyIntoModSlot(built.vpkPath, destPath, freshSlot);
             // A reused slot may have a stale exported-GLB cache; drop it so the
             // Locker tile re-exports the new model.
             await clearSoulModelCache(destMetaKey!);
@@ -1481,12 +1521,14 @@ ipcMain.handle(
                 destPath = await resolveModVpk(deadlockPath, replaceMetaKey);
                 if (destPath) destMetaKey = replaceMetaKey;
             }
+            let freshSlot = false;
             if (!destPath) {
                 destPath = await allocateEnabledVpkPath(deadlockPath);
                 destMetaKey = metaKeyFor(destPath);
+                freshSlot = true;
             }
 
-            await fs.copyFile(built.vpkPath, destPath);
+            await copyIntoModSlot(built.vpkPath, destPath, freshSlot);
             // A reused slot may have a stale exported-GLB cache; drop it so the
             // Locker tile re-exports the new model.
             await clearSoulModelCache(destMetaKey!);

--- a/electron/main/services/archiveCrc.ts
+++ b/electron/main/services/archiveCrc.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from 'fs';
 import { validateDownloadUrl } from './security';
 import { GRIMOIRE_USER_AGENT } from './userAgent';
+import { gamebananaRateLimiter } from './rateLimiter';
 
 export interface ArchiveVpkCrcEntry {
     name: string;
@@ -192,6 +193,11 @@ async function fetchArchiveRange(
     validateDownloadUrl(url);
 
     const expected = end - start + 1;
+    // These ranged GETs hit GameBanana's file hosts and unknown-mod detection
+    // fires many of them per archive at PROBE_CONCURRENCY. Claim the same 10
+    // req/sec budget the JSON client uses, otherwise that client thinks it is
+    // inside the limit while the real request rate is well over it.
+    await gamebananaRateLimiter.acquire();
     const response = await fetch(url, {
         headers: {
             Range: `bytes=${start}-${end}`,
@@ -243,6 +249,7 @@ async function fetchArchiveSuffixRange(
     throwIfAborted(signal);
     validateDownloadUrl(url);
 
+    await gamebananaRateLimiter.acquire();
     const response = await fetch(url, {
         headers: {
             Range: `bytes=-${suffixBytes}`,

--- a/electron/main/services/stats.ts
+++ b/electron/main/services/stats.ts
@@ -24,6 +24,7 @@ import type {
     BuildSearchParams,
 } from '../../../src/types/deadlock-stats'
 import { GRIMOIRE_USER_AGENT } from './userAgent'
+import { statsApiRateLimiter } from './rateLimiter'
 
 // Local flat types for counter/synergy stats (API returns flat arrays, not nested)
 export interface FlatHeroCounterStats {
@@ -83,6 +84,11 @@ async function fetchFromAPI<T>(
     if (options?.apiKey) {
         headers['X-API-KEY'] = options.apiKey
     }
+
+    // Every deadlock-api call in this service funnels through here, so this is
+    // the one place the 5 req/sec budget has to be claimed. It was missing: the
+    // limiter existed but nothing outside saltIngest ever acquired it.
+    await statsApiRateLimiter.acquire()
 
     const response = await fetch(url.toString(), {
         headers,

--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -4,7 +4,22 @@ import { upsertMods, getSyncState, updateSyncState, getModCount, type CachedMod 
 import type { GameBananaMod } from '../../../src/types/gamebanana';
 
 const SYNC_PER_PAGE = 50;
-const SECTIONS = ['Mod', 'Sound', 'Gui', 'Model', 'Wip'] as const;
+// Deadlock only has these three submission sections. 'Gui' and 'Model' were
+// listed here once and both failed without losing any content, so don't add
+// them back: GameBanana's Game/20948 record (_aSections) has no Gui or Model
+// entry at all. What they look like they cover is already synced as Mod root
+// categories ('HUD' and 'Model Replacement' respectively).
+//
+// They also failed in two different ways, the second one silently:
+//   Gui   -> apiv11 500s server-side (missing classes/Model/Gui.php) and
+//            returns HTML, so fetchJson throws and spams the log every sync.
+//   Model -> apiv11 rejects _aFilters[Generic_Game] as UNKNOWN_FILTER. That
+//            error body is valid JSON, so fetchSubmissions does not throw; it
+//            just reports 0 records and syncSection writes a success state for
+//            an empty section. Dropping the filter is NOT the fix: /Model/Index
+//            returns the same 3136 site-wide records for any _idGameRow, so
+//            without it the catalog fills with non-Deadlock content.
+const SECTIONS = ['Mod', 'Sound', 'Wip'] as const;
 type SectionType = typeof SECTIONS[number];
 
 export interface SyncProgress {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,6 +41,7 @@ import {
   type VanillaRestoreResult,
 } from '../lib/api';
 
+import { shouldBlurNsfw } from '../lib/appSettings';
 import { getAssetPath } from '../lib/assetPath';
 import { rollMemeTooltip } from '../lib/easterEggs';
 import { DEFAULT_SIDEBAR_HERO, getSidebarHeroImageStyle, getHeroRenderPath, resolveAppearanceBg } from '../lib/lockerUtils';
@@ -327,6 +328,11 @@ export default function Sidebar() {
     }
   }, []);
 
+  // Hoisted out of the callback below so its dep array can stay narrow: reading
+  // the whole `settings` object inside would make the callback churn on every
+  // unrelated settings change.
+  const blurNsfw = shouldBlurNsfw(settings);
+
   const refreshDiscoverNotifications = useCallback(async () => {
     if (!settings?.experimentalSocial) {
       setDiscoverNotificationCount(0);
@@ -336,7 +342,7 @@ export default function Sidebar() {
     try {
       const res = await socialListProfiles({
         sort: 'new',
-        hideNsfw: settings.hideNsfwPreviews ?? true,
+        hideNsfw: blurNsfw,
         page: 1,
       });
       const newest = newestCreatedAt(res.profiles);
@@ -364,7 +370,7 @@ export default function Sidebar() {
     } catch {
       // Keep the previous badge value during transient social API failures.
     }
-  }, [discoverActive, settings?.experimentalSocial, settings?.hideNsfwPreviews]);
+  }, [discoverActive, settings?.experimentalSocial, blurNsfw]);
 
   useEffect(() => {
     void refreshConflictCount();

--- a/src/components/SyncIndicator.tsx
+++ b/src/components/SyncIndicator.tsx
@@ -8,9 +8,9 @@ interface SyncIndicatorProps {
     className?: string;
 }
 
-// The section names ('Mod', 'Sound', 'Gui', 'Model', 'Wip') arrive from the
-// main process as raw English identifiers; map them to localized labels, falling
-// back to the raw value for anything unmapped.
+// The section names ('Mod', 'Sound', 'Wip') arrive from the main process as raw
+// English identifiers; map them to localized labels, falling back to the raw
+// value for anything unmapped.
 function localizedSection(section: string, t: TFunction): string {
     return t(`sync.sections.${section}`, { defaultValue: section });
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -56,6 +56,13 @@ function detectFromNavigator(): string {
   // i18n.init (before the resource store exists, so hasResourceBundle would
   // throw), and later only as the system-default fallback. Downloaded languages
   // are explicit user choices, applied via applyLanguagePreference, not detected.
+  //
+  // The global is guarded because this runs at module load (i18n.init below),
+  // so every importer of this module inherits the assumption. Electron always
+  // has a navigator, but Node only defines one from v21, and the tests import
+  // this transitively (api.ts) under vitest's node environment. The sibling
+  // localStorage read is already defensive for the same reason.
+  if (typeof navigator === 'undefined') return FALLBACK_LANGUAGE;
   const candidates = [navigator.language, ...(navigator.languages ?? [])];
   for (const raw of candidates) {
     if (!raw) continue;

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -5,3 +5,18 @@ export function getActiveDeadlockPath(settings: AppSettings | null): string | nu
   if (settings.devMode) return settings.devDeadlockPath;
   return settings.deadlockPath;
 }
+
+/**
+ * Whether NSFW thumbnails should be blurred on the surfaces that have no
+ * blur control of their own (Locker, Discover, Profiles, the Discover sidebar
+ * peek). Browse is deliberately excluded: it owns `browseNsfwContentMode`.
+ *
+ * The legacy `hideNsfwPreviews` key has no writer left (its only assignment is
+ * the default), so reading it alone left these surfaces permanently blurred
+ * with no way to change it. `installedHideNsfwPreviews` is the key the Settings
+ * toggle actually writes, so it leads here and the legacy key stays only as the
+ * migration fallback for installs that predate the split.
+ */
+export function shouldBlurNsfw(settings: AppSettings | null): boolean {
+  return settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -775,6 +775,10 @@
       "dateFormat": "Date Format",
       "dateFormatDescription": "How upload and update dates are shown on mods and files."
     },
+    "errors": {
+      "loadFailed": "Could not load your settings: {{error}}",
+      "saveFailed": "Could not save that setting: {{error}}"
+    },
     "experimental": {
       "description": "These features are still in development and may be incomplete or buggy.",
       "statsDashboard": "Stats Dashboard",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -757,8 +757,6 @@
       "hideNsfw": "Hide NSFW Content",
       "hideNsfwDescription": "Blur thumbnail images for mods marked as NSFW.",
       "hideOutdated": "Hide Outdated Mods",
-      "blurInstalledNsfw": "Blur Installed NSFW Content",
-      "blurInstalledNsfwDescription": "Blur thumbnail images for installed mods marked as NSFW.",
       "expandLocker": "Expand Locker cards by default",
       "switchVariants": "Switch variants instead of stacking them",
       "enableAfterDownload": "Enable mods after download",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -60,8 +60,6 @@
     "sections": {
       "Mod": "Mods",
       "Sound": "Sounds",
-      "Gui": "GUI",
-      "Model": "Models",
       "Wip": "WiPs"
     }
   },

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2005,
+  "totalKeys": 2007,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2005,
+      "translatedKeys": 2007,
       "pct": 100
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,23 +1,23 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2007,
+  "totalKeys": 2005,
   "languages": [
     {
       "code": "bg",
       "name": "български",
-      "translatedKeys": 1971,
+      "translatedKeys": 1969,
       "pct": 98
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2007,
+      "translatedKeys": 2005,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
-      "translatedKeys": 1869,
+      "translatedKeys": 1867,
       "pct": 93
     },
     {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,23 +1,23 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2005,
+  "totalKeys": 2003,
   "languages": [
     {
       "code": "bg",
       "name": "български",
-      "translatedKeys": 1969,
+      "translatedKeys": 1967,
       "pct": 98
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2005,
+      "translatedKeys": 2003,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
-      "translatedKeys": 1867,
+      "translatedKeys": 1865,
       "pct": 93
     },
     {

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -30,7 +30,7 @@ import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import MyPublishedSection from '../components/social/MyPublishedSection';
 import PublishPickerDialog from '../components/social/PublishPickerDialog';
 import PublishDialog from '../components/social/PublishDialog';
-import { getActiveDeadlockPath } from '../lib/appSettings';
+import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { formatRelativeDate } from '../lib/dates';
 
 // 'mine' is a client-side view, not a backend sort. We branch on it before
@@ -51,7 +51,7 @@ function isoFromUnix(unixSec: number): string {
 export default function Discover() {
   const { t } = useTranslation();
   const settings = useAppStore((s) => s.settings);
-  const hideNsfw = settings?.hideNsfwPreviews ?? true;
+  const hideNsfw = shouldBlurNsfw(settings);
   const signedIn = useSocialStore((s) => s.status.signedIn);
   const user = useSocialStore((s) => s.status.user);
   const signInBusy = useSocialStore((s) => s.loading);

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1406,7 +1406,22 @@ export default function Installed() {
     }
   };
 
-  const closeModDetails = () => {
+  // Stable identities for ModDetailsModal's prev/next props. Inline arrows there
+  // broke the modal's memo AND, because it lists these two in its keydown effect
+  // deps, re-registered four window listeners on every Installed render (which
+  // happens on drag, hover-intent and selection). Declared up here with the
+  // other detail-overlay hooks so they stay above this component's early
+  // returns; the entries and navigateToDetailsEntry they close over are read at
+  // click time, not render time. The props still flip to undefined when
+  // navigation is unavailable, so the effect re-runs exactly when it should.
+  const navigateToPreviousDetails = useStableCallback(() => {
+    if (previousDetailsEntry) navigateToDetailsEntry(previousDetailsEntry);
+  });
+  const navigateToNextDetails = useStableCallback(() => {
+    if (nextDetailsEntry) navigateToDetailsEntry(nextDetailsEntry);
+  });
+
+  const closeModDetails = useStableCallback(() => {
     setDetailsMod(null);
     setDetailsError(null);
     setDetailsOffline(false);
@@ -1415,7 +1430,7 @@ export default function Installed() {
     setDetailsSourceModId(null);
     setDetailsActiveFileIds(new Set());
     setDetailsDates(null);
-  };
+  });
 
   // Open a GameBanana item linked from description/changelog/comments inside
   // the same details modal (in-app), rather than the OS browser. Works for
@@ -1496,7 +1511,7 @@ export default function Installed() {
   // the [mods] useEffect) picks the new flag up. Optimistically toggle the
   // local state first so the pill flips immediately even if the IPC + scan
   // round-trip is slow.
-  const handleToggleIgnoreUpdates = async () => {
+  const handleToggleIgnoreUpdates = useStableCallback(async () => {
     if (!detailsSourceModId) return;
     const next = !detailsIgnoreUpdates;
     setDetailsIgnoreUpdates(next);
@@ -1507,7 +1522,7 @@ export default function Installed() {
       console.error('[Installed] toggle ignoreUpdates failed:', err);
       setDetailsIgnoreUpdates(!next);
     }
-  };
+  });
 
   const inspectUnknownModFilters = async (
     mod: Mod,
@@ -1967,7 +1982,7 @@ export default function Installed() {
     });
   };
 
-  const handleDetailsDownload = async (fileId: number, fileName: string) => {
+  const handleDetailsDownload = useStableCallback(async (fileId: number, fileName: string) => {
     if (!detailsMod) return;
     try {
       // Decide whether this pick replaces the source install or adds a sibling:
@@ -2045,7 +2060,7 @@ export default function Installed() {
     } catch (err) {
       setDetailsError(String(err));
     }
-  };
+  });
 
   /**
    * Re-download each target mod and restore its pre-update enabled state.
@@ -4504,12 +4519,8 @@ export default function Installed() {
           onClose={closeModDetails}
           onViewArtist={openArtistPage}
           onDownload={handleDetailsDownload}
-          onNavigatePrevious={
-            previousDetailsEntry ? () => navigateToDetailsEntry(previousDetailsEntry) : undefined
-          }
-          onNavigateNext={
-            nextDetailsEntry ? () => navigateToDetailsEntry(nextDetailsEntry) : undefined
-          }
+          onNavigatePrevious={previousDetailsEntry ? navigateToPreviousDetails : undefined}
+          onNavigateNext={nextDetailsEntry ? navigateToNextDetails : undefined}
           previousLabel={previousDetailsEntry ? entryName(previousDetailsEntry) : undefined}
           nextLabel={nextDetailsEntry ? entryName(nextDetailsEntry) : undefined}
           onOpenGameBananaItem={openLinkedGameBananaItem}
@@ -7155,6 +7166,11 @@ function EditableModTitle({
   }
 
   const commit = async () => {
+    // Enter commits, which sets `saving` and disables the input below. Disabling
+    // a focused input makes the browser fire focusout, so onBlur re-entered
+    // commit and renamed twice (the parent has not reloaded yet, so the
+    // trimmed !== name check still passed on the second pass).
+    if (saving) return;
     const trimmed = value.trim();
     if (!trimmed || trimmed === name) {
       setEditing(false);

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -10,7 +10,7 @@ import {
   setModGlobalType,
   setModLockerHero,
 } from '../lib/api';
-import { getActiveDeadlockPath } from '../lib/appSettings';
+import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { getAssetPath } from '../lib/assetPath';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
 import { LockerHeroView } from './LockerHero';
@@ -1054,7 +1054,7 @@ export default function Locker() {
                     : [...prev, hero.id]
                 )
               }
-              hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+              hideNsfwPreviews={shouldBlurNsfw(settings)}
             />
           ))}
         </div>
@@ -1085,7 +1085,7 @@ export default function Locker() {
                       src={mod.thumbnailUrl}
                       alt={mod.name}
                       nsfw={mod.nsfw}
-                      hideNsfw={settings?.hideNsfwPreviews ?? true}
+                      hideNsfw={shouldBlurNsfw(settings)}
                       className="w-full h-full"
                       fallback={
                         <div className="w-full h-full flex items-center justify-center text-text-secondary text-xs">
@@ -1153,7 +1153,7 @@ export default function Locker() {
             onToggleVariant={(modId) => toggleHeroVariant(overlayHero.id, modId)}
             onReorderSkins={(orderedModIds) => reorderHeroSkins(overlayHero.id, orderedModIds)}
             onRequestDeleteSkin={(ids, name) => setDeletePrompt({ ids, name })}
-            hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+            hideNsfwPreviews={shouldBlurNsfw(settings)}
             includedSkinKeys={shuffleIncluded}
             onToggleShuffleIncluded={toggleShuffleIncluded}
             shuffleVariantChoices={shuffleVariants}
@@ -1192,7 +1192,7 @@ export default function Locker() {
         >
           <LockerGlobalView
             groups={globalGroups}
-            hideNsfw={settings?.hideNsfwPreviews ?? true}
+            hideNsfw={shouldBlurNsfw(settings)}
             onBack={() => navigate('/locker')}
             onToggle={selectGlobalMod}
             onSetGlobalType={tagModGlobalType}

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -29,7 +29,7 @@ import CrosshairPreview from '../components/crosshair/CrosshairPreview';
 import ExportProfileModal from '../components/profiles/ExportProfileModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import PublishDialog from '../components/social/PublishDialog';
-import { getActiveDeadlockPath } from '../lib/appSettings';
+import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import Tx from '../components/translation/Tx';
 import type { Mod } from '../types/mod';
 
@@ -1095,7 +1095,7 @@ export default function Profiles() {
       {showImport && (
         <ImportProfileDialog
           activeDeadlockPath={getActiveDeadlockPath(settings)}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={shouldBlurNsfw(settings)}
           onClose={() => setShowImport(false)}
           onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}
         />
@@ -1106,7 +1106,7 @@ export default function Profiles() {
       {restoringSnapshotJson !== null && (
         <ImportProfileDialog
           activeDeadlockPath={getActiveDeadlockPath(settings)}
-          hideNsfwPreviews={settings?.hideNsfwPreviews ?? true}
+          hideNsfwPreviews={shouldBlurNsfw(settings)}
           initialInput={restoringSnapshotJson}
           onClose={() => setRestoringSnapshotJson(null)}
           onImported={() => { void loadProfileList({ silent: true }); void loadMods(); }}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,7 +17,7 @@ import {
   openPerformanceConfigFile,
 } from '../lib/api';
 import { showToast } from '../stores/toastStore';
-import { getActiveDeadlockPath } from '../lib/appSettings';
+import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
 import { Input, Textarea } from '../components/common/forms';
@@ -1053,10 +1053,10 @@ export default function Settings() {
         <Card title={<Tx k="settings.sections.preferences" fallback="Preferences" />} icon={Shield}>
           <div className="space-y-6">
             <Toggle
-              checked={settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true}
+              checked={shouldBlurNsfw(settings)}
               onChange={handleInstalledHideNsfwChange}
-              label={<Tx k="settings.preferences.blurInstalledNsfw" fallback="Blur Installed NSFW Content" />}
-              description={<Tx k="settings.preferences.blurInstalledNsfwDescription" fallback="Blur thumbnail images for installed mods marked as NSFW." />}
+              label={<Tx k="settings.preferences.hideNsfw" fallback="Hide NSFW Content" />}
+              description={<Tx k="settings.preferences.hideNsfwDescription" fallback="Blur thumbnail images for mods marked as NSFW." />}
             />
 
             <div className="h-px bg-white/5" />

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -2,8 +2,9 @@ import { create } from 'zustand';
 import type { Mod, AppSettings, AppearanceSurface, EditLocalModArgs, GlobalModType } from '../types/mod';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { setDateFormat } from '../lib/dateFormat';
-import { applyLanguagePreference } from '../i18n';
+import i18n, { applyLanguagePreference } from '../i18n';
 import * as api from '../lib/api';
+import { showToast } from './toastStore';
 import { buildHeroList } from '../lib/lockerUtils';
 import { modRestoreKey, planSoloByKeys, planRestore } from '../lib/soloRestore';
 import {
@@ -408,7 +409,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       applyLanguagePreference(settings.language);
       set({ settings, settingsLoading: false });
     } catch (err) {
+      // settingsError is kept for any surface that wants to render it inline,
+      // but toast it too: nothing rendered this field, so a failed load used to
+      // leave the app looking unconfigured with no explanation.
       set({ settingsError: String(err), settingsLoading: false });
+      showToast(i18n.t('settings.errors.loadFailed', { error: String(err) }), {
+        tone: 'error',
+        duration: 8000,
+      });
     }
   },
 
@@ -425,7 +433,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         get().loadMods();
       }
     } catch (err) {
+      // A failed write deliberately leaves `settings` untouched, so the control
+      // snaps back to its old value. Without this toast that read as "the
+      // toggle doesn't work" for every one of Settings' save call sites.
       set({ settingsError: String(err), settingsLoading: false });
+      showToast(i18n.t('settings.errors.saveFailed', { error: String(err) }), {
+        tone: 'error',
+        duration: 8000,
+      });
     }
   },
 


### PR DESCRIPTION
Fixes the confirmed bugs from the 2026-07-24 pre-release audit, plus the CI process gap that let them all through green, plus one catalog-sync bug found separately while investigating the errors in the runtime log. One commit per finding.

## Bugs

**Data loss: VPK copies could clobber each other.** `allocateEnabledVpkPath` reserves nothing on disk, so between the allocate and the `fs.copyFile` a concurrent enable or download saw the same pakNN as free and renamed its own VPK in. The copy then overwrote it and that mod silently lost its file. All four allocate-then-copy handlers now claim the slot exclusively first via the existing `reserveOutputSlot`, whose docstring already named this exact TOCTOU.

**Rate limiters were decorative.** `stats.ts` never imported `rateLimiter`, so `fetchFromAPI` was a bare fetch behind every deadlock-api handler in the service. `archiveCrc`'s ranged GETs also bypassed the GameBanana limiter while firing many per archive at `PROBE_CONCURRENCY`, which meant the JSON client believed it was inside 10 req/sec while the real rate was well over it. Both now acquire.

**Every Settings save failed silently.** `settingsError` was written on failure and read nowhere. A failed write leaves `settings` untouched so the control snaps back, which read as "the toggle is broken". Both load and save failures now toast.

**NSFW blur was stuck on in Locker, Discover and Profiles.** `hideNsfwPreviews` has no writer left (only the default; `settings.ts` uses it purely as a migration source). Browse and Installed got their own keys when the setting was split, but these surfaces kept reading the dead one. New `shouldBlurNsfw()` leads with the key the toggle actually writes and keeps the legacy one as the migration fallback. Since that toggle now governs every surface without a control of its own, it is relabelled to the existing broader "Hide NSFW Content" strings, and the `blurInstalledNsfw*` keys that orphaned are removed from the en catalog (en only: the manifest generator counts only source-catalog keys, so the stale bg and fr entries are already ignored by both the manifest and the runtime, and Weblate reconciles them from en).

**Renaming a mod committed twice.** Enter sets `saving`, which disables the input; disabling a focused input fires focusout, so `onBlur` re-entered `commit` and the `trimmed !== name` guard still passed because the parent had not reloaded yet.

**`ModDetailsModal`'s memo was dead.** Installed passed five unstable callbacks. Two are in the modal's keydown effect deps, so four window listeners re-registered on every Installed render, which happens on drag, hover-intent and selection.

## Catalog sync

Not from the audit. Found by investigating the errors in the runtime log, where a `SyncService` stack trace had been repeating on every sync cycle since at least 2026-07-12.

**Two of the five synced sections do not exist for Deadlock.** `SECTIONS` listed `Mod`, `Sound`, `Gui`, `Model`, `Wip`, but the game's own record (`Game/20948` `_aSections`) has no `Gui` or `Model` entry at all. Both failed, in two different ways, and the second one silently:

- `Gui` 500s server-side on GameBanana (`require_once` of a missing `classes/Model/Gui.php`) and returns HTML, so `fetchJson` throws. That is the recurring stack trace, roughly every 30 minutes.
- `Model` is rejected with `UNKNOWN_FILTER` on `_aFilters[Generic_Game]`. That error body is valid JSON, so `fetchSubmissions` did not throw. It fell through to an empty `_aRecords`, and `syncSection` wrote a success state for zero mods. The local cache carried a `('Model', 0, 0)` `sync_state` row with no rows to go with it.

No content is lost. What the two look like they cover is already synced as Mod root categories: the cache holds 396 "Model Replacement" and 366 "HUD" mods under `section=Mod`.

Dropping the filter is deliberately not the fix for `Model`. `/Model/Index` returns the same 3136 records for `_idGameRow=20948`, for an unrelated game id, and for no game param at all, so without it the catalog fills with non-Deadlock content. `SECTIONS` carries a comment so the two do not get added back.

`sync.sections.Gui` and `sync.sections.Model` orphaned as a result. Removed from the en catalog only, on the same reasoning as the `blurInstalledNsfw` keys above.

## CI

Lint, Typecheck, i18n and Build ran; the 612 tests did not. A PR could break every one of them and still go green. Added a Test step.

**The gate immediately earned its keep.** It went red on `navigator is not defined`: `HeroPoseViewer.test.ts` was failing at collection and silently taking its 12 tests with it, so the suite was really 600 tests, not 612. `detectFromNavigator` in `src/i18n.ts` reads the global unguarded and runs at module load via `i18n.init`, so every importer inherits that assumption, including tests that reach it transitively through `lib/api.ts` under vitest's node environment. Node only defines a `navigator` from v21, so this passes on a modern local Node and fails on CI's Node 20. Not a regression from this PR: `appStore` already imported `i18n`, so the suite has been broken on Node 20 all along and nothing was running it. Fixed by falling back to English when the global is absent, matching the sibling `localStorage` read that is already defensive for the same reason. Electron always has a `navigator`, so runtime detection is unchanged.

## Verification

`pnpm lint`, `pnpm exec tsc -b --noEmit`, `pnpm exec vitest run` (612 passed / 50 files), `pnpm i18n:check` and the locale manifest check all pass. The suite was additionally run against `node:20` in Docker to match the CI runtime: 612/612, up from 600 before the i18n fix.

The catalog-sync claims were checked against the live apiv11 rather than inferred: the `Gui` 500 and the `Model` `UNKNOWN_FILTER` were both reproduced directly, `_aSections` was read off the Deadlock game record to confirm neither section exists for this game, `/Model/Index` was queried with three different game params to confirm it ignores all of them, and the 396 plus 366 category counts come from the local `mods-cache.db`.

## Not in this PR

- **Em-dashes still shipping in the en catalog** (4 in `conflicts.*`, already translated into bg and fr). Deliberately left out: editing those English sources invalidates the existing translations, so it wants its own PR alongside the Weblate round-trip.
- **Screenshot refresh.** The working tree had all 8 README-referenced PNGs moved into an untracked `old/` folder with 3 placeholder-named replacements, which would have broken 8 README images. Left on disk, untracked, for a separate pass.
