### PR TITLE
Installed: A-Z sort for the disabled shelf, and stop card moves dragging the viewport

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1060,7 +1060,10 @@
       "enabled_one": "Enabled",
       "enabled_other": "Enabled",
       "disabled_one": "Disabled",
-      "disabled_other": "Disabled"
+      "disabled_other": "Disabled",
+      "sortAlphabetical": "A-Z",
+      "sortAlphabeticalHint": "Sort disabled mods A to Z. Pinned mods stay on top.",
+      "sortCustomHint": "Back to your own order (pinned first, then how you arranged them)."
     },
     "view": {
       "viewOptions": "View options",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2025,
+  "totalKeys": 2028,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2025,
+      "translatedKeys": 2028,
       "pct": 100
     },
     {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -52,6 +52,7 @@ import {
   MoreHorizontal,
   Wand2,
   SlidersHorizontal,
+  ArrowDownAZ,
   ArrowDownUp,
   Link2,
   ChevronDown,
@@ -458,7 +459,14 @@ const SortableEntryCard = memo(function SortableEntryCard({
       // on hover we lift containment (-> visible) and raise z so the expanded card
       // renders whole and on top. The has-menu-open lift does the same for an open
       // action menu that would otherwise paint behind the next card.
-      className={`flex flex-col has-[[data-card-menu-open]]:z-20 [content-visibility:auto] ${isList ? '' : 'hover:[content-visibility:visible] hover:z-10'} ${sortableDisabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
+      // overflow-anchor:none opts every card out of the browser's scroll
+      // anchoring. Without it, pinning a card near the bottom of a long library
+      // dragged the viewport along with it: Chrome had picked that card as the
+      // scroll anchor, so when the star moved it to the top of the disabled
+      // section the scroller "helpfully" followed it thousands of pixels up.
+      // Excluding cards leaves the grid container as the anchor, which never
+      // moves on a reorder, so the view stays put through pin / unpin / delete.
+      className={`flex flex-col has-[[data-card-menu-open]]:z-20 [overflow-anchor:none] [content-visibility:auto] ${isList ? '' : 'hover:[content-visibility:visible] hover:z-10'} ${sortableDisabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       style={style}
       {...attributes}
       {...listeners}
@@ -949,9 +957,22 @@ export default function Installed() {
   const [tagFilter, setTagFilter] = useState<string[]>([]);
   const installedHideNsfwPreviews =
     settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true;
+  // Disabled-section sort, deliberately separate from the top-bar sort above.
+  // That one spans both sections and turns the whole page read-only (a sorted
+  // enabled list no longer maps to load order). The disabled library is a
+  // shelf, not load order, so it can be alphabetized on its own without
+  // costing the enabled section its drag handles. 'custom' is the shipped
+  // behavior (pinned first, then the manual drag order); 'name' sorts A to Z
+  // inside those same pin bands.
+  const [disabledSortMode, setDisabledSortMode] = useState<'custom' | 'name'>(() =>
+    localStorage.getItem('installedDisabledSort') === 'name' ? 'name' : 'custom'
+  );
   useEffect(() => {
     localStorage.setItem('installedSortMode', sortMode);
   }, [sortMode]);
+  useEffect(() => {
+    localStorage.setItem('installedDisabledSort', disabledSortMode);
+  }, [disabledSortMode]);
   useEffect(() => {
     localStorage.setItem('installedSourceSel', JSON.stringify(sourceSel));
   }, [sourceSel]);
@@ -3379,13 +3400,20 @@ export default function Installed() {
   const disabledDefaultIndex = new Map(
     defaultSortedDisabled.map((entry, index) => [entry.key, index])
   );
+  // A-Z drops the saved drag order (that's the point of asking for it) but
+  // keeps the pinned band: the star's promise is "pins it to the top", so
+  // favorites sort A-Z among themselves, then everything else does.
+  const disabledAlphabetical = disabledSortMode === 'name';
   const visibleDisabled = statusSel.includes('disabled')
     ? [...defaultSortedDisabled].sort(createDisabledEntryComparator({
         favorites: disabledFavorites,
-        manualOrder: disabledOrder,
+        manualOrder: disabledAlphabetical ? [] : disabledOrder,
         keyOf: entryDisabledPreferenceKey,
-        fallback: (left, right) =>
-          (disabledDefaultIndex.get(left.key) ?? 0) - (disabledDefaultIndex.get(right.key) ?? 0),
+        fallback: disabledAlphabetical
+          ? (left, right) =>
+              entryName(left).localeCompare(entryName(right), undefined, { sensitivity: 'base' })
+          : (left, right) =>
+              (disabledDefaultIndex.get(left.key) ?? 0) - (disabledDefaultIndex.get(right.key) ?? 0),
       }))
     : [];
   const totalMatches = visibleEnabled.length + visibleDisabled.length;
@@ -3636,6 +3664,10 @@ export default function Installed() {
 
   const renderSortableSection = (section: DragSection) => {
     const entries = previewEntriesForSection(section);
+    // A-Z is a display order, so a drop in the disabled section would have
+    // nowhere to be saved. The enabled section keeps its handles either way.
+    const sectionSortable =
+      sortableEnabled && !(section === 'disabled' && disabledAlphabetical);
     const activeEntry = draggingSection === section
       ? entries.find((entry) => entry.key === draggingKey)
       : undefined;
@@ -3664,7 +3696,7 @@ export default function Installed() {
             {(gridWarm ? entries : entries.slice(0, INITIAL_MOUNT_COUNT)).map((entry) => (
               <SortableEntryCard
                 key={entry.key}
-                sortableDisabled={!sortableEnabled}
+                sortableDisabled={!sectionSortable}
                 {...cardPropsFor(entry)}
               />
             ))}
@@ -4247,8 +4279,29 @@ export default function Installed() {
 
       {visibleDisabled.length > 0 && (
         <div>
-          <div className="flex items-baseline justify-between mb-[14px]">
+          <div className="flex items-center justify-between gap-3 mb-[14px]">
             <SectionHeader count={visibleDisabled.length} className="!mb-0 !text-xs !font-semibold !tracking-[0.06em]">{t('installed.sections.disabled', { count: visibleDisabled.length })}</SectionHeader>
+            {/* Sort toggle for the disabled shelf only, parked on the header
+                row so it reads as belonging to this section and not to the
+                top bar's page-wide sort. */}
+            <button
+              type="button"
+              onClick={() => setDisabledSortMode(disabledAlphabetical ? 'custom' : 'name')}
+              aria-pressed={disabledAlphabetical}
+              title={
+                disabledAlphabetical
+                  ? t('installed.sections.sortCustomHint')
+                  : t('installed.sections.sortAlphabeticalHint')
+              }
+              className={`inline-flex flex-shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.06em] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 ${
+                disabledAlphabetical
+                  ? 'border-accent/40 bg-accent/10 text-accent'
+                  : 'border-white/[0.08] bg-bg-tertiary/50 text-text-secondary hover:border-white/20 hover:text-text-primary'
+              }`}
+            >
+              <ArrowDownAZ className="h-3.5 w-3.5" />
+              {t('installed.sections.sortAlphabetical')}
+            </button>
           </div>
           {renderSortableSection('disabled')}
         </div>


### PR DESCRIPTION
Two requests from Discord, both about the disabled section on Installed.

## A-Z sort

A small toggle now sits on the right of the `DISABLED (n)` header row.

- **Off** (default): unchanged behavior. Pinned first, then your own drag order.
- **On**: A to Z. Pinned mods still float to the top and sort A-Z among themselves, since the star's promise is "pins it to the top once you disable it".
- Persisted in localStorage (`installedDisabledSort`).

It is deliberately *not* the top-bar sort. That one spans both sections and turns the page read-only, because a sorted enabled list no longer maps to load order. The disabled library is a shelf, not load order, so alphabetizing it costs the enabled section nothing. Drag-reorder in the disabled section switches off while A-Z is on (a drop would have nowhere to be saved); the enabled section keeps its handles either way.

## The scroll jump when you pin a mod

Pinning a card near the bottom of a long library flung the page thousands of pixels up.

Root cause is Chrome **scroll anchoring**, not focus and not `content-visibility`. The browser had picked the card under the viewport as its scroll anchor; the star moves that card to the top of the disabled section, so the scroller followed its anchor up there. Cards now carry `overflow-anchor:none`, which leaves the grid container as the anchor, and that never moves on a reorder. The same fix covers enable/disable toggles, where a card jumps between sections.

Ruled out along the way: blurring the clicked button does not help (focus is not the mechanism), and `contain-intrinsic-size: auto <len>` is already set, so skipped cards were never collapsing.

## Verification

Driven over CDP against a throwaway instance seeded with a 280-mod library (grouped variants included):

| action | before | after |
|---|---|---|
| pin a card from the bottom | scrollTop 70063 -> 3065 | 38011 -> 38011 |
| enable toggle from the bottom | n/a | no change |
| delete (single, grouped, mid-list, bottom, grid + list) | no jump | no jump |

Reported alongside this was a jump when deleting. I could not reproduce that one in any configuration I tried. The anchoring fix covers it if it was the same "a card moved" mechanism (deleting one variant out of a group can move the surviving card between the pinned and unpinned bands, which would do it), otherwise it needs a more specific repro.

Gates: `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check`, manifest regenerated with `pnpm i18n:manifest`, 612 vitest tests pass.