### PR TITLE
fix(appearance): blend sticky headers with app background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -155,6 +155,19 @@ body {
   font-family: var(--font-radiance);
 }
 
+/* Repaint the app's fixed ambient background inside sticky chrome. This keeps
+   content scrolling underneath opaque without turning the chrome into a flat
+   strip: fixed attachment anchors the same glow to the same viewport pixels as
+   Layout's full-window layer. */
+.app-background-fixed {
+  background-color: var(--color-bg-primary);
+  background-image: var(--app-bg-glow, none);
+  background-attachment: fixed;
+  background-position: 0 0;
+  background-repeat: no-repeat;
+  background-size: 100vw 100vh;
+}
+
 /* Themed scrollbars */
 * {
   scrollbar-width: thin;

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -3062,12 +3062,17 @@ export default function Browse() {
       <div className="flex-1 min-w-0 h-full overflow-y-auto" ref={scrollContainerRef}>
       {/* Header: artist banner in artist mode, otherwise the search/filter row. */}
       {/* Solid by default. A solid bg-primary band would read as a flat patch
-          over an active background glow, so only then does it go translucent:
-          backdrop-blur over this (large, frequently scrolled) grid is not a cost
-          worth paying for users who never turned a glow on. */}
+          over an active background glow, so only then does it go translucent.
+          The transparent-sidebar option repaints the same fixed app background
+          inside the band. That preserves the corner glow at its viewport
+          position while hiding content that scrolls beneath the sticky header. */}
       <div
         className={`sticky top-0 z-40 p-4 border-b border-border ${
-          settings?.backgroundGradient ? 'bg-bg-primary/80 backdrop-blur-md' : 'bg-bg-primary'
+          settings?.sidebarTransparent
+            ? 'app-background-fixed'
+            : settings?.backgroundGradient
+              ? 'bg-bg-primary/80 backdrop-blur-md'
+              : 'bg-bg-primary'
         }`}
       >
         {artistMode && submitter ? (

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -3991,7 +3991,13 @@ export default function Installed() {
 
   return (
     <div ref={installedScrollRef} className="h-full overflow-y-auto px-4 pb-5 sm:px-6">
-      <div className="sticky top-0 z-30 -mx-4 mb-4 border-b border-white/5 bg-bg-primary/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-bg-primary/80 sm:-mx-6 sm:px-6">
+      <div
+        className={`sticky top-0 z-30 -mx-4 mb-4 border-b border-white/5 px-4 py-3 sm:-mx-6 sm:px-6 ${
+          settings?.sidebarTransparent
+            ? 'app-background-fixed'
+            : 'bg-bg-primary/95 backdrop-blur supports-[backdrop-filter]:bg-bg-primary/80'
+        }`}
+      >
         {/* Row 1: search + view controls. The search takes every pixel the
             controls don't need (uncapped flex-1) so there's no dead gap at wide
             window widths, and shrinks to min-w instead of pushing the controls


### PR DESCRIPTION
## Summary
- make Installed and Browse sticky headers follow the transparent-sidebar setting
- repaint the fixed app background inside those headers so the ambient corner glow stays aligned
- keep scrolling content from bleeding through the sticky toolbar

## Validation
- `pnpm exec eslint src/pages/Browse.tsx src/pages/Installed.tsx`
- `pnpm typecheck`
- `GRIMOIRE_SOCIAL_BASE_URL=https://grimoire-social.example.workers.dev pnpm build`