### PR TITLE
fix: browse update state for replaced files, and a username leak in bug reports

### DIFF
--- a/electron/main/services/diagnostics.sanitize.test.ts
+++ b/electron/main/services/diagnostics.sanitize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const homedir = vi.hoisted(() => vi.fn(() => '/home/tester'));
+
+vi.mock('os', () => ({ default: { homedir }, homedir }));
+vi.mock('electron-log', () => ({
+    default: { functions: {}, info: vi.fn(), transports: { console: {}, file: {} } },
+}));
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test', isPackaged: true } }));
+vi.mock('./updater', () => ({ getInstallSource: () => 'test' }));
+vi.mock('./syncService', () => ({
+    getSyncStatus: () => ({}),
+    isSyncInProgress: () => false,
+    needsSync: () => false,
+}));
+vi.mock('./modDatabase', () => ({ getModCount: () => 0 }));
+
+import { sanitize } from './diagnostics';
+
+describe('sanitize', () => {
+    it('redacts a plain Windows user path', () => {
+        const out = sanitize(String.raw`Downloading to: C:\Users\Alice\AppData\Local\Temp\x.zip`);
+
+        expect(out).toBe(String.raw`Downloading to: C:\Users\<user>\AppData\Local\Temp\x.zip`);
+    });
+
+    // Regression: electron-log runs object arguments through util.inspect, which
+    // escapes backslashes. The path-shaped patterns only matched single
+    // backslashes, so every `console.log('...', someObject)` leaked the username.
+    it('redacts a Windows user path inside util.inspect output', () => {
+        const out = sanitize(
+            String.raw`  { path: 'C:\\Users\\Alice\\AppData\\Local\\Temp\\pak15_dir.vpk' }`
+        );
+
+        expect(out).not.toContain('Alice');
+        expect(out).toBe(String.raw`  { path: 'C:\\Users\\<user>\\AppData\\Local\\Temp\\pak15_dir.vpk' }`);
+    });
+
+    // The line that actually leaked, verbatim from the filed report: downloadMod
+    // logs its extracted-VPK array as an object argument.
+    it('redacts the extracted-VPK log line that leaked in the 1.26.0 report', () => {
+        homedir.mockReturnValueOnce(String.raw`C:\Users\T`);
+
+        const out = sanitize(
+            String.raw`    path: 'C:\\Users\\T\\AppData\\Local\\Temp\\grimoire-download-gSbz42\\pak15_dir.vpk',`
+        );
+
+        expect(out).toBe(
+            String.raw`    path: '<home>\\AppData\\Local\\Temp\\grimoire-download-gSbz42\\pak15_dir.vpk',`
+        );
+    });
+
+    it('redacts a Windows user path regardless of drive-letter casing', () => {
+        expect(sanitize(String.raw`d:\users\Alice\Games`)).toBe(String.raw`d:\users\<user>\Games`);
+    });
+
+    // The structured patterns stop at whitespace, so a spaced username used to
+    // survive as `C:\Users\<user> Smith` — and the home-dir pass could no longer
+    // match its literal to clean up after it.
+    it('redacts a Windows username containing a space', () => {
+        homedir.mockReturnValueOnce(String.raw`C:\Users\John Smith`);
+
+        const out = sanitize(String.raw`Downloading to: C:\Users\John Smith\AppData\Local\Temp\x.zip`);
+
+        expect(out).not.toContain('Smith');
+        expect(out).toBe(String.raw`Downloading to: <home>\AppData\Local\Temp\x.zip`);
+    });
+
+    it('redacts a spaced Windows username inside util.inspect output', () => {
+        homedir.mockReturnValueOnce(String.raw`C:\Users\John Smith`);
+
+        const out = sanitize(String.raw`{ path: 'C:\\Users\\John Smith\\AppData\\x.zip' }`);
+
+        expect(out).not.toContain('Smith');
+        expect(out).toBe(String.raw`{ path: '<home>\\AppData\\x.zip' }`);
+    });
+
+    it('redacts posix home paths, including ones that are not the running user', () => {
+        const out = sanitize('/home/tester/.config and /home/someoneelse/live/init.php');
+
+        expect(out).toBe('<home>/.config and /home/<user>/live/init.php');
+    });
+
+    it('keeps redacting non-path secrets', () => {
+        expect(sanitize('id 76561198012345678')).toBe('id <steamid64>');
+        expect(sanitize('Authorization: Bearer abc.def.ghi')).toBe('Authorization: Bearer <token>');
+        expect(sanitize('mail me at a.b@example.com')).toBe('mail me at <email>');
+    });
+
+    it('leaves install paths outside the user profile intact', () => {
+        const path = String.raw`C:\Program Files\esoc\Grimoire\resources\app.asar`;
+
+        expect(sanitize(path)).toBe(path);
+    });
+});

--- a/electron/main/services/diagnostics.ts
+++ b/electron/main/services/diagnostics.ts
@@ -67,8 +67,10 @@ const SANITIZERS: Array<{ pattern: RegExp; replacement: string }> = [
     // PII; the username is.
     { pattern: /\/home\/[^/\s"'`]+/g, replacement: '/home/<user>' },
     { pattern: /\/Users\/[^/\s"'`]+/g, replacement: '/Users/<user>' },
-    // Windows: `C:\Users\Alice\...` -> `C:\Users\<user>\...`.
-    { pattern: /([A-Za-z]:\\Users\\)[^\\\s"'`]+/g, replacement: '$1<user>' },
+    // Windows: `C:\Users\Alice\...` -> `C:\Users\<user>\...`. The `\\{1,2}` also
+    // catches the doubled-backslash form `C:\\Users\\Alice\\...` that
+    // util.inspect emits when electron-log serializes an object argument.
+    { pattern: /([A-Za-z]:\\{1,2}Users\\{1,2})[^\\\s"'`]+/gi, replacement: '$1<user>' },
 
     // SteamID64 — real Steam user IDs start 7656119 and are 17 digits.
     { pattern: /\b7656119\d{10}\b/g, replacement: '<steamid64>' },
@@ -84,19 +86,25 @@ const SANITIZERS: Array<{ pattern: RegExp; replacement: string }> = [
     { pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, replacement: '<email>' },
 ];
 
-/** Strip PII / secrets from a diagnostic-bound string. The patterns above
- *  cover the structured shapes; we also do a final pass that wipes any
- *  literal occurrence of the running user's home dir, which catches edge
- *  cases like a custom Windows username with spaces that the regex misses. */
+/** Strip PII / secrets from a diagnostic-bound string. A first pass wipes any
+ *  literal occurrence of the running user's home dir; the structured patterns
+ *  above then cover everything else (other users' paths, tokens, emails). */
 export function sanitize(text: string): string {
     let out = text;
-    for (const { pattern, replacement } of SANITIZERS) {
-        out = out.replace(pattern, replacement);
-    }
+    // Home dir first: the structured patterns stop at whitespace, so a username
+    // with a space (`C:\Users\John Smith`) would otherwise be half-redacted into
+    // something this pass can no longer match literally.
     const home = os.homedir();
     if (home && home.length > 3) {
-        const escaped = home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        out = out.replace(new RegExp(escaped, 'g'), '<home>');
+        // Doubled-backslash form before the plain one: util.inspect escapes
+        // backslashes when electron-log serializes an object argument.
+        for (const variant of [home.replace(/\\/g, '\\\\'), home]) {
+            const escaped = variant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            out = out.replace(new RegExp(escaped, 'gi'), '<home>');
+        }
+    }
+    for (const { pattern, replacement } of SANITIZERS) {
+        out = out.replace(pattern, replacement);
     }
     return out;
 }

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -455,8 +455,8 @@ function ModDetailsModal({
     // current file shown while an update is available is the update target:
     // clicking it replaces the now-superseded installed version, so call it
     // "Update". Archived files are never update targets (they're the old ones).
-    // Browse never sets updateAvailable, so its non-installed files stay
-    // "Install" (Browse adds files, it doesn't replace).
+    // Both hosts set updateAvailable, so a file the author replaced reads the
+    // same way whether you reach it from Installed or from Browse.
     if (installedFileIds.has(fileId)) return t('modDetails.actions.reinstall');
     if (updateAvailable && !archived) return t('profiles.actions.update');
     return t('modDetails.actions.install');

--- a/src/lib/updateFileMatch.test.ts
+++ b/src/lib/updateFileMatch.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { hasPendingUpdate } from './updateFileMatch';
+import type { GameBananaFile } from '../types/gamebanana';
+
+const file = (id: number, fileName: string, isArchived = false): GameBananaFile => ({
+  id,
+  fileName,
+  fileSize: 1,
+  downloadUrl: `https://gamebanana.com/dl/${id}`,
+  downloadCount: 0,
+  isArchived,
+});
+
+const variant = (gameBananaFileId: number, gameBananaId = 650634) => ({
+  gameBananaId,
+  gameBananaFileId,
+});
+
+describe('hasPendingUpdate', () => {
+  // The QOL Lock report: 9 files installed, then the author replaced the main
+  // archive (qollock_319_30july.zip #1769081 -> qollock_319_31july.zip #1780000)
+  // and the old row vanished from the listing entirely.
+  const qolLockFiles = [
+    file(1627686, 'optional_addon_neutral_icons.zip'),
+    file(1627687, 'optional_addon_sinners_icon.zip'),
+    file(1631511, 'optional_addon_footstep_occlusion.zip'),
+    file(1680726, 'optional_announcer_slot1_seven_josefumivo.zip'),
+    file(1641691, 'optional_announcer_slot2__graves_bregraham.zip'),
+    file(1641703, 'optional_announcer_slot3_drifter_viewtifulvalentine.zip'),
+    file(1641769, 'optional_announcer_slot4_viscous_josefumivo.zip'),
+    file(1680727, 'optional_announcer_slot5_rem_zmpixie.zip'),
+    file(1780000, 'qollock_319_31july.zip'),
+  ];
+  const qolLockInstalled = [
+    variant(1769081), // the replaced main file, no longer in the listing
+    variant(1627686),
+    variant(1627687),
+    variant(1631511),
+    variant(1680726),
+    variant(1641691),
+    variant(1641703),
+    variant(1641769),
+    variant(1680727),
+  ];
+
+  it('flags a mod whose installed file the author replaced', () => {
+    expect(hasPendingUpdate(650634, qolLockFiles, qolLockInstalled)).toBe(true);
+  });
+
+  it('does not flag a mod whose installed files are all still live', () => {
+    const upToDate = qolLockInstalled.map((v) =>
+      v.gameBananaFileId === 1769081 ? variant(1780000) : v
+    );
+
+    expect(hasPendingUpdate(650634, qolLockFiles, upToDate)).toBe(false);
+  });
+
+  it('flags a superseded file that was archived rather than deleted', () => {
+    const files = [file(1, 'old.zip', true), file(2, 'new.zip')];
+
+    expect(hasPendingUpdate(650634, files, [variant(1)])).toBe(true);
+  });
+
+  it('respects ignoreUpdates on the installed variant', () => {
+    const files = [file(2, 'new.zip')];
+
+    expect(hasPendingUpdate(650634, files, [{ ...variant(1), ignoreUpdates: true }])).toBe(false);
+  });
+
+  it('ignores variants belonging to a different mod', () => {
+    const files = [file(2, 'new.zip')];
+
+    expect(hasPendingUpdate(650634, files, [variant(1, 999999)])).toBe(false);
+  });
+
+  it('ignores custom imports and legacy installs with no file id', () => {
+    const files = [file(2, 'new.zip')];
+
+    expect(hasPendingUpdate(650634, files, [{ gameBananaId: 650634 }])).toBe(false);
+    expect(hasPendingUpdate(650634, files, [variant(0)])).toBe(false);
+  });
+
+  it('treats an unloaded or fully archived file list as "unknown", not "outdated"', () => {
+    expect(hasPendingUpdate(650634, [], [variant(1)])).toBe(false);
+    expect(hasPendingUpdate(650634, [file(2, 'old.zip', true)], [variant(1)])).toBe(false);
+  });
+});

--- a/src/lib/updateFileMatch.ts
+++ b/src/lib/updateFileMatch.ts
@@ -16,6 +16,39 @@ export interface UpdateMatchSignals {
   sourceFileName?: string;
 }
 
+/** The installed-variant fields that decide whether an update is pending. */
+export interface InstalledVariantUpdateState {
+  gameBananaId?: number;
+  gameBananaFileId?: number;
+  ignoreUpdates?: boolean;
+}
+
+/**
+ * True when any installed variant of `gameBananaId` points at a file id that is
+ * no longer live on the mod page. An author who re-uploads a file gets a new
+ * file id and the old row is usually deleted outright rather than archived, so
+ * a missing id is the signal that the local copy has been superseded.
+ *
+ * `files` is the mod's full current file list, archived entries included. An
+ * empty list means "not loaded yet" and never flags an update.
+ */
+export function hasPendingUpdate(
+  gameBananaId: number,
+  files: GameBananaFile[],
+  installed: readonly InstalledVariantUpdateState[],
+): boolean {
+  const liveFileIds = new Set(files.filter((f) => !f.isArchived).map((f) => f.id));
+  if (liveFileIds.size === 0) return false;
+  return installed.some(
+    (mod) =>
+      mod.gameBananaId === gameBananaId &&
+      typeof mod.gameBananaFileId === 'number' &&
+      mod.gameBananaFileId > 0 &&
+      !mod.ignoreUpdates &&
+      !liveFileIds.has(mod.gameBananaFileId),
+  );
+}
+
 /** Minimum share of the old filename's meaningful tokens that must reappear
  *  in a candidate's filename before a name-based match is trusted. */
 const MIN_NAME_SCORE = 0.6;

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -102,6 +102,7 @@ import ImportCollectionModal from '../components/ImportCollectionModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, findCategoryByName } from '../lib/lockerUtils';
 import { formatAbsoluteDate, formatRelativeDate } from '../lib/dates';
+import { hasPendingUpdate } from '../lib/updateFileMatch';
 import { showToast } from '../stores/toastStore';
 
 const DEFAULT_PER_PAGE = 36;
@@ -2759,6 +2760,15 @@ export default function Browse() {
     return map;
   }, [installedMods]);
 
+  // Without this, a file the author re-uploaded renders as a plain "Install" and
+  // the mod reads as never downloaded, even though the Installed page flags the
+  // same mod as updatable. The open modal's file list is already the live list,
+  // so the check costs no extra request here.
+  const selectedModUpdateAvailable = useMemo(
+    () => (selectedMod ? hasPendingUpdate(selectedMod.id, selectedMod.files ?? [], installedMods) : false),
+    [selectedMod, installedMods]
+  );
+
   const queuedByModId = useMemo(() => {
     const map = new Map<number, QueuedDownloadState>();
     downloadQueue.forEach((queued, index) => {
@@ -3108,6 +3118,7 @@ export default function Browse() {
         mod={selectedMod}
         section={selectedDetailsSection}
         installed={installedIds.has(selectedMod.id)}
+        updateAvailable={selectedModUpdateAvailable}
         installedFileIds={installedFileIds}
         installedFileStates={installedFileStates}
         onEnableFile={toggleMod}


### PR DESCRIPTION
Two bugs from the same Discord report on 1.26.0.

## Browse showed QOL Lock's main file as not downloaded

The author re-uploaded the main archive the same day (`qollock_319_30july.zip` -> `qollock_319_31july.zip`). GameBanana gives a re-upload a new file id and drops the old row from the listing entirely, so the id Grimoire had on disk matched nothing. Browse only knows "installed" and "not installed", so the replacement rendered as a plain Install button and the whole mod read as never downloaded, while the Installed tab was already flagging it as updatable.

Browse now runs the same check the Installed page does: an installed file id that is no longer live means the local copy is superseded. No extra request, because the open details modal's file list is already the live one. `ModDetailsModal` needed no changes, it already renders `updateAvailable` as an Update button plus a header pill.

Pulled the rule into `hasPendingUpdate()` in `src/lib/updateFileMatch.ts`, next to the existing "which file replaced mine" resolver.

## Bug reports leaked the Windows username

The sanitizer only matched single-backslash paths. electron-log runs object arguments through `util.inspect`, which escapes backslashes, so `C:\\Users\\T\\...` sailed through untouched. In the filed report you can see it both ways on adjacent lines: the plain string log is clean, the extracted-VPK object dump right below it is not. `downloadMod` is where people hit it, but there are ~95 object-arg log sites in the main process that could do the same.

While in there: the homedir pass ran last, so a username with a space had already been mangled into `C:\Users\<user> Smith` by the structured patterns and the literal match could no longer clean up the surname. It runs first now.

## Testing

`diagnostics.sanitize.test.ts`, 9 cases including the leaked line verbatim. Checked they fail 5/9 against the old code.

`updateFileMatch.test.ts`, 7 cases built from the real QOL Lock file ids.

Full suite 746 passing, tsc and lint clean.

## Not fixed here

Clicking Update in Browse still only downloads. It won't remove the superseded copy or re-enable the new one the way the Installed page's update flow does, so you end up with both VPKs. Pre-existing, but the new label makes it easier to walk into.

`isUpdate` in `ModDetailsModal.tsx` treats every non-installed current file as an update target. Right for QOL Lock since only one file was uninstalled, wrong for a mod where you installed one of several optional files and they all light up. Shared with the Installed page, so it needs its own change.
