### PR TITLE
fix(browse): filters that silently did nothing on the local catalog route

### DIFF
--- a/electron/main/services/searchService.ts
+++ b/electron/main/services/searchService.ts
@@ -82,6 +82,56 @@ function applyContentFilters(
     }
 }
 
+/**
+ * Category/hero scoping, shared by the FTS and fallback paths.
+ *
+ * The cached catalog has no usable `category_id`. GameBanana's list endpoint
+ * returns `_aRootCategory` with a name but no `_idRow`, so sync writes null for
+ * every row (6625 of 6625 on a full mirror). Matching on it therefore returned
+ * nothing, silently: no rows, no error, no fallback. It stayed hidden because a
+ * category filter only routes to the local catalog when some *other*
+ * catalog-only filter is already active (a search, an NSFW or date window, or
+ * any hidden creator), so most installs never saw it, and the ones that did saw
+ * an empty grid rather than a failure.
+ *
+ * `category_name` is stored, so the renderer resolves the picked category to its
+ * root name and we match on that instead. A root-level pick is exact; a
+ * subcategory pick widens to its root rather than returning nothing, which is
+ * the best the cached columns allow. The id comparison stays as a last resort
+ * for the day rows carry real ids.
+ */
+function applyCategoryFilter(
+    conditions: string[],
+    params: Record<string, unknown>,
+    categoryId: SearchOptions['categoryId'],
+    categoryName: SearchOptions['categoryName'],
+    heroName: SearchOptions['heroName'],
+    skinsCategoryId: SearchOptions['skinsCategoryId']
+): void {
+    if (categoryId === undefined) return;
+
+    if (heroName && skinsCategoryId !== undefined) {
+        // Hero search: find ALL mods with the hero name in the title, whatever
+        // their category. Same missing-id constraint as above, which is why this
+        // cannot simply scope to the hero's subcategory.
+        params.heroNamePattern = `%${heroName.toLowerCase()}%`;
+        conditions.push('LOWER(mods.name) LIKE @heroNamePattern');
+        console.log(`[searchMods] Hero search: heroName="${heroName}" (searching all categories)`);
+        return;
+    }
+
+    if (categoryName) {
+        params.categoryName = categoryName;
+        conditions.push('mods.category_name = @categoryName COLLATE NOCASE');
+        console.log(`[searchMods] Category search: categoryName="${categoryName}" (root category of ${categoryId})`);
+        return;
+    }
+
+    conditions.push('mods.category_id = @categoryId');
+    params.categoryId = categoryId;
+    console.log(`[searchMods] Category search: falling back to category_id=${categoryId} (no root name resolved)`);
+}
+
 /** Exclude hidden GameBanana submitters at query time so counts and pagination
  *  describe the visible catalog. Null submitter ids remain visible because
  *  there is no stable creator identity to compare against. */
@@ -118,19 +168,26 @@ function applyHiddenCreatorFilter(
 function runFallbackSubstringSearch(
     database: ReturnType<typeof initDatabase>,
     rawQuery: string,
-    section: string | undefined,
-    categoryId: number | undefined,
-    heroName: string | undefined,
-    skinsCategoryId: number | undefined,
-    sortBy: SearchOptions['sortBy'],
-    nsfw: SearchOptions['nsfw'],
-    addedWithin: SearchOptions['addedWithin'],
-    addedFrom: number | undefined,
-    addedTo: number | undefined,
-    hiddenCreatorIds: SearchOptions['hiddenCreatorIds'],
+    // Every scoping value here is forwarded verbatim from the caller's options.
+    // Passing the object rather than fourteen positional arguments is what stops
+    // a new filter from being silently threaded into the wrong slot.
+    options: SearchOptions,
     limit: number,
     offset: number
 ): SearchResult {
+    const {
+        section,
+        categoryId,
+        categoryName,
+        heroName,
+        skinsCategoryId,
+        sortBy,
+        nsfw,
+        addedWithin,
+        addedFrom,
+        addedTo,
+        hiddenCreatorIds,
+    } = options;
     const conditions: string[] = [];
     const params: Record<string, unknown> = {};
 
@@ -153,16 +210,7 @@ function runFallbackSubstringSearch(
         params.section = section;
     }
 
-    if (categoryId !== undefined) {
-        if (heroName && skinsCategoryId !== undefined) {
-            params.heroNamePattern = `%${heroName.toLowerCase()}%`;
-            conditions.push('LOWER(mods.name) LIKE @heroNamePattern');
-        } else {
-            conditions.push('mods.category_id = @categoryId');
-            params.categoryId = categoryId;
-        }
-    }
-
+    applyCategoryFilter(conditions, params, categoryId, categoryName, heroName, skinsCategoryId);
     applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
     applyHiddenCreatorFilter(conditions, params, hiddenCreatorIds);
 
@@ -199,6 +247,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         query,
         section,
         categoryId,
+        categoryName,
         heroName,
         skinsCategoryId,
         sortBy = 'relevance',
@@ -248,21 +297,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         params.section = section;
     }
 
-    // Filter by category/hero with name-based search for hero filtering
-    if (categoryId !== undefined) {
-        if (heroName && skinsCategoryId !== undefined) {
-            // Hero search: Find ALL mods with hero name in title, regardless of category.
-            // This catches mods in Skins, Skins/Mina, and even mods in other categories.
-            params.heroNamePattern = `%${heroName.toLowerCase()}%`;
-            conditions.push('LOWER(mods.name) LIKE @heroNamePattern');
-            console.log(`[searchMods] Hero search: heroName="${heroName}" (searching all categories)`);
-        } else {
-            // Standard category filter
-            conditions.push('mods.category_id = @categoryId');
-            params.categoryId = categoryId;
-        }
-    }
-
+    applyCategoryFilter(conditions, params, categoryId, categoryName, heroName, skinsCategoryId);
     applyContentFilters(conditions, params, nsfw, addedWithin, addedFrom, addedTo);
     applyHiddenCreatorFilter(conditions, params, hiddenCreatorIds);
 
@@ -295,16 +330,7 @@ export function searchMods(options: SearchOptions): SearchResult {
         return runFallbackSubstringSearch(
             database,
             query.slice(0, 500),
-            section,
-            categoryId,
-            heroName,
-            skinsCategoryId,
-            sortBy,
-            nsfw,
-            addedWithin,
-            addedFrom,
-            addedTo,
-            hiddenCreatorIds,
+            { ...options, sortBy, nsfw, addedWithin },
             limit,
             offset
         );

--- a/src/components/common/HeroSelect.test.tsx
+++ b/src/components/common/HeroSelect.test.tsx
@@ -22,8 +22,17 @@ function BrowseFilterHarness() {
         setFiltersOpen(false);
       }
     };
+    // Mirrors AnchoredPopover's dismiss-on-Escape. One Escape has to back out
+    // of the hero listbox without taking the popover hosting it down too.
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setFiltersOpen(false);
+    };
     window.addEventListener('mousedown', onMouseDown);
-    return () => window.removeEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
   }, [filtersOpen]);
 
   return (
@@ -117,6 +126,53 @@ describe('HeroSelect inside a dismissable popover', () => {
 
     expect(document.querySelector('[data-testid="filter-popover"]')).not.toBeNull();
     expect(document.querySelector('[data-testid="selected-hero"]')?.textContent).toBe('abrams');
+  });
+
+  it('closes only the listbox on Escape, leaving the parent popover open', () => {
+    act(() => root.render(<BrowseFilterHarness />));
+
+    openHeroSelect();
+    expect(document.querySelector('[role="listbox"]')).not.toBeNull();
+
+    // Focus lands on the search box when the listbox opens, so that is where a
+    // real Escape originates.
+    act(() => {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.querySelector('[data-testid="filter-popover"]')).not.toBeNull();
+
+    // A second Escape, now that the listbox is gone, belongs to the popover.
+    act(() => {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(document.querySelector('[data-testid="filter-popover"]')).toBeNull();
+  });
+
+  it('closes only the listbox on Escape from an option, not the parent popover', () => {
+    act(() => root.render(<BrowseFilterHarness />));
+
+    openHeroSelect();
+    const input = document.querySelector<HTMLInputElement>('input[aria-label="Search heroes"]');
+    act(() => {
+      input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+    expect(document.activeElement?.getAttribute('role')).toBe('option');
+
+    act(() => {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.querySelector('[data-testid="filter-popover"]')).not.toBeNull();
   });
 
   it('filters heroes as the user types and offers a useful empty state', () => {

--- a/src/components/common/HeroSelect.tsx
+++ b/src/components/common/HeroSelect.tsx
@@ -287,11 +287,6 @@ export function HeroSelect({
         event.preventDefault();
         focusOption(visibleOptions.length - 1);
         break;
-      case 'Escape':
-        event.preventDefault();
-        closeSelect();
-        buttonRef.current?.focus();
-        break;
       case 'Enter':
       case ' ':
         event.preventDefault();
@@ -310,12 +305,25 @@ export function HeroSelect({
         event.preventDefault();
         focusOption(visibleOptions.length - 1);
         break;
-      case 'Escape':
-        event.preventDefault();
-        closeSelect();
-        buttonRef.current?.focus();
-        break;
     }
+  };
+
+  /**
+   * Escape is handled once, at the portal root, rather than per control.
+   *
+   * Two reasons. Focus can sit on things with no key handler of their own (the
+   * clear-search button, the empty-state button), and those used to leak the
+   * key. More importantly the native keydown must stop here: an ancestor
+   * popover dismisses on a window-level Escape listener (see AnchoredPopover),
+   * so a key that only closed this listbox was collapsing the whole filter
+   * panel with it.
+   */
+  const handleListboxKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    event.stopPropagation();
+    closeSelect();
+    buttonRef.current?.focus();
   };
 
   const clearSearch = () => {
@@ -356,6 +364,7 @@ export function HeroSelect({
           // Keep its mouse gesture inside this logical boundary so an ancestor's
           // window-level outside-click listener cannot unmount us before click.
           onMouseDown={(event) => event.stopPropagation()}
+          onKeyDown={handleListboxKeyDown}
           // z-80 is the context-menu/popover rung of the ladder in index.css:
           // portaled to <body>, this has to clear modals and page chrome alike.
           // Positioned by positionListbox before paint; the inline top/left are

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1474,6 +1474,33 @@ export default function Browse() {
       ? (categoryId === 'all' ? undefined : categoryId)
       : heroCategoryId;
 
+  // Category id -> the name of its ROOT category.
+  //
+  // The local catalog cannot be filtered by category id at all: GameBanana's
+  // list endpoint omits `_aRootCategory._idRow`, so every cached row has a null
+  // `category_id` and the id comparison matched nothing. Only the root category
+  // *name* is stored, so resolving the picked category to that name here is what
+  // lets a local-route category filter return anything.
+  //
+  // Walks the whole tree rather than reading `categoryOptions` so that ids which
+  // never reach the dropdown still map: hero subcategories, entries dropped for
+  // having no items, and stale ids restored from a previous session.
+  const rootCategoryNameById = useMemo(() => {
+    const map = new Map<number, string>();
+    const walk = (nodes: GameBananaCategoryNode[], rootName: string | null) => {
+      for (const node of nodes) {
+        const root = rootName ?? node.name;
+        map.set(node.id, root);
+        if (node.children?.length) walk(node.children, root);
+      }
+    };
+    walk(categories, null);
+    return map;
+  }, [categories]);
+
+  const effectiveCategoryName =
+    effectiveCategoryId === undefined ? undefined : rootCategoryNameById.get(effectiveCategoryId);
+
   // Debounce the search input: every keystroke previously fired a full FTS5
   // query + count + render, which felt slow even when the DB was fast. 250ms
   // is short enough that typing-to-results still feels responsive but long
@@ -1922,6 +1949,10 @@ export default function Browse() {
         query: effectiveSearch.trim() || undefined,
         section: section,
         categoryId: effectiveCategoryId,
+        // The cached rows have no category id, only a root category name; see
+        // rootCategoryNameById. Ignored when a hero is selected, which scopes by
+        // title instead.
+        categoryName: effectiveCategoryName,
         // Enhanced hero search: pass hero name and skins parent ID
         heroName: selectedHeroName,
         skinsCategoryId: skinsCat?.id,
@@ -2005,7 +2036,7 @@ export default function Browse() {
         setLoadingMore(false);
       }
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, hiddenCreatorIds, modCategories, fetchFilterStamp]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, effectiveCategoryName, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, hiddenCreatorIds, modCategories, fetchFilterStamp]);
 
   // Value-compare gate for the filter-reset: remember what filters last
   // triggered a reset; only reset when the new combination is actually

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1527,7 +1527,10 @@ export default function Browse() {
     return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
   }, [addedWithin, addedTo]);
 
-  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
+  // The root name resolves asynchronously with the category tree. Keep it in
+  // the request identity so an early id-only local query cannot suppress the
+  // corrected name-based query when that tree arrives.
+  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${effectiveCategoryName ?? ''}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
   const browseResultsCacheRef = useRef<Map<string, BrowseResultCacheEntry>>(new Map());
   const browseScrollCacheRef = useRef<Map<string, number>>(new Map());
   const activeFetchFilterStampRef = useRef(fetchFilterStamp);

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1501,6 +1501,15 @@ export default function Browse() {
   const effectiveCategoryName =
     effectiveCategoryId === undefined ? undefined : rootCategoryNameById.get(effectiveCategoryId);
 
+  // Hero options always come from the Mod category tree, even while browsing
+  // Sound or Wip. Resolve this outside searchLocal so the asynchronously loaded
+  // name can participate in the request identity below.
+  const skinsCategory = findCategoryByName(modCategories, 'Skins');
+  const skinsCategoryId = skinsCategory?.id;
+  const selectedHeroName = heroCategoryId !== 'all' && skinsCategory?.children
+    ? skinsCategory.children.find((child) => child.id === heroCategoryId)?.name
+    : undefined;
+
   // Debounce the search input: every keystroke previously fired a full FTS5
   // query + count + render, which felt slow even when the DB was fast. 250ms
   // is short enough that typing-to-results still feels responsive but long
@@ -1527,10 +1536,10 @@ export default function Browse() {
     return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
   }, [addedWithin, addedTo]);
 
-  // The root name resolves asynchronously with the category tree. Keep it in
-  // the request identity so an early id-only local query cannot suppress the
-  // corrected name-based query when that tree arrives.
-  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${effectiveCategoryName ?? ''}|${heroCategoryId}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
+  // Category and hero names resolve asynchronously with their category trees.
+  // Keep both in the request identity so an early id-only local query cannot
+  // suppress the corrected name-based query when either tree arrives.
+  const fetchFilterStamp = `${effectiveSearch}|${sort}|${section}|${effectiveCategoryId}|${effectiveCategoryName ?? ''}|${heroCategoryId}|${selectedHeroName ?? ''}|${nsfw}|${addedWithin}|${customAddedFrom ?? ''}|${customAddedTo ?? ''}|${perPage}|${submitter?.id ?? ''}|${hiddenCreatorsStamp}`;
   const browseResultsCacheRef = useRef<Map<string, BrowseResultCacheEntry>>(new Map());
   const browseScrollCacheRef = useRef<Map<string, number>>(new Map());
   const activeFetchFilterStampRef = useRef(fetchFilterStamp);
@@ -1940,14 +1949,6 @@ export default function Browse() {
         name: 'name',
       };
 
-      // Hero list lives under Mod -> Skins, but we want the filter to work on
-      // any section (Sound mods include the hero name in the title), so always
-      // resolve the hero from the Mod-category tree.
-      const skinsCat = findCategoryByName(modCategories, 'Skins');
-      const selectedHeroName = heroCategoryId !== 'all' && skinsCat?.children
-        ? skinsCat.children.find(c => c.id === heroCategoryId)?.name
-        : undefined;
-
       const result = await window.electronAPI.searchLocalMods({
         query: effectiveSearch.trim() || undefined,
         section: section,
@@ -1958,7 +1959,7 @@ export default function Browse() {
         categoryName: effectiveCategoryName,
         // Enhanced hero search: pass hero name and skins parent ID
         heroName: selectedHeroName,
-        skinsCategoryId: skinsCat?.id,
+        skinsCategoryId,
         sortBy: sortMap[sort] || 'relevance',
         nsfw,
         addedWithin,
@@ -2039,7 +2040,7 @@ export default function Browse() {
         setLoadingMore(false);
       }
     }
-  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, effectiveCategoryName, heroCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, hiddenCreatorIds, modCategories, fetchFilterStamp]);
+  }, [page, effectiveSearch, section, sort, perPage, effectiveCategoryId, effectiveCategoryName, selectedHeroName, skinsCategoryId, nsfw, addedWithin, customAddedFrom, customAddedTo, hiddenCreatorIds, fetchFilterStamp]);
 
   // Value-compare gate for the filter-reset: remember what filters last
   // triggered a reset; only reset when the new combination is actually

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -391,6 +391,12 @@ export interface SearchLocalModsOptions {
     query?: string;
     section?: string;
     categoryId?: number;
+    /** Root category name for `categoryId`, resolved from the live category
+     *  tree. The cached catalog stores only a mod's root category *name* (the
+     *  list API omits `_aRootCategory._idRow`, so every cached `category_id` is
+     *  null), so this is what actually scopes a local category filter. Without
+     *  it the id comparison matches no rows at all. */
+    categoryName?: string;
     // Enhanced hero search
     heroName?: string;
     skinsCategoryId?: number;


### PR DESCRIPTION
Two Browse filter bugs found while investigating a Discord report ("Character Filter on Browse is bugged") that could not be reproduced on the maintainer's machine.

## 1. Escape collapsed the whole Filters panel

Escape inside the hero dropdown closed the listbox **and** the popover hosting it, in one keystroke. `HeroSelect`'s per-control Escape branches called `preventDefault()` but not `stopPropagation()`, so the native keydown carried on to `AnchoredPopover`'s window listener.

Escape is now handled once at the portal root and stopped there. Moving it off the option and search handlers also covers focus positions that had no key handler at all (the clear-search button, the empty-state button), which leaked the key the same way.

Verified against a real Electron build, not just jsdom:

```
before:  after Escape -> { filtersPanel: false, listbox: false }
after:   after Escape -> { filtersPanel: true,  listbox: false }
```

A second Escape still dismisses the panel.

## 2. The Category filter returned nothing on the local route

Picking a Category produced an empty grid whenever Browse routed to the local catalog.

Every cached row has a **null `category_id`** (6625 of 6625 on a full mirror). GameBanana's list endpoint returns `_aRootCategory` with a name but no `_idRow`, so `syncService` writes null and `mods.category_id = @categoryId` matches nothing: no rows, no error, no fallback.

It stayed hidden because a category filter on its own routes remote. It only goes local when another catalog-only filter is already active, and `useLocalSearch` counts `hiddenCreatorIds.length > 0` as one of those. **Any hidden creator therefore pins every Browse query to the one backend that cannot answer a category filter.** That is why the report read as platform-specific: the reporter's Linux install had ten hidden creators, his Windows install had none.

`category_name` *is* stored, so the renderer now resolves the picked category to its root name and the query matches on that.

Against a real 6625-row catalog:

| predicate | rows |
|---|---|
| `category_id = 33327` (old) | 0 |
| `category_name = 'Skins'` | 2238 |
| `category_name = 'HUD'` | 371 |
| `category_name = 'maps'` (case-insensitive) | 31 |

### Known limitation

`category_name` holds the **root** category only, while the dropdown flattens subcategories too. Root-level picks are exact; subcategory picks widen to their root rather than returning nothing. Making them exact needs real ids backfilled (a per-mod detail fetch, or a name-to-id map built from the live tree). Tracked as follow-up, not in this PR.

## Also in here

- The duplicated category logic in the FTS and substring-fallback paths is folded into one `applyCategoryFilter` helper so the two cannot drift. The fallback's copy had no logging at all.
- `runFallbackSubstringSearch` now takes its options object instead of fourteen positional arguments, every one of which was already forwarded verbatim from the same object.
- A `[searchMods] Category search: ...` trace line, so the next diagnostic report shows which path a category filter took.

## Testing

- Two regression tests added to `HeroSelect.test.tsx` covering Escape from the search box and from an option. The existing harness only modelled outside-click, so it gained a window-level Escape listener mirroring `AnchoredPopover`.
- Full suite green: 55 files, 724 tests.
- `pnpm typecheck` and eslint clean.

**Not verified:** the runtime path of `categoryName` through the actual UI. `tsc -b` covers the contract across all three files and the IPC handler forwards the options object as-is, so there is no mapping layer to get wrong, but a manual click of a Category with a hidden creator set is worth doing before release.
