### PR TITLE
fix(stats): keep tracked player avatars current

### DIFF
--- a/electron/main/ipc/stats.ts
+++ b/electron/main/ipc/stats.ts
@@ -10,6 +10,7 @@ import type {
     HeroStatsParams,
     BuildSearchParams,
     TrackedPlayer,
+    PlayerSteamProfile,
     MMRSnapshot,
     StoredMatch,
     PlayerMatch,
@@ -44,7 +45,12 @@ ipcMain.handle('stats:addTrackedPlayer', async (_, accountId: number, isPrimary 
         throw new Error('Player not found')
     }
 
+    // Prefer Steam's live persona + avatar over deadlock-api's cached scrape.
     const profile = profiles[0]
+    const live = await statsApi.getSteamCommunityProfile(accountId)
+    if (live?.persona_name) profile.persona_name = live.persona_name
+    if (live?.avatar_url) profile.avatar_url = live.avatar_url
+
     statsDb.addTrackedPlayer(profile, isPrimary)
 
     // Also fetch and save initial MMR
@@ -75,6 +81,78 @@ ipcMain.handle('stats:getPrimaryPlayer', (): TrackedPlayer | null => {
 ipcMain.handle('stats:setPrimaryPlayer', (_, accountId: number) => {
     statsDb.setPrimaryPlayer(accountId)
 })
+
+/**
+ * Refresh the cached Steam persona name + avatar for every tracked player.
+ *
+ * The only other refresh lives in stats:syncPlayerData, which covers the
+ * selected player alone, so a second tracked account kept whatever avatar it
+ * had when it was added. One batched request covers all of them. maxAgeSeconds
+ * skips the call when every row was already refreshed that recently; pass 0 to
+ * force it. Returns the rows as stored, refreshed or not.
+ */
+ipcMain.handle(
+    'stats:refreshTrackedProfiles',
+    async (_, maxAgeSeconds = 0): Promise<TrackedPlayer[]> => {
+        const tracked = statsDb.getTrackedPlayers()
+        if (tracked.length === 0) return tracked
+
+        if (maxAgeSeconds > 0) {
+            const cutoff = Math.floor(Date.now() / 1000) - maxAgeSeconds
+            if (tracked.every((p) => (p.last_updated ?? 0) > cutoff)) return tracked
+        }
+
+        // deadlock-api covers every tracked player in one request, but it serves
+        // its own periodic scrape of Steam, so it is the fallback rather than
+        // the source of truth. Steam Community is asked per player below.
+        let apiProfiles: PlayerSteamProfile[] = []
+        try {
+            apiProfiles = await statsApi.getPlayerSteamProfiles(tracked.map((p) => p.account_id))
+        } catch (err) {
+            console.warn('[stats:refreshTrackedProfiles] deadlock-api fetch failed:', err)
+        }
+
+        for (const player of tracked) {
+            const apiProfile = apiProfiles.find((p) => p.account_id === player.account_id)
+            const live = await statsApi.getSteamCommunityProfile(player.account_id)
+
+            if (!live && !apiProfile) {
+                console.warn(
+                    `[stats:refreshTrackedProfiles] ${player.account_id}: no profile from Steam or deadlock-api`
+                )
+                continue
+            }
+
+            const personaName = live?.persona_name ?? apiProfile?.persona_name
+            const avatarUrl = live?.avatar_url ?? apiProfile?.avatar_url
+
+            try {
+                statsDb.updatePlayerProfile({
+                    account_id: player.account_id,
+                    steam_id: apiProfile?.steam_id,
+                    persona_name: personaName,
+                    avatar_url: avatarUrl,
+                })
+                console.log(
+                    `[stats:refreshTrackedProfiles] ${player.account_id}: avatar ${
+                        player.avatar_url === avatarUrl ? 'unchanged' : 'updated'
+                    } from ${live ? 'Steam' : 'deadlock-api'}${
+                        live && apiProfile && live.avatar_url !== apiProfile.avatar_url
+                            ? ` (deadlock-api is behind, its snapshot says ${apiProfile.last_updated})`
+                            : ''
+                    }`
+                )
+            } catch (err) {
+                console.warn(
+                    `[stats:refreshTrackedProfiles] Failed to store profile ${player.account_id}:`,
+                    err
+                )
+            }
+        }
+
+        return statsDb.getTrackedPlayers()
+    }
+)
 
 // ============================================
 // Player Data (API)
@@ -322,13 +400,23 @@ ipcMain.handle('stats:syncPlayerData', async (_, accountId: number) => {
         results.errors.push(`Match history: ${err}`)
     }
 
-    // Refresh cached Steam persona name + avatar
+    // Refresh cached Steam persona name + avatar, Steam first
     try {
+        const live = await statsApi.getSteamCommunityProfile(accountId)
         const profiles = await statsApi.getPlayerSteamProfiles([accountId])
-        if (profiles.length > 0) {
-            statsDb.updatePlayerProfile(profiles[0])
+        const apiProfile = profiles[0]
+        if (live || apiProfile) {
+            statsDb.updatePlayerProfile({
+                account_id: accountId,
+                steam_id: apiProfile?.steam_id,
+                persona_name: live?.persona_name ?? apiProfile?.persona_name,
+                avatar_url: live?.avatar_url ?? apiProfile?.avatar_url,
+            })
         }
     } catch (err) {
+        // Nothing reads results.errors, so log it too: a silent failure here is
+        // exactly what a frozen avatar looks like.
+        console.warn('[stats:syncPlayerData] Profile refresh failed:', err)
         results.errors.push(`Profile: ${err}`)
     }
 

--- a/electron/main/services/rateLimiter.ts
+++ b/electron/main/services/rateLimiter.ts
@@ -75,6 +75,15 @@ export const statsApiRateLimiter = new RateLimiter({
     burstSize: 10,
 });
 
+// Steam Community rate limiter: 1 request per second.
+// steamcommunity.com is a public web endpoint with no documented budget and a
+// habit of soft-blocking bursts, and we only ever read a handful of tracked
+// players, so keep it slow and polite.
+export const steamCommunityRateLimiter = new RateLimiter({
+    maxRequestsPerSecond: 1,
+    burstSize: 3,
+});
+
 // Grimoire Social API rate limiter: 5 requests per second.
 // Defensive client-side throttle. The worker enforces strict per-action
 // limits (publish 1/10min via DO, like 30/min via RL API, etc.) on its

--- a/electron/main/services/stats.ts
+++ b/electron/main/services/stats.ts
@@ -24,7 +24,7 @@ import type {
     BuildSearchParams,
 } from '../../../src/types/deadlock-stats'
 import { GRIMOIRE_USER_AGENT } from './userAgent'
-import { statsApiRateLimiter } from './rateLimiter'
+import { statsApiRateLimiter, steamCommunityRateLimiter } from './rateLimiter'
 
 // Local flat types for counter/synergy stats (API returns flat arrays, not nested)
 export interface FlatHeroCounterStats {
@@ -376,6 +376,77 @@ export async function getPlayerSteamProfiles(
         steam_id: String(profile.account_id),
         is_private: false,
     }))
+}
+
+// ============================================
+// Steam Community (persona name + avatar, straight from the source)
+// ============================================
+
+const STEAM_COMMUNITY_BASE = 'https://steamcommunity.com/profiles'
+
+// Deadlock account ids are Steam "account ids": the low 32 bits of a 64-bit
+// SteamID. Adding the base back is exact only in BigInt, since the result is
+// well past Number.MAX_SAFE_INTEGER.
+const STEAM_ID64_BASE = 76561197960265728n
+
+export function toSteamId64(accountId: number): string {
+    return (BigInt(accountId) + STEAM_ID64_BASE).toString()
+}
+
+export interface SteamCommunityProfile {
+    persona_name?: string
+    avatar_url?: string
+}
+
+// The profile's own steamID/avatarFull are emitted before the <groups> block,
+// and every group carries an avatarFull of its own, so parsing has to stop at
+// the first group.
+function firstTag(xml: string, tag: string): string | undefined {
+    const match = new RegExp(`<${tag}>(?:<!\\[CDATA\\[)?(.*?)(?:\\]\\]>)?</${tag}>`, 's').exec(xml)
+    const value = match?.[1]?.trim()
+    return value ? value : undefined
+}
+
+/**
+ * Read a player's current persona name + avatar from the public Steam
+ * Community XML.
+ *
+ * deadlock-api serves its own periodic scrape of Steam, and that snapshot can
+ * sit weeks behind: a player who changes their avatar sees the old one in
+ * Grimoire indefinitely, because no amount of refreshing changes what the
+ * upstream cache holds. Steam itself is the authority, needs no API key, and
+ * answers for private profiles too (the avatar is public either way).
+ *
+ * Returns null on any failure so callers can fall back to the deadlock-api
+ * copy rather than losing the profile entirely.
+ */
+export async function getSteamCommunityProfile(
+    accountId: number
+): Promise<SteamCommunityProfile | null> {
+    try {
+        await steamCommunityRateLimiter.acquire()
+
+        const response = await fetch(`${STEAM_COMMUNITY_BASE}/${toSteamId64(accountId)}?xml=1`, {
+            headers: {
+                Accept: 'text/xml,application/xml',
+                'User-Agent': GRIMOIRE_USER_AGENT,
+            },
+            signal: AbortSignal.timeout(10000),
+        })
+        if (!response.ok) return null
+
+        const xml = await response.text()
+        const profileOnly = xml.split('<groups>')[0]
+        if (!profileOnly.includes('<steamID64>')) return null
+
+        const profile: SteamCommunityProfile = {
+            persona_name: firstTag(profileOnly, 'steamID'),
+            avatar_url: firstTag(profileOnly, 'avatarFull'),
+        }
+        return profile.persona_name || profile.avatar_url ? profile : null
+    } catch {
+        return null
+    }
 }
 
 /**

--- a/electron/main/services/statsDatabase.ts
+++ b/electron/main/services/statsDatabase.ts
@@ -239,9 +239,9 @@ export function addTrackedPlayer(profile: PlayerSteamProfile, isPrimary = false)
     `)
     stmt.run({
         account_id: profile.account_id,
-        steam_id: profile.steam_id,
-        persona_name: profile.persona_name,
-        avatar_url: profile.avatar_url,
+        steam_id: profile.steam_id ?? null,
+        persona_name: profile.persona_name ?? profile.personaname ?? null,
+        avatar_url: profile.avatar_url ?? profile.avatarfull ?? profile.avatar ?? null,
         is_primary: isPrimary ? 1 : 0,
     })
 
@@ -304,21 +304,34 @@ export function setPrimaryPlayer(accountId: number): void {
 
 /**
  * Update player profile
+ *
+ * Fields the API leaves out are kept rather than overwritten. A partial
+ * profile (an account deadlock-api has not fully scraped) used to take the
+ * whole update down with it, since better-sqlite3 refuses to bind undefined,
+ * and one throw here froze that player's cached persona name and avatar for
+ * good.
  */
-export function updatePlayerProfile(profile: PlayerSteamProfile): void {
+export type PlayerProfileUpdate = Partial<PlayerSteamProfile> & { account_id: number }
+
+export function updatePlayerProfile(profile: PlayerProfileUpdate): void {
     const database = initDatabase()
     database
         .prepare(
             `
         UPDATE players SET
-            steam_id = ?,
-            persona_name = ?,
-            avatar_url = ?,
+            steam_id = COALESCE(?, steam_id),
+            persona_name = COALESCE(?, persona_name),
+            avatar_url = COALESCE(?, avatar_url),
             last_updated = unixepoch()
         WHERE account_id = ?
     `
         )
-        .run(profile.steam_id, profile.persona_name, profile.avatar_url, profile.account_id)
+        .run(
+            profile.steam_id ?? null,
+            profile.persona_name ?? profile.personaname ?? null,
+            profile.avatar_url ?? profile.avatarfull ?? profile.avatar ?? null,
+            profile.account_id
+        )
 }
 
 // ============================================

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -661,6 +661,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             ipcRenderer.invoke('stats:getPlayerMatchHistory', accountId, limit, minMatchId),
         getPlayerSteamProfiles: (accountIds: number[]) =>
             ipcRenderer.invoke('stats:getPlayerSteamProfiles', accountIds),
+        refreshTrackedProfiles: (maxAgeSeconds?: number) =>
+            ipcRenderer.invoke('stats:refreshTrackedProfiles', maxAgeSeconds),
 
         // Local Database
         getLocalMMRHistory: (accountId: number, limit?: number) =>

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -26,6 +26,10 @@ import { LeaderboardTab } from '../components/stats/tabs/LeaderboardTab'
 
 type Tab = 'overview' | 'matches' | 'social' | 'leaderboard'
 
+// Opening the tab re-pulls Steam personas + avatars that are older than this.
+// Refresh forces the pull regardless.
+const PROFILE_MAX_AGE_S = 30 * 60
+
 const TABS: { id: Tab; icon: LucideIcon; playerScoped: boolean }[] = [
     { id: 'overview', icon: BarChart3, playerScoped: true },
     { id: 'matches', icon: Gamepad2, playerScoped: true },
@@ -39,6 +43,7 @@ export default function Stats() {
 
     const detectSteamUsers = usePlayerStore((s) => s.detectSteamUsers)
     const loadTrackedPlayers = usePlayerStore((s) => s.loadTrackedPlayers)
+    const refreshTrackedProfiles = usePlayerStore((s) => s.refreshTrackedProfiles)
     const trackedPlayers = usePlayerStore((s) => s.trackedPlayers)
     const selectedAccountId = usePlayerStore((s) => s.selectedAccountId)
     const selectPlayer = usePlayerStore((s) => s.selectPlayer)
@@ -52,7 +57,8 @@ export default function Stats() {
         if (usePlayerStore.getState().trackedPlayers.status === 'idle') {
             loadTrackedPlayers()
         }
-    }, [detectSteamUsers, loadHeroes, loadTrackedPlayers])
+        refreshTrackedProfiles(PROFILE_MAX_AGE_S)
+    }, [detectSteamUsers, loadHeroes, loadTrackedPlayers, refreshTrackedProfiles])
 
     // Auto-select the primary (or first) tracked player.
     useEffect(() => {
@@ -63,7 +69,7 @@ export default function Stats() {
     }, [trackedPlayers.data, selectedAccountId, selectPlayer])
 
     const handleRefresh = () => {
-        loadTrackedPlayers()
+        refreshTrackedProfiles(0)
         if (selectedAccountId) {
             syncPlayerData(selectedAccountId)
             const social = useSocialStore.getState()

--- a/src/stores/stats/playerStore.ts
+++ b/src/stores/stats/playerStore.ts
@@ -44,6 +44,7 @@ interface PlayerState {
 
     detectSteamUsers: () => Promise<void>
     loadTrackedPlayers: () => Promise<void>
+    refreshTrackedProfiles: (maxAgeSeconds?: number) => Promise<void>
     addTrackedPlayer: (accountId: number, isPrimary?: boolean) => Promise<void>
     removeTrackedPlayer: (accountId: number) => Promise<void>
     setPrimaryPlayer: (accountId: number) => Promise<void>
@@ -113,6 +114,20 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
             set({ trackedPlayers: asyncLoaded(players) })
         } catch (err) {
             set((s) => ({ trackedPlayers: asyncError(s.trackedPlayers, err) }))
+        }
+    },
+
+    // Pulls a fresh persona name + avatar for every tracked player, not just the
+    // selected one, so a Steam avatar change shows up on all of them. Silent by
+    // design: the cached profile is a perfectly good fallback.
+    refreshTrackedProfiles: async (maxAgeSeconds = 0) => {
+        try {
+            const players = (await window.electronAPI.stats.refreshTrackedProfiles(
+                maxAgeSeconds
+            )) as TrackedPlayer[]
+            set({ trackedPlayers: asyncLoaded(players) })
+        } catch {
+            // Keep whatever is already on screen.
         }
     },
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1067,6 +1067,7 @@ export interface ElectronAPI {
         getPlayerHeroStats: (accountId: number) => Promise<unknown>;
         getPlayerMatchHistory: (accountId: number, limit?: number, minMatchId?: number) => Promise<unknown>;
         getPlayerSteamProfiles: (accountIds: number[]) => Promise<unknown[]>;
+        refreshTrackedProfiles: (maxAgeSeconds?: number) => Promise<unknown[]>;
 
         // Local Database
         getLocalMMRHistory: (accountId: number, limit?: number) => Promise<unknown[]>;


### PR DESCRIPTION
Reported in Discord: a Steam avatar change never showed up in the Stats tab, while a second tracked account did update. Two separate causes.

## The profile was barely ever refreshed

The cached persona name and avatar were only refreshed inside `stats:syncPlayerData`, which the renderer calls for the **selected** player alone, and only when you click Refresh. Opening the tab never re-pulled them, so a tracked player kept whatever avatar it had when it was first added.

New `stats:refreshTrackedProfiles` handler covers every tracked player in one pass and runs on tab open (for profiles older than 30 minutes) as well as on Refresh.

## deadlock-api was serving a stale scrape

The bigger one. deadlock-api keeps its own periodic scrape of Steam, and that snapshot can sit well behind reality. For the reported account it still returned the previous persona and avatar, stamped with a fresh looking `last_updated`:

| Source | Persona | Avatar |
|---|---|---|
| Steam | `moonmichael4233` | `8617c001...` |
| deadlock-api | `Ubuntu 12.04` | `b92da8d3...` (snapshot 2026-07-26) |

No amount of refreshing fixes an upstream cache, so persona and avatar now come from Steam Community's public XML (`steamcommunity.com/profiles/<id64>?xml=1`), with deadlock-api as the fallback. No API key needed, and it answers for private profiles too since the avatar is public either way. Rate limited to 1 req/sec (undocumented public endpoint, and we only ever read a handful of players).

Two details worth flagging for review:

- The account-id to SteamID64 conversion uses BigInt. `76561197960265728 + accountId` lands past `Number.MAX_SAFE_INTEGER` and is silently wrong in plain JS numbers.
- XML parsing stops at `<groups>`, because every group in the response carries an `<avatarFull>` of its own.

## A silent freeze in the DB write

`updatePlayerProfile` bound fields straight off the API response, and better-sqlite3 refuses to bind `undefined`. A partial profile threw into a `results.errors` array nothing reads, which froze that player's name and avatar permanently. Missing fields now leave the stored value alone (`COALESCE`), and the failure paths log.

## Verification

Ran a throwaway instance against an isolated userData seeded with exactly the stale value deadlock-api serves for the reported account. Opening the Stats tab:

```
[stats:refreshTrackedProfiles] 129641403: avatar updated from Steam (deadlock-api is behind, its snapshot says 2026-07-26T03:29:51Z)
```

Header rendered the current persona and avatar. Also confirmed the batched path refreshes a second, never-selected tracked account.

`pnpm typecheck` and `pnpm exec eslint` clean on every touched file, 660/660 vitest pass.

## Note

Persona names now track Steam as well, so anyone whose deadlock-api name was stale will start seeing their real current Steam name.