### PR TITLE
fix: prevent packaged logger EPIPE

### DIFF
--- a/electron/main/services/diagnostics.logger.test.ts
+++ b/electron/main/services/diagnostics.logger.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const logger = vi.hoisted(() => ({
+    functions: {},
+    info: vi.fn(),
+    transports: {
+        console: { level: 'silly' as string | false },
+        file: {
+            level: 'silly' as string | false,
+            maxSize: 0,
+            format: '',
+            getFile: () => ({ path: '/tmp/main.log' }),
+        },
+    },
+}));
+
+vi.mock('electron-log', () => ({ default: logger }));
+vi.mock('electron', () => ({
+    app: {
+        getVersion: () => '0.0.0-test',
+        isPackaged: true,
+    },
+}));
+vi.mock('./updater', () => ({ getInstallSource: () => 'test' }));
+vi.mock('./syncService', () => ({
+    getSyncStatus: () => ({}),
+    isSyncInProgress: () => false,
+    needsSync: () => false,
+}));
+vi.mock('./modDatabase', () => ({ getModCount: () => 0 }));
+
+import { initLogger } from './diagnostics';
+
+describe('main-process logger', () => {
+    it('does not write packaged-app logs to a launcher pipe that may close', () => {
+        initLogger();
+
+        expect(logger.transports.file.level).toBe('info');
+        expect(logger.transports.console.level).toBe(false);
+        expect(logger.info).toHaveBeenCalledOnce();
+    });
+});

--- a/electron/main/services/diagnostics.ts
+++ b/electron/main/services/diagnostics.ts
@@ -30,7 +30,12 @@ export function initLogger(): void {
     loggerInitialized = true;
 
     log.transports.file.level = 'info';
-    log.transports.console.level = 'debug';
+    // A packaged GUI app cannot assume its launcher's stdout/stderr pipes will
+    // remain open. Writing a later log line to a closed pipe emits an
+    // unhandled EPIPE and Electron shows it as a main-process crash dialog.
+    // Development keeps terminal output; installed builds use the rolling
+    // file below as their durable diagnostic destination.
+    log.transports.console.level = app.isPackaged ? false : 'debug';
     // Rotate at ~5 MB. electron-log keeps one archived copy (main.old.log) by
     // default, so total log footprint is capped around 10 MB.
     log.transports.file.maxSize = 5 * 1024 * 1024;


### PR DESCRIPTION
## Summary

- disable the `electron-log` console transport in packaged builds
- keep development console output and the rolling diagnostic file unchanged
- add regression coverage for packaged logger configuration

## Root cause

Packaged GUI builds kept forwarding every main-process log to stdout in addition to the rolling file. When an AppImage launcher's stdout pipe closed, a later periodic log write emitted an unhandled `EPIPE`, which Electron surfaced as a main-process error dialog.

## User impact

Installed builds no longer depend on a launcher or terminal pipe remaining open. Diagnostic logs continue to be written to the rolling file for bug reports.

Fixes #327.

## Validation

- reproduced the exact closed-pipe `EPIPE` failure with a spawned-process harness
- verified the harness exits normally with the console transport disabled
- `pnpm test` — 55 files, 672 tests passed
- `pnpm typecheck`
- targeted ESLint on both changed files
- production `pnpm build` with a scoped HTTPS `GRIMOIRE_SOCIAL_BASE_URL`
- `pnpm i18n:manifest` and push-hook i18n checks