### PR TITLE
chore(release): v1.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the 1.25.1 patch release.

Five PRs since v1.25.0:

- #309 fix(stats): keep tracked player avatars current
- #310 fix(browse): keep hero filter open on mouse selection
- #311 feat(browse): add hero filter search
- #312 fix(browse): stop the filters panel clipping behind the sidebar
- #313 fix(installed): collapse imprint button to an icon

A small feature (#311) rides in a patch, consistent with prior cuts: minor is reserved for a themed release.

## Validation

- `pnpm exec vitest run`: 669 tests across 54 suites pass
- `pnpm typecheck` clean for tracked sources
- `node scripts/gen-locale-manifest.mjs --check`: manifest up to date

Local `typecheck` / `i18n:check` failures come only from untracked WIP in the working tree (`src/components/social/*`, `src/stores/postsStore.ts`, `electron/main/services/pakModelTextures.ts`). No tracked file imports them, so CI's clean checkout is unaffected.