### PR TITLE
chore(release): v1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump only. No functional changes.

Cuts v1.26.0 over the nine PRs merged since v1.25.1:

- #315 Locker hero typeahead highlighting (@oldreceipt) + #319 follow-ups
- #316 Categorized settings navigation (@Skeptic-systems), background glow, transparent sidebar
- #318 Document the side-by-side grimoire-social checkout (closes #317)
- #320 Performance Config discoverability and sync state across panes
- #321 Blend sticky headers with app background
- #322 Browse filters that silently did nothing on the local catalog route
- #323 Six pinned, selectable fps presets
- #324 Clear sidebar scrollbar track when transparent

Minor rather than patch: the settings restructure plus the preset rework is a themed pass, not a fix batch.

Verified on this branch before pushing: `pnpm lint`, `tsc -b`, `vitest run` (730 passed / 55 files), `i18n:check`, locale manifest `--check`, `perf:presets --check` (in sync with pinned upstreams), and a full `electron-vite build`. A local `Grimoire-1.26.0.AppImage` was packaged and launched clean.

Release notes are drafted locally and go on the tag with `gh release edit v1.26.0 --notes-file ...` once the release workflow has run. Note for the notes: #323 is a behavior change for anyone with `experimentalPerformanceConfig` on, since gameplay and visibility convars are now opt-in and drop on the next apply.
