### PR TITLE
fix(installed): collapse imprint button to an icon

### DIFF
--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -4023,10 +4023,11 @@ export default function Installed() {
                 claiming a second strip below the search. Copy-enabled sits
                 inside topStatusActions, immediately after Fix Unknown. */}
             {topStatusActions}
-            {/* Retroactive bulk imprint launcher (experimental, opt-in). Compact
-                secondary button so it rides the same cluster as the filter
-                control without claiming its own strip. Opens the preflight
-                modal. */}
+            {/* Retroactive bulk imprint launcher (experimental, opt-in).
+                Icon-only, same shape/height as the other toolbar icon buttons
+                (copy enabled, fix order, filter) so it rides the cluster
+                without claiming its own strip. Name lives in the tooltip /
+                aria-label. Opens the preflight modal. */}
             {/* Hide-when-done: the button only exists while something could
                 still be imprinted. After a successful bulk run loadMods()
                 refreshes the list, the count reaches zero, and the button
@@ -4035,14 +4036,12 @@ export default function Installed() {
             {settings?.experimentalVpkImprinting && pendingImprintCount > 0 && (
               <Button
                 variant="secondary"
-                size="sm"
                 icon={Fingerprint}
+                className="!px-2.5"
                 onClick={() => { void openImprintModal(); }}
                 aria-label={t('installed.actions.imprintInstalledMods')}
                 title={t('installed.actions.imprintInstalledModsHint')}
-              >
-                {t('installed.actions.imprintInstalledMods')}
-              </Button>
+              />
             )}
             {/* Sort + filter: load order / recent / name, GameBanana vs local
                 import, hero, and metadata tags. The badge counts active


### PR DESCRIPTION
The retroactive "Imprint installed mods" launcher was the only labelled button sitting in the Installed toolbar's icon cluster, and `size="sm"` left it visibly shorter than the icons on either side of it.

Dropped the text and switched it to the same recipe the other toolbar icon buttons use (copy enabled, fix order, filter): default size plus `!px-2.5`. The row is now one uniform height.

The button's name is still reachable: `aria-label` carries `installed.actions.imprintInstalledMods`, and the existing `title` hint still shows on hover. No i18n keys were removed.

Only shows up with `experimentalVpkImprinting` on and at least one un-imprinted mod, so it's the same visibility condition as before.

## Before / after

Before: `[icon] [icon] [ Imprint installed mods ] [icon] [icon] ...` (that one button shorter than the rest)
After: `[icon] [icon] [icon] [icon] [icon] ...`

## Testing

- `pnpm typecheck` clean for `src/pages/Installed.tsx`.
- Pre-existing failures elsewhere in the working tree (untracked WIP under `src/components/social/`, `src/stores/postsStore.ts`, `electron/main/services/pakModelTextures.ts`) are unrelated and not part of this branch.