### PR TITLE
docs: document the side-by-side grimoire-social checkout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,46 @@ Thanks for your interest in contributing.
 Requirements:
 
 - [Node.js](https://nodejs.org/) 20+
-- [pnpm](https://pnpm.io/) 9+
+- [pnpm](https://pnpm.io/) 10+ (pnpm 9 mis-links the out-of-root workspace package below)
 - [Git](https://git-scm.com/)
+
+Grimoire shares its wire-format types with its companion service,
+[grimoire-social](https://github.com/Slush97/grimoire-social) (also open source),
+through the `@grimoire/social-types` workspace package. `pnpm-workspace.yaml`
+resolves it from `../grimoire-social/packages/social-types`, so **the two repos
+have to sit side by side** and grimoire-social needs its own install (that's
+where the `zod` peer dependency comes from). Cloning grimoire alone fails with
+`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.
 
 ```bash
 git clone https://github.com/Slush97/grimoire.git
-cd grimoire
+git clone https://github.com/Slush97/grimoire-social.git
+
+cd grimoire-social
+pnpm install
+
+cd ../grimoire
 pnpm install
 pnpm exec electron-rebuild -f -w better-sqlite3
 pnpm dev
+```
+
+You end up with:
+
+```
+parent-dir/
+  grimoire/
+  grimoire-social/
+```
+
+`pnpm dev` needs nothing else: the social client falls back to
+`http://localhost:8787` (wrangler dev) when `GRIMOIRE_SOCIAL_BASE_URL` is unset,
+and nothing else in the app depends on the service being up. The `package:*`
+scripts do refuse to build without `GRIMOIRE_SOCIAL_BASE_URL` set to an https
+URL, so pass one if you're producing installers locally:
+
+```bash
+GRIMOIRE_SOCIAL_BASE_URL=https://example.invalid pnpm package:linux
 ```
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -80,15 +80,29 @@ Offline-first and no telemetry: a fresh install phones home for nothing.
 
 ## Development
 
+Grimoire shares wire-format types with its companion service,
+[grimoire-social](https://github.com/Slush97/grimoire-social), through a
+workspace package resolved from `../grimoire-social`. Clone both side by side,
+or `pnpm install` fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. Needs Node 20+
+and pnpm 10+.
+
 ```bash
 git clone https://github.com/Slush97/grimoire.git
-cd grimoire
+git clone https://github.com/Slush97/grimoire-social.git
+
+cd grimoire-social
+pnpm install
+
+cd ../grimoire
 pnpm install
 pnpm exec electron-rebuild -f -w better-sqlite3
 pnpm dev
 ```
 
-Package builds: `pnpm package:win` or `pnpm package:linux`.
+Package builds: `pnpm package:win` or `pnpm package:linux` (both require
+`GRIMOIRE_SOCIAL_BASE_URL` set to an https URL).
+
+More detail in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Security
 


### PR DESCRIPTION
`pnpm-workspace.yaml` resolves `@grimoire/social-types` from `../grimoire-social/packages/social-types`, so cloning grimoire on its own fails at install with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. CI works because it checks out both repos; local dev works because both sit side by side. Neither the README nor CONTRIBUTING mentioned any of that.

Documents the two-repo clone (install in grimoire-social first, that's where the `zod` peer dep resolves), bumps the stated pnpm floor to 10 since 9 mis-links the out-of-root package, and notes that `pnpm dev` needs no env while `package:*` requires `GRIMOIRE_SOCIAL_BASE_URL`.

Closes #317
