### PR TITLE
fix(browse): stop catalog-backed filters failing silently

### DIFF
--- a/electron/main/ipc/diagnostics.ts
+++ b/electron/main/ipc/diagnostics.ts
@@ -1,6 +1,22 @@
 import { ipcMain } from 'electron';
 import { buildReportText } from '../services/diagnostics';
 
+// Renderer-side trace bridge.
+//
+// initLogger() only hooks console.* in the MAIN process, so nothing the
+// renderer logs has ever reached main.log. That is why a Browse page that
+// silently drops filters produced a diagnostic report with zero evidence in
+// it: every decision that matters happens renderer-side. Routing a handful of
+// deliberate trace points through here makes them show up in bug reports.
+//
+// Fire-and-forget (ipcMain.on, not handle) so tracing can never block a render,
+// and both fields are clamped so a runaway caller cannot flood the log file.
+ipcMain.on('diagnostics:trace', (_, scope: unknown, message: unknown) => {
+    const safeScope = typeof scope === 'string' && scope ? scope.slice(0, 32) : 'renderer';
+    const safeMessage = typeof message === 'string' ? message.slice(0, 512) : String(message);
+    console.log(`[${safeScope}] ${safeMessage}`);
+});
+
 ipcMain.handle(
     'diagnostics:buildReport',
     (_, description: unknown, options: unknown): Promise<string> => {

--- a/electron/main/services/diagnostics.ts
+++ b/electron/main/services/diagnostics.ts
@@ -12,6 +12,11 @@ import { app } from 'electron';
 import { promises as fs } from 'fs';
 import os from 'os';
 import { getInstallSource } from './updater';
+// Static, not dynamic: ipc/modDatabase already imports both of these at
+// startup, so a dynamic import saved nothing and only drew a rollup
+// "dynamically imported but also statically imported" warning.
+import { getSyncStatus, isSyncInProgress, needsSync } from './syncService';
+import { getModCount } from './modDatabase';
 
 // Tail size for the diagnostic report. 256 KB is ~3-5k log lines: plenty of
 // context for the typical "I just hit a bug" report without ballooning the
@@ -128,7 +133,10 @@ export async function buildReportText(
     if (sanitizedDesc) {
         parts.push('--- what happened ---', sanitizedDesc);
     }
-    parts.push('--- catalog ---', await buildCatalogSection());
+    // Sanitized like every other body in the report: the failure path below
+    // surfaces errno messages from initDatabase(), which carry the full
+    // userData path (and therefore the OS username) on EACCES/ENOENT.
+    parts.push('--- catalog ---', sanitize(buildCatalogSection()));
     const logLabel = includeFullLog
         ? '--- full main.log (sanitized) ---'
         : `--- last ${Math.round(REPORT_TAIL_BYTES / 1024)} KB of main.log (sanitized) ---`;
@@ -141,15 +149,9 @@ export async function buildReportText(
  *  Browse routes its content-rating, date-added, A-Z and full-text filters
  *  through this mirror and silently falls back to the (much less capable)
  *  remote API when it is thin or missing. Reports used to carry no trace of
- *  that at all, which made "my filters do nothing" undiagnosable. Imported
- *  lazily so initLogger() does not drag the sync/database graph in at startup. */
-async function buildCatalogSection(): Promise<string> {
+ *  that at all, which made "my filters do nothing" undiagnosable. */
+function buildCatalogSection(): string {
     try {
-        const [{ getSyncStatus, isSyncInProgress, needsSync }, { getModCount }] = await Promise.all([
-            import('./syncService'),
-            import('./modDatabase'),
-        ]);
-
         const lines = [
             `Total cached mods: ${getModCount()}`,
             `Sync in progress:  ${isSyncInProgress()}`,

--- a/electron/main/services/diagnostics.ts
+++ b/electron/main/services/diagnostics.ts
@@ -128,11 +128,44 @@ export async function buildReportText(
     if (sanitizedDesc) {
         parts.push('--- what happened ---', sanitizedDesc);
     }
+    parts.push('--- catalog ---', await buildCatalogSection());
     const logLabel = includeFullLog
         ? '--- full main.log (sanitized) ---'
         : `--- last ${Math.round(REPORT_TAIL_BYTES / 1024)} KB of main.log (sanitized) ---`;
     parts.push(logLabel, sanitizedLog || '<log file empty>');
     return parts.join('\n\n');
+}
+
+/** State of the local catalog mirror.
+ *
+ *  Browse routes its content-rating, date-added, A-Z and full-text filters
+ *  through this mirror and silently falls back to the (much less capable)
+ *  remote API when it is thin or missing. Reports used to carry no trace of
+ *  that at all, which made "my filters do nothing" undiagnosable. Imported
+ *  lazily so initLogger() does not drag the sync/database graph in at startup. */
+async function buildCatalogSection(): Promise<string> {
+    try {
+        const [{ getSyncStatus, isSyncInProgress, needsSync }, { getModCount }] = await Promise.all([
+            import('./syncService'),
+            import('./modDatabase'),
+        ]);
+
+        const lines = [
+            `Total cached mods: ${getModCount()}`,
+            `Sync in progress:  ${isSyncInProgress()}`,
+            `Needs sync:        ${needsSync()}`,
+        ];
+        for (const [section, state] of Object.entries(getSyncStatus())) {
+            lines.push(
+                state
+                    ? `  ${section}: ${state.count} mods, last sync ${new Date(state.lastSync * 1000).toISOString()}`
+                    : `  ${section}: never synced`
+            );
+        }
+        return lines.join('\n');
+    } catch (err) {
+        return `<could not read catalog state: ${err instanceof Error ? err.message : String(err)}>`;
+    }
 }
 
 async function readFullLog(path: string): Promise<string> {

--- a/electron/main/services/gamebanana.ts
+++ b/electron/main/services/gamebanana.ts
@@ -668,6 +668,14 @@ export async function fetchSubmissions(
         updated: 'Generic_LatestModified',
     };
 
+    // 'name' (A-Z) has no apiv11 token and is served from the local mirror.
+    // Reaching here with it means Browse routed remote, and the caller is
+    // about to get default ordering back with no indication anything was
+    // dropped. Say so, rather than leaving it to look like a sort bug.
+    if (sort && sort !== 'default' && !sortMap[sort]) {
+        console.warn(`[GameBanana] browse: sort "${sort}" has no apiv11 token; returning default order`);
+    }
+
     // Fields to request from GameBanana API (including NSFW flag)
     const fields = '_idRow,_sName,_sProfileUrl,_tsDateAdded,_tsDateModified,_nLikeCount,_nViewCount,_nDownloadCount,_bHasFiles,_bIsNsfw,_aSubmitter,_aPreviewMedia,_aRootCategory';
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -531,6 +531,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         return () => ipcRenderer.removeListener('sync-progress', handler);
     },
 
+    // Write a renderer-side trace line into main.log so it reaches diagnostic
+    // reports. Deliberately one-way and unawaited; see ipc/diagnostics.ts.
+    traceDiagnostic: (scope: string, message: string) => ipcRenderer.send('diagnostics:trace', scope, message),
+
     // Crosshair Presets
     getCrosshairPresets: () => ipcRenderer.invoke('crosshair:getPresets'),
     saveCrosshairPreset: (name: string, settings: CrosshairSettings, thumbnail: string) =>

--- a/src/components/common/DynamicSelect.tsx
+++ b/src/components/common/DynamicSelect.tsx
@@ -4,7 +4,7 @@ import { ChevronDown } from 'lucide-react';
 interface DynamicSelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onChange'> {
     value: string | number;
     onChange: (value: string) => void;
-    options: Array<{ value: string | number; label: string }>;
+    options: Array<{ value: string | number; label: string; disabled?: boolean }>;
     className?: string;
     disabled?: boolean;
 }
@@ -51,7 +51,7 @@ export function DynamicSelect({
                 {...props}
             >
                 {options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
+                    <option key={opt.value} value={opt.value} disabled={opt.disabled}>
                         {opt.label}
                     </option>
                 ))}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2346,7 +2346,9 @@
       "recentlyAdded": "Recently Added",
       "recentlyUpdated": "Recently Updated",
       "mostViewed": "Most Viewed",
-      "nameAZ": "Name (A-Z)"
+      "nameAZ": "Name (A-Z)",
+      "nameAZSyncing": "Name (A-Z, syncing)",
+      "nameAZNeedsCatalog": "Name (A-Z, needs catalog)"
     },
     "filters": {
       "title": "Filters",
@@ -2372,7 +2374,9 @@
       "thisMonth": "This month",
       "customRange": "Custom range",
       "from": "From",
-      "to": "To"
+      "to": "To",
+      "catalogSyncing": "Syncing the mod catalog. Content and date filters will be ready shortly.",
+      "catalogUnavailable": "Content and date filters need the local mod catalog. Sync it from Settings."
     },
     "previewVolume": "Preview volume",
     "loadMore": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2043,
+  "totalKeys": 2047,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2043,
+      "translatedKeys": 2047,
       "pct": 100
     },
     {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -104,6 +104,21 @@ import { formatAbsoluteDate, formatRelativeDate } from '../lib/dates';
 import { showToast } from '../stores/toastStore';
 
 const DEFAULT_PER_PAGE = 36;
+// Row count below which the local catalog mirror is treated as unusable. A
+// part-synced catalog returns misleadingly thin results, so the filters that
+// depend on it stay disabled until it is worth querying.
+const LOCAL_CACHE_MIN_ROWS = 100;
+
+// Trace into main.log (and therefore into diagnostic reports). The renderer's
+// own console never reaches that file, so filter routing decisions were
+// invisible in every bug report; these are the points worth reconstructing
+// after the fact. Guarded because the bridge is absent in unit tests.
+function traceBrowse(message: string): void {
+  try {
+    window.electronAPI?.traceDiagnostic?.('Browse', message);
+  } catch { /* tracing must never break the page */ }
+}
+
 type SortOption = 'default' | 'popular' | 'recent' | 'updated' | 'views' | 'name';
 // Effective render mode derived from layout + card size. 'compact' is no
 // longer a user choice: it's what small cards become below the size threshold.
@@ -1408,19 +1423,61 @@ export default function Browse() {
     };
   }, [viewMenuOpen]);
 
-  // Check if local cache is available for search
+  // Availability of the local catalog mirror. Content rating, date-added, A-Z
+  // sort and FTS search can ONLY be served from it, so this one flag decides
+  // whether those filters do anything at all.
+  //
+  // It used to be read once per mount with no way to change afterwards, which
+  // meant landing on Browse before the background sync crossed the threshold
+  // left the page in remote mode for the entire mount: the content/date
+  // controls stayed hidden and A-Z silently returned default order, with
+  // nothing logged. Now the sync-progress stream re-checks it, and
+  // `catalogSyncing` lets the UI say why a filter is unavailable instead of
+  // quietly dropping it.
   const [hasLocalCache, setHasLocalCache] = useState(false);
-  useEffect(() => {
-    const checkLocalCache = async () => {
-      try {
-        const count = await window.electronAPI.getLocalModCount();
-        setHasLocalCache(count > 100);
-      } catch {
-        setHasLocalCache(false);
-      }
-    };
-    checkLocalCache();
+  const [catalogSyncing, setCatalogSyncing] = useState(false);
+
+  const refreshLocalCacheState = useCallback(async (reason: string) => {
+    try {
+      const count = await window.electronAPI.getLocalModCount();
+      const ready = count >= LOCAL_CACHE_MIN_ROWS;
+      setHasLocalCache(ready);
+      traceBrowse(`catalog check (${reason}): count=${count} threshold=${LOCAL_CACHE_MIN_ROWS} ready=${ready}`);
+    } catch (err) {
+      setHasLocalCache(false);
+      traceBrowse(`catalog check (${reason}) failed: ${String(err)}`);
+    }
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void refreshLocalCacheState('mount');
+    window.electronAPI.isSyncInProgress()
+      .then((inProgress) => {
+        if (cancelled) return;
+        setCatalogSyncing(inProgress);
+        if (inProgress) traceBrowse('catalog sync already in progress at mount');
+      })
+      .catch(() => { /* indicator only; routing still works off the count */ });
+
+    const unsub = window.electronAPI.onSyncProgress((data) => {
+      if (cancelled) return;
+      if (data.phase === 'fetching') {
+        setCatalogSyncing(true);
+        return;
+      }
+      setCatalogSyncing(false);
+      // A finished section can push the catalog over the usable threshold.
+      // Re-checking here is what stops a cold start from disabling the
+      // catalog-backed filters for the rest of the mount.
+      void refreshLocalCacheState(`sync ${data.phase} ${data.section}`);
+    });
+
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, [refreshLocalCacheState]);
 
   // Fetch initial download queue state on mount
   useEffect(() => {
@@ -1684,6 +1741,30 @@ export default function Browse() {
   useEffect(() => {
     setLocalSearchFailed(false);
   }, [debouncedSearch, heroCategoryId, nsfw, addedWithin, section, sort, hiddenCreatorsStamp]);
+
+  // The single most useful line for diagnosing "my filters do nothing": which
+  // backend the current filter set routes to, and when it routes remote, which
+  // of the active filters the remote API cannot express.
+  useEffect(() => {
+    if (useLocalSearch) {
+      traceBrowse(`route=local section=${section} search="${debouncedSearch}" hero=${heroCategoryId} nsfw=${nsfw} added=${addedWithin} sort=${sort}`);
+      return;
+    }
+    const unsupported: string[] = [];
+    if (addedWithin !== 'all') unsupported.push(`added=${addedWithin}`);
+    if (sort === 'name') unsupported.push('sort=name');
+    const because = submitter
+      ? 'artist mode'
+      : !hasLocalCache
+        ? 'no local catalog'
+        : localSearchFailed
+          ? 'local search failed'
+          : 'no catalog-only filter active';
+    traceBrowse(
+      `route=remote (${because}) section=${section} search="${debouncedSearch}" hero=${heroCategoryId} nsfw=${nsfw} added=${addedWithin} sort=${sort}` +
+      (unsupported.length ? ` DROPPED=[${unsupported.join(', ')}]` : '')
+    );
+  }, [useLocalSearch, section, debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, submitter, hasLocalCache, localSearchFailed]);
 
   const fetchMods = useCallback(async () => {
     // Don't fetch from API if we're using local search
@@ -3374,6 +3455,9 @@ export default function Browse() {
               </div>
             )}
 
+            {/* A-Z has no apiv11 sort token, so it can only come from the local
+                mirror. Offering it against a cold catalog meant picking it
+                silently returned default order. Mark it unavailable instead. */}
             <DynamicSelect
               value={sort}
               onChange={(val) => setSort(val as SortOption)}
@@ -3383,13 +3467,24 @@ export default function Browse() {
                 { value: 'recent', label: t('browse.sort.recentlyAdded') },
                 { value: 'updated', label: t('browse.sort.recentlyUpdated') },
                 { value: 'views', label: t('browse.sort.mostViewed') },
-                { value: 'name', label: t('browse.sort.nameAZ') },
+                {
+                  value: 'name',
+                  label: hasLocalCache
+                    ? t('browse.sort.nameAZ')
+                    : catalogSyncing
+                      ? t('browse.sort.nameAZSyncing')
+                      : t('browse.sort.nameAZNeedsCatalog'),
+                  disabled: !hasLocalCache,
+                },
               ]}
             />
 
-            {/* Filters popover — houses hero + category selectors. Collapses two
-                always-visible dropdowns into one control with an active-count badge. */}
-            {(heroOptions.length > 0 || categoryOptions.length > 0 || hasLocalCache) && (() => {
+            {/* Filters popover: hero + category selectors, plus the
+                catalog-backed content/recency filters. Always rendered now.
+                It used to be conditional on there being something to show,
+                which meant a cold catalog could remove the control entirely
+                rather than explain itself. */}
+            {(() => {
               const filterCount =
                 (heroCategoryId !== 'all' ? 1 : 0) +
                 (categoryId !== 'all' ? 1 : 0) +
@@ -3490,63 +3585,72 @@ export default function Browse() {
                           </div>
                         )}
 
-                        {/* Content rating + recency are served by the local catalog
-                            mirror, so they only show once it's available. */}
-                        {hasLocalCache && (
-                          <div className="block">
-                            <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.content')}</span>
-                            <Select
-                              aria-label={t('browse.filters.filterByContentRating')}
-                              value={nsfw}
-                              onChange={(e) => setNsfw(e.target.value as BrowseNsfwFilter)}
-                            >
-                              <option value="all">{t('browse.filters.contentAll')}</option>
-                              <option value="sfw">{t('browse.filters.sfwOnly')}</option>
-                              <option value="nsfw">{t('browse.filters.nsfwOnly')}</option>
-                            </Select>
-                          </div>
+                        {/* Content rating + recency can only be answered by the
+                            local catalog mirror. These used to be hidden
+                            entirely without it, so a cold cache looked like
+                            "the filters are missing/broken" with no
+                            explanation. Render them disabled and say why. */}
+                        {!hasLocalCache && (
+                          <p className="rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[11px] text-text-secondary">
+                            {catalogSyncing
+                              ? t('browse.filters.catalogSyncing')
+                              : t('browse.filters.catalogUnavailable')}
+                          </p>
                         )}
 
-                        {hasLocalCache && (
-                          <div className="block">
-                            <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.added')}</span>
-                            <Select
-                              aria-label={t('browse.filters.filterByDateAdded')}
-                              value={addedWithin}
-                              onChange={(e) => setAddedWithin(e.target.value as BrowseTimeRange)}
-                            >
-                              <option value="all">{t('browse.filters.anyTime')}</option>
-                              <option value="today">{t('browse.filters.today')}</option>
-                              <option value="week">{t('browse.filters.thisWeek')}</option>
-                              <option value="month">{t('browse.filters.thisMonth')}</option>
-                              <option value="custom">{t('browse.filters.customRange')}</option>
-                            </Select>
-                            {addedWithin === 'custom' && (
-                              <div className="mt-2 grid grid-cols-2 gap-2">
-                                <label className="block">
-                                  <span className="block text-[11px] text-text-tertiary mb-1">{t('browse.filters.from')}</span>
-                                  <input
-                                    type="date"
-                                    value={addedFrom}
-                                    max={addedTo || undefined}
-                                    onChange={(e) => setAddedFrom(e.target.value)}
-                                    className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
-                                  />
-                                </label>
-                                <label className="block">
-                                  <span className="block text-[11px] text-text-tertiary mb-1">{t('browse.filters.to')}</span>
-                                  <input
-                                    type="date"
-                                    value={addedTo}
-                                    min={addedFrom || undefined}
-                                    onChange={(e) => setAddedTo(e.target.value)}
-                                    className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
-                                  />
-                                </label>
-                              </div>
-                            )}
-                          </div>
-                        )}
+                        <div className="block">
+                          <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.content')}</span>
+                          <Select
+                            aria-label={t('browse.filters.filterByContentRating')}
+                            value={nsfw}
+                            disabled={!hasLocalCache}
+                            onChange={(e) => setNsfw(e.target.value as BrowseNsfwFilter)}
+                          >
+                            <option value="all">{t('browse.filters.contentAll')}</option>
+                            <option value="sfw">{t('browse.filters.sfwOnly')}</option>
+                            <option value="nsfw">{t('browse.filters.nsfwOnly')}</option>
+                          </Select>
+                        </div>
+
+                        <div className="block">
+                          <span className="block text-xs font-medium text-text-secondary mb-1.5">{t('browse.filters.added')}</span>
+                          <Select
+                            aria-label={t('browse.filters.filterByDateAdded')}
+                            value={addedWithin}
+                            disabled={!hasLocalCache}
+                            onChange={(e) => setAddedWithin(e.target.value as BrowseTimeRange)}
+                          >
+                            <option value="all">{t('browse.filters.anyTime')}</option>
+                            <option value="today">{t('browse.filters.today')}</option>
+                            <option value="week">{t('browse.filters.thisWeek')}</option>
+                            <option value="month">{t('browse.filters.thisMonth')}</option>
+                            <option value="custom">{t('browse.filters.customRange')}</option>
+                          </Select>
+                          {addedWithin === 'custom' && (
+                            <div className="mt-2 grid grid-cols-2 gap-2">
+                              <label className="block">
+                                <span className="block text-[11px] text-text-tertiary mb-1">{t('browse.filters.from')}</span>
+                                <input
+                                  type="date"
+                                  value={addedFrom}
+                                  max={addedTo || undefined}
+                                  onChange={(e) => setAddedFrom(e.target.value)}
+                                  className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                                />
+                              </label>
+                              <label className="block">
+                                <span className="block text-[11px] text-text-tertiary mb-1">{t('browse.filters.to')}</span>
+                                <input
+                                  type="date"
+                                  value={addedTo}
+                                  min={addedFrom || undefined}
+                                  onChange={(e) => setAddedTo(e.target.value)}
+                                  className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded-md text-xs text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent cursor-pointer"
+                                />
+                              </label>
+                            </div>
+                          )}
+                        </div>
                       </div>
                     </div>
                   )}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1436,6 +1436,11 @@ export default function Browse() {
   // quietly dropping it.
   const [hasLocalCache, setHasLocalCache] = useState(false);
   const [catalogSyncing, setCatalogSyncing] = useState(false);
+  // `hasLocalCache` starts false and only becomes true once an async count
+  // comes back, so it is indistinguishable from "genuinely no catalog" until
+  // then. Fetching before the answer arrives would always open remote and
+  // then need a corrective second request. Gate the first fetch on this.
+  const [catalogChecked, setCatalogChecked] = useState(false);
 
   const refreshLocalCacheState = useCallback(async (reason: string) => {
     try {
@@ -1446,19 +1451,28 @@ export default function Browse() {
     } catch (err) {
       setHasLocalCache(false);
       traceBrowse(`catalog check (${reason}) failed: ${String(err)}`);
+    } finally {
+      setCatalogChecked(true);
     }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
     void refreshLocalCacheState('mount');
-    window.electronAPI.isSyncInProgress()
-      .then((inProgress) => {
-        if (cancelled) return;
-        setCatalogSyncing(inProgress);
-        if (inProgress) traceBrowse('catalog sync already in progress at mount');
-      })
-      .catch(() => { /* indicator only; routing still works off the count */ });
+
+    // Terminal phases arrive once per section (Mod, Sound, Wip) and the run
+    // continues after a failed one, so a phase alone cannot say whether the
+    // whole sync is done. Ask, rather than assuming this was the last section.
+    const refreshSyncingFlag = (reason: string) => {
+      window.electronAPI.isSyncInProgress()
+        .then((inProgress) => {
+          if (cancelled) return;
+          setCatalogSyncing(inProgress);
+          if (inProgress) traceBrowse(`catalog sync in progress (${reason})`);
+        })
+        .catch(() => { /* indicator only; routing runs off the count */ });
+    };
+    refreshSyncingFlag('mount');
 
     const unsub = window.electronAPI.onSyncProgress((data) => {
       if (cancelled) return;
@@ -1466,7 +1480,7 @@ export default function Browse() {
         setCatalogSyncing(true);
         return;
       }
-      setCatalogSyncing(false);
+      refreshSyncingFlag(`after ${data.phase} ${data.section}`);
       // A finished section can push the catalog over the usable threshold.
       // Re-checking here is what stops a cold start from disabling the
       // catalog-backed filters for the rest of the mount.
@@ -2185,13 +2199,35 @@ export default function Browse() {
     };
   }, [sections, section, setCategoryId, setHeroCategoryId]);
 
+  // fetchMods and searchLocal share `lastFetchedStampRef`, and its key
+  // (`page` + fetchFilterStamp) describes the FILTERS only, not which backend
+  // answered them. So when the catalog becomes usable mid-session the fetch
+  // effect below re-runs, calls searchLocal instead of fetchMods, and the
+  // shared gate sees an identical stamp and early-returns: the grid keeps the
+  // remote, default-ordered results and the local mirror is never queried
+  // until the user happens to touch a filter. Worse, the route trace would
+  // report `route=local` over remote data, which is exactly backwards in the
+  // state the tracing exists to explain. Dropping the stamp on a routing flip
+  // lets the pending query re-run against the backend that can actually
+  // serve it. Declared before the fetch effect so it clears the gate first.
+  const lastRoutedLocalRef = useRef(useLocalSearch);
   useEffect(() => {
+    if (lastRoutedLocalRef.current === useLocalSearch) return;
+    lastRoutedLocalRef.current = useLocalSearch;
+    lastFetchedStampRef.current = null;
+    traceBrowse(`routing flipped to ${useLocalSearch ? 'local' : 'remote'}; re-running current query`);
+  }, [useLocalSearch]);
+
+  useEffect(() => {
+    // Wait for the first catalog answer so the opening request goes straight
+    // to the right backend instead of always starting remote and correcting.
+    if (!catalogChecked) return;
     if (useLocalSearch) {
       searchLocal();
     } else {
       fetchMods();
     }
-  }, [fetchMods, searchLocal, useLocalSearch, refreshKey]);
+  }, [fetchMods, searchLocal, useLocalSearch, refreshKey, catalogChecked]);
 
   useEffect(() => {
     if (activeDeadlockPath) {
@@ -3585,11 +3621,14 @@ export default function Browse() {
                           </div>
                         )}
 
-                        {/* Content rating + recency can only be answered by the
-                            local catalog mirror. These used to be hidden
-                            entirely without it, so a cold cache looked like
-                            "the filters are missing/broken" with no
-                            explanation. Render them disabled and say why. */}
+                        {/* Recency can only be answered by the local catalog
+                            mirror, and content rating is only enforced there
+                            at query time (displayMods still post-filters nsfw
+                            for the remote paths, but on an already-truncated
+                            page). These used to be hidden entirely without a
+                            catalog, so a cold cache looked like "the filters
+                            are missing/broken" with no explanation. Render
+                            them disabled and say why. */}
                         {!hasLocalCache && (
                           <p className="rounded-md border border-border bg-bg-tertiary px-2 py-1.5 text-[11px] text-text-secondary">
                             {catalogSyncing

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -936,6 +936,9 @@ export interface ElectronAPI {
     updateModNsfw: (modId: number, isNsfw: boolean) => Promise<void>;
     updateModDownloadCount: (modId: number, downloadCount: number) => Promise<void>;
     onSyncProgress: (callback: (data: SyncProgressData) => void) => () => void;
+    /** Write a renderer-side trace line into main.log (and therefore into
+     *  diagnostic reports). Fire-and-forget, returns nothing. */
+    traceDiagnostic: (scope: string, message: string) => void;
 
     // Crosshair Presets
     getCrosshairPresets: () => Promise<{ presets: CrosshairPreset[]; activePresetId: string | null }>;


### PR DESCRIPTION
Follow-up to a user diagnostic report ("my filters are not working" on the Browse page). Their log contained no errors at all, which turned out to be the point.

## The problem

Content rating, date added, A-Z sort and full-text search can only be answered by the local catalog mirror. Browse gated all of them behind one flag:

```ts
const [hasLocalCache, setHasLocalCache] = useState(false);
useEffect(() => { /* getLocalModCount() > 100 */ }, []);   // once per mount, never again
```

Nothing could change it afterwards. Landing on Browse before the background sync crossed the threshold left the page in remote mode for the entire mount, and the remote path cannot express those filters:

- Content rating and Added were wrapped in `{hasLocalCache && ...}`, so they vanished from the panel with no explanation.
- `browseMods` takes no nsfw or date parameters at all, so date filtering had no remote fallback.
- A-Z was still offered, but `sortMap` in `gamebanana.ts` has no `name` token, so the `if (sort && sortMap[sort])` guard just skipped `_sSort` and default order came back.

None of this logged anything, and `initLogger()` only hooks `console.*` in the main process, so no renderer-side decision has ever reached `main.log`. The diagnostic report had nothing to go on.

## Changes

**Re-check the catalog.** Subscribes to the existing `onSyncProgress` stream and re-runs the count when a section completes, so a cold start recovers instead of staying degraded until the user navigates away and back.

**Fail visibly.** Content and Added now always render, disabled, above an inline reason ("Syncing the mod catalog..." or "...need the local mod catalog. Sync it from Settings."). A-Z is disabled and relabelled "Name (A-Z, needs catalog)" rather than silently no-opping. `browseMods` warns when any sort arrives without an apiv11 token so this cannot regress quietly.

**Trace bridge.** New one-way `diagnostics:trace` IPC (clamped scope and message) exposed as `window.electronAPI.traceDiagnostic`. Browse records the catalog check and, on every filter change, which backend it routed to plus which active filters the remote path dropped:

```
[Browse] catalog check (mount): count=0 threshold=100 ready=false
[Browse] route=remote (no local catalog) section=Mod search="" hero=all nsfw=all added=week sort=name DROPPED=[added=week, sort=name]
[Browse] catalog check (sync complete Mod): count=4127 threshold=100 ready=true
[Browse] route=local section=Mod search="" hero=all nsfw=all added=week sort=name
```

**Catalog state in diagnostic reports.** New `--- catalog ---` section with total rows, sync-in-progress, needs-sync, and per-section counts with last-sync timestamps. Imported lazily so `initLogger()` does not pull the sync and database graph in at startup.

## Notes

- Threshold changed from `count > 100` to `count >= 100` behind a named constant. One row of difference in a heuristic.
- `pnpm i18n:manifest` re-run for the four new en keys.

## Verification

`tsc` (app + node), `eslint`, `check-i18n`, `gen-locale-manifest --check`, and the full Vitest suite (660 tests, 52 files) all pass.

This does not prove it was the reporter's exact failure, since their log predates the tracing. But the next report from a build with this in it will say so outright.
