### PR TITLE
feat (nix): devShell and from-source flake packaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,19 @@ Requirements:
 - [pnpm](https://pnpm.io/) 10+ (pnpm 9 mis-links the out-of-root workspace package below)
 - [Git](https://git-scm.com/)
 
+With Nix, `flake.nix` provides all of the above via `nix develop`. On NixOS
+also enable `programs.nix-ld.enable = true;` (the dev workflow runs
+npm-fetched binaries: Electron, vpkmerge, 7za). Setup is the same as below,
+inside the shell:
+
+```bash
+cd grimoire-social && nix develop -c pnpm install
+cd ../grimoire && nix develop
+pnpm install
+pnpm exec electron-rebuild -f -w better-sqlite3
+pnpm dev
+```
+
 Grimoire shares its wire-format types with its companion service,
 [grimoire-social](https://github.com/Slush97/grimoire-social) (also open source),
 through the `@grimoire/social-types` workspace package. `pnpm-workspace.yaml`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ sudo apt update && sudo apt install grimoire
 
 Afterwards `sudo apt upgrade` keeps it current. More detail: [docs/apt-repo.md](docs/apt-repo.md).
 
+### Nix / NixOS (flake)
+
+Built from source via the repo's flake:
+
+```nix
+# flake.nix
+inputs.grimoire.url = "github:Slush97/grimoire";
+
+# use the package directly
+inputs.grimoire.packages.${pkgs.system}.default
+
+# or overlay it into pkgs
+nixpkgs.overlays = [ inputs.grimoire.overlays.default ];
+environment.systemPackages = [ pkgs.grimoire ];
+```
+
+Exposes `packages.<system>.{grimoire,vpkmerge}` and `overlays.default`.
+Updates come through the flake, not the in-app updater.
+
 Requires Deadlock installed via Steam.
 
 ## Features

--- a/electron/main/services/modMerger.ts
+++ b/electron/main/services/modMerger.ts
@@ -103,9 +103,6 @@ function firstExistingPath(paths: string[]): string | null {
 }
 
 function devVpkmergeBinaryPath(): string | null {
-    const explicit = process.env['VPKMERGE_BINARY'];
-    if (explicit && existsSync(explicit)) return explicit;
-
     const repoRoot = app.getAppPath();
     const siblingRoot = resolve(repoRoot, '..', 'vpkmerge', 'target');
     const exeName = process.platform === 'win32' ? 'vpkmerge.exe' : 'vpkmerge';
@@ -121,6 +118,12 @@ function devVpkmergeBinaryPath(): string | null {
  * extraResources places it at process.resourcesPath/vpkmerge/.
  */
 export function vpkmergeBinaryPath(): string {
+    // An explicit override wins in dev AND packaged builds. Distro packages
+    // (e.g. nix) that run the app outside electron-builder's layout cannot
+    // rely on process.resourcesPath and point this at their own binary.
+    const explicit = process.env['VPKMERGE_BINARY'];
+    if (explicit && existsSync(explicit)) return explicit;
+
     if (!app.isPackaged) {
         const local = devVpkmergeBinaryPath();
         if (local) return local;

--- a/electron/main/services/updater.ts
+++ b/electron/main/services/updater.ts
@@ -16,6 +16,7 @@ export function getInstallSource(): InstallSource {
         if (
             exec.startsWith('/opt/') ||
             exec.startsWith('/usr/') ||
+            exec.startsWith('/nix/store/') ||
             exec.startsWith('/snap/') ||
             exec.startsWith('/var/lib/flatpak/') ||
             exec.startsWith('/app/')

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "grimoire-social": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779261108,
+        "narHash": "sha256-f+wUZOR7dqigxd/IZtay1BrLS5rcSnaDage3NXxqsPE=",
+        "owner": "Slush97",
+        "repo": "grimoire-social",
+        "rev": "efffe0b92a49d6cc8d82406d6fc163c2fd3662a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Slush97",
+        "repo": "grimoire-social",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785454630,
@@ -18,7 +34,26 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "grimoire-social": "grimoire-social",
+        "nixpkgs": "nixpkgs",
+        "vpkmerge": "vpkmerge"
+      }
+    },
+    "vpkmerge": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783195121,
+        "narHash": "sha256-DjGEiL6Zfm1chawjeT23KXKvmncCjDssFzguPmHNWUw=",
+        "owner": "Slush97",
+        "repo": "vpkmerge",
+        "rev": "f716f7a95aa64cb8534b18c6edc81f29a849db9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Slush97",
+        "ref": "v0.19.0",
+        "repo": "vpkmerge",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,40 @@
 {
-  description = "Grimoire devShell (contributor tooling, not a package build)";
+  description = "Grimoire: Deadlock mod manager (from-source package + contributor devShell)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Sibling repo: pnpm-lock links @grimoire/social-types from
+    # ../grimoire-social; the package build materializes this input there.
+    grimoire-social = {
+      url = "github:Slush97/grimoire-social";
+      flake = false;
+    };
+    # Rust CLI the app shells out to for VPK merge/split. Keep the ref in
+    # sync with VPKMERGE_VERSION in scripts/fetch-vpkmerge.mjs.
+    vpkmerge = {
+      url = "github:Slush97/vpkmerge?ref=v0.19.0";
+      flake = false;
+    };
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      grimoire-social,
+      vpkmerge,
+    }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
+      pkgs = import nixpkgs {
+        inherit system;
+        # electron_40 is nixpkgs-flagged insecure (EOL upstream) but is the
+        # newest Electron the locked electron-builder stack can rebuild
+        # natives for (node-abi ends at 40; see the callPackage below). The
+        # predicate permits insecure Electron only, nothing else. Drop it
+        # when electron-builder's node-abi learns the current Electron.
+        config.allowInsecurePredicate = pkg: (pkg.pname or "") == "electron";
+      };
       lib = pkgs.lib;
 
       nodeVersion = pkgs.nodejs_22.version;
@@ -75,8 +100,39 @@
           "/lib64/ld-linux-x86-64.so.2"
         else
           throw "unsupported system: ${system}";
+      vpkmergePkg = pkgs.callPackage ./nix/vpkmerge.nix { src = vpkmerge; };
+      grimoirePkg = pkgs.callPackage ./nix/grimoire.nix {
+        grimoire-src = self;
+        social-src = grimoire-social;
+        vpkmerge = vpkmergePkg;
+        # Not the default electron (41+): electron-builder 26's bundled
+        # @electron/rebuild uses node-abi 3.85, whose registry ends at
+        # Electron 40. Bump when the locked electron-builder stack catches up.
+        electron = pkgs.electron_40;
+      };
     in
     {
+      # From-source build. nixpkgs PR #519608 packages the released AppImage
+      # instead (grimoire-deadlock, stalled unreviewed); this flake is the
+      # canonical source build.
+      packages.${system} = {
+        default = grimoirePkg;
+        grimoire = grimoirePkg;
+        vpkmerge = vpkmergePkg;
+      };
+
+      overlays.default = final: prev: {
+        vpkmerge = final.callPackage ./nix/vpkmerge.nix { src = vpkmerge; };
+        grimoire = final.callPackage ./nix/grimoire.nix {
+          grimoire-src = self;
+          social-src = grimoire-social;
+          vpkmerge = final.vpkmerge;
+          # See packages: node-abi in the locked electron-builder stack
+          # ends at Electron 40.
+          electron = final.electron_40;
+        };
+      };
+
       devShells.${system}.default = pkgs.mkShell {
         packages =
           (with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,142 @@
+{
+  description = "Grimoire devShell (contributor tooling, not a package build)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      lib = pkgs.lib;
+
+      nodeVersion = pkgs.nodejs_22.version;
+      nodeVersionOk = lib.versionAtLeast nodeVersion "22.12.0";
+
+      # Electron 35.7.5 (locked in pnpm-lock.yaml) is not in nixpkgs anymore;
+      # we run the npm-fetched Electron binary via nix-ld instead. The
+      # runtime shared-library list below (electronLibPath) is copied
+      # VERBATIM (not abbreviated from memory) from nixpkgs'
+      # pkgs/development/tools/electron/binary/generic.nix at the
+      # nixos-unstable revision this flake.lock pins:
+      #   rev 1559d3daa3ecc813a650b79375ea61b6741b8746
+      #   pkgs/development/tools/electron/binary/generic.nix (electronLibPath)
+      electronRuntimeLibs = with pkgs; [
+        alsa-lib
+        at-spi2-atk
+        cairo
+        cups
+        dbus
+        expat
+        gdk-pixbuf
+        glib
+        gtk3
+        gtk4
+        nss
+        nspr
+        libx11
+        libxcb
+        libxcomposite
+        libxdamage
+        libxext
+        libxfixes
+        libxrandr
+        libxkbfile
+        pango
+        pciutils
+        stdenv.cc.cc
+        systemd
+        libnotify
+        pipewire
+        libsecret
+        libpulseaudio
+        speechd-minimal
+        libdrm
+        libgbm
+        libxkbcommon
+        libxshmfence
+        libGL
+        vulkan-loader
+      ];
+
+      gappsDataDirs = lib.concatStringsSep ":" [
+        "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}"
+        "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}"
+      ];
+
+      # ELF interpreter path is derived per-system rather than hardcoded,
+      # even though this flake only exposes x86_64-linux today.
+      expectedInterpreter =
+        if system == "aarch64-linux" then
+          "/lib/ld-linux-aarch64.so.1"
+        else if system == "x86_64-linux" then
+          "/lib64/ld-linux-x86-64.so.2"
+        else
+          throw "unsupported system: ${system}";
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages =
+          (with pkgs; [
+            nodejs_22
+            pnpm_10
+            python3
+            gnumake
+            pkg-config
+            git
+            p7zip
+            procps
+            util-linux
+          ])
+          ++ electronRuntimeLibs;
+
+        shellHook = ''
+          # Extend (never replace) the host's nix-ld library path so libraries
+          # configured via programs.nix-ld.libraries stay visible.
+          export NIX_LD_LIBRARY_PATH="${lib.makeLibraryPath electronRuntimeLibs}''${NIX_LD_LIBRARY_PATH:+:$NIX_LD_LIBRARY_PATH}"
+
+          if ! ${lib.boolToString nodeVersionOk}; then
+            echo "ERROR: nodejs_22 (${nodeVersion}) is older than the required 22.12.0." >&2
+            echo "  @electron/rebuild 4.0.2 needs Node >=22.12.0. Bump the nixpkgs input." >&2
+            exit 1
+          fi
+
+          # Extend (never replace) XDG_DATA_DIRS so GSettings schemas used by
+          # GTK/Electron (via wrapGAppsHook upstream, which we don't use since
+          # we run the npm-fetched Electron binary unwrapped) are found.
+          export XDG_DATA_DIRS="${gappsDataDirs}''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+
+          echo "== Grimoire devShell diagnostics =="
+
+          if [ -e "${expectedInterpreter}" ]; then
+            echo "  [ok] ELF interpreter present: ${expectedInterpreter}"
+          else
+            echo "  [warn] ELF interpreter missing: ${expectedInterpreter}"
+            echo "         Enable nix-ld on this host: programs.nix-ld.enable = true;"
+          fi
+
+          if command -v unshare >/dev/null 2>&1 && unshare -Ur true >/dev/null 2>&1; then
+            echo "  [ok] unprivileged user namespaces available (Chromium sandbox can run)"
+          else
+            echo "  [warn] unshare -Ur true failed: unprivileged userns unavailable."
+            echo "         The Electron sandbox needs this. Never pass --no-sandbox as a workaround."
+          fi
+
+          if [ ! -d "../grimoire-social/packages/social-types" ]; then
+            echo "  [warn] ../grimoire-social/packages/social-types not found."
+            echo "         Clone grimoire-social as a sibling checkout and install it FIRST"
+            echo "         (grimoire's zod resolution and @grimoire/social-types both come from there)."
+          fi
+
+          echo ""
+          echo "First-run commands (run in this order, after grimoire-social's own"
+          echo "'pnpm install' has completed):"
+          echo "  pnpm install --frozen-lockfile"
+          echo "  pnpm exec electron-rebuild -f -w better-sqlite3"
+          echo "  pnpm dev"
+        '';
+      };
+    };
+}

--- a/nix/grimoire.nix
+++ b/nix/grimoire.nix
@@ -1,0 +1,191 @@
+# Grimoire built from source. Pattern follows nixpkgs cherry-studio
+# (electron-vite + electron-builder --dir + native modules rebuilt against
+# nixpkgs electron headers). The derivation never invokes the project's
+# direct @electron/rebuild CLI (the route that SIGILL'd in the stalled
+# nixpkgs PR #519608); electron-builder's internal rebuild handles natives,
+# steered to the nix headers via npm_config_nodedir.
+#
+# The upstream Electron pin (35.7.5) is EOL and absent from nixpkgs, so this
+# runs on nixpkgs' current electron. better-sqlite3 is rebuilt against the
+# same electron's headers, keeping the native ABI consistent. If runtime
+# breakage from the 35 -> current API drift ever appears, pin the oldest
+# electron_NN still in nixpkgs here.
+{
+  lib,
+  stdenv,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs_22,
+  electron,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  writableTmpDirAsHomeHook,
+  python3,
+  p7zip,
+  xdg-utils,
+  procps,
+  grimoire-src,
+  social-src,
+  vpkmerge,
+}:
+
+let
+  pnpm = pnpm_10;
+
+  packageJson = builtins.fromJSON (builtins.readFile (grimoire-src + "/package.json"));
+
+  # The pnpm lockfile links @grimoire/social-types from
+  # ../grimoire-social/packages/social-types, and electron.vite.config.ts
+  # aliases the same path. Materialize the sibling checkout next to the
+  # unpacked source, IDENTICALLY in the pnpm fetcher and the main build:
+  # pnpm validates the out-of-tree importer in both.
+  siblingPostUnpack = ''
+    cp -r ${social-src} "$(dirname "$sourceRoot")/grimoire-social"
+    chmod -R u+w "$(dirname "$sourceRoot")/grimoire-social" "$sourceRoot"
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "grimoire";
+  version = packageJson.version;
+
+  src = grimoire-src;
+  postUnpack = siblingPostUnpack;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    postUnpack = siblingPostUnpack;
+    inherit pnpm;
+    # The hash changes when pnpm-lock.yaml, the pinned pnpm major,
+    # fetcherVersion, or social-types' package.json change.
+    fetcherVersion = 4;
+    hash = "sha256-T3fw9+/NfUuk7O+dkAXeKPaH8MaD2znFrOPN6+MW+yA=";
+  };
+
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm
+    pnpmConfigHook
+    makeWrapper
+    copyDesktopItems
+    # electron-builder writes caches under $HOME.
+    writableTmpDirAsHomeHook
+    # node-gyp for the better-sqlite3 rebuild.
+    python3
+  ];
+
+  strictDeps = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    NO_UPDATE_NOTIFIER = "1";
+    # Baked textually into the bundle by the vite define; the production
+    # build refuses to run without an https value.
+    GRIMOIRE_SOCIAL_BASE_URL = "https://grimoire-social.slusheliott.workers.dev";
+  };
+
+  # pnpmConfigHook installed with --ignore-scripts (the vpkmerge postinstall
+  # download and husky prepare are skipped by design). The aliased
+  # social-types sources import zod; guarantee resolution from grimoire's own
+  # node_modules since the sibling has none in the sandbox.
+  postConfigure = ''
+    if [ ! -e ../grimoire-social/packages/social-types/node_modules/zod ]; then
+      mkdir -p ../grimoire-social/packages/social-types/node_modules
+      ln -s "$PWD/node_modules/zod" ../grimoire-social/packages/social-types/node_modules/zod
+    fi
+  '';
+
+  # resources/vpkmerge is gitignored (normally fetched by the postinstall
+  # script), but electron-builder.yml lists it as extraResources. Provide the
+  # nix-built binary under the exact name the app resolves. Runtime primarily
+  # uses VPKMERGE_BINARY from the wrapper; this keeps the packaged layout
+  # complete and self-consistent.
+  preBuild = ''
+    mkdir -p resources/vpkmerge
+    cp ${lib.getExe vpkmerge} resources/vpkmerge/vpkmerge-linux-x86_64
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    node_modules/.bin/electron-vite build
+
+    npm_config_nodedir=${electron.headers} npm_config_build_from_source=true \
+      node_modules/.bin/electron-builder --dir \
+        --config electron-builder.yml \
+        --config.electronDist="$PWD/electron-dist" \
+        --config.electronVersion=${electron.version} \
+        --config.buildDependenciesFromSource=true
+
+    runHook postBuild
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "grimoire";
+      desktopName = "Grimoire";
+      comment = "Mod manager for Deadlock";
+      exec = "grimoire %U";
+      icon = "grimoire";
+      terminal = false;
+      categories = [ "Game" ];
+      # gb1click deep links arrive on the grimoire: scheme.
+      mimeTypes = [ "x-scheme-handler/grimoire" ];
+      # package.json name; also keeps userData at ~/.config/grimoire.
+      startupWMClass = "grimoire";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/grimoire
+    cp -r release/linux-unpacked/resources $out/share/grimoire/
+
+    for size in 16 24 32 48 64 128 256 512; do
+      install -Dm644 resources/icons/"$size"x"$size".png \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/grimoire.png"
+    done
+
+    # ELECTRON_FORCE_IS_PACKAGED: undocumented but verified in Electron
+    # source (presence check in App::IsPackaged) and used by several nixpkgs
+    # packages. Without it `electron <app>` reports isPackaged=false, which
+    # auto-opens devtools and skips the production CSP. If Electron ever
+    # drops the variable, gate those upstream on execPath instead.
+    # USE_SYSTEM_7ZA makes 7zip-bin return bare "7za"; p7zip is on PATH.
+    makeWrapper ${lib.getExe electron} $out/bin/grimoire \
+      --inherit-argv0 \
+      --set ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default VPKMERGE_BINARY ${lib.getExe vpkmerge} \
+      --set-default USE_SYSTEM_7ZA true \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          p7zip
+          xdg-utils
+          procps
+        ]
+      } \
+      --add-flags $out/share/grimoire/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit electron;
+    inherit (finalAttrs) pnpmDeps;
+  };
+
+  meta = {
+    description = "Mod manager and companion tool for Deadlock";
+    homepage = "https://github.com/Slush97/grimoire";
+    changelog = "https://github.com/Slush97/grimoire/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "grimoire";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/nix/vpkmerge.nix
+++ b/nix/vpkmerge.nix
@@ -1,0 +1,30 @@
+# vpkmerge CLI (github.com/Slush97/vpkmerge), pinned via the flake's
+# `vpkmerge` input. The repo is a Cargo workspace (core + cli + tauri GUI +
+# morphic); buildAndTestSubdir restricts build and tests to the CLI crate so
+# the GUI's system dependencies stay out of the closure.
+{
+  lib,
+  rustPlatform,
+  src,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "vpkmerge";
+  version = "0.19.0";
+  inherit src;
+
+  cargoHash = "sha256-WHskudYgD4tgu8hY4bexh3KsSF8LhjMdimhQFrKiCPw=";
+
+  buildAndTestSubdir = "vpkmerge-cli";
+
+  meta = {
+    description = "Command-line tool to combine and split Valve Pak (VPK) files";
+    homepage = "https://github.com/Slush97/vpkmerge";
+    license = lib.licenses.mit;
+    mainProgram = "vpkmerge";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Adds a flake.nix that covers both a contributor devshell and from-source
packages for grimoire and vpkmerge, so nix users can compile instead of
wrapping the AppImage.

The devshell pins the toolchain (Node 22, pnpm 10) and runs the
npm-fetched Electron via nix-ld. Prereqs and usage are in CONTRIBUTING.md.

The package builds the app from source the same way CI does: electron-vite,
then electron-builder with better-sqlite3 rebuilt against nixpkgs Electron
headers. Verified end to end on a real install: extraction, merging,
catalog sync, social login, protocol handler.

Two runtime fixes came out of this. Both stand alone without nix:

- `VPKMERGE_BINARY` now also wins in packaged builds. Distro packages that
  run the app outside electron-builder's layout cannot use
  `process.resourcesPath`.
- The updater treats `/nix/store/` installs as managed, same reasoning as
  `/opt` and `/usr`.

Related: nixpkgs #519608 wraps the AppImage and has sat unreviewed for
months. A repo-owned flake tracks releases with no lag, and the nix files
follow nixpkgs idiom, so an in-tree port stays cheap if wanted later.

Companion PR at Slush97/grimoire-social#6