### PR TITLE
fix(replays): link the addons replays folder so downloads decompress

### DIFF
--- a/electron/main/services/replayFolder.test.ts
+++ b/electron/main/services/replayFolder.test.ts
@@ -1,0 +1,70 @@
+/**
+ * ensureReplayFolderLink against a temp Deadlock tree. The point of the fix is
+ * that citadel/replays and citadel/addons/replays resolve to ONE directory, so
+ * every assertion here is about the two paths agreeing, not about either one in
+ * isolation. No electron touchpoints in this dep chain, so the real service runs.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, lstatSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ensureReplayFolderLink } from './replayFolder';
+
+function sandbox(): { root: string; real: string; link: string } {
+  const root = mkdtempSync(join(tmpdir(), 'grimoire-replays-'));
+  const citadel = join(root, 'game', 'citadel');
+  mkdirSync(join(citadel, 'addons'), { recursive: true });
+  return { root, real: join(citadel, 'replays'), link: join(citadel, 'addons', 'replays') };
+}
+
+describe('ensureReplayFolderLink', () => {
+  it('creates citadel/replays and links the addons copy at it', () => {
+    const { root, real, link } = sandbox();
+
+    ensureReplayFolderLink(root);
+
+    expect(lstatSync(real).isDirectory()).toBe(true);
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+
+    // The link is the point: a replay written through addons is readable from
+    // the folder the game decompresses out of.
+    writeFileSync(join(link, '123.dem'), 'demo');
+    expect(readFileSync(join(real, '123.dem'), 'utf-8')).toBe('demo');
+  });
+
+  it('is idempotent', () => {
+    const { root, link } = sandbox();
+
+    ensureReplayFolderLink(root);
+    ensureReplayFolderLink(root);
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+  });
+
+  it('moves replays out of a pre-existing real addons folder before linking', () => {
+    const { root, real, link } = sandbox();
+    mkdirSync(link, { recursive: true });
+    writeFileSync(join(link, '456.dem'), 'stranded');
+    writeFileSync(join(link, '789.dem.partial'), 'incomplete');
+
+    ensureReplayFolderLink(root);
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readdirSync(real).sort()).toEqual(['456.dem', '789.dem.partial']);
+  });
+
+  it('keeps the real folder rather than clobbering a replay to make room', () => {
+    const { root, real, link } = sandbox();
+    mkdirSync(real, { recursive: true });
+    mkdirSync(link, { recursive: true });
+    writeFileSync(join(real, '456.dem'), 'canonical');
+    writeFileSync(join(link, '456.dem'), 'stale');
+
+    expect(() => ensureReplayFolderLink(root)).toThrow();
+
+    expect(lstatSync(link).isDirectory()).toBe(true);
+    expect(lstatSync(link).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(real, '456.dem'), 'utf-8')).toBe('canonical');
+    expect(existsSync(join(link, '456.dem'))).toBe(true);
+  });
+});

--- a/electron/main/services/replayFolder.ts
+++ b/electron/main/services/replayFolder.ts
@@ -1,0 +1,53 @@
+import { lstatSync, existsSync, mkdirSync, readdirSync, renameSync, rmdirSync, symlinkSync } from 'fs';
+import { join } from 'path';
+import { getAddonsPath, getCitadelPath } from './deadlock';
+
+/**
+ * Keep downloaded replays decompressible on a modded install.
+ *
+ * Any modded gameinfo.gi lists an addon folder ahead of `Game citadel`, and the
+ * engine then downloads replays into citadel/addons/replays while the replay
+ * manager still unpacks out of citadel/replays. The download lands in one folder
+ * and the decompress step looks in the other, so every replay fails with
+ * CITADEL_REPLAY_MANAGER_ERROR_PARTIAL_DECOMPRESSION_FAILURE.
+ *
+ * Deleting citadel/addons/replays is not the fix: the engine still writes there,
+ * it just recreates it and stays broken. Instead make both paths the same
+ * directory. citadel/replays is the real folder (it is where a vanilla install
+ * writes, so the user's replays keep working if they stop using grimoire) and
+ * citadel/addons/replays becomes a link to it.
+ */
+export function ensureReplayFolderLink(deadlockPath: string): void {
+    const real = join(getCitadelPath(deadlockPath), 'replays');
+    const link = join(getAddonsPath(deadlockPath), 'replays');
+
+    mkdirSync(real, { recursive: true });
+
+    // lstat, not existsSync: a link whose target is missing has to read as
+    // present, or we'd try to create it again on top of itself.
+    let existing;
+    try {
+        existing = lstatSync(link);
+    } catch {
+        existing = null;
+    }
+
+    if (existing?.isSymbolicLink()) return;
+
+    if (existing) {
+        // A real folder, from a modded run before this fix. Move its replays into
+        // the canonical folder so nothing is stranded, then let it become the link.
+        for (const name of readdirSync(link)) {
+            const dest = join(real, name);
+            if (existsSync(dest)) continue; // never clobber a replay already there
+            renameSync(join(link, name), dest);
+        }
+        // Throws ENOTEMPTY if a name collision was skipped above, which leaves the
+        // folder untouched rather than losing a file to make room for the link.
+        rmdirSync(link);
+    }
+
+    // 'junction' is what lets this work on Windows without admin rights. The
+    // argument is ignored everywhere else.
+    symlinkSync(real, link, 'junction');
+}

--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { join, extname } from 'path';
 import { getGameinfoPath, getDisabledPath, getCitadelPath, getGrimoirePath, getOverflowFolderNames, getAddonFolderPaths, hasDeadworksContentRoot, DEADWORKS_SEARCH_PATH } from './deadlock';
+import { ensureReplayFolderLink } from './replayFolder';
 
 // The canonical SearchPaths block for Deadlock with mod support
 const SEARCH_PATHS_BLOCK = `SearchPaths
@@ -259,6 +260,16 @@ export function fixGameinfo(deadlockPath: string): GameinfoStatus {
             message: 'gameinfo.gi not found',
             candidates: findGameinfoCandidates(deadlockPath),
         };
+    }
+
+    // The modded search paths are what redirect replay downloads into the addons
+    // folder, so this repair owns the link that keeps them decompressible. Runs
+    // before the already-configured early return: an install can have correct
+    // search paths and still be missing the link. Best-effort, like the backup.
+    try {
+        ensureReplayFolderLink(deadlockPath);
+    } catch (err) {
+        console.error('[system] Could not link the replays folder:', err);
     }
 
     try {


### PR DESCRIPTION
## The report

> keep the replays folder in the addons folder because otherwise the replays fail to decompress

## What's actually going on

Grimoire never moved anything. Nothing in the codebase has ever read, written, created, or deleted a `replays` folder (checked the tree and the full history). Every addons scan filters to `.vpk`, so a `replays` folder sitting there is invisible to us.

The bug is a side effect of the search paths we write. A modded `gameinfo.gi` lists an addon folder ahead of `Game citadel`, so the engine downloads replays into `citadel/addons/replays` while the replay manager still unpacks out of `citadel/replays`. Download goes to one folder, decompress looks in the other, every replay fails with `CITADEL_REPLAY_MANAGER_ERROR_PARTIAL_DECOMPRESSION_FAILURE`.

That's also why deleting the addons folder doesn't help: the engine writes there regardless and just recreates it. The report is right that it has to stay.

## The fix

Make both paths the same directory. `citadel/replays` is the real folder, `citadel/addons/replays` becomes a link to it. Then it doesn't matter which one the engine picks.

- `citadel/replays` is the real one because it's where a vanilla install writes, so a user's replays keep working if they stop using grimoire.
- Windows gets a junction (`fs.symlink(..., 'junction')`), which needs no admin rights. The type argument is ignored on Linux.
- Users already in the broken state have replays stranded in a real `citadel/addons/replays`. Those get moved across before the folder is replaced by the link. On a name collision the existing file in `citadel/replays` wins and the move is abandoned, leaving both folders untouched, rather than deleting a replay to make room for a link.

Runs from `fixGameinfo`, before its already-configured early return, since the search paths it writes are what cause the redirect in the first place. An install can have correct search paths and still be missing the link. Best-effort, same as the gameinfo backup: a link failure never blocks the repair.

## Test plan

- 4 new tests in `replayFolder.test.ts` against a temp Deadlock tree: link creation, a write through the addons side being readable from the real folder, idempotency, migration out of a pre-existing real folder, and the collision bail-out.
- Full suite green (734 tests), lint clean, `tsc --noEmit` clean, `electron-vite build` clean.
- Not verified on a live Windows install: the junction path has no coverage beyond Node's documented behavior.

Sources for the mechanism: [playdeadlock forums](https://forums.playdeadlock.com/threads/replays-fail-to-decompress.36749/), [Steam fix guide](https://steamcommunity.com/sharedfiles/filedetails/?id=3616486535), [deadlock-mod-manager#198](https://github.com/deadlock-mod-manager/deadlock-mod-manager/issues/198) (same bug, same conclusion).