### PR TITLE
fix(settings): Performance Config discoverability and sync state across panes

### DIFF
--- a/src/components/settings/BackgroundGradientPicker.tsx
+++ b/src/components/settings/BackgroundGradientPicker.tsx
@@ -46,8 +46,10 @@ function GradientTile({
       style={{ background: gradient ? backgroundGradientPreviewCss(gradient) : BACKGROUND_BASE }}
     >
       {children}
+      {/* Ringed badge: it is accent-colored and the swatch under it can be any
+          hue, so on the warm presets it would otherwise sit orange-on-amber. */}
       {active && (
-        <span className="absolute right-1 top-1 rounded-sm bg-accent p-0.5 text-accent-foreground">
+        <span className="absolute right-1 top-1 rounded-sm bg-accent p-0.5 text-accent-foreground ring-1 ring-black/40">
           <Check className="h-2.5 w-2.5" aria-hidden />
         </span>
       )}
@@ -176,7 +178,7 @@ export default function BackgroundGradientPicker() {
             aria-hidden
           />
           {isCustomActive && (
-            <span className="absolute right-1 top-1 rounded-sm bg-accent p-0.5 text-accent-foreground">
+            <span className="absolute right-1 top-1 rounded-sm bg-accent p-0.5 text-accent-foreground ring-1 ring-black/40">
               <Check className="h-2.5 w-2.5" aria-hidden />
             </span>
           )}

--- a/src/components/settings/sections/ExperimentalSection.tsx
+++ b/src/components/settings/sections/ExperimentalSection.tsx
@@ -1,14 +1,21 @@
 import { useState } from 'react';
-import { Beaker, Wrench } from 'lucide-react';
+import { ArrowRight, Beaker, Wrench } from 'lucide-react';
 import { useAppStore } from '../../../stores/appStore';
 import { createDevDeadlockPath } from '../../../lib/api';
 import { Card, Toggle } from '../../common/ui';
 import Tx from '../../translation/Tx';
 import type { AppSettings } from '../../../types/mod';
 
+interface ExperimentalSectionProps {
+  /** Jump to the pane that actually holds the Performance Config controls.
+   *  Named for the intent rather than the destination so this section never
+   *  has to know the page's section ids. */
+  onShowPerformanceConfig?: () => void;
+}
+
 // Feature flags plus the dev-only dummy game directory. Both are "you asked
 // for it" territory, so they live away from the everyday preferences.
-export default function ExperimentalSection() {
+export default function ExperimentalSection({ onShowPerformanceConfig }: ExperimentalSectionProps) {
   const { settings, saveSettings } = useAppStore();
   const [isCreatingDevPath, setIsCreatingDevPath] = useState(false);
 
@@ -102,12 +109,34 @@ export default function ExperimentalSection() {
 
           <div className="h-px bg-white/5" />
 
-          <Toggle
-            checked={settings?.experimentalPerformanceConfig ?? false}
-            onChange={(checked) => update({ experimentalPerformanceConfig: checked })}
-            label={<Tx k="settings.experimental.performanceConfig" fallback="Performance Config" />}
-            description={<Tx k="settings.toggles.performanceConfig" fallback="One-click fps boost using Sqooky's community preset. Mods keep working. Remove any time." />}
-          />
+          {/* This is the one flag whose payload lands in a different pane: the
+              card it unlocks renders under Game setup, so without a pointer the
+              toggle looks like it did nothing. Wrapped with the toggle so the
+              two are a single child of the space-y-6 stack (a negative margin
+              would lose to space-y's higher-specificity rule). */}
+          <div>
+            <Toggle
+              checked={settings?.experimentalPerformanceConfig ?? false}
+              onChange={(checked) => update({ experimentalPerformanceConfig: checked })}
+              label={<Tx k="settings.experimental.performanceConfig" fallback="Performance Config" />}
+              description={<Tx k="settings.toggles.performanceConfig" fallback="One-click fps boost using Sqooky's community preset. Mods keep working. Remove any time." />}
+            />
+            {settings?.experimentalPerformanceConfig && onShowPerformanceConfig && (
+              <div className="mt-2 pl-14">
+                <button
+                  type="button"
+                  onClick={onShowPerformanceConfig}
+                  className="inline-flex items-center gap-1 rounded-sm text-xs text-accent transition-colors cursor-pointer hover:text-accent-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
+                >
+                  <Tx
+                    k="settings.experimental.performanceConfigWhere"
+                    fallback="Open its controls in Game setup"
+                  />
+                  <ArrowRight className="h-3 w-3" aria-hidden />
+                </button>
+              </div>
+            )}
+          </div>
 
           <div className="h-px bg-white/5" />
 

--- a/src/components/settings/sections/MaintenanceSection.tsx
+++ b/src/components/settings/sections/MaintenanceSection.tsx
@@ -53,6 +53,17 @@ export default function MaintenanceSection() {
       .catch(() => setPreviewCacheBytes(null));
   }, []);
 
+  // A sync outlives this component: it runs in main, and switching settings
+  // panes unmounts us. Ask main whether one is already running so we come back
+  // showing the spinner instead of an idle button that quietly no-ops (main
+  // refuses a second sync while one is in flight).
+  useEffect(() => {
+    window.electronAPI
+      .isSyncInProgress()
+      .then(setIsSyncing)
+      .catch(() => {});
+  }, []);
+
   // Listen for sync progress
   useEffect(() => {
     const unsub = window.electronAPI.onSyncProgress((data) => {
@@ -60,6 +71,9 @@ export default function MaintenanceSection() {
         setSyncProgress({ section: data.section, modsProcessed: data.modsProcessed, totalMods: data.totalMods });
       } else if (data.phase === 'complete') {
         setSyncProgress(null);
+        // Also clears the button for a sync we adopted on mount rather than
+        // started ourselves: that one has no handler waiting on it to finish.
+        setIsSyncing(false);
         // Reload sync status after completion
         window.electronAPI.getSyncStatus().then(setSyncStatus);
       }

--- a/src/lib/backgroundGradient.ts
+++ b/src/lib/backgroundGradient.ts
@@ -24,7 +24,10 @@ export const BACKGROUND_GRADIENT_PRESETS: BackgroundGradientPreset[] = [
   { id: 'verdant', name: 'Verdant', from: '#10b981', to: '#84cc16' },
   { id: 'nebula',  name: 'Nebula',  from: '#6366f1', to: '#f43f5e' },
   { id: 'gold',    name: 'Gold',    from: '#f59e0b', to: '#eab308' },
-  { id: 'ash',     name: 'Ash',     from: '#64748b', to: '#1e293b' },
+  // Slate rather than slate-into-navy: #1e293b over a #0f0f0f base lands about
+  // seven points off the background, so the old pairing rendered as a single
+  // grey smudge and its swatch was indistinguishable from "No glow".
+  { id: 'ash',     name: 'Ash',     from: '#94a3b8', to: '#64748b' },
 ];
 
 /** Peak alpha at each corner. Low enough that body text over the glow keeps
@@ -48,26 +51,43 @@ function rgba(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-/**
- * The `background` shorthand for a gradient. Sizes are percentages so the same
- * string works on a full window and on a 56px preview tile.
- *
- * `intensity` scales the peak alpha: the preview tiles run a little hotter than
- * the real layer, because at thumbnail size a whisper of color reads as nothing.
- */
-export function backgroundGradientCss(gradient: BackgroundGradient, intensity = 1): string {
-  const alpha = GLOW_ALPHA * intensity;
-  // Radii stay well under half the viewport so the two glows hug their corners
-  // and never meet in the middle: the center of the page stays neutral.
+interface GlowGeometry {
+  /** Peak alpha at each corner. */
+  alpha: number;
+  /** Radial-gradient size, as percentages of the painted box. */
+  size: string;
+  /** Where the color has faded out entirely. */
+  stop: string;
+}
+
+/** The real layer. Radii stay well under half the viewport so the two glows hug
+ *  their corners and never meet in the middle: the center of the page stays
+ *  neutral, and text over it keeps its contrast. */
+const LAYER: GlowGeometry = { alpha: GLOW_ALPHA, size: '55% 50%', stop: '70%' };
+
+/** Swatches identify a preset; they do not simulate it. Reusing the layer's
+ *  geometry on an 80x48 tile tints only about a quarter of it and leaves the
+ *  rest flat #0f0f0f, so every preset read as the same near-black rectangle
+ *  sitting under a row of vivid accent chips. Swatches therefore get much
+ *  larger radii and a higher alpha: both colors are legible at thumbnail size
+ *  and the two glows meet in the middle instead of hugging opposite corners. */
+const SWATCH: GlowGeometry = { alpha: 0.7, size: '120% 110%', stop: '88%' };
+
+function glowLayers(gradient: BackgroundGradient, { alpha, size, stop }: GlowGeometry): string {
   return [
-    `radial-gradient(55% 50% at 0% 0%, ${rgba(gradient.from, alpha)} 0%, transparent 70%)`,
-    `radial-gradient(55% 50% at 100% 100%, ${rgba(gradient.to, alpha)} 0%, transparent 70%)`,
+    `radial-gradient(${size} at 0% 0%, ${rgba(gradient.from, alpha)} 0%, transparent ${stop})`,
+    `radial-gradient(${size} at 100% 100%, ${rgba(gradient.to, alpha)} 0%, transparent ${stop})`,
   ].join(', ');
 }
 
-/** Preview tile background: the glow over the app's own base color. */
+/** The `background` shorthand for the real, full-window glow layer. */
+export function backgroundGradientCss(gradient: BackgroundGradient): string {
+  return glowLayers(gradient, LAYER);
+}
+
+/** Swatch background: the bolder preview glow over the app's own base color. */
 export function backgroundGradientPreviewCss(gradient: BackgroundGradient): string {
-  return `${backgroundGradientCss(gradient, 1.6)}, ${BACKGROUND_BASE}`;
+  return `${glowLayers(gradient, SWATCH)}, ${BACKGROUND_BASE}`;
 }
 
 /** True when both corners match, ignoring hex case. */

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -814,6 +814,7 @@
       "vpkImprint": "Imprint installed mods",
       "deadworksServers": "Deadworks Servers",
       "performanceConfig": "Performance Config",
+      "performanceConfigWhere": "Open its controls in Game setup",
       "foundry": "Door Stuck"
     },
     "support": {

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2070,
+  "totalKeys": 2071,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2070,
+      "translatedKeys": 2071,
       "pct": 100
     },
     {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -120,7 +120,9 @@ export default function Settings() {
             </Card>
           )}
           {section === 'updates' && <UpdatesSection />}
-          {section === 'experimental' && <ExperimentalSection />}
+          {section === 'experimental' && (
+            <ExperimentalSection onShowPerformanceConfig={() => setActiveSection('game')} />
+          )}
           {section === 'maintenance' && <MaintenanceSection />}
           {section === 'support' && <SupportSection />}
         </div>


### PR DESCRIPTION
Two follow-ups to #316, which split the Settings page into a nav plus per-category panes.

## Performance Config was findable only by accident

It is the one experimental flag whose payload lands in a *different* pane. The toggle is in **Advanced > Experimental Features**; the `PerformanceConfigCard` it unlocks renders in **Game > Game setup** (`GameSection.tsx:330`). Before the split both lived in one continuous scroll about thirty lines apart, so flipping the toggle showed you the card. After it, the toggle appears to do nothing.

Enabling the flag now reveals a link to the pane that holds the controls. The other flags are fine: Deadworks and Door Stuck add a visible sidebar tab, and Social already adds its own nav entry.

The callback is named `onShowPerformanceConfig` rather than something like `onNavigate` so the section never needs to know the page's section ids.

## Maintenance forgot an in-flight catalog sync

Sync state lived purely in `MaintenanceSection` local state, but a sync runs in main and outlives the component. Switching panes mid-sync unmounted it, and coming back showed an idle-looking Sync button. Pressing it was harmless (`syncService.ts:207` refuses a concurrent sync) but read as broken.

It now asks main via the existing `isSyncInProgress()` channel, and the `complete` phase clears the button for a sync adopted on mount, which has no `finally` waiting on it. `UpdatesSection` already did the equivalent by re-fetching `updater.getStatus()`; this brings Maintenance in line.

## Deliberately not changed

- **Browse's sticky header going translucent + `backdrop-blur-md` under an active glow.** Correctly gated so users without a glow pay nothing. Judging blur cost over that grid needs a scroll measurement with a large catalog, not a guess. Still worth a look before it reaches a release.
- **URL-addressable panes, and `aria-current` vs a real tablist.** A tablist without roving tabindex and arrow keys is worse than the buttons it would replace.

## Verification

`typecheck`, `lint`, `i18n:check` (1829 keys OK), `gen-locale-manifest --check`, and `vitest` (671 passing) all green. One new en key, `manifest.json` regenerated as required. Verified live over HMR in `pnpm dev`.