### PR TITLE
fix(locker): keep card chrome above the shared 3D canvas on prop tabs

### DIFF
--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -1771,9 +1771,20 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
 
       {/* Right pane: the selected type's mods as cards. Keyed on the active type
           so its content re-runs the fade on every tab switch (the tab-content
-          transition), which doubles as the drill-in entrance on first mount. */}
+          transition), which doubles as the drill-in entrance on first mount.
+
+          The fade is skipped on prop-container tabs (Soul Container / Spirit
+          Urn): animate-fade-in fills forwards, and a running-or-filling opacity
+          animation makes this wrapper a permanent stacking context, which traps
+          the cards' z-10 tags and z-20 kebab/delete chrome at the wrapper's
+          z-auto level, UNDER the shared model canvas (z-[5], a sibling below).
+          The models pop in on their own schedule anyway (the overlay canvas
+          ignores CSS opacity), so those tabs lose nothing real. */}
       <div ref={paneRef} className="relative z-10 flex-1 overflow-y-auto scrollbar-glass">
-        <div key={activeType} className="space-y-4 p-6 animate-fade-in">
+        <div
+          key={activeType}
+          className={`space-y-4 p-6 ${isPropContainer ? '' : 'animate-fade-in'}`}
+        >
           {activeType ? (
             <>
               <div className="flex items-baseline gap-2">
@@ -1851,8 +1862,9 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                       // Skipped for prop containers: their model is painted by the
                       // shared overlay canvas, which ignores the card's CSS
                       // opacity, so an opacity entrance would briefly float the
-                      // model over an invisible card. The parent fade + the
-                      // model's own load-in cover their entrance instead.
+                      // model over an invisible card. (The pane wrapper's fade is
+                      // skipped on these tabs too, see above.) The model's own
+                      // load-in covers their entrance instead.
                       style={
                         isPropContainer
                           ? undefined


### PR DESCRIPTION
## Bug

On the Locker Global view's Soul Container and Spirit Urn tabs, the delete and retag (kebab) buttons painted BEHIND the card's 3D model. Clicks still worked (the shared canvas is pointer-events-none); it was purely a paint-order bug.

## Root cause

The z-ladder for these tabs is: shared soul-model canvas at z-[5] (a fixed overlay, sibling of the tab content inside the scroll pane), card tags at z-10, kebab/delete at z-20. That ladder only holds if nothing between the buttons and the pane creates a stacking context.

The tab-content wrapper had `animate-fade-in`, which is `animation: fadeIn 0.3s ease-out forwards`. Per the CSS animations spec, an animation of `opacity` makes the element a stacking context while running OR filling, and `forwards` fills forever. The wrapper therefore became a permanent stacking context at its own z-auto level, flattening the whole card grid (z-20 chrome included) beneath the canvas's z-[5].

## Fix

Skip the wrapper fade on the two prop-container tabs, exactly the way the cards already skip their `animate-scale-in` entrance there. With no opacity animation on those tabs there is no stacking context at all, so chrome sits above the model at all times, including during entrance. Other tabs keep their fade. Nothing visual is lost: the overlay canvas ignores CSS opacity, so the fade never applied to the models anyway (the existing code comments already note this).

Comments at both sites updated to record the trap.

## Verification

- ESLint clean on `src/pages/Locker.tsx`; typecheck errors in the working tree are all from untracked WIP files unrelated to this change.
- Manual: switch to the Soul Container or Spirit Urn tab and hover a card; the kebab and trash paint over the model instead of behind it.

## Follow-up (not in this PR)

`forwards` on `fadeIn` is visually a no-op (end state equals the natural opacity of 1, and no call site pairs the class with an animation delay), so dropping it from `.animate-fade-in` would defuse this landmine globally. Left out because it touches all 43 call sites and deserves its own z-order sanity pass.