### PR TITLE
chore(release): v1.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the v1.25.0 release. Only `package.json` changes.

## What ships in v1.25.0

Six PRs since v1.24.0, all merged to `main`:

- #306 feat(installed): user lists for organizing installed mods
- #304 Installed: A-Z sort for the disabled shelf, and stop card moves dragging the viewport
- #303 Batch local mod import
- #307 fix(browse): stop catalog-backed filters failing silently
- #305 fix(ui): don't dismiss dialogs when a drag merely ends on the backdrop
- #302 fix(installed): let the search bar fill the row

Minor bump: a cluster of related Installed-page organization features (lists, batch import, A-Z shelf sort) rather than isolated fixes.

## Verification

Run against a clean checkout of `main` plus the bump: `tsc -b`, `eslint .`, 660 tests across 52 files, `check-i18n.mjs`, and `gen-locale-manifest.mjs --check` all pass.