### PR TITLE
fix(browse): keep the catalog mirror fresh on launch

### DIFF
--- a/electron/main/ipc/modDatabase.ts
+++ b/electron/main/ipc/modDatabase.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { initDatabase, getModById, getModCount, wipeDatabase, getModsNsfwStatus, updateModNsfw, getModsDownloadCounts, updateModDownloadCount } from '../services/modDatabase';
 import { searchMods, getCategories, getSectionStats, type SearchOptions } from '../services/searchService';
-import { syncAllSections, syncSingleSection, getSyncStatus, needsSync, isSyncInProgress } from '../services/syncService';
+import { syncAllSections, syncSingleSection, syncCatalogHead, getSyncStatus, needsSync, isSyncInProgress } from '../services/syncService';
 
 // Initialize database on module load
 initDatabase();
@@ -14,6 +14,11 @@ ipcMain.handle('sync-all-mods', async () => {
 
 ipcMain.handle('sync-section', async (_, section: string) => {
     await syncSingleSection(section);
+    return { success: true };
+});
+
+ipcMain.handle('refresh-catalog-head', async () => {
+    await syncCatalogHead();
     return { success: true };
 });
 

--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -201,6 +201,62 @@ async function syncSection(section: SectionType): Promise<void> {
 }
 
 /**
+ * Cheap launch-time freshness pass: pull only page 1 of each section.
+ *
+ * `needsSync` gates the full paginated sync on a 24h staleness threshold, so
+ * a user who opens Grimoire more than once a day used to browse a mirror that
+ * could be a full day behind GameBanana with nothing refreshing it. That is
+ * invisible on the default grid (Browse routes to the live API there), but any
+ * catalog-only filter (search, hero, NSFW/date, A-Z sort, or *any* hidden
+ * creator) serves the stale rows.
+ *
+ * Sorted explicitly by date modified ('updated' -> Generic_LatestModified) so
+ * page 1 really is the 50 most recently touched submissions, covering both new
+ * uploads and edits to existing ones for three requests total. Do NOT drop the
+ * sort and lean on the default list order: checked against the live endpoint on
+ * 2026-07-30, /Wip/Index comes back unordered, and /Mod/Index left the two most
+ * recently modified rows off page 1 entirely.
+ *
+ * Deliberately does NOT write sync_state: this is a top-up, not a full mirror
+ * refresh, and claiming otherwise would suppress the real sync for another 24h.
+ * Progress is emitted terminal-only so the sync indicator stays quiet (it
+ * renders nothing for a 'complete' phase) while Browse still gets the signal
+ * it needs to re-query.
+ */
+export async function syncCatalogHead(): Promise<void> {
+    if (isSyncing) {
+        console.debug('[SyncService] Head sync skipped, sync already in progress');
+        return;
+    }
+
+    isSyncing = true;
+    try {
+        for (const section of SECTIONS) {
+            try {
+                const first = await fetchSubmissions(section, 1, SYNC_PER_PAGE, undefined, undefined, 'updated');
+                const mods = first.records.map(mod => mapToCache(mod, section));
+                timedUpsert(section, 1, mods);
+                console.debug(`[SyncService] ${section}: head sync refreshed ${mods.length} rows`);
+                emitProgress({
+                    section,
+                    currentPage: 1,
+                    totalPages: 1,
+                    modsProcessed: mods.length,
+                    totalMods: mods.length,
+                    phase: 'complete',
+                });
+            } catch (err) {
+                // Best-effort: a failed top-up leaves the existing mirror in
+                // place, and the 24h full sync still reports its own errors.
+                console.warn(`[SyncService] ${section}: head sync failed`, err);
+            }
+        }
+    } finally {
+        isSyncing = false;
+    }
+}
+
+/**
  * Sync all sections
  */
 export async function syncAllSections(): Promise<void> {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -515,6 +515,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Mod Database (Local Cache)
     syncAllMods: () => ipcRenderer.invoke('sync-all-mods'),
     syncSection: (section: string) => ipcRenderer.invoke('sync-section', section),
+    refreshCatalogHead: () => ipcRenderer.invoke('refresh-catalog-head'),
     wipeModCache: () => ipcRenderer.invoke('wipe-mod-cache'),
     getSyncStatus: () => ipcRenderer.invoke('get-sync-status'),
     needsSync: () => ipcRenderer.invoke('needs-sync'),

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -81,12 +81,21 @@ export default function Layout() {
         if (!settings.hasCompletedSetup) {
           setShowWelcome(true);
         } else {
-          // Auto-sync if database needs it (first launch or stale data)
+          // Auto-sync if database needs it (first launch or stale data).
+          // Otherwise still top up the head of each section: the full sync only
+          // fires past a 24h staleness threshold, so without this a user who
+          // opens Grimoire daily browses a mirror that is always a day behind
+          // (visible to anyone whose filters route to the local catalog, which
+          // includes everyone with a hidden creator).
           const needsSync = await window.electronAPI.needsSync();
           if (needsSync) {
             console.log('[Layout] Database needs sync, starting in background...');
             window.electronAPI.syncAllMods().catch(err => {
               console.error('[Layout] Background sync failed:', err);
+            });
+          } else {
+            window.electronAPI.refreshCatalogHead().catch(err => {
+              console.error('[Layout] Catalog head refresh failed:', err);
             });
           }
         }

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1743,6 +1743,14 @@ export default function Browse() {
     return (hasSearchQuery || hasHeroFilter || hasContentFilter || needsLocalSort) && hasLocalCache && !localSearchFailed;
   }, [submitter, debouncedSearch, heroCategoryId, nsfw, addedWithin, sort, hiddenCreatorIds.length, hasLocalCache, localSearchFailed]);
 
+  // Mirror of the routing decision for callbacks that outlive a render (the
+  // sync-completion listener below subscribes once and must read the *current*
+  // route, not the one captured at subscribe time).
+  const useLocalSearchRef = useRef(useLocalSearch);
+  useEffect(() => {
+    useLocalSearchRef.current = useLocalSearch;
+  }, [useLocalSearch]);
+
   // Reset the failure flag whenever the user changes filters so a one-off
   // backend error doesn't permanently disable local search.
   useEffect(() => {
@@ -2206,6 +2214,46 @@ export default function Browse() {
     lastFetchedStampRef.current = null;
     traceBrowse(`routing flipped to ${useLocalSearch ? 'local' : 'remote'}; re-running current query`);
   }, [useLocalSearch]);
+
+  // A finished catalog sync writes new rows straight into mods-cache.db, but
+  // the grid keeps whatever it fetched at mount: the fetch effect below only
+  // re-runs on a filter change or `refreshKey`, and `lastFetchedStampRef`
+  // short-circuits an identical query. So a background sync could land a day's
+  // worth of new mods and a local-route grid would keep showing the pre-sync
+  // list for the entire session (and across navigation, since the session cache
+  // rehydrates it) until the user pressed Refresh. That is the "opening the app
+  // never shows new mods, refreshing does" report.
+  //
+  // Re-run the current query instead, but only where it costs the user nothing:
+  //   - local route only; remote results don't come from the mirror at all
+  //   - page 1 only, so someone who paginated deep is never yanked back to a
+  //     shorter list mid-scroll (they still get fresh rows on their next filter
+  //     change or Refresh)
+  // The list is never blanked, so searchLocal swaps it in place and the scroll
+  // offset survives.
+  useEffect(() => {
+    const unsub = window.electronAPI.onSyncProgress((data) => {
+      if (data.phase !== 'complete') return;
+      // Every cached result set in this session was read before those rows
+      // existed, so drop them all rather than letting a filter switch restore
+      // pre-sync results. Scroll offsets are kept (separate map).
+      browseResultsCacheRef.current.clear();
+      // Only the section on screen needs a live re-query; the others refetch
+      // when the user switches to them. Sections sync one at a time, so this is
+      // what keeps a three-section sync from firing three redundant queries.
+      if (data.section !== section) return;
+      if (!useLocalSearchRef.current) return;
+      if (pageRef.current !== 1) return;
+      traceBrowse(`catalog sync finished (${data.section}); re-running current query`);
+      requestGenerationRef.current += 1;
+      // Both gates that would otherwise swallow the re-run: the stamp gate, and
+      // the one-shot skip a just-hydrated session cache leaves behind.
+      lastFetchedStampRef.current = null;
+      restoredCacheSkipStampRef.current = null;
+      setRefreshKey((k) => k + 1);
+    });
+    return unsub;
+  }, [section]);
 
   useEffect(() => {
     // Wait for the first catalog answer so the opening request goes straight

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -976,6 +976,9 @@ export interface ElectronAPI {
     // Mod Database (Local Cache)
     syncAllMods: () => Promise<{ success: boolean }>;
     syncSection: (section: string) => Promise<{ success: boolean }>;
+    /** Launch-time top-up: page 1 of each section only, leaving the 24h full-sync
+     *  cadence (`needsSync`) untouched. */
+    refreshCatalogHead: () => Promise<{ success: boolean }>;
     wipeModCache: () => Promise<{ success: boolean }>;
     getSyncStatus: () => Promise<Record<string, { lastSync: number; count: number } | null>>;
     needsSync: () => Promise<boolean>;


### PR DESCRIPTION
## The report

> mods dont refresh kind of? when i open the manager they arent updated, even if it auto updates them, but if i manual update its fine

Opening Grimoire showed a stale mod catalog that only a manual Refresh would fix. Most visible for users with a **hidden creator**: `hiddenCreatorIds.length > 0` is part of `hasContentFilter`, so those users are pinned to the local mirror for *every* Browse query. Search, hero filter, NSFW/date filters and A-Z sort route there too. The default unfiltered grid was never affected, since it reads the live API.

## Two causes

**1. Launches mostly synced nothing.** `needsSync()` only reports true past a 24h staleness threshold, and `Layout.tsx` is its only caller. Anyone opening the app more than once a day synced nothing at all, so the mirror could sit a full day behind GameBanana with nothing refreshing it.

`syncCatalogHead()` adds a cheap freshness pass: page 1 of each section (Mod, Sound, Wip), three requests, run on launch whenever the full sync is not due. It deliberately does **not** write `sync_state`, so the 24h full sync still fires on schedule, and it shares the `isSyncing` mutex so it cannot race one. Progress is emitted terminal-only, so the sync indicator stays quiet (it renders nothing for a `complete` phase) while Browse still gets the signal it needs.

The head pass sorts explicitly by `Generic_LatestModified` instead of leaning on the default list order. Checked against the live endpoint while writing this: `/Wip/Index` comes back unordered, and `/Mod/Index` left the two most recently modified rows off page 1 entirely. The existing comment in `gamebanana.ts` claiming the default order equals date-modified does not hold per-section.

**2. Browse never re-queried after a sync finished.** Its fetch effect re-runs only on a filter change or `refreshKey`, and `lastFetchedStampRef` short-circuits an identical query. So a completed sync could write hundreds of rows while the grid kept rendering the pre-sync list for the entire session, and across navigation too, since the session cache rehydrates it. Only `handleRefresh` did the full dance (sync + drop caches + null the stamp + bump `refreshKey`), which is exactly why manual always looked correct.

Now a completed sync re-runs the current query, gated so it costs the user nothing:

- local route only (remote results do not come from the mirror)
- current section only (sections sync one at a time; this stops a three-section sync firing three redundant queries)
- page 1 only, so someone who paginated deep is never yanked back to a shorter list mid-scroll

The list is never blanked, so `searchLocal` swaps it in place and the scroll offset survives. Cached result sets for other filters are dropped, since they all predate the new rows.

## Verification

- `pnpm typecheck` and ESLint clean.
- `pnpm exec vitest run`: 770 tests, 59 files, all passing.
- The commit was typechecked on its own in a detached worktree, isolated from unrelated local WIP.
- Sort behavior confirmed against live apiv11 for all three sections.

No user-facing strings, so no i18n catalog change.

## Not covered here

- A user who has already paginated deep when a sync lands keeps their list until their next filter change or Refresh. Auto-refreshing there means resetting to page 1.
- `syncSection` (the full sync) still paginates with no sort token, so its page boundaries can shift mid-crawl. It fetches every page, so the blast radius is a few rows landing twice or not at all per run, and the next sync corrects it. Pre-existing, worth a follow-up if gaps show up in the mirror.