### PR TITLE
fix(browse): keep hero filter open on mouse selection

### DIFF
--- a/src/components/common/HeroSelect.test.tsx
+++ b/src/components/common/HeroSelect.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act, useEffect, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HeroSelect } from './HeroSelect';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+function BrowseFilterHarness() {
+  const [filtersOpen, setFiltersOpen] = useState(true);
+  const [hero, setHero] = useState('all');
+  const filtersRef = useRef<HTMLDivElement>(null);
+
+  // Mirrors Browse's outside-click behavior. HeroSelect's listbox is portaled
+  // to document.body, so a mouse selection must not look outside this popover.
+  useEffect(() => {
+    if (!filtersOpen) return;
+    const onMouseDown = (event: MouseEvent) => {
+      if (filtersRef.current && !filtersRef.current.contains(event.target as Node)) {
+        setFiltersOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onMouseDown);
+    return () => window.removeEventListener('mousedown', onMouseDown);
+  }, [filtersOpen]);
+
+  return (
+    <div>
+      <output data-testid="selected-hero">{hero}</output>
+      {filtersOpen && (
+        <div ref={filtersRef} data-testid="filter-popover">
+          <HeroSelect
+            ariaLabel="Filter by hero"
+            value={hero}
+            onChange={setHero}
+            options={[
+              { value: 'all', label: 'All heroes' },
+              { value: 'abrams', label: 'Abrams', heroName: 'Abrams' },
+            ]}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+describe('HeroSelect inside a dismissable popover', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps the parent popover open and applies a hero selected with the mouse', () => {
+    act(() => root.render(<BrowseFilterHarness />));
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Filter by hero"]'
+    );
+    expect(trigger).not.toBeNull();
+    act(() => trigger!.click());
+
+    const abrams = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="option"]')
+    ).find((option) => option.textContent?.includes('Abrams'));
+    expect(abrams).toBeDefined();
+
+    act(() => {
+      abrams!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+      abrams!.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0 }));
+      abrams!.click();
+    });
+
+    expect(document.querySelector('[data-testid="filter-popover"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="selected-hero"]')?.textContent).toBe('abrams');
+  });
+});

--- a/src/components/common/HeroSelect.tsx
+++ b/src/components/common/HeroSelect.tsx
@@ -288,6 +288,10 @@ export function HeroSelect({
           ref={listRef}
           role="listbox"
           aria-label={ariaLabel}
+          // The listbox is portaled outside any popover containing HeroSelect.
+          // Keep its mouse gesture inside this logical boundary so an ancestor's
+          // window-level outside-click listener cannot unmount us before click.
+          onMouseDown={(event) => event.stopPropagation()}
           // z-80 is the context-menu/popover rung of the ladder in index.css:
           // portaled to <body>, this has to clear modals and page chrome alike.
           // Positioned by positionListbox before paint; the inline top/left are

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts', 'electron/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'electron/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

- keep the Browse filter popover open when a hero is selected with the mouse
- stop the portaled hero listbox's mouse gesture at its logical event boundary
- add a regression test covering the real Browse outside-click interaction

## Root cause

`HeroSelect` portals its listbox to `document.body`, outside the Browse filter popover's DOM subtree. A mouse selection therefore reached Browse's window-level `mousedown` outside-click listener, which unmounted the filter before the option's later `click` could apply the hero. Keyboard selection never emitted that `mousedown`, which is why Enter already worked.

## User impact

Hero filtering on Browse now works consistently with mouse and keyboard. Selecting a hero closes only the hero listbox while leaving the broader filter popover open.

## Validation

- `pnpm test` — 53 files, 661 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` with the documented example `GRIMOIRE_SOCIAL_BASE_URL`
- live Electron check: clicked Abrams, confirmed the Filters dialog stayed open and the selected hero changed to Abrams