### PR TITLE
fix(sidebar): clear scrollbar track when transparent

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -862,7 +862,12 @@ export default function Sidebar() {
         </button>
       </div>
 
-      <nav ref={navScrollRef} className="flex-1 min-h-0 overflow-y-auto p-2">
+      <nav
+        ref={navScrollRef}
+        className={`flex-1 min-h-0 overflow-y-auto p-2 ${
+          transparentSidebar ? 'scrollbar-track-transparent' : ''
+        }`}
+      >
         <div className="relative">
           <ul ref={navListRef} className="relative z-10 space-y-0.5">
             {navItems.map(({ to, icon: Icon, labelKey, label, tooltip, tone, badge, badgeTone }, index) => {

--- a/src/index.css
+++ b/src/index.css
@@ -193,6 +193,22 @@ body {
   background: var(--color-accent);
 }
 
+/* A transparent surface must not inherit the default solid scrollbar track.
+   Keep the normal themed thumb, but let the app background continue beneath
+   the gutter instead of painting a bg-secondary strip. */
+.scrollbar-track-transparent {
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.scrollbar-track-transparent::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-track-transparent::-webkit-scrollbar-thumb {
+  border-color: transparent;
+  background-clip: padding-box;
+}
+
 /* Scrollbar variant for panels that sit over imagery (the Locker hero detail
    and Global drill-in shells use a feathered frosted-glass background with a
    transparent panel). The default solid bg-secondary track would paint a hard


### PR DESCRIPTION
## Summary
- make the sidebar navigation scrollbar track transparent when Transparent sidebar is enabled
- retain the themed scrollbar thumb and hover state
- leave scrollbars on opaque surfaces unchanged

## Verification
- `pnpm typecheck`
- `pnpm eslint src/components/Sidebar.tsx`
- `git diff --check`