### PR TITLE
fix(ui): don't dismiss dialogs when a drag merely ends on the backdrop

### DIFF
--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { createPortal } from 'react-dom';
+import { useBackdropDismiss } from './common/useBackdropDismiss';
 import {
   Volume2,
   Loader2,
@@ -246,6 +247,17 @@ function ModDetailsModal({
   const [imageRatios, setImageRatios] = useState<Record<number, number>>({});
   const [deleteCandidate, setDeleteCandidate] = useState<{ modId: string; fileName: string } | null>(null);
   const [deleteInProgress, setDeleteInProgress] = useState(false);
+  // Backdrop dismissal for the two nested overlays. The hook ignores drags
+  // that only end on the backdrop, so releasing a text selection (or the
+  // lightbox drag) outside the panel no longer closes them.
+  const lightboxBackdropRef = useBackdropDismiss<HTMLDivElement>(
+    () => setLightboxOpen(false),
+    lightboxOpen
+  );
+  const deleteBackdropRef = useBackdropDismiss<HTMLDivElement>(
+    () => setDeleteCandidate(null),
+    !!deleteCandidate && !deleteInProgress
+  );
 
   // Default the archived section open when the file you currently have installed
   // lives there. That's the common update case: an author archives the old
@@ -1064,14 +1076,11 @@ function ModDetailsModal({
 
         {deleteCandidate && (
           <div
+            ref={deleteBackdropRef}
             className="fixed inset-0 z-[60] flex items-center justify-center bg-black/65 p-4"
             role="alertdialog"
             aria-modal="true"
             aria-labelledby="delete-file-title"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (!deleteInProgress) setDeleteCandidate(null);
-            }}
           >
             <div
               className="w-full max-w-md rounded-lg border border-border bg-bg-secondary p-5 shadow-2xl"
@@ -1717,11 +1726,8 @@ function ModDetailsModal({
           the global keydown listener so users can flip pictures while zoomed. */}
       {lightboxOpen && currentImageFullUrl && (
         <div
+          ref={lightboxBackdropRef}
           className="fixed inset-0 z-[60] bg-black/95 flex items-center justify-center p-4 animate-fade-in"
-          onClick={(e) => {
-            e.stopPropagation();
-            setLightboxOpen(false);
-          }}
           role="dialog"
           aria-modal="true"
           aria-label={`${mod.name} - full size image`}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
+import { useBackdropDismiss } from './useBackdropDismiss';
 
 // Standard modal shell: portal to body, dimmed backdrop, Escape and
 // backdrop-click dismissal, focus hand-off into the panel and restore on
@@ -50,6 +51,7 @@ export function Modal({
 }: ModalProps) {
     const panelRef = useRef<HTMLDivElement>(null);
     const restoreFocusRef = useRef<HTMLElement | null>(null);
+    const backdropRef = useBackdropDismiss<HTMLDivElement>(onClose, open && dismissable);
     const [mounted, setMounted] = useState(open);
     // Render-time adjustment so opening re-mounts on the same commit.
     if (open && !mounted) setMounted(true);
@@ -129,15 +131,13 @@ export function Modal({
 
     return createPortal(
         <div
+            ref={backdropRef}
             className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 ${
                 closing ? 'animate-fade-out pointer-events-none' : 'animate-fade-in'
             } ${backdropClassName}`}
             role="dialog"
             aria-modal="true"
             aria-labelledby={labelledBy}
-            onClick={(e) => {
-                if (dismissable && e.target === e.currentTarget) onClose();
-            }}
         >
             <div
                 ref={panelRef}

--- a/src/components/common/useBackdropDismiss.ts
+++ b/src/components/common/useBackdropDismiss.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Click-to-dismiss for an overlay backdrop that ignores drags which merely
+ * *end* on the backdrop.
+ *
+ * The naive version (`onClick` on the backdrop, guarded by
+ * `e.target === e.currentTarget`, or by the panel calling stopPropagation)
+ * misfires: a drag that starts inside the panel (selecting text in an input,
+ * dragging the panel's scrollbar) and releases over the backdrop produces a
+ * click whose target is their common ancestor, which is the backdrop itself.
+ * The panel never sees that click, so nothing stops it, and the dialog closes
+ * out from under the gesture.
+ *
+ * Requiring the gesture to both start and end on the backdrop fixes that, and
+ * also ignores the mirror case (press the backdrop, release inside the panel).
+ *
+ * Attach the returned ref to the backdrop element, and do not also hang an
+ * onClick dismiss on it.
+ */
+export function useBackdropDismiss<T extends HTMLElement = HTMLDivElement>(
+    onDismiss: () => void,
+    enabled = true
+) {
+    const ref = useRef<T>(null);
+    // Ref rather than a local, so it survives the re-subscribe that inline
+    // onDismiss props cause on every render.
+    const downOnBackdropRef = useRef(false);
+
+    useEffect(() => {
+        if (!enabled) return;
+        const onDown = (e: MouseEvent) => {
+            downOnBackdropRef.current = e.button === 0 && e.target === ref.current;
+        };
+        const onUp = (e: MouseEvent) => {
+            const dismiss =
+                downOnBackdropRef.current && e.button === 0 && e.target === ref.current;
+            downOnBackdropRef.current = false;
+            if (dismiss) onDismiss();
+        };
+        // Capture phase: children that stopPropagation() must not be able to
+        // desync the origin flag or swallow the release. Target identity is
+        // what gates the dismiss, so nested overlays never cross-talk.
+        window.addEventListener('mousedown', onDown, true);
+        window.addEventListener('mouseup', onUp, true);
+        return () => {
+            window.removeEventListener('mousedown', onDown, true);
+            window.removeEventListener('mouseup', onUp, true);
+        };
+    }, [enabled, onDismiss]);
+
+    return ref;
+}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -89,6 +89,7 @@ import MergeModsModal from '../components/MergeModsModal';
 import MergedContentsModal from '../components/MergedContentsModal';
 import PriorityEditor from '../components/PriorityEditor';
 import { Modal } from '../components/common/Modal';
+import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
@@ -1431,6 +1432,17 @@ export default function Installed() {
     setDetailsActiveFileIds(new Set());
     setDetailsDates(null);
   });
+
+  // Backdrops for the details loading/error overlays. Selecting the error text
+  // to copy it and releasing outside the panel used to dismiss the error.
+  const detailsLoadingBackdropRef = useBackdropDismiss<HTMLDivElement>(
+    closeModDetails,
+    detailsLoading
+  );
+  const detailsErrorBackdropRef = useBackdropDismiss<HTMLDivElement>(
+    closeModDetails,
+    !!detailsError && !detailsMod
+  );
 
   // Open a GameBanana item linked from description/changelog/comments inside
   // the same details modal (in-app), rather than the OS browser. Works for
@@ -4465,8 +4477,8 @@ export default function Installed() {
 
       {detailsLoading && createPortal(
         <div
+          ref={detailsLoadingBackdropRef}
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in"
-          onClick={closeModDetails}
         >
           <div
             className="bg-bg-secondary border border-border rounded-xl p-6 flex items-center gap-3"
@@ -4481,8 +4493,8 @@ export default function Installed() {
 
       {detailsError && !detailsMod && createPortal(
         <div
+          ref={detailsErrorBackdropRef}
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-          onClick={closeModDetails}
         >
           <div
             className="bg-bg-secondary border border-border rounded-xl p-6 max-w-md"
@@ -4967,14 +4979,15 @@ function UnknownFilterGuessModal({
 }) {
   const { t } = useTranslation();
   const { mod } = state;
+  const backdropRef = useBackdropDismiss<HTMLDivElement>(onClose);
 
   return createPortal(
     <div
+      ref={backdropRef}
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
       role="dialog"
       aria-modal="true"
       aria-labelledby="unknown-filter-title"
-      onClick={onClose}
     >
       <div
         className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
@@ -5073,15 +5086,16 @@ function BulkUnknownFixModal({
     (mod) => !pendingIds.has(mod.id) && cache[mod.id]?.crcMatch.status === 'not-found'
   ).length;
   const [confirmFindAll, setConfirmFindAll] = useState(false);
+  const backdropRef = useBackdropDismiss<HTMLDivElement>(onClose);
 
   return createPortal(
     <>
     <div
+      ref={backdropRef}
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 animate-fade-in"
       role="dialog"
       aria-modal="true"
       aria-labelledby="bulk-unknown-title"
-      onClick={onClose}
     >
       <div
         className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-5xl max-h-[85vh] flex flex-col overflow-hidden shadow-2xl"
@@ -8234,6 +8248,9 @@ interface EditLocalModModalProps {
 
 function EditLocalModModal({ mod, onClose, onSave }: EditLocalModModalProps) {
   const { t } = useTranslation();
+  // Drag-selecting the name field and releasing outside the panel used to
+  // close this dialog and drop the edit.
+  const backdropRef = useBackdropDismiss<HTMLDivElement>(onClose);
   const [name, setName] = useState(mod.name);
   const [imagePath, setImagePath] = useState('');
   const [thumbnailDataUrl, setThumbnailDataUrl] = useState(mod.thumbnailUrl ?? '');
@@ -8308,8 +8325,8 @@ function EditLocalModModal({ mod, onClose, onSave }: EditLocalModModalProps) {
 
   return createPortal(
     <div
+      ref={backdropRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-bg-primary/75 p-4 backdrop-blur-sm"
-      onClick={onClose}
     >
       <div
         className="w-full max-w-md rounded-lg border border-border bg-bg-secondary p-5 shadow-2xl"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import {
   openPerformanceConfigFile,
 } from '../lib/api';
 import { showToast } from '../stores/toastStore';
+import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
 import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { formatDateParts } from '../lib/dateFormat';
 import { Card, Badge, Toggle, Button } from '../components/common/ui';
@@ -276,6 +277,13 @@ export default function Settings() {
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [customPickerOpen, commitCustomDraft]);
+
+  // Dismiss on backdrop click, but not when the gesture merely ends there
+  // (drag-selecting the hex field and releasing outside used to commit).
+  const customPickerBackdropRef = useBackdropDismiss<HTMLDivElement>(
+    useCallback(() => void commitCustomDraft(), [commitCustomDraft]),
+    customPickerOpen
+  );
 
   const handleLockerCardsExpandedByDefaultChange = async (checked: boolean) => {
     if (settings) {
@@ -973,8 +981,8 @@ export default function Settings() {
 
                     {customPickerOpen && createPortal(
                       <div
+                        ref={customPickerBackdropRef}
                         className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in"
-                        onClick={() => void commitCustomDraft()}
                         role="presentation"
                       >
                         <div


### PR DESCRIPTION
Discord report: holding M1 to select text in the merge-mods window and dragging out before releasing closes the window. Solion confirmed the same thing when renaming during a custom VPK upload.

It wasn't specific to either surface: every dialog behaved this way.

## Cause

The backdrop dismissed on `click`, guarded by `e.target === e.currentTarget`.

When you press inside the panel and release over the backdrop, the browser fires the `click` on the **common ancestor** of the press and release targets, which is the backdrop itself. So the guard saw a genuine backdrop click. Panels calling `stopPropagation` didn't help either, since that click never travels through the panel.

## Fix

Dismissal now resolves on `mouseup`, and only when the gesture **both started and ended** on the backdrop. Extracted as `useBackdropDismiss` (`src/components/common/useBackdropDismiss.ts`).

Also fixes the mirror case (press backdrop, release inside panel) and drags that begin on a panel scrollbar, which failed the same way.

Applied to:

- `common/Modal.tsx`, the shared primitive, covering 23 dialogs including both reported surfaces
- `Installed.tsx`: `EditLocalModModal` (the custom-VPK rename), the two unknown-mod fixers, details loading/error overlays
- `Settings.tsx`: custom accent picker, where a drag-out also silently **committed** the draft
- `ModDetailsModal.tsx`: delete confirm and image lightbox

Escape and `dismissable={false}` are unchanged. `BrowseFileQuickPicker` and the Locker retag menu use a sibling backdrop rather than a wrapping one, so the click never propagates through them: not affected, untouched.

## Verification

Drove real CDP mouse gestures against the actual `Modal.tsx`, and confirmed the test was meaningful by stashing the fix and re-running:

| case | before | after |
|---|---|---|
| drag out of input, release on backdrop | closes | stays open |
| press backdrop, release inside panel | closes | stays open |
| plain backdrop click | closes | closes |

`pnpm typecheck`, `pnpm lint`, and 612 tests pass.

## Note

The repo has no DOM test environment (vitest is node-only, no jsdom/testing-library), so this has no automated regression coverage. I used a temporary harness and deleted it rather than adding a test-stack dependency out of scope for a bug fix. Happy to wire in jsdom plus a real regression test as a follow-up if wanted.