### PR TITLE
chore(release): v1.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump only: `package.json` 1.23.0 -> 1.24.0. No code changes.

Minor rather than patch because the 8 commits since `v1.23.0` are a feature cluster: merges became editable (add sources into an existing merge, flatten merged mods), plus the Discord-requested organization batch (disabled-mod favorites and persistent reorder, shuffle variant selection, hidden creators).

## Contents since v1.23.0

- #296 Discord feature requests: merge editing, disabled-mod prefs, shuffle variants
- #297 Hidden creator controls in Browse
- #300 Pre-release cleanup: 7 audit bugs, catalog-sync fix, CI test gate
- #292 Cached mod details when GameBanana is unreachable
- #293 Remove-crosshair button on profile cards
- #295 Real mod names on import when the share hint is missing
- #298 Restore calibrated per-hero framing
- #294 bg translations

## Gates (local, Node 26)

- `tsc -b` clean
- `eslint .` 0 problems
- `vitest run` 612 passed / 50 files
- `i18n:check` OK (1769 referenced keys), locale manifest in sync
- `pnpm build` succeeds with `GRIMOIRE_SOCIAL_BASE_URL` set

## Before tagging

The two merge flows from #296 (add-into-merge, flatten) have unit coverage but have never been exercised against a live game install. Smoke test both before pushing the `v1.24.0` tag.

Release notes for the GitHub Release body are drafted and ready to paste.