### PR TITLE
feat(installed): user lists for organizing installed mods

### DIFF
--- a/src/components/ImageContextMenu.tsx
+++ b/src/components/ImageContextMenu.tsx
@@ -15,12 +15,17 @@ interface ImageContextMenuProps {
    *  as onRevealInFolder: mod cards offer this on right-click, and the image
    *  menu swallows those clicks. Callers pass it only for imprinted mods. */
   onViewImprint?: () => void;
+  /** Extra menu items appended below the reveal/imprint block (the Installed
+   *  card's "Add to list" submenu). Same rationale as onRevealInFolder: this
+   *  menu swallows the card's right-clicks, so card-level actions have to be
+   *  threaded through to stay reachable from the thumbnail. */
+  extraItems?: ReactNode;
   children: ReactNode;
 }
 
 type CopyState = 'idle' | 'copying' | 'copied' | 'failed';
 
-export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, onViewImprint, children }: ImageContextMenuProps) {
+export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, onViewImprint, extraItems, children }: ImageContextMenuProps) {
   const { t } = useTranslation();
   const [imageCopyState, setImageCopyState] = useState<CopyState>('idle');
   const [urlCopyState, setUrlCopyState] = useState<CopyState>('idle');
@@ -163,6 +168,12 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
                   {t('installed.imprintDetails.menuEntry')}
                 </MenuItem>
               )}
+            </>
+          )}
+          {extraItems && (
+            <>
+              <MenuSeparator />
+              {extraItems}
             </>
           )}
       </MenuContent>

--- a/src/components/common/HeroSelect.tsx
+++ b/src/components/common/HeroSelect.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown } from 'lucide-react';
 import { getHeroChipIconPath } from '../../lib/lockerUtils';
 
@@ -18,6 +19,12 @@ interface HeroSelectProps {
   className?: string;
   size?: 'sm' | 'md';
 }
+
+const LISTBOX_GAP = 4;
+const VIEWPORT_PADDING = 8;
+const MAX_LISTBOX_HEIGHT = 288;
+/** Below this much room underneath the trigger, flipping up beats scrolling. */
+const MIN_DOWNWARD_SPACE = 160;
 
 function HeroIcon({ heroName }: { heroName?: string }) {
   if (!heroName) return null;
@@ -45,6 +52,7 @@ export function HeroSelect({
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const typeaheadRef = useRef('');
   const typeaheadTimerRef = useRef<number | null>(null);
@@ -61,13 +69,67 @@ export function HeroSelect({
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      // The listbox is portaled to <body>, so it is not inside rootRef any
+      // more: without checking it too, clicking an option would read as an
+      // outside click and close the menu before the option could fire.
+      if (!rootRef.current?.contains(target) && !listRef.current?.contains(target)) {
         setOpen(false);
       }
     };
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
   }, [open]);
+
+  /**
+   * Measure the trigger and write the listbox's fixed position straight to the
+   * node. Imperative on purpose: holding the rect in state would re-render the
+   * whole select on every scroll tick, and the position is display-only.
+   */
+  const positionListbox = useCallback(() => {
+    const button = buttonRef.current;
+    const listbox = listRef.current;
+    if (!button || !listbox) return;
+
+    const rect = button.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom - LISTBOX_GAP - VIEWPORT_PADDING;
+    const spaceAbove = rect.top - LISTBOX_GAP - VIEWPORT_PADDING;
+    const flipUp = spaceBelow < MIN_DOWNWARD_SPACE && spaceAbove > spaceBelow;
+
+    listbox.style.left = `${rect.left}px`;
+    listbox.style.width = `${rect.width}px`;
+    if (flipUp) {
+      listbox.style.top = 'auto';
+      listbox.style.bottom = `${window.innerHeight - rect.top + LISTBOX_GAP}px`;
+    } else {
+      listbox.style.bottom = 'auto';
+      listbox.style.top = `${rect.bottom + LISTBOX_GAP}px`;
+    }
+    const available = Math.max(0, flipUp ? spaceAbove : spaceBelow);
+    listbox.style.maxHeight = `${Math.min(available, MAX_LISTBOX_HEIGHT)}px`;
+  }, []);
+
+  /**
+   * The listbox renders in a portal rather than as an absolutely-positioned
+   * child, so no ancestor's `overflow` can clip it (the Installed sort/filter
+   * popover scrolls, and an in-flow listbox was cut off at its edge). The cost
+   * of leaving the trigger's containing block is that position has to be
+   * measured and kept in sync with anything that can move the trigger.
+   *
+   * Layout effect, not a plain effect: this runs after the portal is in the DOM
+   * but before paint, so the listbox is never visible at an unpositioned spot.
+   */
+  useLayoutEffect(() => {
+    if (!open) return;
+    positionListbox();
+    // Capture phase so scrolling any ancestor (not just the window) is caught.
+    window.addEventListener('scroll', positionListbox, true);
+    window.addEventListener('resize', positionListbox);
+    return () => {
+      window.removeEventListener('scroll', positionListbox, true);
+      window.removeEventListener('resize', positionListbox);
+    };
+  }, [open, positionListbox]);
 
   useEffect(() => {
     if (!open) return;
@@ -221,11 +283,17 @@ export function HeroSelect({
         <ChevronDown className="h-4 w-4 flex-shrink-0 text-text-secondary" aria-hidden="true" />
       </button>
 
-      {open && (
+      {open && createPortal(
         <div
+          ref={listRef}
           role="listbox"
           aria-label={ariaLabel}
-          className="absolute z-50 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-border bg-bg-secondary shadow-xl py-1"
+          // z-80 is the context-menu/popover rung of the ladder in index.css:
+          // portaled to <body>, this has to clear modals and page chrome alike.
+          // Positioned by positionListbox before paint; the inline top/left are
+          // only a starting point so the node has a box to measure against.
+          className="fixed z-[80] overflow-y-auto overscroll-contain rounded-md border border-border bg-bg-secondary shadow-xl py-1"
+          style={{ top: 0, left: 0 }}
         >
           {options.map((option, index) => {
             const active = option.value === value;
@@ -257,7 +325,8 @@ export function HeroSelect({
               </button>
             );
           })}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/components/common/menu.tsx
+++ b/src/components/common/menu.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import * as RadixContextMenu from '@radix-ui/react-context-menu';
-import { type LucideIcon } from 'lucide-react';
+import { Check, ChevronRight, type LucideIcon } from 'lucide-react';
 
 // Shared right-click menu primitives (styled wrappers over Radix
 // context-menu). One source for the menu surface and item styling that was
@@ -50,12 +50,18 @@ interface MenuItemProps {
   onSelect: (event: Event) => void;
 }
 
+// Row geometry, shared by every item kind so a checkbox or submenu row lines up
+// with a plain MenuItem. Tone is appended separately (MenuItem varies it).
+const ITEM_GEOMETRY_CLASS =
+  'flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer data-[disabled]:cursor-default data-[disabled]:opacity-50';
+const DEFAULT_TONE_CLASS = 'text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10';
+
 export function MenuItem({ children, icon: Icon, spinning, tone = 'default', disabled, onSelect }: MenuItemProps) {
   const toneClass = tone === 'success'
     ? 'text-state-success focus:bg-state-success/10 data-[highlighted]:bg-state-success/10'
     : tone === 'danger'
       ? 'text-state-danger focus:bg-state-danger/10 data-[highlighted]:bg-state-danger/10'
-      : 'text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10';
+      : DEFAULT_TONE_CLASS;
 
   return (
     <RadixContextMenu.Item
@@ -64,7 +70,7 @@ export function MenuItem({ children, icon: Icon, spinning, tone = 'default', dis
         event.stopPropagation();
         onSelect(event);
       }}
-      className={`flex h-8 select-none items-center gap-2 rounded-md px-2 outline-none transition-colors cursor-pointer data-[disabled]:cursor-default data-[disabled]:opacity-50 ${toneClass}`}
+      className={`${ITEM_GEOMETRY_CLASS} ${toneClass}`}
     >
       {Icon && <Icon className={`h-4 w-4 flex-shrink-0 text-current ${spinning ? 'animate-spin' : ''}`} />}
       <span className="min-w-0 flex-1 truncate">{children}</span>
@@ -84,4 +90,80 @@ export function MenuLabel({ children, className = '' }: { children: ReactNode; c
 
 export function MenuSeparator() {
   return <RadixContextMenu.Separator className="my-1 h-px bg-white/10" />;
+}
+
+export const MenuSub = RadixContextMenu.Sub;
+
+export function MenuSubTrigger({ children, icon: Icon }: { children: ReactNode; icon?: LucideIcon }) {
+  return (
+    <RadixContextMenu.SubTrigger
+      className={`${ITEM_GEOMETRY_CLASS} ${DEFAULT_TONE_CLASS} data-[state=open]:bg-white/10`}
+    >
+      {Icon && <Icon className="h-4 w-4 flex-shrink-0 text-current" />}
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
+    </RadixContextMenu.SubTrigger>
+  );
+}
+
+export function MenuSubContent({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <RadixContextMenu.Portal>
+      <RadixContextMenu.SubContent
+        collisionPadding={12}
+        sideOffset={2}
+        className={`${MENU_SURFACE_CLASS} ${className}`}
+      >
+        {children}
+      </RadixContextMenu.SubContent>
+    </RadixContextMenu.Portal>
+  );
+}
+
+interface MenuCheckboxItemProps {
+  children: ReactNode;
+  checked: boolean;
+  disabled?: boolean;
+  /** Trailing text (a count, a hint). Never truncates before the label does. */
+  hint?: ReactNode;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+/**
+ * Multi-select row. Radix closes the menu on select by default; ticking several
+ * lists in a row is the normal case here, so we preventDefault to keep it open.
+ */
+export function MenuCheckboxItem({
+  children,
+  checked,
+  disabled,
+  hint,
+  onCheckedChange,
+}: MenuCheckboxItemProps) {
+  return (
+    <RadixContextMenu.CheckboxItem
+      checked={checked}
+      disabled={disabled}
+      onSelect={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onCheckedChange={onCheckedChange}
+      className={`${ITEM_GEOMETRY_CLASS} ${DEFAULT_TONE_CLASS}`}
+    >
+      <span
+        className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+          checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
+        }`}
+      >
+        <RadixContextMenu.ItemIndicator>
+          <Check className="h-3 w-3" />
+        </RadixContextMenu.ItemIndicator>
+      </span>
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {hint !== undefined && (
+        <span className="flex-shrink-0 text-[11px] tabular-nums opacity-60">{hint}</span>
+      )}
+    </RadixContextMenu.CheckboxItem>
+  );
 }

--- a/src/components/common/menu.tsx
+++ b/src/components/common/menu.tsx
@@ -124,8 +124,6 @@ interface MenuCheckboxItemProps {
   children: ReactNode;
   checked: boolean;
   disabled?: boolean;
-  /** Trailing text (a count, a hint). Never truncates before the label does. */
-  hint?: ReactNode;
   onCheckedChange: (checked: boolean) => void;
 }
 
@@ -137,7 +135,6 @@ export function MenuCheckboxItem({
   children,
   checked,
   disabled,
-  hint,
   onCheckedChange,
 }: MenuCheckboxItemProps) {
   return (
@@ -161,9 +158,6 @@ export function MenuCheckboxItem({
         </RadixContextMenu.ItemIndicator>
       </span>
       <span className="min-w-0 flex-1 truncate">{children}</span>
-      {hint !== undefined && (
-        <span className="flex-shrink-0 text-[11px] tabular-nums opacity-60">{hint}</span>
-      )}
     </RadixContextMenu.CheckboxItem>
   );
 }

--- a/src/components/installed/FilterCheckList.tsx
+++ b/src/components/installed/FilterCheckList.tsx
@@ -1,0 +1,89 @@
+/**
+ * A labelled block of multi-select checkboxes in the Installed sort/filter
+ * popover. Shared by TAGS and LISTS, which are the same control over different
+ * data: a header with an optional Clear, then a scrolling column of rows that
+ * union within the block and AND with the other filter axes.
+ *
+ * Rows are buttons with role="checkbox" rather than real inputs because the
+ * whole row is the hit target and the mark is decorative. The role and
+ * aria-checked are what make that readable to a screen reader.
+ */
+import { type ReactNode } from 'react';
+import { Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export interface FilterCheckOption {
+  key: string;
+  label: string;
+  count: number;
+}
+
+interface FilterCheckListProps {
+  /** Block heading, already uppercased by the caller's translation. */
+  label: string;
+  options: readonly FilterCheckOption[];
+  selected: readonly string[];
+  onToggle: (key: string) => void;
+  onClear: () => void;
+  /** Optional trailing control in the header (the LISTS block's Manage link). */
+  action?: ReactNode;
+}
+
+export function FilterCheckList({
+  label,
+  options,
+  selected,
+  onToggle,
+  onClear,
+  action,
+}: FilterCheckListProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mt-3 border-t border-border pt-3">
+      <div className="mb-1.5 flex items-center justify-between">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
+          {label}
+        </span>
+        <div className="flex items-center gap-2">
+          {selected.length > 0 && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="text-[11px] text-accent hover:underline cursor-pointer"
+            >
+              {t('common.actions.clear')}
+            </button>
+          )}
+          {action}
+        </div>
+      </div>
+      <div className="max-h-48 space-y-0.5 overflow-y-auto pr-1">
+        {options.map((option) => {
+          const checked = selected.includes(option.key);
+          return (
+            <button
+              key={option.key}
+              type="button"
+              role="checkbox"
+              aria-checked={checked}
+              onClick={() => onToggle(option.key)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary cursor-pointer"
+            >
+              <span
+                aria-hidden
+                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+                  checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
+                }`}
+              >
+                {checked && <Check className="h-3 w-3" />}
+              </span>
+              <span className="flex-1 truncate">{option.label}</span>
+              <span className="text-[11px] opacity-60">{option.count}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/installed/ManageModListsModal.tsx
+++ b/src/components/installed/ManageModListsModal.tsx
@@ -1,0 +1,155 @@
+/**
+ * Rename and delete Installed lists.
+ *
+ * Deleting a list only forgets the grouping: the mods themselves are never
+ * touched. That is worth saying in the UI, because a list of mods with a
+ * delete button next to it reads as destructive when it isn't.
+ */
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Modal } from '../common/Modal';
+import { Button, IconButton, ModalHeader } from '../common/ui';
+import { Input } from '../common/forms';
+import type { ModList } from '../../lib/modLists';
+
+interface ManageModListsModalProps {
+  lists: readonly ModList[];
+  /** Live member counts by list id (orphaned keys excluded). */
+  counts: ReadonlyMap<string, number>;
+  onClose: () => void;
+  /** Returns false when the name was rejected (blank, or already in use). */
+  onRename: (id: string, name: string) => boolean;
+  onDelete: (id: string) => void;
+}
+
+interface ListRowProps {
+  list: ModList;
+  count: number;
+  onRename: (id: string, name: string) => boolean;
+  onDelete: (id: string) => void;
+}
+
+function ListRow({ list, count, onRename, onDelete }: ListRowProps) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState(list.name);
+  const [rejected, setRejected] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const commit = () => {
+    const next = draft.trim();
+    if (!next || next === list.name) {
+      setDraft(list.name);
+      setRejected(false);
+      return;
+    }
+    // A duplicate name is refused by the store, which would otherwise leave the
+    // field showing a name the list does not actually have.
+    if (!onRename(list.id, next)) {
+      setDraft(list.name);
+      setRejected(true);
+      return;
+    }
+    setRejected(false);
+  };
+
+  return (
+    <li className="rounded-md border border-border bg-bg-tertiary/40 p-2">
+      <div className="flex items-center gap-2">
+        <Input
+          inputSize="sm"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setRejected(false);
+          }}
+          onBlur={commit}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              event.currentTarget.blur();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              setDraft(list.name);
+              setRejected(false);
+            }
+          }}
+          aria-label={t('installed.lists.nameLabel')}
+          maxLength={80}
+        />
+        <span className="flex-shrink-0 whitespace-nowrap text-xs tabular-nums text-text-secondary">
+          {t('installed.lists.memberCount', { count })}
+        </span>
+        {confirmingDelete ? (
+          <div className="flex flex-shrink-0 items-center gap-1">
+            <Button size="sm" variant="danger" onClick={() => onDelete(list.id)}>
+              {t('common.actions.delete')}
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setConfirmingDelete(false)}>
+              {t('common.actions.cancel')}
+            </Button>
+          </div>
+        ) : (
+          <IconButton
+            size="sm"
+            tone="danger"
+            icon={Trash2}
+            label={t('installed.lists.deleteList', { name: list.name })}
+            onClick={() => setConfirmingDelete(true)}
+          />
+        )}
+      </div>
+      {rejected && (
+        <p className="mt-1 px-1 text-[11px] text-state-danger">{t('installed.lists.duplicateName')}</p>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Rendered conditionally by the caller, so each opening starts with fresh row
+ * drafts and no half-armed delete confirmations.
+ */
+export function ManageModListsModal({
+  lists,
+  counts,
+  onClose,
+  onRename,
+  onDelete,
+}: ManageModListsModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      onClose={onClose}
+      labelledBy="manage-mod-lists-title"
+      size="md"
+      panelClassName="flex max-h-[min(680px,calc(100vh-2rem))] flex-col overflow-hidden"
+    >
+      <ModalHeader
+        titleId="manage-mod-lists-title"
+        title={t('installed.lists.manageTitle')}
+        subtitle={t('installed.lists.manageSubtitle')}
+        onClose={onClose}
+        closeLabel={t('common.actions.close')}
+      />
+      <div className="min-h-0 overflow-y-auto p-5">
+        {lists.length === 0 ? (
+          <p className="text-sm text-text-secondary">{t('installed.lists.emptyHint')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {lists.map((list) => (
+              <ListRow
+                key={list.id}
+                list={list}
+                count={counts.get(list.id) ?? 0}
+                onRename={onRename}
+                onDelete={onDelete}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/installed/ModListMenu.tsx
+++ b/src/components/installed/ModListMenu.tsx
@@ -1,0 +1,116 @@
+/**
+ * The "Add to list" entry point on an Installed card's right-click menu, plus
+ * the small dialog for naming a new list.
+ *
+ * Lists organize the library and nothing else: assigning one never enables,
+ * disables, or reorders a mod. See src/lib/modLists.ts for the store.
+ */
+import { useState, type FormEvent } from 'react';
+import { ListPlus, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Modal } from '../common/Modal';
+import { Button, ModalHeader } from '../common/ui';
+import { Input } from '../common/forms';
+import {
+  MenuCheckboxItem,
+  MenuItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubContent,
+  MenuSubTrigger,
+} from '../common/menu';
+import type { ModList } from '../../lib/modLists';
+
+interface ModListSubmenuProps {
+  lists: readonly ModList[];
+  /** List ids this card's mod already belongs to. */
+  memberIds: readonly string[];
+  onToggle: (listId: string) => void;
+  onCreateNew: () => void;
+}
+
+export function ModListSubmenu({ lists, memberIds, onToggle, onCreateNew }: ModListSubmenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <MenuSub>
+      <MenuSubTrigger icon={ListPlus}>{t('installed.lists.menuTrigger')}</MenuSubTrigger>
+      {/* Cap the height: a user with many lists would otherwise get a submenu
+          taller than the window. */}
+      <MenuSubContent className="max-h-72 overflow-y-auto">
+        {lists.map((list) => (
+          <MenuCheckboxItem
+            key={list.id}
+            checked={memberIds.includes(list.id)}
+            onCheckedChange={() => onToggle(list.id)}
+          >
+            {list.name}
+          </MenuCheckboxItem>
+        ))}
+        {lists.length > 0 && <MenuSeparator />}
+        <MenuItem icon={Plus} onSelect={onCreateNew}>
+          {t('installed.lists.newList')}
+        </MenuItem>
+      </MenuSubContent>
+    </MenuSub>
+  );
+}
+
+interface CreateModListModalProps {
+  /** Name of the mod being filed, shown as the dialog subtitle. */
+  modName?: string;
+  onClose: () => void;
+  onCreate: (name: string) => void;
+}
+
+/**
+ * Rendered conditionally by the caller (`{creating && <CreateModListModal/>}`),
+ * so each opening is a fresh mount: the draft name starts empty and autoFocus
+ * fires without an effect. Trades the Modal exit animation for that, same as
+ * most dialogs in the app.
+ */
+export function CreateModListModal({ modName, onClose, onCreate }: CreateModListModalProps) {
+  const { t } = useTranslation();
+  const [name, setName] = useState('');
+  const trimmed = name.trim();
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!trimmed) return;
+    onCreate(trimmed);
+    onClose();
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy="create-mod-list-title" size="sm">
+      <form onSubmit={submit}>
+        <ModalHeader
+          titleId="create-mod-list-title"
+          title={t('installed.lists.createTitle')}
+          subtitle={modName}
+          subtitleTitle={modName}
+          onClose={onClose}
+          closeLabel={t('common.actions.close')}
+        />
+        <div className="p-5">
+          <Input
+            autoFocus
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={t('installed.lists.namePlaceholder')}
+            aria-label={t('installed.lists.nameLabel')}
+            maxLength={80}
+          />
+        </div>
+        <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            {t('common.actions.cancel')}
+          </Button>
+          <Button type="submit" disabled={!trimmed}>
+            {t('installed.lists.create')}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/lib/modLists.test.ts
+++ b/src/lib/modLists.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MOD_LISTS_KEY,
   type ModList,
+  addListMembership,
   buildListMembershipIndex,
   countLiveMembers,
   createList,
@@ -161,26 +162,39 @@ describe('renameList', () => {
   it('renames in place, preserving id and membership', () => {
     // The id is what an active filter selection references, so a rename must
     // not change it.
-    const lists = renameList([list('ivy', 'Ivy', ['gamebanana:1'])], 'ivy', 'Ivy Skins');
+    const { lists, applied } = renameList([list('ivy', 'Ivy', ['gamebanana:1'])], 'ivy', 'Ivy Skins');
 
+    expect(applied).toBe(true);
     expect(lists).toEqual([list('ivy', 'Ivy Skins', ['gamebanana:1'])]);
   });
 
   it('no-ops on a blank name or an unknown id', () => {
     const original = [list('a', 'A')];
 
-    expect(renameList(original, 'a', '  ')).toEqual(original);
-    expect(renameList(original, 'missing', 'B')).toEqual(original);
+    expect(renameList(original, 'a', '  ')).toEqual({ lists: original, applied: false });
+    expect(renameList(original, 'missing', 'B')).toEqual({ lists: original, applied: false });
   });
 
   it('no-ops when another list already uses the name', () => {
     const original = [list('a', 'A'), list('b', 'B')];
 
-    expect(renameList(original, 'b', 'a')).toEqual(original);
+    expect(renameList(original, 'b', 'a')).toEqual({ lists: original, applied: false });
   });
 
   it('allows a list to re-case its own name', () => {
-    expect(renameList([list('a', 'ivy')], 'a', 'Ivy')).toEqual([list('a', 'Ivy')]);
+    expect(renameList([list('a', 'ivy')], 'a', 'Ivy')).toEqual({
+      lists: [list('a', 'Ivy')],
+      applied: true,
+    });
+  });
+
+  it('reports applied for a name that survives trimming and clamping', () => {
+    // The dialog keys its rejection message off `applied`, so it must not be
+    // re-derived from a normalization rule duplicated outside this module.
+    const { lists, applied } = renameList([list('a', 'A')], 'a', `  ${'x'.repeat(200)}  `);
+
+    expect(applied).toBe(true);
+    expect(lists[0].name).toHaveLength(80);
   });
 });
 
@@ -192,6 +206,62 @@ describe('deleteList', () => {
   it('no-ops on an unknown id', () => {
     const original = [list('a', 'A')];
     expect(deleteList(original, 'missing')).toEqual(original);
+  });
+});
+
+describe('addListMembership', () => {
+  it('adds the key when absent and is a no-op when already present', () => {
+    const added = addListMembership([list('a', 'A')], 'a', 'gamebanana:1');
+    expect(added).toEqual([list('a', 'A', ['gamebanana:1'])]);
+
+    expect(addListMembership(added, 'a', 'gamebanana:1')).toEqual(added);
+  });
+
+  it('no-ops on an unknown id or a blank key', () => {
+    const original = [list('a', 'A')];
+
+    expect(addListMembership(original, 'missing', 'k')).toEqual(original);
+    expect(addListMembership(original, 'a', '')).toEqual(original);
+  });
+
+  it('does not mutate the input list or its keys array', () => {
+    const keys: string[] = [];
+    const original = [list('a', 'A', keys)];
+
+    addListMembership(original, 'a', 'k');
+
+    expect(keys).toEqual([]);
+    expect(original[0].keys).toBe(keys);
+  });
+});
+
+describe('create-then-file (the "New list..." dialog flow)', () => {
+  // Mirrors createListForEntry in Installed.tsx. createList reuses a list whose
+  // name already matches, so this composition has to be add-only: toggling here
+  // un-filed a mod that was already in the list whose name the user typed.
+  const createAndFile = (lists: readonly ModList[], name: string, prefKey: string) => {
+    const created = createList(lists, name);
+    return created.id ? addListMembership(created.lists, created.id, prefKey) : created.lists;
+  };
+
+  it('files the mod into a newly created list', () => {
+    expect(createAndFile([], 'Ivy', 'gamebanana:1')).toEqual([
+      list('ivy', 'Ivy', ['gamebanana:1']),
+    ]);
+  });
+
+  it('keeps the mod filed when the typed name matches a list it is already in', () => {
+    const existing = [list('ivy', 'Ivy', ['gamebanana:1'])];
+
+    expect(createAndFile(existing, 'IVY', 'gamebanana:1')).toEqual(existing);
+  });
+
+  it('files into the matched list rather than duplicating it', () => {
+    const existing = [list('ivy', 'Ivy', ['gamebanana:1'])];
+
+    expect(createAndFile(existing, 'ivy', 'gamebanana:2')).toEqual([
+      list('ivy', 'Ivy', ['gamebanana:1', 'gamebanana:2']),
+    ]);
   });
 });
 

--- a/src/lib/modLists.test.ts
+++ b/src/lib/modLists.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  MOD_LISTS_KEY,
+  type ModList,
+  buildListMembershipIndex,
+  countLiveMembers,
+  createList,
+  deleteList,
+  readStoredModLists,
+  renameList,
+  toggleListMembership,
+  writeStoredModLists,
+} from './modLists';
+
+const installLocalStorage = (values: Record<string, string> = {}) => {
+  const storage = new Map(Object.entries(values));
+  const localStorage = {
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
+  };
+  vi.stubGlobal('localStorage', localStorage);
+  return { storage, localStorage };
+};
+
+const list = (id: string, name: string, keys: string[] = []): ModList => ({ id, name, keys });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('storage key', () => {
+  it('is a frozen literal', () => {
+    // Renaming this orphans every list already saved by a shipped build.
+    // Treat the string as a wire format.
+    expect(MOD_LISTS_KEY).toBe('installedModLists');
+  });
+});
+
+describe('readStoredModLists', () => {
+  it('returns an empty list when storage is absent or malformed', () => {
+    installLocalStorage({ [MOD_LISTS_KEY]: '{bad json' });
+    expect(readStoredModLists()).toEqual([]);
+
+    installLocalStorage({ [MOD_LISTS_KEY]: JSON.stringify({ not: 'an array' }) });
+    expect(readStoredModLists()).toEqual([]);
+
+    installLocalStorage();
+    expect(readStoredModLists()).toEqual([]);
+  });
+
+  it('drops entries that are not usable lists', () => {
+    installLocalStorage({
+      [MOD_LISTS_KEY]: JSON.stringify([
+        null,
+        'a string',
+        { id: 'no-name' },
+        { name: 'no id' },
+        { id: '  ', name: 'blank id' },
+        { id: 'blank-name', name: '   ' },
+        list('keep', 'Keep'),
+      ]),
+    });
+
+    expect(readStoredModLists()).toEqual([list('keep', 'Keep')]);
+  });
+
+  it('drops duplicate ids, keeping the first', () => {
+    installLocalStorage({
+      [MOD_LISTS_KEY]: JSON.stringify([list('dup', 'First', ['a']), list('dup', 'Second', ['b'])]),
+    });
+
+    expect(readStoredModLists()).toEqual([list('dup', 'First', ['a'])]);
+  });
+
+  it('repairs a missing or dirty keys array instead of dropping the list', () => {
+    installLocalStorage({
+      [MOD_LISTS_KEY]: JSON.stringify([
+        { id: 'a', name: 'No keys field' },
+        { id: 'b', name: 'Dirty keys', keys: ['x', 1, null, 'x', '', 'y'] },
+        { id: 'c', name: 'Keys not an array', keys: 'nope' },
+      ]),
+    });
+
+    expect(readStoredModLists()).toEqual([
+      list('a', 'No keys field'),
+      list('b', 'Dirty keys', ['x', 'y']),
+      list('c', 'Keys not an array'),
+    ]);
+  });
+
+  it('round-trips what writeStoredModLists saved', () => {
+    const { storage } = installLocalStorage();
+    const lists = [list('ivy', 'Ivy', ['gamebanana:1']), list('ui', 'UI', [])];
+
+    writeStoredModLists(lists);
+    expect(JSON.parse(storage.get(MOD_LISTS_KEY) ?? 'null')).toEqual(lists);
+    expect(readStoredModLists()).toEqual(lists);
+  });
+});
+
+describe('createList', () => {
+  it('appends a list with a slugified id', () => {
+    const { lists, id } = createList([], '  Ivy Skins  ');
+
+    expect(id).toBe('ivy-skins');
+    expect(lists).toEqual([list('ivy-skins', 'Ivy Skins')]);
+  });
+
+  it('returns a null id and no new list for a blank name', () => {
+    const { lists, id } = createList([list('a', 'A')], '   ');
+
+    expect(id).toBeNull();
+    expect(lists).toEqual([list('a', 'A')]);
+  });
+
+  it('reuses an existing list when the name matches case-insensitively', () => {
+    // "New list: ivy" when an Ivy list exists should file the mod under Ivy
+    // rather than creating a confusing second list with the same label.
+    const existing = [list('ivy', 'Ivy', ['gamebanana:1'])];
+    const { lists, id } = createList(existing, 'IVY');
+
+    expect(id).toBe('ivy');
+    expect(lists).toEqual(existing);
+  });
+
+  it('disambiguates ids that would collide after slugifying', () => {
+    // Different names, same slug: the second must not steal the first's id, or
+    // every filter selection and membership lookup would alias.
+    const first = createList([], 'Ivy Skins');
+    const second = createList(first.lists, 'Ivy/Skins');
+
+    expect(first.id).toBe('ivy-skins');
+    expect(second.id).toBe('ivy-skins-2');
+    expect(second.lists.map((l) => l.id)).toEqual(['ivy-skins', 'ivy-skins-2']);
+  });
+
+  it('falls back to a seed id when the name has no latin characters', () => {
+    const first = createList([], 'Русские моды');
+    const second = createList(first.lists, '日本語');
+
+    expect(first.id).toBe('list');
+    expect(second.id).toBe('list-2');
+  });
+
+  it('clamps an overlong name', () => {
+    const { lists } = createList([], 'x'.repeat(200));
+
+    expect(lists[0].name).toHaveLength(80);
+  });
+
+  it('does not mutate its input', () => {
+    const original = [list('a', 'A')];
+    const { lists } = createList(original, 'B');
+
+    expect(original).toEqual([list('a', 'A')]);
+    expect(lists).not.toBe(original);
+  });
+});
+
+describe('renameList', () => {
+  it('renames in place, preserving id and membership', () => {
+    // The id is what an active filter selection references, so a rename must
+    // not change it.
+    const lists = renameList([list('ivy', 'Ivy', ['gamebanana:1'])], 'ivy', 'Ivy Skins');
+
+    expect(lists).toEqual([list('ivy', 'Ivy Skins', ['gamebanana:1'])]);
+  });
+
+  it('no-ops on a blank name or an unknown id', () => {
+    const original = [list('a', 'A')];
+
+    expect(renameList(original, 'a', '  ')).toEqual(original);
+    expect(renameList(original, 'missing', 'B')).toEqual(original);
+  });
+
+  it('no-ops when another list already uses the name', () => {
+    const original = [list('a', 'A'), list('b', 'B')];
+
+    expect(renameList(original, 'b', 'a')).toEqual(original);
+  });
+
+  it('allows a list to re-case its own name', () => {
+    expect(renameList([list('a', 'ivy')], 'a', 'Ivy')).toEqual([list('a', 'Ivy')]);
+  });
+});
+
+describe('deleteList', () => {
+  it('removes only the named list', () => {
+    expect(deleteList([list('a', 'A'), list('b', 'B')], 'a')).toEqual([list('b', 'B')]);
+  });
+
+  it('no-ops on an unknown id', () => {
+    const original = [list('a', 'A')];
+    expect(deleteList(original, 'missing')).toEqual(original);
+  });
+});
+
+describe('toggleListMembership', () => {
+  it('adds the key when absent and removes it when present', () => {
+    const added = toggleListMembership([list('a', 'A')], 'a', 'gamebanana:1');
+    expect(added).toEqual([list('a', 'A', ['gamebanana:1'])]);
+
+    expect(toggleListMembership(added, 'a', 'gamebanana:1')).toEqual([list('a', 'A')]);
+  });
+
+  it('leaves other lists untouched', () => {
+    const lists = toggleListMembership([list('a', 'A'), list('b', 'B')], 'a', 'k');
+
+    expect(lists[1]).toEqual(list('b', 'B'));
+  });
+
+  it('no-ops on an unknown id or a blank key', () => {
+    const original = [list('a', 'A')];
+
+    expect(toggleListMembership(original, 'missing', 'k')).toEqual(original);
+    expect(toggleListMembership(original, 'a', '')).toEqual(original);
+  });
+
+  it('does not mutate the input list or its keys array', () => {
+    const keys: string[] = [];
+    const original = [list('a', 'A', keys)];
+
+    toggleListMembership(original, 'a', 'k');
+
+    expect(keys).toEqual([]);
+    expect(original[0].keys).toBe(keys);
+  });
+});
+
+describe('buildListMembershipIndex', () => {
+  it('maps each key to every list containing it, in list order', () => {
+    const index = buildListMembershipIndex([
+      list('a', 'A', ['k1', 'k2']),
+      list('b', 'B', ['k2']),
+    ]);
+
+    expect(index.get('k1')).toEqual(['a']);
+    expect(index.get('k2')).toEqual(['a', 'b']);
+    expect(index.get('missing')).toBeUndefined();
+  });
+
+  it('is empty for lists with no members', () => {
+    expect(buildListMembershipIndex([list('a', 'A')]).size).toBe(0);
+  });
+});
+
+describe('countLiveMembers', () => {
+  it('counts only keys present in the library', () => {
+    // Orphaned keys are kept in storage (a reinstalled GameBanana mod produces
+    // the same key) but must not inflate the count shown next to the list.
+    const counts = countLiveMembers(
+      [list('a', 'A', ['live1', 'orphan', 'live2'])],
+      new Set(['live1', 'live2'])
+    );
+
+    expect(counts.get('a')).toBe(2);
+  });
+
+  it('reports zero for an empty list rather than omitting it', () => {
+    // A freshly created list has to stay visible in the filter popover, which
+    // means it needs an entry here even with nothing in it.
+    const counts = countLiveMembers([list('a', 'A')], new Set(['anything']));
+
+    expect(counts.get('a')).toBe(0);
+    expect(counts.has('a')).toBe(true);
+  });
+});

--- a/src/lib/modLists.ts
+++ b/src/lib/modLists.ts
@@ -136,20 +136,56 @@ export function createList(
  * Rename in place. A blank name, an unknown id, or a name already used by a
  * *different* list all no-op, so the caller can bind this straight to an input
  * without validating first. Re-casing a list's own name is allowed.
+ *
+ * `applied` reports whether the rename took, because the caller needs to tell a
+ * rejected name from an accepted one to restore the field and explain why.
+ * Reported here rather than re-derived by the caller: comparing against the
+ * normalized name outside this module means duplicating the trim-and-clamp
+ * rules, which then rot silently the moment MAX_NAME_LENGTH changes.
  */
-export function renameList(lists: readonly ModList[], id: string, rawName: string): ModList[] {
+export function renameList(
+  lists: readonly ModList[],
+  id: string,
+  rawName: string
+): { lists: ModList[]; applied: boolean } {
   const name = normalizeName(rawName);
-  if (!name) return [...lists];
-  if (!lists.some((list) => list.id === id)) return [...lists];
+  if (!name) return { lists: [...lists], applied: false };
+  if (!lists.some((list) => list.id === id)) return { lists: [...lists], applied: false };
 
   const token = nameToken(name);
-  if (lists.some((list) => list.id !== id && nameToken(list.name) === token)) return [...lists];
+  if (lists.some((list) => list.id !== id && nameToken(list.name) === token)) {
+    return { lists: [...lists], applied: false };
+  }
 
-  return lists.map((list) => (list.id === id ? { ...list, name } : list));
+  return {
+    lists: lists.map((list) => (list.id === id ? { ...list, name } : list)),
+    applied: true,
+  };
 }
 
 export function deleteList(lists: readonly ModList[], id: string): ModList[] {
   return lists.filter((list) => list.id !== id);
+}
+
+/**
+ * File one mod into one list, idempotently. Unknown ids and blank keys no-op.
+ *
+ * Separate from toggleListMembership because the create-a-list flow must never
+ * un-file: createList reuses an existing list when the name matches, so typing
+ * the name of a list the mod is already in would otherwise toggle it back out,
+ * which is the opposite of what "New list" asks for.
+ */
+export function addListMembership(
+  lists: readonly ModList[],
+  id: string,
+  prefKey: string
+): ModList[] {
+  if (!prefKey) return [...lists];
+  return lists.map((list) =>
+    list.id === id && !list.keys.includes(prefKey)
+      ? { ...list, keys: [...list.keys, prefKey] }
+      : list
+  );
 }
 
 /** Add or remove one mod from one list. Unknown ids no-op. */

--- a/src/lib/modLists.ts
+++ b/src/lib/modLists.ts
@@ -1,0 +1,207 @@
+/**
+ * User-authored lists for the Installed page: named buckets a mod can belong
+ * to, used purely to organize and filter the library.
+ *
+ * Lists are deliberately a *view* concept. They never enable, disable, or
+ * reorder anything: that is what Mod Profiles are for, and a list that also
+ * toggled mods would be a profile with a worse name. The only thing a list
+ * does is narrow which cards the Installed grid shows.
+ *
+ * Membership is keyed by `modPreferenceKey` (see disabledModPrefs.ts), so it
+ * survives the pakNN rename that enabling/disabling performs, and a GameBanana
+ * group shares a key with singletons from the same submission.
+ *
+ * Orphans are kept, never pruned, including when a mod is deleted. A key with no
+ * matching installed mod can come back: reinstalling a GameBanana mod produces
+ * the same `gamebanana:<id>` key, and a temporarily unreadable game folder must
+ * not silently destroy the user's organization. Pruning on delete would also be
+ * wrong for groups, which share one key across every variant of a submission:
+ * deleting a single variant would unfile the whole group. Counts shown in the UI
+ * come from live entries only, so a stale key costs nothing but a few bytes.
+ *
+ * The localStorage key string is frozen: changing it orphans every list already
+ * saved by a shipped build.
+ */
+
+export const MOD_LISTS_KEY = 'installedModLists';
+
+/** Defensive clamp so pathological stored data can't blow out the filter UI. */
+const MAX_NAME_LENGTH = 80;
+
+export interface ModList {
+  /** Opaque, stable across renames. Filter selections reference this. */
+  id: string;
+  name: string;
+  /** modPreferenceKey values. */
+  keys: string[];
+}
+
+function normalizeName(raw: string): string {
+  return raw.trim().slice(0, MAX_NAME_LENGTH);
+}
+
+/** Case-insensitive name identity, so "Ivy" and "ivy" are the same list. */
+function nameToken(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function slugifyListName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A readable id derived from the name, disambiguated against existing ids.
+ * Derived rather than random so the store stays pure and unit-testable without
+ * stubbing Date.now or Math.random. Ids are opaque: a non-latin name slugifies
+ * to empty and falls back to the `list` seed, which is fine.
+ */
+function uniqueListId(name: string, taken: ReadonlySet<string>): string {
+  const seed = slugifyListName(name) || 'list';
+  if (!taken.has(seed)) return seed;
+  // At most taken.size ids can collide, so this always terminates with a hit.
+  for (let suffix = 2; suffix <= taken.size + 2; suffix += 1) {
+    const candidate = `${seed}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return seed;
+}
+
+function normalizeList(value: unknown, taken: Set<string>): ModList | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.id !== 'string' || typeof raw.name !== 'string') return null;
+
+  const id = raw.id.trim();
+  const name = normalizeName(raw.name);
+  if (!id || !name || taken.has(id)) return null;
+
+  const keys = Array.isArray(raw.keys)
+    ? Array.from(new Set(raw.keys.filter((key): key is string => typeof key === 'string' && !!key)))
+    : [];
+
+  taken.add(id);
+  return { id, name, keys };
+}
+
+export function readStoredModLists(): ModList[] {
+  try {
+    const stored = localStorage.getItem(MOD_LISTS_KEY);
+    if (!stored) return [];
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    const taken = new Set<string>();
+    return parsed
+      .map((value) => normalizeList(value, taken))
+      .filter((list): list is ModList => list !== null);
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoredModLists(lists: readonly ModList[]): void {
+  try {
+    localStorage.setItem(MOD_LISTS_KEY, JSON.stringify(lists));
+  } catch {
+    // Lists remain usable for this session when storage is unavailable.
+  }
+}
+
+/**
+ * Add a list, or return the existing one when the name is already taken.
+ * Reusing the match is deliberate: "New list: Ivy" when an Ivy list exists
+ * should put the mod in Ivy, not create a confusing second Ivy.
+ *
+ * Returns a null id for an empty name so the caller can no-op without having to
+ * pre-validate.
+ */
+export function createList(
+  lists: readonly ModList[],
+  rawName: string
+): { lists: ModList[]; id: string | null } {
+  const name = normalizeName(rawName);
+  if (!name) return { lists: [...lists], id: null };
+
+  const token = nameToken(name);
+  const existing = lists.find((list) => nameToken(list.name) === token);
+  if (existing) return { lists: [...lists], id: existing.id };
+
+  const id = uniqueListId(name, new Set(lists.map((list) => list.id)));
+  return { lists: [...lists, { id, name, keys: [] }], id };
+}
+
+/**
+ * Rename in place. A blank name, an unknown id, or a name already used by a
+ * *different* list all no-op, so the caller can bind this straight to an input
+ * without validating first. Re-casing a list's own name is allowed.
+ */
+export function renameList(lists: readonly ModList[], id: string, rawName: string): ModList[] {
+  const name = normalizeName(rawName);
+  if (!name) return [...lists];
+  if (!lists.some((list) => list.id === id)) return [...lists];
+
+  const token = nameToken(name);
+  if (lists.some((list) => list.id !== id && nameToken(list.name) === token)) return [...lists];
+
+  return lists.map((list) => (list.id === id ? { ...list, name } : list));
+}
+
+export function deleteList(lists: readonly ModList[], id: string): ModList[] {
+  return lists.filter((list) => list.id !== id);
+}
+
+/** Add or remove one mod from one list. Unknown ids no-op. */
+export function toggleListMembership(
+  lists: readonly ModList[],
+  id: string,
+  prefKey: string
+): ModList[] {
+  if (!prefKey) return [...lists];
+  return lists.map((list) => {
+    if (list.id !== id) return list;
+    const has = list.keys.includes(prefKey);
+    return {
+      ...list,
+      keys: has ? list.keys.filter((key) => key !== prefKey) : [...list.keys, prefKey],
+    };
+  });
+}
+
+/**
+ * prefKey -> list ids. Built once per lists change so the per-entry filter and
+ * card-prop passes stay cheap Map lookups instead of scanning every list.
+ */
+export function buildListMembershipIndex(lists: readonly ModList[]): Map<string, string[]> {
+  const byKey = new Map<string, string[]>();
+  for (const list of lists) {
+    for (const key of list.keys) {
+      const ids = byKey.get(key);
+      if (ids) ids.push(list.id);
+      else byKey.set(key, [list.id]);
+    }
+  }
+  return byKey;
+}
+
+/**
+ * Live member count per list id, counted from the keys actually present in the
+ * library. Orphaned keys are excluded so a list that reads "3" always has three
+ * cards behind it. Lists with no live members are still present with a 0, which
+ * is what keeps a freshly created (empty) list visible in the filter popover.
+ */
+export function countLiveMembers(
+  lists: readonly ModList[],
+  liveKeys: ReadonlySet<string>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const list of lists) {
+    let count = 0;
+    for (const key of list.keys) {
+      if (liveKeys.has(key)) count += 1;
+    }
+    counts.set(list.id, count);
+  }
+  return counts;
+}

--- a/src/lib/modLists.ts
+++ b/src/lib/modLists.ts
@@ -9,7 +9,11 @@
  *
  * Membership is keyed by `modPreferenceKey` (see disabledModPrefs.ts), so it
  * survives the pakNN rename that enabling/disabling performs, and a GameBanana
- * group shares a key with singletons from the same submission.
+ * group shares a key with singletons from the same submission. The one gap is
+ * that key's last-resort `mod:<id>` form, which is derived from the pakNN
+ * filename and so is not rename-stable: it only applies to a mod with neither a
+ * GameBanana id nor a sha256, which the metadata sidecar backfills for every
+ * installed VPK. Favorites have carried the same caveat since they shipped.
  *
  * Orphans are kept, never pruned, including when a mod is deleted. A key with no
  * matching installed mod can come back: reinstalling a GameBanana mod produces
@@ -223,9 +227,17 @@ export function buildListMembershipIndex(lists: readonly ModList[]): Map<string,
 
 /**
  * Live member count per list id, counted from the keys actually present in the
- * library. Orphaned keys are excluded so a list that reads "3" always has three
- * cards behind it. Lists with no live members are still present with a 0, which
- * is what keeps a freshly created (empty) list visible in the filter popover.
+ * library. Orphaned keys are excluded, so the count tracks what is installed
+ * rather than what was ever filed.
+ *
+ * It counts distinct keys, not cards. Those differ only when two physically
+ * distinct installs share content identity (the same local VPK installed twice
+ * => one sha256 key, two cards), in which case the count reads low by the
+ * duplicate. Filing one of them files both, so a per-card count would be the
+ * more confusing of the two numbers.
+ *
+ * Lists with no live members are still present with a 0, which is what keeps a
+ * freshly created (empty) list visible in the filter popover.
  */
 export function countLiveMembers(
   lists: readonly ModList[],

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1054,7 +1054,24 @@
       "status": "Status",
       "enabled": "Enabled",
       "hero": "Hero",
-      "tags": "Tags"
+      "tags": "Tags",
+      "lists": "Lists"
+    },
+    "lists": {
+      "menuTrigger": "Add to list",
+      "newList": "New list...",
+      "createTitle": "New list",
+      "create": "Create",
+      "nameLabel": "List name",
+      "namePlaceholder": "e.g. Ivy skins",
+      "manage": "Manage",
+      "manageTitle": "Manage lists",
+      "manageSubtitle": "Lists only group mods for browsing. Deleting one never deletes any mods.",
+      "emptyHint": "No lists yet. Right-click a mod and choose Add to list.",
+      "memberCount_one": "{{count}} mod",
+      "memberCount_other": "{{count}} mods",
+      "duplicateName": "Another list already uses that name.",
+      "deleteList": "Delete {{name}}"
     },
     "sections": {
       "enabled_one": "Enabled",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2028,
+  "totalKeys": 2043,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1960,
-      "pct": 97
+      "pct": 96
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2028,
+      "translatedKeys": 2043,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1858,
-      "pct": 92
+      "pct": 91
     },
     {
       "code": "ru",

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -122,6 +122,7 @@ import {
 } from '../lib/modLists';
 import { CreateModListModal, ModListSubmenu } from '../components/installed/ModListMenu';
 import { ManageModListsModal } from '../components/installed/ManageModListsModal';
+import { FilterCheckList } from '../components/installed/FilterCheckList';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
 import { FormField, Input, Select } from '../components/common/forms';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -493,6 +494,9 @@ const SortableEntryCard = memo(function SortableEntryCard({
 // Stable fallback for cards with no conflicts; a fresh [] per render would
 // defeat InstalledEntryCard's memo on every page-level state change.
 const EMPTY_CONFLICTS: ModConflict[] = [];
+/** Floor for the measured sort/filter popover height, so a very short window
+ *  leaves it scrollable rather than collapsing it to nothing. */
+const MIN_FILTER_PANEL_HEIGHT = 160;
 /** Shared identity for "belongs to no list", so memoized cards don't re-render. */
 const EMPTY_LIST_IDS: string[] = [];
 
@@ -954,6 +958,7 @@ export default function Installed() {
   // order no longer maps to load-order priority.
   const [filterOpen, setFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
+  const filterPanelRef = useRef<HTMLDivElement>(null);
   // Retroactive "Imprint installed mods" (path B). A single state machine drives
   // the shared modal through four phases: an up-front preflight dry-run that
   // classifies every candidate into buckets before the user commits, a live
@@ -1038,6 +1043,28 @@ export default function Installed() {
       window.removeEventListener('mousedown', onMouseDown);
       window.removeEventListener('keydown', onKey);
     };
+  }, [filterOpen]);
+  // Cap the sort/filter popover to whatever room is left below the toolbar:
+  // uncapped, at short window heights everything below TAGS was cut off with no
+  // way to reach it (the inner lists scroll, the popover itself did not).
+  //
+  // Measured rather than a `calc(100vh - <constant>)`, because the toolbar's
+  // distance from the top of the viewport is not a constant: it moves with the
+  // header, the batch-import bar, browser zoom, and the native window frame on
+  // Windows. A stale constant either wastes space or lets the panel run off the
+  // bottom, which is the bug this is fixing.
+  useLayoutEffect(() => {
+    if (!filterOpen) return;
+    const panel = filterPanelRef.current;
+    if (!panel) return;
+    const applyMaxHeight = () => {
+      // Top-anchored, so this stays correct across repeated applications.
+      const { top } = panel.getBoundingClientRect();
+      panel.style.maxHeight = `${Math.max(MIN_FILTER_PANEL_HEIGHT, window.innerHeight - top - 12)}px`;
+    };
+    applyMaxHeight();
+    window.addEventListener('resize', applyMaxHeight);
+    return () => window.removeEventListener('resize', applyMaxHeight);
   }, [filterOpen]);
   const [conflictMap, setConflictMap] = useState<Map<string, ModConflict[]>>(new Map());
   // Raw pair count from detectConflicts. conflictMap.size / 2 only works when
@@ -3113,6 +3140,11 @@ export default function Installed() {
     () => countLiveMembers(modLists, new Set(allEntries.map(entryDisabledPreferenceKey))),
     [modLists, allEntries]
   );
+  // Shaped for FilterCheckList, which the TAGS block uses too.
+  const listFilterOptions = useMemo(
+    () => modLists.map((list) => ({ key: list.id, label: list.name, count: listCounts.get(list.id) ?? 0 })),
+    [modLists, listCounts]
+  );
 
   // Conflict arrays per entry key, with identities that persist across
   // renders (plus the module-level EMPTY_CONFLICTS fallback) so memoized
@@ -4032,13 +4064,13 @@ export default function Installed() {
                 </span>
               )}
               {filterOpen && (
-                // Capped to the viewport: at short window heights everything
-                // below TAGS used to be cut off unreachably (the inner lists
-                // scroll, the popover itself did not). Trade-off: the HERO
-                // listbox is absolutely positioned, so it now clips at the
-                // popover edge rather than overlaying the page, but scrolling
-                // brings it into view and it also scrolls internally.
-                <div className="absolute right-0 top-full z-40 mt-2 max-h-[calc(100vh-5.5rem)] w-64 overflow-y-auto overscroll-contain rounded-lg border border-border bg-bg-secondary p-3 text-sm font-sans shadow-xl shadow-black/40 [&_button]:font-sans">
+                // max-height is measured, not declared: see the layout effect
+                // above. HeroSelect portals its listbox, so the HERO dropdown
+                // overlays the page instead of clipping at this scroll edge.
+                <div
+                  ref={filterPanelRef}
+                  className="absolute right-0 top-full z-40 mt-2 w-64 overflow-y-auto overscroll-contain rounded-lg border border-border bg-bg-secondary p-3 text-sm font-sans shadow-xl shadow-black/40 [&_button]:font-sans"
+                >
                   <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
                     <ArrowDownUp className="h-3.5 w-3.5" /> {t('installed.filters.sort')}
                   </div>
@@ -4166,106 +4198,42 @@ export default function Installed() {
                   )}
 
                   {tagOptions.length > 1 && (
-                    <div className="mt-3 border-t border-border pt-3">
-                      <div className="mb-1.5 flex items-center justify-between">
-                        <span className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
-                          {t('installed.filters.tags')}
-                        </span>
-                        {tagFilter.length > 0 && (
-                          <button
-                            type="button"
-                            onClick={() => setTagFilter([])}
-                            className="text-[11px] text-accent hover:underline cursor-pointer"
-                          >
-                            {t('common.actions.clear')}
-                          </button>
-                        )}
-                      </div>
-                      <div className="max-h-48 space-y-0.5 overflow-y-auto pr-1">
-                        {tagOptions.map((opt) => {
-                          const checked = tagFilter.includes(opt.key);
-                          return (
-                            <button
-                              key={opt.key}
-                              type="button"
-                              onClick={() =>
-                                setTagFilter((prev) =>
-                                  checked ? prev.filter((k) => k !== opt.key) : [...prev, opt.key]
-                                )
-                              }
-                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary cursor-pointer"
-                            >
-                              <span
-                                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
-                                  checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
-                                }`}
-                              >
-                                {checked && <Check className="h-3 w-3" />}
-                              </span>
-                              <span className="flex-1 truncate">{opt.label}</span>
-                              <span className="text-[11px] opacity-60">{opt.count}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
+                    <FilterCheckList
+                      label={t('installed.filters.tags')}
+                      options={tagOptions}
+                      selected={tagFilter}
+                      onToggle={(key) =>
+                        setTagFilter((prev) =>
+                          prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
+                        )
+                      }
+                      onClear={() => setTagFilter([])}
+                    />
                   )}
 
                   {/* Rendered from modLists, not from the entry tag buckets, so
                       a list you just created stays visible while it is empty. */}
                   {modLists.length > 0 && (
-                    <div className="mt-3 border-t border-border pt-3">
-                      <div className="mb-1.5 flex items-center justify-between">
-                        <span className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
-                          {t('installed.filters.lists')}
-                        </span>
-                        <div className="flex items-center gap-2">
-                          {listFilter.length > 0 && (
-                            <button
-                              type="button"
-                              onClick={() => setListFilter([])}
-                              className="text-[11px] text-accent hover:underline cursor-pointer"
-                            >
-                              {t('common.actions.clear')}
-                            </button>
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => setManagingLists(true)}
-                            className="text-[11px] text-text-secondary hover:text-text-primary hover:underline cursor-pointer"
-                          >
-                            {t('installed.lists.manage')}
-                          </button>
-                        </div>
-                      </div>
-                      <div className="max-h-48 space-y-0.5 overflow-y-auto pr-1">
-                        {modLists.map((list) => {
-                          const checked = listFilter.includes(list.id);
-                          return (
-                            <button
-                              key={list.id}
-                              type="button"
-                              onClick={() =>
-                                setListFilter((prev) =>
-                                  checked ? prev.filter((id) => id !== list.id) : [...prev, list.id]
-                                )
-                              }
-                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary cursor-pointer"
-                            >
-                              <span
-                                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
-                                  checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
-                                }`}
-                              >
-                                {checked && <Check className="h-3 w-3" />}
-                              </span>
-                              <span className="flex-1 truncate">{list.name}</span>
-                              <span className="text-[11px] opacity-60">{listCounts.get(list.id) ?? 0}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
+                    <FilterCheckList
+                      label={t('installed.filters.lists')}
+                      options={listFilterOptions}
+                      selected={listFilter}
+                      onToggle={(id) =>
+                        setListFilter((prev) =>
+                          prev.includes(id) ? prev.filter((selected) => selected !== id) : [...prev, id]
+                        )
+                      }
+                      onClear={() => setListFilter([])}
+                      action={
+                        <button
+                          type="button"
+                          onClick={() => setManagingLists(true)}
+                          className="text-[11px] text-text-secondary hover:text-text-primary hover:underline cursor-pointer"
+                        >
+                          {t('installed.lists.manage')}
+                        </button>
+                      }
+                    />
                   )}
 
                   {activeAdjustmentCount > 0 && (

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -69,7 +69,7 @@ import {
   Star,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from '../components/common/menu';
+import { MenuContent, MenuItem, MenuRoot, MenuSeparator, MenuTrigger } from '../components/common/menu';
 import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
@@ -108,6 +108,19 @@ import {
   writeStoredDisabledFavorites,
   writeStoredDisabledOrder,
 } from '../lib/disabledModPrefs';
+import {
+  type ModList,
+  buildListMembershipIndex,
+  countLiveMembers,
+  createList,
+  deleteList,
+  readStoredModLists,
+  renameList,
+  toggleListMembership,
+  writeStoredModLists,
+} from '../lib/modLists';
+import { CreateModListModal, ModListSubmenu } from '../components/installed/ModListMenu';
+import { ManageModListsModal } from '../components/installed/ManageModListsModal';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
 import { FormField, Input, Select } from '../components/common/forms';
 import { HeroSelect } from '../components/common/HeroSelect';
@@ -479,6 +492,8 @@ const SortableEntryCard = memo(function SortableEntryCard({
 // Stable fallback for cards with no conflicts; a fresh [] per render would
 // defeat InstalledEntryCard's memo on every page-level state change.
 const EMPTY_CONFLICTS: ModConflict[] = [];
+/** Shared identity for "belongs to no list", so memoized cards don't re-render. */
+const EMPTY_LIST_IDS: string[] = [];
 
 interface InstalledEntryCardProps {
   entry: ModEntry;
@@ -515,6 +530,12 @@ interface InstalledEntryCardProps {
   onCopyShareCode: (mod: Mod) => void;
   onSelectToggle: (entry: ModEntry) => void;
   onToggleFavorite: (entry: ModEntry) => void;
+  /** All user lists, for the card's "Add to list" submenu. */
+  lists: readonly ModList[];
+  /** Ids of the lists this entry belongs to (EMPTY_LIST_IDS when none). */
+  listIds: readonly string[];
+  onToggleList: (entry: ModEntry, listId: string) => void;
+  onCreateList: (entry: ModEntry) => void;
 }
 
 /**
@@ -557,6 +578,10 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
   onCopyShareCode,
   onSelectToggle,
   onToggleFavorite,
+  lists,
+  listIds,
+  onToggleList,
+  onCreateList,
 }: InstalledEntryCardProps) {
   if (entry.kind === 'single') {
     const mod = entry.mod;
@@ -602,6 +627,10 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
         // for the moment it later gets disabled. On an enabled card the star is
         // a marker only, it never reorders the (load-order) enabled section.
         onToggleFavorite={() => onToggleFavorite(entry)}
+        lists={lists}
+        listIds={listIds}
+        onToggleList={(listId) => onToggleList(entry, listId)}
+        onCreateList={() => onCreateList(entry)}
       />
     );
   }
@@ -646,6 +675,12 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
       onSelectToggle={() => onSelectToggle(entry)}
       favorite={favorite}
       onToggleFavorite={() => onToggleFavorite(entry)}
+      // A group shares one preference key with its variants, so filing the card
+      // files the whole submission. That matches how the star already behaves.
+      lists={lists}
+      listIds={listIds}
+      onToggleList={(listId) => onToggleList(entry, listId)}
+      onCreateList={() => onCreateList(entry)}
       group={{
         variantCount: entry.variants.length,
         // Display friendly names for enabled files when possible.
@@ -768,6 +803,12 @@ export default function Installed() {
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [disabledFavorites, setDisabledFavorites] = useState(readStoredDisabledFavorites);
   const [disabledOrder, setDisabledOrder] = useState(readStoredDisabledOrder);
+  // User-authored lists (see lib/modLists.ts). Purely an organization axis:
+  // membership never changes what is enabled, only which cards are shown.
+  const [modLists, setModLists] = useState(readStoredModLists);
+  // Entry the "New list" dialog was opened from, so creating also files it.
+  const [creatingListFor, setCreatingListFor] = useState<ModEntry | null>(null);
+  const [managingLists, setManagingLists] = useState(false);
 
   // Source mods absorbed into a merged VPK still live on disk (disabled) so
   // unmerge can restore them, but the user shouldn't see them as separate
@@ -955,6 +996,10 @@ export default function Installed() {
   const [statusSel, setStatusSel] = useState<('enabled' | 'disabled')[]>(['enabled', 'disabled']);
   const [heroFilter, setHeroFilter] = useState('all');
   const [tagFilter, setTagFilter] = useState<string[]>([]);
+  // Selected list ids. A separate axis from tagFilter (which holds derived
+  // category keys) so the two AND together: "in my Ivy list AND tagged Skins"
+  // is the useful reading, where folding lists into tagFilter would OR them.
+  const [listFilter, setListFilter] = useState<string[]>([]);
   const installedHideNsfwPreviews =
     settings?.installedHideNsfwPreviews ?? settings?.hideNsfwPreviews ?? true;
   // Disabled-section sort, deliberately separate from the top-bar sort above.
@@ -3045,6 +3090,29 @@ export default function Installed() {
     return byKey;
   }, [allEntries]);
 
+  // List membership, deliberately kept OUT of entryFacetMeta: that cache is
+  // rebuilt only when allEntries changes, so folding list ids into it would
+  // either show stale membership after an assignment or force the whole facet
+  // cache to be thrown away on every click. A separate index keyed the same way
+  // stays correct and costs one Map lookup.
+  const listMembership = useMemo(() => buildListMembershipIndex(modLists), [modLists]);
+  // Per-entry list ids with identities that persist across renders (plus the
+  // module-level EMPTY_LIST_IDS fallback), same contract as entryConflicts.
+  const entryListIds = useMemo(() => {
+    const byKey = new Map<string, string[]>();
+    for (const entry of allEntries) {
+      const ids = listMembership.get(entryDisabledPreferenceKey(entry));
+      if (ids?.length) byKey.set(entry.key, ids);
+    }
+    return byKey;
+  }, [allEntries, listMembership]);
+  // Counts shown in the filter popover and the manage dialog. Live entries only,
+  // so an orphaned key (uninstalled mod) never inflates a list's count.
+  const listCounts = useMemo(
+    () => countLiveMembers(modLists, new Set(allEntries.map(entryDisabledPreferenceKey))),
+    [modLists, allEntries]
+  );
+
   // Conflict arrays per entry key, with identities that persist across
   // renders (plus the module-level EMPTY_CONFLICTS fallback) so memoized
   // cards only re-render when their own conflicts change.
@@ -3128,6 +3196,40 @@ export default function Installed() {
     const next = toggleFavoriteKey(disabledFavorites, entryDisabledPreferenceKey(entry));
     writeStoredDisabledFavorites(next);
     setDisabledFavorites(next);
+  });
+
+  // List mutations follow the same persist-outside-the-updater rule as the
+  // favorite toggle above: modLists.ts is pure, this commits the result.
+  const commitModLists = useStableCallback((next: ModList[]) => {
+    writeStoredModLists(next);
+    setModLists(next);
+  });
+  const toggleEntryList = useStableCallback((entry: ModEntry, listId: string) => {
+    commitModLists(toggleListMembership(modLists, listId, entryDisabledPreferenceKey(entry)));
+  });
+  const openCreateListFor = useStableCallback((entry: ModEntry) => setCreatingListFor(entry));
+  // Create, and file the entry the dialog was opened from into the new list.
+  // createList reuses an existing list when the name matches, so typing the
+  // name of a list you already have files it there instead of duplicating.
+  const createListForEntry = useStableCallback((name: string) => {
+    const entry = creatingListFor;
+    const { lists, id } = createList(modLists, name);
+    if (!id) return;
+    commitModLists(entry ? toggleListMembership(lists, id, entryDisabledPreferenceKey(entry)) : lists);
+  });
+  const renameModList = useStableCallback((id: string, name: string) => {
+    const next = renameList(modLists, id, name);
+    // renameList no-ops on a rejected name (blank, or taken by another list);
+    // the dialog uses this to restore the field and explain why.
+    const applied = next.some((list) => list.id === id && list.name === name.trim().slice(0, 80));
+    if (applied) commitModLists(next);
+    return applied;
+  });
+  const deleteModList = useStableCallback((id: string) => {
+    commitModLists(deleteList(modLists, id));
+    // Drop the selection too, or the grid keeps filtering on a list that no
+    // longer exists and shows an empty shelf with no visible cause.
+    setListFilter((prev) => prev.filter((selected) => selected !== id));
   });
   // "Start with only this mod enabled": solo the entry (disable everything else)
   // then launch. For a group we keep its already-enabled variants, or enable
@@ -3357,11 +3459,11 @@ export default function Installed() {
   };
 
   // Filter by search query (substring on name), source (GameBanana vs local
-  // import), hero, and tags, then optionally re-sort. Status (enabled/disabled)
-  // is applied per-section below. Drag-and-drop reorder is disabled whenever any
-  // of these is active (see viewIsReorderable) because the displayed order no
-  // longer maps to load-order priority; the canonical priority order lives on
-  // enabledEntries/compactOrder and is untouched.
+  // import), hero, tags, and user lists, then optionally re-sort. Status
+  // (enabled/disabled) is applied per-section below. Drag-and-drop reorder is
+  // disabled whenever any of these is active (see viewIsReorderable) because the
+  // displayed order no longer maps to load-order priority; the canonical
+  // priority order lives on enabledEntries/compactOrder and is untouched.
   const searchNeedle = search.trim().toLowerCase();
   const matchesSearchEntry = (entry: ModEntry) =>
     !searchNeedle || entrySearchText(entry).toLowerCase().includes(searchNeedle);
@@ -3371,8 +3473,17 @@ export default function Installed() {
     heroFilter === 'all' || heroNamesOf(entry).includes(heroFilter);
   const matchesTagEntry = (entry: ModEntry) =>
     tagFilter.length === 0 || tagKeysOf(entry).some((key) => tagFilter.includes(key));
+  // Selecting several lists unions them (same as tags), but the list axis as a
+  // whole ANDs with the others.
+  const matchesListEntry = (entry: ModEntry) =>
+    listFilter.length === 0 ||
+    (entryListIds.get(entry.key) ?? EMPTY_LIST_IDS).some((id) => listFilter.includes(id));
   const matchesAllFilters = (entry: ModEntry) =>
-    matchesSearchEntry(entry) && matchesSourceEntry(entry) && matchesHeroEntry(entry) && matchesTagEntry(entry);
+    matchesSearchEntry(entry) &&
+    matchesSourceEntry(entry) &&
+    matchesHeroEntry(entry) &&
+    matchesTagEntry(entry) &&
+    matchesListEntry(entry);
   const sortEntries = (entries: ModEntry[]): ModEntry[] => {
     if (sortMode === 'name') {
       return [...entries].sort((a, b) =>
@@ -3388,11 +3499,17 @@ export default function Installed() {
   const sourceActive = sourceSel.length !== 2;
   const statusActive = statusSel.length !== 2;
   const heroActive = heroFilter !== 'all';
-  const filtersActive = sourceActive || statusActive || heroActive || tagFilter.length > 0;
+  const filtersActive =
+    sourceActive || statusActive || heroActive || tagFilter.length > 0 || listFilter.length > 0;
   const sortActive = sortMode !== 'priority';
   const viewIsReorderable = !searchNeedle && !filtersActive && !sortActive;
   const activeAdjustmentCount =
-    (sourceActive ? 1 : 0) + (statusActive ? 1 : 0) + (heroActive ? 1 : 0) + tagFilter.length + (sortActive ? 1 : 0);
+    (sourceActive ? 1 : 0) +
+    (statusActive ? 1 : 0) +
+    (heroActive ? 1 : 0) +
+    tagFilter.length +
+    listFilter.length +
+    (sortActive ? 1 : 0);
   const visibleEnabled = statusSel.includes('enabled')
     ? sortEntries(enabledEntries.filter(matchesAllFilters))
     : [];
@@ -3658,6 +3775,10 @@ export default function Installed() {
     onCopyShareCode: copyEntryShareCode,
     onSelectToggle: selectToggleEntry,
     onToggleFavorite: toggleEntryFavorite,
+    lists: modLists,
+    listIds: entryListIds.get(entry.key) ?? EMPTY_LIST_IDS,
+    onToggleList: toggleEntryList,
+    onCreateList: openCreateListFor,
   });
 
   const renderEntryCard = (entry: ModEntry) => <InstalledEntryCard {...cardPropsFor(entry)} />;
@@ -3908,7 +4029,13 @@ export default function Installed() {
                 </span>
               )}
               {filterOpen && (
-                <div className="absolute right-0 top-full z-40 mt-2 w-64 rounded-lg border border-border bg-bg-secondary p-3 text-sm font-sans shadow-xl shadow-black/40 [&_button]:font-sans">
+                // Capped to the viewport: at short window heights everything
+                // below TAGS used to be cut off unreachably (the inner lists
+                // scroll, the popover itself did not). Trade-off: the HERO
+                // listbox is absolutely positioned, so it now clips at the
+                // popover edge rather than overlaying the page, but scrolling
+                // brings it into view and it also scrolls internally.
+                <div className="absolute right-0 top-full z-40 mt-2 max-h-[calc(100vh-5.5rem)] w-64 overflow-y-auto overscroll-contain rounded-lg border border-border bg-bg-secondary p-3 text-sm font-sans shadow-xl shadow-black/40 [&_button]:font-sans">
                   <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
                     <ArrowDownUp className="h-3.5 w-3.5" /> {t('installed.filters.sort')}
                   </div>
@@ -4081,6 +4208,63 @@ export default function Installed() {
                     </div>
                   )}
 
+                  {/* Rendered from modLists, not from the entry tag buckets, so
+                      a list you just created stays visible while it is empty. */}
+                  {modLists.length > 0 && (
+                    <div className="mt-3 border-t border-border pt-3">
+                      <div className="mb-1.5 flex items-center justify-between">
+                        <span className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
+                          {t('installed.filters.lists')}
+                        </span>
+                        <div className="flex items-center gap-2">
+                          {listFilter.length > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => setListFilter([])}
+                              className="text-[11px] text-accent hover:underline cursor-pointer"
+                            >
+                              {t('common.actions.clear')}
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => setManagingLists(true)}
+                            className="text-[11px] text-text-secondary hover:text-text-primary hover:underline cursor-pointer"
+                          >
+                            {t('installed.lists.manage')}
+                          </button>
+                        </div>
+                      </div>
+                      <div className="max-h-48 space-y-0.5 overflow-y-auto pr-1">
+                        {modLists.map((list) => {
+                          const checked = listFilter.includes(list.id);
+                          return (
+                            <button
+                              key={list.id}
+                              type="button"
+                              onClick={() =>
+                                setListFilter((prev) =>
+                                  checked ? prev.filter((id) => id !== list.id) : [...prev, list.id]
+                                )
+                              }
+                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-text-secondary transition-colors hover:bg-white/5 hover:text-text-primary cursor-pointer"
+                            >
+                              <span
+                                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+                                  checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
+                                }`}
+                              >
+                                {checked && <Check className="h-3 w-3" />}
+                              </span>
+                              <span className="flex-1 truncate">{list.name}</span>
+                              <span className="text-[11px] opacity-60">{listCounts.get(list.id) ?? 0}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+
                   {activeAdjustmentCount > 0 && (
                     <button
                       type="button"
@@ -4090,6 +4274,7 @@ export default function Installed() {
                         setStatusSel(['enabled', 'disabled']);
                         setHeroFilter('all');
                         setTagFilter([]);
+                        setListFilter([]);
                       }}
                       className="mt-3 w-full rounded-md border border-border px-2 py-1.5 text-[11px] uppercase tracking-wider text-text-secondary transition-colors hover:border-white/20 hover:text-text-primary cursor-pointer"
                     >
@@ -4444,6 +4629,25 @@ export default function Installed() {
             await editLocalInstalledMod(localEditMod, args);
             setLocalEditMod(null);
           }}
+        />
+      )}
+
+      {/* Conditionally rendered so each opening is a fresh mount: draft names
+          and armed delete confirmations reset without a sync effect. */}
+      {creatingListFor && (
+        <CreateModListModal
+          modName={entryName(creatingListFor)}
+          onClose={() => setCreatingListFor(null)}
+          onCreate={createListForEntry}
+        />
+      )}
+      {managingLists && (
+        <ManageModListsModal
+          lists={modLists}
+          counts={listCounts}
+          onClose={() => setManagingLists(false)}
+          onRename={renameModList}
+          onDelete={deleteModList}
         />
       )}
 
@@ -6834,6 +7038,12 @@ interface ModCardProps {
    *  marker: it takes effect once the entry is disabled. */
   favorite?: boolean;
   onToggleFavorite?: () => void;
+  /** User lists, for the right-click "Add to list" submenu. Organization only:
+   *  membership never enables, disables, or reorders anything. */
+  lists?: readonly ModList[];
+  listIds?: readonly string[];
+  onToggleList?: (listId: string) => void;
+  onCreateList?: () => void;
   entryKey?: string;
   /** Present when this card represents grouped files from the same
    *  GameBanana mod. Swaps the filename meta for an enabled/total count and
@@ -6860,6 +7070,9 @@ interface ModMediaPreviewProps {
   isGroupCard: boolean;
   onRevealInFolder?: () => void;
   onViewImprint?: () => void;
+  /** The card's "Add to list" submenu, threaded down because the image menu
+   *  rendered here swallows the right-clicks that would reach the card. */
+  listMenu?: ReactNode;
 }
 
 function SoundPlaceholder() {
@@ -6901,6 +7114,7 @@ function ModMediaPreview({
   isGroupCard,
   onRevealInFolder,
   onViewImprint,
+  listMenu,
 }: ModMediaPreviewProps) {
   const { t } = useTranslation();
   const isSound = mod.sourceSection === 'Sound' && !!mod.audioUrl;
@@ -6935,7 +7149,7 @@ function ModMediaPreview({
     />
   );
   const soundMedia = mod.thumbnailUrl ? image : soundHeroRenderUrl ? (
-    <ImageContextMenu src={soundHeroRenderUrl} alt={soundHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint}>
+    <ImageContextMenu src={soundHeroRenderUrl} alt={soundHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint} extraItems={listMenu}>
       <img
         src={soundHeroRenderUrl}
         alt={soundHeroName ?? mod.name}
@@ -7041,6 +7255,9 @@ interface ModListRowContentProps {
   actions: ReactNode;
   onRevealInFolder?: () => void;
   onViewImprint?: () => void;
+  /** The card's "Add to list" submenu, threaded down for the same reason as in
+   *  ModMediaPreview: the thumbnail's image menu swallows the card's clicks. */
+  listMenu?: ReactNode;
 }
 
 function lockerHeroSourceLabel(source: Mod['lockerHeroSource']): string {
@@ -7288,6 +7505,7 @@ function ModListRowContent({
   actions,
   onRevealInFolder,
   onViewImprint,
+  listMenu,
 }: ModListRowContentProps) {
   const { t } = useTranslation();
   const isSound = mod.sourceSection === 'Sound' && !!mod.audioUrl;
@@ -7334,7 +7552,7 @@ function ModListRowContent({
         onDragStart={stopMediaDrag}
       >
         {listHeroRenderUrl ? (
-          <ImageContextMenu src={listHeroRenderUrl} alt={listHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint}>
+          <ImageContextMenu src={listHeroRenderUrl} alt={listHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint} extraItems={listMenu}>
             <img
               src={listHeroRenderUrl}
               alt={listHeroName ?? mod.name}
@@ -7460,6 +7678,10 @@ function ModCard({
   onSelectToggle,
   favorite = false,
   onToggleFavorite,
+  lists,
+  listIds = EMPTY_LIST_IDS,
+  onToggleList,
+  onCreateList,
   entryKey,
   group,
 }: ModCardProps) {
@@ -7477,6 +7699,17 @@ function ModCard({
   // "View imprint" mirrors reveal-in-folder: offered on the card's right-click
   // menu and the image menus (which swallow right-clicks), hidden in select mode.
   const imprintAction = selectMode ? undefined : onViewImprint;
+  // "Add to list" follows the same rules: shared across the card menu and both
+  // image menus, and stood down in select mode where clicks belong to selection.
+  const listSubmenu =
+    !selectMode && lists && onToggleList && onCreateList ? (
+      <ModListSubmenu
+        lists={lists}
+        memberIds={listIds}
+        onToggle={onToggleList}
+        onCreateNew={onCreateList}
+      />
+    ) : null;
   const variantStatusLabel = group ? `${group.enabledCount}/${group.variantCount}` : null;
   const enabledTitle = group?.enabledLabels.join(', ') ?? '';
   const variantStatusTitle = group
@@ -8080,6 +8313,7 @@ function ModCard({
             actions={actions}
             onRevealInFolder={revealAction}
             onViewImprint={imprintAction}
+            listMenu={listSubmenu}
           />
         ) : (
         <>
@@ -8188,6 +8422,7 @@ function ModCard({
             isGroupCard={isGroupCard}
             onRevealInFolder={revealAction}
             onViewImprint={imprintAction}
+            listMenu={listSubmenu}
           />
         );
         })()}
@@ -8261,6 +8496,12 @@ function ModCard({
     </div>
       </MenuTrigger>
       <MenuContent>
+        {listSubmenu && (
+          <>
+            {listSubmenu}
+            <MenuSeparator />
+          </>
+        )}
         <MenuItem icon={FolderOpen} onSelect={handleRevealInFolder}>
           {t('installed.card.revealInFolder')}
         </MenuItem>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -110,6 +110,7 @@ import {
 } from '../lib/disabledModPrefs';
 import {
   type ModList,
+  addListMembership,
   buildListMembershipIndex,
   countLiveMembers,
   createList,
@@ -3211,18 +3212,20 @@ export default function Installed() {
   // Create, and file the entry the dialog was opened from into the new list.
   // createList reuses an existing list when the name matches, so typing the
   // name of a list you already have files it there instead of duplicating.
+  // Filing is add-only for exactly that reason: a toggle here would un-file a
+  // mod that is already in the list whose name was typed.
   const createListForEntry = useStableCallback((name: string) => {
     const entry = creatingListFor;
     const { lists, id } = createList(modLists, name);
     if (!id) return;
-    commitModLists(entry ? toggleListMembership(lists, id, entryDisabledPreferenceKey(entry)) : lists);
+    commitModLists(entry ? addListMembership(lists, id, entryDisabledPreferenceKey(entry)) : lists);
   });
   const renameModList = useStableCallback((id: string, name: string) => {
-    const next = renameList(modLists, id, name);
-    // renameList no-ops on a rejected name (blank, or taken by another list);
-    // the dialog uses this to restore the field and explain why.
-    const applied = next.some((list) => list.id === id && list.name === name.trim().slice(0, 80));
-    if (applied) commitModLists(next);
+    // renameList no-ops on a rejected name (blank, or taken by another list)
+    // and reports which happened; the dialog uses this to restore the field
+    // and explain why.
+    const { lists, applied } = renameList(modLists, id, name);
+    if (applied) commitModLists(lists);
     return applied;
   });
   const deleteModList = useStableCallback((id: string) => {


### PR DESCRIPTION
Requested by a user: a way to group installed mods into lists / categories.

File a mod into one or more lists from its right-click menu, then narrow the grid by list from the sort/filter popover. Rename and delete live behind **Manage** in that popover's LISTS block.

Lists are deliberately a *view* concept: they never enable, disable, or reorder anything. That is what Mod Profiles are for, and a list that also toggled mods would be a profile with a worse name.

## Design notes

- **Membership is keyed by the existing `modPreferenceKey`**, so it survives the pakNN rename that enabling/disabling performs. A GameBanana group shares a key with singletons from the same submission, so filing the card files the whole submission, matching how the star already behaves.
- **Lists are their own filter axis** rather than extra keys in `tagFilter`, so they AND with tags and heroes instead of OR-ing ("in my Ivy list AND tagged Skins" is the useful reading). This also keeps them out of `entryFacetMeta`, which is memoized on `allEntries` alone and would otherwise show stale membership right after an assignment.
- **Orphaned keys are kept, never pruned**, including on mod delete. A reinstalled GameBanana mod produces the same key, and pruning would be wrong for groups anyway (deleting one variant would unfile the whole submission). Counts come from live entries only, so a stale key is invisible.
- **The LISTS block renders from the stored lists**, not from entry tag buckets, so a list you just created stays visible while it is empty.
- Deleting a list also clears it from the active filter, or you get an empty shelf with no visible cause.

## Drive-by fix: filter popover cutoff

The sort/filter popover had no height constraint, so at short window heights every section below TAGS was cut off with no way to reach it (the inner lists scrolled, the popover itself did not). Pre-existing, but the new LISTS block made it worse. Now capped to the viewport with `overflow-y-auto`.

Trade-off worth a look: `HeroSelect` renders its listbox as an absolutely-positioned child rather than a portal, so it now clips at the popover edge instead of overlaying the page. It still scrolls into view and scrolls internally, which beats unreachable content. Portaling `HeroSelect` would be the proper fix if this is annoying in practice.

## Verification

- 27 new unit tests in `src/lib/modLists.test.ts` (frozen storage key, malformed-storage tolerance, purity, id disambiguation, duplicate-name handling, orphan-excluding counts). Full suite: 653/653 passing.
- `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check`, and the manifest check all pass.
- Driven end to end in a running instance at a 615px window height: create from the submenu, assign/unassign with the menu staying open for multi-assign, filter down and back, rename preserving id and membership, duplicate-name rejection with the inline error, and delete.

## Notes for review

- New primitives in `common/menu.tsx` (`MenuSub`, `MenuSubTrigger`, `MenuSubContent`, `MenuCheckboxItem`) are additive. `MenuItem`'s emitted class string is unchanged; the shared row geometry was just factored into a constant.
- `ImageContextMenu` gains an `extraItems` slot. The thumbnail's menu swallows the card's right-clicks, so card actions have to be threaded through it, same as the existing `onRevealInFolder` / `onViewImprint` props.
- Storage is localStorage, matching where the disabled-shelf star already lives. All mutation logic is pure and in `modLists.ts`, so moving to a main-process store (for reinstall survival or profile export) later is a contained change.