### PR TITLE
feat(locker): add hero typeahead highlighting

### DIFF
--- a/src/lib/lockerHeroTypeahead.test.ts
+++ b/src/lib/lockerHeroTypeahead.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendHeroTypeaheadCharacter,
+  backspaceHeroTypeahead,
+  expireHeroTypeaheadQuery,
+  isHeroTypeaheadKey,
+  reconcileHeroTypeaheadHeroes,
+  type HeroTypeaheadState,
+} from './lockerHeroTypeahead';
+
+const heroes = [
+  { id: 1, name: 'Ivy' },
+  { id: 2, name: 'Shiv' },
+  { id: 3, name: 'Seven' },
+  { id: 4, name: 'Haze' },
+];
+
+const emptyState: HeroTypeaheadState = {
+  query: '',
+  highlightedHeroIds: null,
+};
+
+describe('locker hero typeahead', () => {
+  it('uses prefix matching for one letter, then substring matching', () => {
+    const withI = appendHeroTypeaheadCharacter(emptyState, 'i', heroes);
+    const withIv = appendHeroTypeaheadCharacter(withI, 'v', heroes);
+
+    expect(withI).toEqual({
+      query: 'i',
+      highlightedHeroIds: [1],
+    });
+    expect(withIv).toEqual({
+      query: 'iv',
+      highlightedHeroIds: [1, 2],
+    });
+  });
+
+  it('accepts punctuation used in hero names', () => {
+    expect(isHeroTypeaheadKey('&', false)).toBe(true);
+    expect(isHeroTypeaheadKey(' ', false)).toBe(false);
+    expect(isHeroTypeaheadKey(' ', true)).toBe(true);
+
+    const moAndKrill = [{ id: 5, name: 'Mo & Krill' }];
+    const state = [...'mo & krill'].reduce(
+      (current, character) =>
+        appendHeroTypeaheadCharacter(current, character, moAndKrill),
+      emptyState
+    );
+
+    expect(state.highlightedHeroIds).toEqual([5]);
+  });
+
+  it('leaves the hero list unfiltered when nothing matches', () => {
+    const withT = appendHeroTypeaheadCharacter(emptyState, 't', heroes);
+    const withTe = appendHeroTypeaheadCharacter(withT, 'e', heroes);
+    const withTes = appendHeroTypeaheadCharacter(withTe, 's', heroes);
+    const withTest = appendHeroTypeaheadCharacter(withTes, 't', heroes);
+
+    expect(withTest).toEqual({
+      query: 'test',
+      highlightedHeroIds: null,
+    });
+  });
+
+  it('edits the active query with Backspace', () => {
+    const withS = appendHeroTypeaheadCharacter(emptyState, 's', heroes);
+    const withSh = appendHeroTypeaheadCharacter(withS, 'h', heroes);
+
+    expect(backspaceHeroTypeahead(withSh, heroes)).toEqual({
+      query: 's',
+      highlightedHeroIds: [2, 3],
+    });
+  });
+
+  it('fades the text without clearing the current highlight', () => {
+    const withS = appendHeroTypeaheadCharacter(emptyState, 's', heroes);
+
+    expect(expireHeroTypeaheadQuery(withS)).toEqual({
+      query: '',
+      highlightedHeroIds: [2, 3],
+    });
+  });
+
+  it('clears a persisted highlight when Backspace is pressed after fading', () => {
+    const expired = expireHeroTypeaheadQuery(
+      appendHeroTypeaheadCharacter(emptyState, 's', heroes)
+    );
+
+    expect(backspaceHeroTypeahead(expired, heroes)).toEqual(emptyState);
+  });
+
+  it('starts a fresh query after the previous text has faded', () => {
+    const withI = appendHeroTypeaheadCharacter(emptyState, 'i', heroes);
+    const withIv = appendHeroTypeaheadCharacter(withI, 'v', heroes);
+    const expired = expireHeroTypeaheadQuery(withIv);
+
+    expect(appendHeroTypeaheadCharacter(expired, 's', heroes)).toEqual({
+      query: 's',
+      highlightedHeroIds: [2, 3],
+    });
+  });
+
+  it('keeps only visible highlights when the displayed heroes change', () => {
+    const expired = expireHeroTypeaheadQuery(
+      appendHeroTypeaheadCharacter(emptyState, 's', heroes)
+    );
+
+    expect(reconcileHeroTypeaheadHeroes(expired, [heroes[1]])).toEqual({
+      query: '',
+      highlightedHeroIds: [2],
+    });
+    expect(reconcileHeroTypeaheadHeroes(expired, [heroes[0]])).toEqual({
+      query: '',
+      highlightedHeroIds: null,
+    });
+  });
+});

--- a/src/lib/lockerHeroTypeahead.ts
+++ b/src/lib/lockerHeroTypeahead.ts
@@ -1,0 +1,100 @@
+export interface HeroTypeaheadHero {
+  id: number;
+  name: string;
+}
+
+export interface HeroTypeaheadState {
+  query: string;
+  highlightedHeroIds: number[] | null;
+}
+
+export function isHeroTypeaheadKey(
+  key: string,
+  hasActiveQuery: boolean
+): boolean {
+  return key.length === 1 && (hasActiveQuery || key.trim().length > 0);
+}
+
+function sameHeroIds(
+  left: readonly number[] | null,
+  right: readonly number[] | null
+): boolean {
+  if (left === right) return true;
+  if (!left || !right || left.length !== right.length) return false;
+  return left.every((id, index) => id === right[index]);
+}
+
+function matchingHeroIds(
+  heroes: readonly HeroTypeaheadHero[],
+  query: string
+): number[] | null {
+  if (query.length === 0) return null;
+
+  const normalizedQuery = query.toLowerCase();
+  const matches = heroes
+    .filter((hero) => {
+      const normalizedName = hero.name.toLowerCase();
+      return query.length === 1
+        ? normalizedName.startsWith(normalizedQuery)
+        : normalizedName.includes(normalizedQuery);
+    })
+    .map((hero) => hero.id);
+
+  return matches.length > 0 ? matches : null;
+}
+
+function withQuery(
+  state: HeroTypeaheadState,
+  query: string,
+  heroes: readonly HeroTypeaheadHero[]
+): HeroTypeaheadState {
+  return {
+    ...state,
+    query,
+    highlightedHeroIds: matchingHeroIds(heroes, query),
+  };
+}
+
+export function appendHeroTypeaheadCharacter(
+  state: HeroTypeaheadState,
+  character: string,
+  heroes: readonly HeroTypeaheadHero[]
+): HeroTypeaheadState {
+  return withQuery(state, `${state.query}${character}`, heroes);
+}
+
+export function backspaceHeroTypeahead(
+  state: HeroTypeaheadState,
+  heroes: readonly HeroTypeaheadHero[]
+): HeroTypeaheadState {
+  return withQuery(state, state.query.slice(0, -1), heroes);
+}
+
+export function expireHeroTypeaheadQuery(
+  state: HeroTypeaheadState
+): HeroTypeaheadState {
+  return {
+    ...state,
+    query: '',
+  };
+}
+
+export function reconcileHeroTypeaheadHeroes(
+  state: HeroTypeaheadState,
+  heroes: readonly HeroTypeaheadHero[]
+): HeroTypeaheadState {
+  const highlightedHeroIds =
+    state.query.length > 0
+      ? matchingHeroIds(heroes, state.query)
+      : state.highlightedHeroIds?.filter((id) =>
+          heroes.some((hero) => hero.id === id)
+        ) ?? null;
+  const normalizedHeroIds =
+    highlightedHeroIds && highlightedHeroIds.length > 0
+      ? highlightedHeroIds
+      : null;
+
+  return sameHeroIds(state.highlightedHeroIds, normalizedHeroIds)
+    ? state
+    : { ...state, highlightedHeroIds: normalizedHeroIds };
+}

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type ComponentType, type SVGProps } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Images, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Shuffle, Sparkles, Star, Trash2 } from 'lucide-react';
@@ -63,11 +64,25 @@ import {
   type HeroCategory,
 } from '../lib/lockerUtils';
 import { shuffleSkinKey, type VariantChoice } from '../lib/lockerRandomizer';
+import {
+  appendHeroTypeaheadCharacter,
+  backspaceHeroTypeahead,
+  expireHeroTypeaheadQuery,
+  isHeroTypeaheadKey,
+  reconcileHeroTypeaheadHeroes,
+  type HeroTypeaheadState,
+} from '../lib/lockerHeroTypeahead';
 
 // Route changes flip the overlay state instantly, which unmounts the hero or
 // global panel on the next frame with no exit transition. Retain the last
 // value for the fade-out duration so the panel can animate away first.
 const OVERLAY_EXIT_MS = 200;
+const HERO_TYPEAHEAD_FADE_DELAY_MS = 700;
+const HERO_TYPEAHEAD_EXPIRE_MS = 2_200;
+const EMPTY_HERO_TYPEAHEAD: HeroTypeaheadState = {
+  query: '',
+  highlightedHeroIds: null,
+};
 
 function useOverlayExit<T>(value: T | null): { item: T | null; closing: boolean } {
   const [retained, setRetained] = useState<T | null>(null);
@@ -233,6 +248,9 @@ export default function Locker() {
   const [hideEmptyHeroes, setHideEmptyHeroes] = useState(
     () => localStorage.getItem('lockerHideEmpty') === 'true'
   );
+  const [heroTypeahead, setHeroTypeahead] =
+    useState<HeroTypeaheadState>(EMPTY_HERO_TYPEAHEAD);
+  const [heroTypeaheadFading, setHeroTypeaheadFading] = useState(false);
   const [abilityRecolorSupport, setAbilityRecolorSupport] = useState<Record<string, boolean>>({});
   // Soul-container GLB import (lazy three.js modal), openable from the global
   // Locker tab. Mirrors the Installed-page trigger.
@@ -286,6 +304,9 @@ export default function Locker() {
   }, []);
   const lockerScrollRef = useRef<HTMLDivElement | null>(null);
   const latestLockerScrollTopRef = useRef(lockerPageScrollTop);
+  const heroTypeaheadRef = useRef(heroTypeahead);
+  const heroTypeaheadFadeTimerRef = useRef<number | null>(null);
+  const heroTypeaheadExpireTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     loadSettings();
@@ -595,6 +616,138 @@ export default function Locker() {
     });
   }, [heroList, hideEmptyHeroes, favoriteHeroes, heroMods, heroSounds]);
 
+  const applyHeroTypeaheadState = useCallback((next: HeroTypeaheadState) => {
+    heroTypeaheadRef.current = next;
+    setHeroTypeahead(next);
+  }, []);
+
+  const clearHeroTypeaheadTimers = useCallback(() => {
+    if (heroTypeaheadFadeTimerRef.current !== null) {
+      window.clearTimeout(heroTypeaheadFadeTimerRef.current);
+      heroTypeaheadFadeTimerRef.current = null;
+    }
+    if (heroTypeaheadExpireTimerRef.current !== null) {
+      window.clearTimeout(heroTypeaheadExpireTimerRef.current);
+      heroTypeaheadExpireTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleHeroTypeaheadFade = useCallback(() => {
+    clearHeroTypeaheadTimers();
+    setHeroTypeaheadFading(false);
+    heroTypeaheadFadeTimerRef.current = window.setTimeout(() => {
+      setHeroTypeaheadFading(true);
+    }, HERO_TYPEAHEAD_FADE_DELAY_MS);
+    heroTypeaheadExpireTimerRef.current = window.setTimeout(() => {
+      applyHeroTypeaheadState(expireHeroTypeaheadQuery(heroTypeaheadRef.current));
+      setHeroTypeaheadFading(false);
+      heroTypeaheadFadeTimerRef.current = null;
+      heroTypeaheadExpireTimerRef.current = null;
+    }, HERO_TYPEAHEAD_EXPIRE_MS);
+  }, [applyHeroTypeaheadState, clearHeroTypeaheadTimers]);
+
+  const clearHeroTypeahead = useCallback(() => {
+    clearHeroTypeaheadTimers();
+    applyHeroTypeaheadState(EMPTY_HERO_TYPEAHEAD);
+    setHeroTypeaheadFading(false);
+  }, [applyHeroTypeaheadState, clearHeroTypeaheadTimers]);
+
+  useEffect(() => {
+    const next = reconcileHeroTypeaheadHeroes(
+      heroTypeaheadRef.current,
+      displayedHeroList
+    );
+    if (next !== heroTypeaheadRef.current) applyHeroTypeaheadState(next);
+  }, [applyHeroTypeaheadState, displayedHeroList]);
+
+  useEffect(() => {
+    if (selectedHeroId !== null || globalSelected) {
+      clearHeroTypeahead();
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.isComposing
+      ) {
+        return;
+      }
+
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest(
+          'input, textarea, select, button, a, [contenteditable="true"], [role="textbox"], [role="button"], [role="menuitem"], [role="option"], [role="listbox"]'
+        )
+      ) {
+        return;
+      }
+      if (document.querySelector('[role="dialog"], [aria-modal="true"]')) return;
+
+      const current = heroTypeaheadRef.current;
+      let next: HeroTypeaheadState | null = null;
+      if (
+        event.key === 'Backspace' &&
+        (current.query.length > 0 || current.highlightedHeroIds !== null)
+      ) {
+        next = backspaceHeroTypeahead(current, displayedHeroList);
+      } else if (
+        isHeroTypeaheadKey(event.key, current.query.length > 0)
+      ) {
+        next = appendHeroTypeaheadCharacter(current, event.key, displayedHeroList);
+      }
+
+      if (!next) return;
+      event.preventDefault();
+      applyHeroTypeaheadState(next);
+      if (next.query.length > 0) {
+        scheduleHeroTypeaheadFade();
+      } else {
+        clearHeroTypeaheadTimers();
+        setHeroTypeaheadFading(false);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [
+    applyHeroTypeaheadState,
+    clearHeroTypeahead,
+    clearHeroTypeaheadTimers,
+    displayedHeroList,
+    globalSelected,
+    scheduleHeroTypeaheadFade,
+    selectedHeroId,
+  ]);
+
+  useEffect(
+    () => () => {
+      clearHeroTypeaheadTimers();
+    },
+    [clearHeroTypeaheadTimers]
+  );
+
+  const highlightedHeroIds = useMemo(
+    () =>
+      heroTypeahead.highlightedHeroIds
+        ? new Set(heroTypeahead.highlightedHeroIds)
+        : null,
+    [heroTypeahead.highlightedHeroIds]
+  );
+  const heroTypeaheadCardState = useCallback(
+    (heroId?: number) => {
+      if (!highlightedHeroIds) return '';
+      return heroId !== undefined && highlightedHeroIds.has(heroId)
+        ? 'relative z-10 opacity-100 ring-2 ring-accent/90 shadow-lg shadow-accent/20'
+        : 'opacity-20';
+    },
+    [highlightedHeroIds]
+  );
+
   const lockerCardsExpandedByDefault = settings?.lockerCardsExpandedByDefault ?? false;
 
   useEffect(() => {
@@ -869,6 +1022,20 @@ export default function Locker() {
     <div ref={lockerScrollRef} className="h-full overflow-y-auto">
       {/* Shared gradient def for the active hero-card customization glyphs. */}
       <FacetSheenDefs />
+      {heroTypeahead.query &&
+        createPortal(
+          <div
+            aria-hidden
+            className={`pointer-events-none fixed bottom-10 right-12 z-[100] max-w-[45vw] truncate text-right font-reaver text-6xl uppercase tracking-wider text-text-primary drop-shadow-[0_2px_20px_rgba(0,0,0,0.75)] transition-opacity ease-out ${
+              heroTypeaheadFading
+                ? 'duration-[1500ms] opacity-0'
+                : 'duration-[0ms] opacity-90'
+            }`}
+          >
+            {heroTypeahead.query}
+          </div>,
+          document.body,
+        )}
       <div className="p-6 space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm text-text-secondary">
@@ -967,30 +1134,38 @@ export default function Locker() {
           {/* Always rendered: soul containers & spirit urns are imported from
               inside this drill-in, so the card must stay reachable even with
               nothing installed yet (otherwise the importer is unreachable). */}
-          <GlobalGalleryCard
-            count={globalCount}
-            typeCount={globalTypeCount}
-            onNavigate={() => navigate('/locker/global')}
-          />
-          {displayedHeroList.map((hero) => (
-            <HeroGalleryCard
-              key={hero.id}
-              hero={hero}
-              facets={heroFacets(hero.id, hero.name)}
-              inShufflePool={shuffleOnLaunch && shufflePoolHeroes.has(hero.id)}
-              cardImage={heroCardImage(hero.id)}
-              hideHeroName={heroHideName(hero.id)}
-              isFavorite={favoriteHeroes.includes(hero.id)}
-              onNavigate={() => goToHero(hero)}
-              onBrowse={() => openHeroInBrowse(hero)}
-              onToggleFavorite={() =>
-                setFavoriteHeroes((prev) =>
-                  prev.includes(hero.id)
-                    ? prev.filter((id) => id !== hero.id)
-                    : [...prev, hero.id]
-                )
-              }
+          <div
+            className={`rounded-2xl ${heroTypeaheadCardState()}`}
+          >
+            <GlobalGalleryCard
+              count={globalCount}
+              typeCount={globalTypeCount}
+              onNavigate={() => navigate('/locker/global')}
             />
+          </div>
+          {displayedHeroList.map((hero) => (
+            <div
+              key={hero.id}
+              className={`rounded-2xl ${heroTypeaheadCardState(hero.id)}`}
+            >
+              <HeroGalleryCard
+                hero={hero}
+                facets={heroFacets(hero.id, hero.name)}
+                inShufflePool={shuffleOnLaunch && shufflePoolHeroes.has(hero.id)}
+                cardImage={heroCardImage(hero.id)}
+                hideHeroName={heroHideName(hero.id)}
+                isFavorite={favoriteHeroes.includes(hero.id)}
+                onNavigate={() => goToHero(hero)}
+                onBrowse={() => openHeroInBrowse(hero)}
+                onToggleFavorite={() =>
+                  setFavoriteHeroes((prev) =>
+                    prev.includes(hero.id)
+                      ? prev.filter((id) => id !== hero.id)
+                      : [...prev, hero.id]
+                  )
+                }
+              />
+            </div>
           ))}
         </div>
       ) : (
@@ -1000,7 +1175,7 @@ export default function Locker() {
           <button
             type="button"
             onClick={() => navigate('/locker/global')}
-            className="group relative flex items-center gap-3 overflow-hidden rounded-lg border border-accent/40 bg-bg-secondary p-4 text-left transition-colors hover:border-accent/70"
+            className={`group relative flex items-center gap-3 overflow-hidden rounded-lg border border-accent/40 bg-bg-secondary p-4 text-left transition-colors hover:border-accent/70 ${heroTypeaheadCardState()}`}
           >
             {/* Environment art bleeds behind the card; the left-to-right
                 gradient keeps the text side dark, mirroring the list-view
@@ -1028,34 +1203,38 @@ export default function Locker() {
             <ChevronDown className="relative z-10 h-4 w-4 -rotate-90 text-text-secondary" />
           </button>
           {displayedHeroList.map((hero) => (
-            <HeroCard
+            <div
               key={hero.id}
-              hero={hero}
-              mods={heroMods.map.get(hero.id) ?? []}
-              sounds={heroSounds.map.get(hero.id) ?? []}
-              hasAbilityRecolor={Boolean(abilityRecolorSupport[hero.name])}
-              cardImage={heroCardImage(hero.id)}
-              expanded={expandedHeroes.has(hero.id)}
-              onToggleExpanded={() => toggleHeroExpanded(hero.id)}
-              onBrowseSkins={() => openHeroInBrowse(hero)}
-              onSelect={(modId) => setActiveSkin(hero.id, modId)}
-              onToggleVariant={(modId) => toggleHeroVariant(hero.id, modId)}
-              onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
-              includedSkinKeys={shuffleIncluded}
-              onToggleShuffleIncluded={toggleShuffleIncluded}
-              shuffleVariantChoices={shuffleVariants}
-              onSetShuffleVariant={setShuffleVariant}
-              shuffleArmed={shuffleOnLaunch}
-              isFavorite={favoriteHeroes.includes(hero.id)}
-              onToggleFavorite={() =>
-                setFavoriteHeroes((prev) =>
-                  prev.includes(hero.id)
-                    ? prev.filter((id) => id !== hero.id)
-                    : [...prev, hero.id]
-                )
-              }
-              hideNsfwPreviews={shouldBlurNsfw(settings)}
-            />
+              className={`rounded-lg ${heroTypeaheadCardState(hero.id)}`}
+            >
+              <HeroCard
+                hero={hero}
+                mods={heroMods.map.get(hero.id) ?? []}
+                sounds={heroSounds.map.get(hero.id) ?? []}
+                hasAbilityRecolor={Boolean(abilityRecolorSupport[hero.name])}
+                cardImage={heroCardImage(hero.id)}
+                expanded={expandedHeroes.has(hero.id)}
+                onToggleExpanded={() => toggleHeroExpanded(hero.id)}
+                onBrowseSkins={() => openHeroInBrowse(hero)}
+                onSelect={(modId) => setActiveSkin(hero.id, modId)}
+                onToggleVariant={(modId) => toggleHeroVariant(hero.id, modId)}
+                onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
+                includedSkinKeys={shuffleIncluded}
+                onToggleShuffleIncluded={toggleShuffleIncluded}
+                shuffleVariantChoices={shuffleVariants}
+                onSetShuffleVariant={setShuffleVariant}
+                shuffleArmed={shuffleOnLaunch}
+                isFavorite={favoriteHeroes.includes(hero.id)}
+                onToggleFavorite={() =>
+                  setFavoriteHeroes((prev) =>
+                    prev.includes(hero.id)
+                      ? prev.filter((id) => id !== hero.id)
+                      : [...prev, hero.id]
+                  )
+                }
+                hideNsfwPreviews={shouldBlurNsfw(settings)}
+              />
+            </div>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

- add Deadlock-style keyboard typeahead to the Locker hero overview without introducing a search field
- use prefix matching for the first character and substring matching for longer queries
- highlight matches immediately while dimming nonmatches in both Gallery and List views
- preserve the normal card state when a query has no matches
- fade the typed query while keeping its highlight, with Backspace clearing a persisted result after the text expires
- protect fields, dialogs, drill-ins, and focused interactive controls from global key capture

## Why

The Locker roster is visual and already optimized for browsing. Invisible typeahead makes jumping to a known hero much faster without adding permanent UI or rearranging the grid.

The timing is tuned for both fast and slower typists: every accepted key resets the window, text holds for 700ms and fades over 1500ms, typing during the fade restores it immediately, and a new query starts only after the full 2200ms expiry.

## Screenshot

<img src="https://raw.githubusercontent.com/oldreceipt/grimoire/assets/locker-hero-typeahead/.github/pr-assets/locker-hero-typeahead/graves-match.png" width="900" alt="Locker hero grid with Graves highlighted and nonmatching heroes dimmed after typing GRAV">

## UX and performance review

- independently reviewed fast typing, slow typing, timer races, Backspace behavior, focused controls, and visual hierarchy
- removed card transitions so feedback appears on the same frame as input
- use opacity-only dimming to avoid unnecessary per-card GPU filters
- per-key matching remains linear over the small visible roster; no PR-blocking performance concerns found

## Validation

- `pnpm test` — 54 files, 671 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm i18n:check`
- locale manifest check
- `pnpm build`
- independent standards and spec reviews
