### PR TITLE
feat(locker): link skins to matching card icon mods

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -180,7 +180,7 @@ function resolveUnknownLockerHero(
 }
 
 function enrichMod(mod: Mod): WireMod {
-    const metadata = getModMetadata(mod.metaKey);
+    let metadata = getModMetadata(mod.metaKey);
     const isUnknown =
         !metadata?.gameBananaId &&
         !(typeof metadata?.modName === 'string' && metadata.modName.trim().length > 0);
@@ -189,6 +189,10 @@ function enrichMod(mod: Mod): WireMod {
     // downloaded ones. resolveGlobalType persists the result + classifier
     // version so subsequent scans skip the parse.
     const globalType = resolveGlobalType(mod, metadata);
+    // resolveGlobalType creates the first metadata row for a VPK dropped
+    // directly into addons. Refresh the reference so the remaining lazy
+    // classifiers—including heroIconOnly—run on that very first get-mods call.
+    metadata = getModMetadata(mod.metaKey);
     if (metadata) {
         let lockerHero = metadata.lockerHero;
         let lockerHeroSource = metadata.lockerHeroSource;
@@ -460,6 +464,10 @@ ipcMain.handle('delete-mod', async (_, modId: string): Promise<void> => {
         throw new Error('No Deadlock path configured');
     }
     await deleteMod(deadlockPath, modId);
+    // Deleting either an enabled linked skin or the icon source behind one can
+    // invalidate the applied card without an enable/disable event. Force source
+    // validation so stale art is removed immediately.
+    await reconcileLinkedCardsQuietly(deadlockPath, { forceRebuild: true });
 });
 
 // detect-unknown-mod-filters

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -19,10 +19,11 @@ import {
 import { metaKeyFor } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
-import { inferHeroFromVpk, classifyGlobalModFromVpk, GLOBAL_CLASSIFIER_VERSION, parseVpkDirectory, parseVpkDirectoriesAsync } from '../services/vpk';
+import { inferHeroFromVpk, classifyGlobalModFromVpk, classifyHeroIconOnlyFromVpk, GLOBAL_CLASSIFIER_VERSION, parseVpkDirectory, parseVpkDirectoriesAsync } from '../services/vpk';
 import { classifyAbilitySoundsFromVpk } from '../services/abilitySounds';
 import { migrateIgnoredConflictKeysForMods } from '../services/conflicts';
 import { isLockerManaged } from '../services/lockerVpk';
+import { reconcileLinkedCardsQuietly } from '../services/lockerCardLinks';
 import {
     detectUnknownModCacheMatches,
     detectUnknownModFilters,
@@ -236,6 +237,22 @@ function enrichMod(mod: Mod): WireMod {
             setModMetadata(mod.metaKey, { abilitySounds: classified });
             abilitySounds = classified;
         }
+        // Companion-icon footprint (one hero's card art and nothing else). Same
+        // lazy + persist + null-sentinel pattern as globalType/abilitySounds, and
+        // it shares the same cached VPK parse, so all three classifications cost
+        // one directory read between them. Drives which mods the Locker offers as
+        // the icon half of a skin link.
+        let heroIconOnly = metadata.heroIconOnly;
+        if (heroIconOnly === undefined) {
+            let classified: string | null = null;
+            try {
+                classified = classifyHeroIconOnlyFromVpk(mod.path);
+            } catch (err) {
+                console.warn(`[enrichMod] VPK icon-only classification failed for ${mod.fileName}:`, err);
+            }
+            setModMetadata(mod.metaKey, { heroIconOnly: classified });
+            heroIconOnly = classified;
+        }
         return {
             ...mod,
             // Use the stored mod name from GameBanana if available
@@ -262,6 +279,7 @@ function enrichMod(mod: Mod): WireMod {
             lockerCosmetics: metadata.lockerCosmetics,
             lockerSounds: metadata.lockerSounds,
             abilitySounds: abilitySounds ?? undefined,
+            heroIconOnly: heroIconOnly ?? undefined,
             soulImport: metadata.soulImport,
             urnImport: metadata.urnImport,
             ignoreUpdates: metadata.ignoreUpdates,
@@ -290,6 +308,7 @@ function needsVpkParseForEnrich(mod: Mod): boolean {
     if (metadata?.globalType === undefined) return true;
     if (metadata.globalType === null && globalTypeStamped < GLOBAL_CLASSIFIER_VERSION) return true;
     if (metadata.abilitySounds === undefined) return true;
+    if (metadata.heroIconOnly === undefined) return true;
     if (!metadata.lockerHero && metadata.sourceSection === 'Sound') return true;
     const isUnknown =
         !metadata.gameBananaId &&
@@ -400,6 +419,11 @@ ipcMain.handle('enable-mod', async (_, modId: string): Promise<Mod> => {
         throw new Error('No Deadlock path configured');
     }
     const mod = await enableMod(deadlockPath, modId);
+    // Enabling a skin that carries a skin -> icon link must bring its icons with
+    // it. Runs AFTER the mutation lock is released (the rebuild shells out to
+    // vpkmerge, so holding the lock would serialize every toggle behind it) and
+    // never throws, so a broken link can't fail the toggle the user clicked.
+    await reconcileLinkedCardsQuietly(deadlockPath);
     return enrichMod(mod);
 });
 
@@ -410,6 +434,8 @@ ipcMain.handle('disable-mod', async (_, modId: string): Promise<Mod> => {
         throw new Error('No Deadlock path configured');
     }
     const mod = await disableMod(deadlockPath, modId);
+    // Disabling a linked skin reverts its icons (see enable-mod above).
+    await reconcileLinkedCardsQuietly(deadlockPath);
     return enrichMod(mod);
 });
 
@@ -938,6 +964,9 @@ ipcMain.handle(
             throw new Error('No Deadlock path configured');
         }
         const result = await setModsEnabledBatch(deadlockPath, { enable: enableIds, disable: disableIds });
+        // Launch shuffle and "solo this mod" both come through here and can swap
+        // every hero's skin at once, so linked icons have to follow the batch.
+        await reconcileLinkedCardsQuietly(deadlockPath);
         const mods = await scanMods(deadlockPath);
         return { mods: mods.map(enrichMod), failures: result.failures };
     }

--- a/electron/main/ipc/portraits.ts
+++ b/electron/main/ipc/portraits.ts
@@ -3,6 +3,13 @@ import { getActiveDeadlockPath } from '../services/settings';
 import { getHeroPortraits } from '../services/heroPortraits';
 import { applyHeroCard, revertHeroCard, getActiveHeroCard } from '../services/heroCards';
 import {
+    getCardLinks,
+    setCardLink,
+    removeCardLink,
+    type ReconcileResult,
+    type SetCardLinkArgs,
+} from '../services/lockerCardLinks';
+import {
     getCustomCardSlots,
     applyCustomHeroCard,
     exportCustomHeroCard,
@@ -28,7 +35,7 @@ import {
     type HeroEffectInfo,
 } from '../services/heroPoseModels';
 import type { HeroPortrait } from '../../../src/types/portrait';
-import type { ApplyHeroCardResult } from '../../../src/types/mod';
+import type { ApplyHeroCardResult, LockerCardLink } from '../../../src/types/mod';
 
 /** Active Deadlock install path (dev override wins, same as ipc/mods.ts). */
 ipcMain.handle(
@@ -64,6 +71,29 @@ ipcMain.handle(
         const deadlockPath = getActiveDeadlockPath();
         if (!deadlockPath) return null;
         return getActiveHeroCard(deadlockPath, heroName);
+    }
+);
+
+// Skin -> icon links. The card art itself still flows through the apply pipeline
+// above; these three only edit the bindings that decide which cards a skin pulls
+// in, then reconcile so the change is live immediately.
+ipcMain.handle('get-card-links', async (): Promise<LockerCardLink[]> => getCardLinks());
+
+ipcMain.handle(
+    'set-card-link',
+    async (_, args: SetCardLinkArgs): Promise<ReconcileResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return setCardLink(deadlockPath, args);
+    }
+);
+
+ipcMain.handle(
+    'remove-card-link',
+    async (_, skinKey: string): Promise<ReconcileResult> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) throw new Error('No Deadlock path configured');
+        return removeCardLink(deadlockPath, skinKey);
     }
 );
 

--- a/electron/main/ipc/profiles.ts
+++ b/electron/main/ipc/profiles.ts
@@ -13,6 +13,7 @@ import {
     type ProfileCrosshairSettings,
     type ApplyProfileResult,
 } from '../services/profiles';
+import { reconcileLinkedCardsQuietly } from '../services/lockerCardLinks';
 import {
     buildPortableProfile,
     parsePortableProfile,
@@ -88,6 +89,11 @@ ipcMain.handle('apply-profile', async (_, profileId: string): Promise<ApplyProfi
     }
 
     const result = await applyProfile(deadlockPath, profileId);
+
+    // A profile switch rewrites enable/disable state across the whole library,
+    // so linked icons have to follow it. Never throws (see
+    // reconcileLinkedCardsQuietly): a link problem must not fail the apply.
+    await reconcileLinkedCardsQuietly(deadlockPath);
 
     // Save as active profile
     const settings = loadSettings();

--- a/electron/main/services/customHeroCards.ts
+++ b/electron/main/services/customHeroCards.ts
@@ -31,6 +31,7 @@ import {
     rebuildLockerCosmetics,
 } from './heroCards';
 import { ensureGrimoireConfigured, migrateManagedVpksToGrimoire } from './lockerVpk';
+import { dropLinksForHeroCodename } from './lockerCardLinkStore';
 import { invalidateVpkParseCache } from './vpk';
 import { fingerprintFile } from './fileMatch';
 import type { ApplyHeroCardResult, LockerCardSelection } from '../../../src/types/mod';
@@ -228,8 +229,14 @@ export async function applyCustomHeroCard(
             modName: 'Custom upload',
             sha256AtApplyTime: fp.sha256,
         },
+        origin: 'manual',
         addedAt: new Date().toISOString(),
     };
+
+    // One owner per hero: uploading custom art takes this hero over from any
+    // skin -> icon link, which would otherwise reconcile back over it on the
+    // next skin toggle.
+    dropLinksForHeroCodename(primaryCodename);
 
     const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];

--- a/electron/main/services/customHeroCards.ts
+++ b/electron/main/services/customHeroCards.ts
@@ -233,14 +233,12 @@ export async function applyCustomHeroCard(
         addedAt: new Date().toISOString(),
     };
 
-    // One owner per hero: uploading custom art takes this hero over from any
-    // skin -> icon link, which would otherwise reconcile back over it on the
-    // next skin toggle.
-    dropLinksForHeroCodename(primaryCodename);
-
     const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    // Commit the ownership handoff only after the custom card rebuild succeeds;
+    // a failed build must leave the previous link metadata intact.
+    dropLinksForHeroCodename(primaryCodename);
     return {
         activeSourceFileName: missing.includes(fileName) ? null : fileName,
         missingSourceFileNames: missing,

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -36,6 +36,7 @@ import {
     migrateManagedVpksToGrimoire,
 } from './lockerVpk';
 import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import { dropAllCardLinks, dropLinksForHeroCodename } from './lockerCardLinkStore';
 import { resolveVpkIdentity } from './vpkIdentity';
 import { codenamesForHero } from './heroPortraits';
 import type {
@@ -163,7 +164,10 @@ function heroCardPrefixes(heroName: string): string[] {
 }
 
 /** Paths under any of this hero's card prefixes that the VPK actually ships.
- *  Matched case-insensitively (Deadlock VPK paths are lowercase by convention). */
+ *  Matched case-insensitively (Deadlock VPK paths are lowercase by convention).
+ *  Exported as heroCardPathsForHero for the skin -> icon link service, which
+ *  validates a candidate icon mod the same way apply does. */
+export { heroCardPaths as heroCardPathsForHero };
 function heroCardPaths(vpkPath: string, heroName: string): string[] {
     const tree = parseVpkDirectoryCached(vpkPath);
     if (!tree) return [];
@@ -173,7 +177,9 @@ function heroCardPaths(vpkPath: string, heroName: string): string[] {
 
 /** Distinct variant tokens (card, vertical, mm, ...) derived from the matched
  *  card filenames. Informational for the manifest; the split takes the whole
- *  per-hero prefix regardless. */
+ *  per-hero prefix regardless. Exported as variantsForHeroPaths so a link
+ *  records the same variant list an apply would. */
+export { variantsFor as variantsForHeroPaths };
 function variantsFor(cardPaths: string[], heroName: string): string[] {
     const leads = codenamesForHero(heroName).map((c) => `${c}_`);
     const variants = new Set<string>();
@@ -343,8 +349,14 @@ export async function applyHeroCard(
             gameBananaId: srcMeta?.gameBananaId,
             sha256AtApplyTime: id.sha256,
         },
+        origin: 'manual',
         addedAt: new Date().toISOString(),
     };
+
+    // One owner per hero: a hand-picked card takes this hero over from any skin
+    // -> icon link that used to drive it. Without this the next skin toggle
+    // would reconcile the link straight back over the user's pick.
+    dropLinksForHeroCodename(primaryCodename);
 
     const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
@@ -373,6 +385,11 @@ export async function revertHeroCard(
     ensureGrimoireConfigured(deadlockPath);
     await migrateManagedVpksToGrimoire(deadlockPath);
 
+    // "Reset to default" must also break the link, or a link-applied card would
+    // come straight back on the next skin toggle and the revert would look like
+    // it silently failed.
+    dropLinksForHeroCodename(primaryCodename);
+
     const current = await currentCardSelections(deadlockPath);
     if (current.length === 0) return { activeSourceFileName: null, missingSourceFileNames: [] };
 
@@ -399,8 +416,11 @@ export async function listAppliedCards(deadlockPath: string): Promise<LockerOver
     }));
 }
 
-/** Clear every applied card (rebuild to empty, which deletes the cards VPK). */
+/** Clear every applied card (rebuild to empty, which deletes the cards VPK).
+ *  Drops the skin -> icon links too: leaving them would silently re-apply their
+ *  cards on the next skin toggle, so "clear" wouldn't stay cleared. */
 export async function clearAllHeroCards(deadlockPath: string): Promise<void> {
+    dropAllCardLinks();
     await rebuildLockerCosmetics(deadlockPath, []);
 }
 

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -353,14 +353,12 @@ export async function applyHeroCard(
         addedAt: new Date().toISOString(),
     };
 
-    // One owner per hero: a hand-picked card takes this hero over from any skin
-    // -> icon link that used to drive it. Without this the next skin toggle
-    // would reconcile the link straight back over the user's pick.
-    dropLinksForHeroCodename(primaryCodename);
-
     const current = await currentCardSelections(deadlockPath);
     const next = [...current.filter((c) => c.heroCodename !== primaryCodename), selection];
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    // Commit the ownership handoff only after the card rebuild succeeds. If the
+    // build fails, the previous link set and its applied card stay consistent.
+    dropLinksForHeroCodename(primaryCodename);
     // A mod card replacing a prior custom upload for this hero leaves the custom
     // staging VPK orphaned; drop it (it's unmounted, just unused).
     if (current.some((c) => c.heroCodename === primaryCodename && c.source.kind === 'custom')) {
@@ -385,17 +383,19 @@ export async function revertHeroCard(
     ensureGrimoireConfigured(deadlockPath);
     await migrateManagedVpksToGrimoire(deadlockPath);
 
-    // "Reset to default" must also break the link, or a link-applied card would
-    // come straight back on the next skin toggle and the revert would look like
-    // it silently failed.
-    dropLinksForHeroCodename(primaryCodename);
-
     const current = await currentCardSelections(deadlockPath);
-    if (current.length === 0) return { activeSourceFileName: null, missingSourceFileNames: [] };
+    if (current.length === 0) {
+        // There may still be a dormant link for a disabled skin. Reset means the
+        // hero should remain default when that skin is enabled later.
+        dropLinksForHeroCodename(primaryCodename);
+        return { activeSourceFileName: null, missingSourceFileNames: [] };
+    }
 
     const removed = current.filter((c) => c.heroCodename === primaryCodename);
     const next = current.filter((c) => c.heroCodename !== primaryCodename);
     const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    // As above, only commit the link-set removal after the VPK change succeeds.
+    dropLinksForHeroCodename(primaryCodename);
     // Drop the staging VPK behind any custom upload we just reverted, so a stale
     // PNG set doesn't linger in userData (it's not mounted, just unused).
     for (const sel of removed) {
@@ -420,8 +420,8 @@ export async function listAppliedCards(deadlockPath: string): Promise<LockerOver
  *  Drops the skin -> icon links too: leaving them would silently re-apply their
  *  cards on the next skin toggle, so "clear" wouldn't stay cleared. */
 export async function clearAllHeroCards(deadlockPath: string): Promise<void> {
-    dropAllCardLinks();
     await rebuildLockerCosmetics(deadlockPath, []);
+    dropAllCardLinks();
 }
 
 interface PortraitManifest {

--- a/electron/main/services/heroIconOnly.test.ts
+++ b/electron/main/services/heroIconOnly.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { classifyHeroIconOnly, classifyGlobalModType } from './vpk';
+
+/**
+ * The path sets below are REAL, taken by parsing the published VPKs. They are
+ * the ground truth this classifier exists to recognize, so keep them verbatim
+ * rather than idealizing them (the stray README.txt and image_compiler sidecar
+ * are exactly what made a naive "only hero art" check fail).
+ */
+
+// GameBanana 680646, "Ralsei Rem Toasted Compatibility Icons".
+const RALSEI_REM_ADDON = [
+    'README.txt',
+    'panorama/image_compiler.vdata_c',
+    'panorama/images/heroes/familiar_card_critical_psd.vtex_c',
+    'panorama/images/heroes/familiar_card_gloat_psd.vtex_c',
+    'panorama/images/heroes/familiar_card_psd.vtex_c',
+    'panorama/images/heroes/familiar_mm_psd.vtex_c',
+    'panorama/images/heroes/familiar_sm_psd.vtex_c',
+    'panorama/images/heroes/familiar_vertical_psd.vtex_c',
+];
+
+// GameBanana 646257, "Lashlyn Toasted Icon Addon".
+const LASHLYN_ADDON = [
+    'README.txt',
+    'panorama/images/heroes/lash_card_psd.vtex_c',
+    'panorama/images/heroes/lash_mm_psd.vtex_c',
+    'panorama/images/heroes/lash_sm_psd.vtex_c',
+    'panorama/images/heroes/lash_vertical_psd.vtex_c',
+];
+
+// GameBanana 687688, "Wraith Full Auto and Telekinesis Icons Revamp": ABILITY
+// icons, a different path family the card pipeline does not handle.
+const WRAITH_ABILITY_ICONS = [
+    'panorama/images/hud/abilities/wraith_aura_psd.vtex_c',
+    'panorama/images/hud/abilities/wraith_lift_psd.vtex_c',
+];
+
+describe('classifyHeroIconOnly', () => {
+    it('recognizes a real per-skin icon addon', () => {
+        expect(classifyHeroIconOnly(RALSEI_REM_ADDON)).toBe('familiar');
+        expect(classifyHeroIconOnly(LASHLYN_ADDON)).toBe('lash');
+    });
+
+    it('tolerates Grimoire imprint sidecars added to an addon', () => {
+        expect(classifyHeroIconOnly([...LASHLYN_ADDON, 'addoninfo.txt', 'modinfo.json'])).toBe(
+            'lash'
+        );
+    });
+
+    it('accepts art nested under a subfolder (heroes/backgrounds/...)', () => {
+        expect(
+            classifyHeroIconOnly([
+                'panorama/images/heroes/drifter_card_psd.vtex_c',
+                'panorama/images/heroes/backgrounds/drifter_bg_psd.vtex_c',
+            ])
+        ).toBe('drifter');
+    });
+
+    it('rejects a multi-hero icon PACK (that is a global mod, not a companion)', () => {
+        expect(
+            classifyHeroIconOnly([
+                'panorama/images/heroes/lash_card_psd.vtex_c',
+                'panorama/images/heroes/familiar_card_psd.vtex_c',
+            ])
+        ).toBeNull();
+        // ...and the existing global classifier still claims it.
+        expect(
+            classifyGlobalModType([
+                'panorama/images/heroes/lash_card_psd.vtex_c',
+                'panorama/images/heroes/familiar_card_psd.vtex_c',
+            ])
+        ).toBe('icons');
+    });
+
+    it('rejects a skin bundle that merely ships its hero card too', () => {
+        expect(
+            classifyHeroIconOnly([
+                'models/heroes_staging/hornet_v3/hornet.vmdl_c',
+                'materials/models/heroes/hornet/body.vmat_c',
+                'panorama/images/heroes/hornet_card_psd.vtex_c',
+            ])
+        ).toBeNull();
+    });
+
+    it('rejects a HUD mod bundled with one hero card', () => {
+        expect(
+            classifyHeroIconOnly([
+                'panorama/images/heroes/lash_card_psd.vtex_c',
+                'panorama/layout/hud/hud_deathpanel.vxml_c',
+            ])
+        ).toBeNull();
+    });
+
+    it('rejects an ability-icon mod: different path family, not a hero card', () => {
+        expect(classifyHeroIconOnly(WRAITH_ABILITY_ICONS)).toBeNull();
+        // Documents the current filing: hero-specific ability icons land in the
+        // global HUD bucket. Follow-up work, not something links can fix.
+        expect(classifyGlobalModType(WRAITH_ABILITY_ICONS)).toBe('hud');
+    });
+
+    it('rejects an empty tree', () => {
+        expect(classifyHeroIconOnly([])).toBeNull();
+    });
+
+    it('matches case-insensitively (VPK paths are lowercase only by convention)', () => {
+        expect(classifyHeroIconOnly(['Panorama/Images/Heroes/Lash_Card_psd.vtex_c'])).toBe('lash');
+    });
+});

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -20,94 +20,12 @@ import { vpkmergeBinaryPath, runVpkmerge } from './modMerger';
 import { getModMetadata } from './metadata';
 import type { HeroPortrait } from '../../../src/types/portrait';
 
-// Display name -> panorama codename. This is the `class_name` namespace
-// (deadlock-api `hero_<codename>`, stripped of the `hero_` prefix) that hero
-// card art lives under as `panorama/images/heroes/<codename>_<variant>`.
-//
-// This deliberately does NOT reuse the sound-codename table (heroSoundCodenames
-// .ts). That table is scoped to the ~35 heroes that ship ability sounds, so it
-// (a) omits heroes whose only modded art is panorama cards (Doorman, Graves,
-// Rem, Sinclair, Venator, Victor, Warden, Wraith) and (b) uses the sound-path
-// codename, which diverges from the panorama/class_name codename for Abrams
-// (sound `abrams` vs panorama `atlas`) and Mo & Krill (`mokrill` vs `krill`).
-// Both bugs made the card picker silently return nothing for those heroes.
-//
-// Source of truth: assets.deadlock-api.com/v2/heroes `class_name`. Both
-// "Doorman" (GameBanana's category name) and "The Doorman" (the API/roster
-// name) are keyed so the lookup works whichever name flows in.
-const PANORAMA_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
-    Abrams: 'atlas',
-    Apollo: 'fencer',
-    Bebop: 'bebop',
-    Billy: 'punkgoat',
-    Calico: 'nano',
-    Celeste: 'unicorn',
-    Doorman: 'doorman',
-    'The Doorman': 'doorman',
-    Drifter: 'drifter',
-    Dynamo: 'dynamo',
-    Graves: 'necro',
-    'Grey Talon': 'orion',
-    Haze: 'haze',
-    Holliday: 'astro',
-    Infernus: 'inferno',
-    Ivy: 'tengu',
-    Kelvin: 'kelvin',
-    'Lady Geist': 'ghost',
-    Lash: 'lash',
-    McGinnis: 'forge',
-    Mina: 'vampirebat',
-    Mirage: 'mirage',
-    'Mo & Krill': 'krill',
-    Paige: 'bookworm',
-    Paradox: 'chrono',
-    Pocket: 'synth',
-    Rem: 'familiar',
-    Seven: 'gigawatt',
-    Shiv: 'shiv',
-    Silver: 'werewolf',
-    Sinclair: 'magician',
-    Venator: 'priest',
-    Victor: 'frank',
-    Vindicta: 'hornet',
-    Viscous: 'viscous',
-    Vyper: 'viper',
-    Warden: 'warden',
-    Wraith: 'wraith',
-    Yamato: 'yamato',
-};
-
-// LEGACY panorama codenames. Six heroes were renamed during development; the
-// deadlock-api `class_name` (above) is the current name, but a lot of shipped
-// community icon packs (catlock, irl_hero_icons, "did you see that", ...) still
-// author their card art under the OLD codename. Verified against the user's
-// installed packs: e.g. "did_you_see_that_icons" ships `archer`/`engineer`/
-// `bull`/`spectre`/`digger`/`sumo`, never `orion`/`forge`/`atlas`/`ghost`/
-// `krill`/`dynamo`. We match BOTH so cards from old and new packs both show.
-const PANORAMA_CODENAME_ALIASES: Readonly<Record<string, string[]>> = {
-    'Grey Talon': ['archer'],
-    McGinnis: ['engineer'],
-    Abrams: ['bull'],
-    'Lady Geist': ['spectre'],
-    'Mo & Krill': ['digger'],
-    Dynamo: ['sumo'],
-};
-
-/** Resolve a hero display name (e.g. "Vindicta") to its primary panorama
- *  codename (e.g. "hornet"), or undefined when the name is unknown. */
-export function codenameForHero(heroName: string): string | undefined {
-    return PANORAMA_CODENAME_BY_HERO[heroName];
-}
-
-/** Every panorama codename a hero's card art might be filed under: the current
- *  class_name first, then any legacy aliases. Empty when the name is unknown.
- *  Card scanning and apply both iterate this so neither old nor new packs are
- *  missed. */
-export function codenamesForHero(heroName: string): string[] {
-    const primary = PANORAMA_CODENAME_BY_HERO[heroName];
-    if (!primary) return [];
-    return [primary, ...(PANORAMA_CODENAME_ALIASES[heroName] ?? [])];
-}
+// The panorama codename tables moved to src/lib/heroCodenames.ts so the renderer
+// can use the same mapping (the Locker's skin -> icon link picker needs to know
+// which installed icon mods belong to a hero). Re-exported here because every
+// existing main-process caller imports these from heroPortraits.
+export { codenameForHero, codenamesForHero } from '../../../src/lib/heroCodenames';
+import { codenamesForHero } from '../../../src/lib/heroCodenames';
 
 function sanitize(value: string): string {
     return value.replace(/[^a-zA-Z0-9_-]+/g, '_');

--- a/electron/main/services/lockerCardLinkStore.ts
+++ b/electron/main/services/lockerCardLinkStore.ts
@@ -1,0 +1,48 @@
+/**
+ * Storage for skin -> icon bindings. Deliberately a LEAF module: it reads and
+ * writes the `locker:cardlinks` metadata row and nothing else.
+ *
+ * heroCards.ts must be able to drop a hero's bindings when the user hand-picks
+ * or reverts that hero's card (the one-owner-per-hero invariant), while
+ * lockerCardLinks.ts needs heroCards to do the rebuild. Keeping the storage here
+ * breaks what would otherwise be an import cycle between those two.
+ */
+import type { LockerCardLink, LockerCardLinksInfo } from '../../../src/types/mod';
+import { withoutHero } from '../../../src/lib/lockerCardLinks';
+import { getModMetadata, setModMetadata, removeModMetadata } from './metadata';
+import { LOCKER_CARD_LINKS_KEY } from './lockerVpk';
+
+/** Every skin -> icon binding currently stored. */
+export function getCardLinks(): LockerCardLink[] {
+    return getModMetadata(LOCKER_CARD_LINKS_KEY)?.lockerCardLinks?.links ?? [];
+}
+
+/** Persist the binding set, clearing the metadata row entirely when it empties
+ *  so an unused synthetic key doesn't linger in the sidecar. */
+export function saveCardLinks(links: LockerCardLink[]): void {
+    if (links.length === 0) {
+        removeModMetadata(LOCKER_CARD_LINKS_KEY);
+        return;
+    }
+    const info: LockerCardLinksInfo = { links, updatedAt: new Date().toISOString() };
+    setModMetadata(LOCKER_CARD_LINKS_KEY, { modName: 'Locker Card Links', lockerCardLinks: info });
+}
+
+/**
+ * Drop every binding that owns `heroCodename`, returning true when something
+ * changed. Called by the manual card paths (apply / revert) so a hand-picked
+ * card takes the hero over from whatever link used to own it, rather than the
+ * two fighting on every subsequent skin toggle.
+ */
+export function dropLinksForHeroCodename(heroCodename: string): boolean {
+    const links = getCardLinks();
+    const next = withoutHero(links, heroCodename);
+    if (next.length === links.length) return false;
+    saveCardLinks(next);
+    return true;
+}
+
+/** Drop every binding (the "clear all Locker overrides" path). */
+export function dropAllCardLinks(): void {
+    saveCardLinks([]);
+}

--- a/electron/main/services/lockerCardLinks.test.ts
+++ b/electron/main/services/lockerCardLinks.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LockerCardLink, LockerCardSelection } from '../../../src/types/mod';
+
+const h = vi.hoisted(() => {
+    const state: {
+        links: unknown[];
+        stored: unknown[];
+        mods: unknown[];
+        metadata: Record<string, Record<string, unknown>>;
+    } = { links: [], stored: [], mods: [], metadata: {} };
+
+    return {
+        state,
+        getCardLinks: vi.fn(() => state.links),
+        saveCardLinks: vi.fn((links: unknown[]) => {
+            state.links = links.map((link) => ({ ...(link as object) }));
+        }),
+        currentCardSelections: vi.fn(async () => state.stored),
+        rebuildLockerCosmetics: vi.fn(async (_path: string, desired: unknown[]) => {
+            state.stored = desired;
+            return { fileName: desired.length > 0 ? 'locker.vpk' : null, missing: [] };
+        }),
+        heroCardPathsForHero: vi.fn(() => [
+            'panorama/images/heroes/familiar_card_psd.vtex_c',
+        ]),
+        variantsForHeroPaths: vi.fn(() => ['card']),
+        scanMods: vi.fn(async () => state.mods),
+        getModMetadata: vi.fn((key: string) => state.metadata[key]),
+        ensureGrimoireConfigured: vi.fn(),
+        codenamesForHero: vi.fn(() => ['familiar']),
+        resolveVpkIdentity: vi.fn(async () => ({ sha256: 'icon-sha' })),
+        vpkmergeBinaryPath: vi.fn(() => '/vpkmerge'),
+    };
+});
+
+vi.mock('./metadata', () => ({ getModMetadata: h.getModMetadata }));
+vi.mock('./lockerVpk', () => ({ ensureGrimoireConfigured: h.ensureGrimoireConfigured }));
+vi.mock('./lockerCardLinkStore', () => ({
+    getCardLinks: h.getCardLinks,
+    saveCardLinks: h.saveCardLinks,
+}));
+vi.mock('./heroCards', () => ({
+    currentCardSelections: h.currentCardSelections,
+    heroCardPathsForHero: h.heroCardPathsForHero,
+    rebuildLockerCosmetics: h.rebuildLockerCosmetics,
+    variantsForHeroPaths: h.variantsForHeroPaths,
+}));
+vi.mock('./heroPortraits', () => ({ codenamesForHero: h.codenamesForHero }));
+vi.mock('./mods', () => ({ scanMods: h.scanMods }));
+vi.mock('./vpkIdentity', () => ({ resolveVpkIdentity: h.resolveVpkIdentity }));
+vi.mock('./modMerger', () => ({ vpkmergeBinaryPath: h.vpkmergeBinaryPath }));
+
+import {
+    reconcileLinkedCards,
+    removeCardLink,
+    setCardLink,
+} from './lockerCardLinks';
+
+const NOW = '2026-08-03T00:00:00.000Z';
+
+function link(over: Partial<LockerCardLink> = {}): LockerCardLink {
+    return {
+        skinKey: 'gamebanana:111',
+        skinName: 'Ralsei Rem',
+        heroName: 'Rem',
+        heroCodename: 'familiar',
+        sourceKey: 'pak04_dir.vpk',
+        sourceModName: 'Matching icons',
+        sourceSha256: 'icon-sha',
+        variants: ['card'],
+        linkedAt: NOW,
+        ...over,
+    };
+}
+
+function appliedLink(over: Partial<LockerCardSelection> = {}): LockerCardSelection {
+    return {
+        heroCodename: 'familiar',
+        heroName: 'Rem',
+        variants: ['card'],
+        source: {
+            kind: 'mod',
+            fileName: 'pak04_dir.vpk',
+            modName: 'Matching icons',
+            sha256AtApplyTime: 'icon-sha',
+        },
+        origin: 'link',
+        linkedSkinKey: 'gamebanana:111',
+        addedAt: NOW,
+        ...over,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    h.state.links = [];
+    h.state.stored = [];
+    h.state.mods = [];
+    h.state.metadata = {};
+});
+
+describe('reconcileLinkedCards lifecycle', () => {
+    it('keeps the no-links hot path free of scans and manifest reads', async () => {
+        await expect(reconcileLinkedCards('/game')).resolves.toEqual({
+            rebuilt: false,
+            missing: [],
+        });
+        expect(h.currentCardSelections).not.toHaveBeenCalled();
+        expect(h.scanMods).not.toHaveBeenCalled();
+    });
+
+    it('removes the applied selection when the final link is unlinked', async () => {
+        h.state.links = [link()];
+        h.state.stored = [appliedLink()];
+
+        await expect(removeCardLink('/game', 'gamebanana:111')).resolves.toEqual({
+            rebuilt: true,
+            missing: [],
+        });
+
+        expect(h.state.links).toEqual([]);
+        expect(h.rebuildLockerCosmetics).toHaveBeenCalledWith('/game', []);
+    });
+
+    it('restores the binding when unlink could not rebuild the applied VPK', async () => {
+        h.state.links = [link()];
+        h.state.stored = [appliedLink()];
+        h.rebuildLockerCosmetics.mockRejectedValueOnce(new Error('build failed'));
+
+        await expect(removeCardLink('/game', 'gamebanana:111')).rejects.toThrow('build failed');
+        expect(h.state.links).toEqual([link()]);
+    });
+
+    it('forces source validation after deletion even when the manifest is unchanged', async () => {
+        h.state.links = [link()];
+        h.state.stored = [appliedLink()];
+        h.state.mods = [
+            { id: 'skin-id', metaKey: 'pak01_dir.vpk', priority: 1, enabled: true },
+        ];
+        h.state.metadata['pak01_dir.vpk'] = { gameBananaId: 111 };
+
+        await reconcileLinkedCards('/game', { forceRebuild: true });
+        expect(h.rebuildLockerCosmetics).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('setCardLink transaction', () => {
+    it('restores the previous link set when the initial apply fails', async () => {
+        const previous = link({
+            skinKey: 'gamebanana:222',
+            heroName: 'Lash',
+            heroCodename: 'lash',
+        });
+        h.state.links = [previous];
+        h.state.mods = [
+            {
+                id: 'icon-id',
+                metaKey: 'pak04_dir.vpk',
+                fileName: 'pak04_dir.vpk',
+                path: '/game/pak04_dir.vpk',
+                priority: 4,
+                enabled: false,
+            },
+            { id: 'skin-id', metaKey: 'pak01_dir.vpk', priority: 1, enabled: true },
+        ];
+        h.state.metadata['pak01_dir.vpk'] = { gameBananaId: 111 };
+        h.state.metadata['pak04_dir.vpk'] = { modName: 'Matching icons' };
+        h.rebuildLockerCosmetics.mockRejectedValueOnce(new Error('build failed'));
+
+        await expect(
+            setCardLink('/game', {
+                skinKey: 'gamebanana:111',
+                skinName: 'Ralsei Rem',
+                heroName: 'Rem',
+                sourceKey: 'pak04_dir.vpk',
+            })
+        ).rejects.toThrow('build failed');
+
+        expect(h.state.links).toEqual([previous]);
+    });
+});

--- a/electron/main/services/lockerCardLinks.ts
+++ b/electron/main/services/lockerCardLinks.ts
@@ -1,0 +1,203 @@
+/**
+ * Skin -> icon links: the main-process side.
+ *
+ * A link says "whenever this skin is enabled, apply that hero's card art from
+ * that icon mod". The heavy lifting is already built (heroCards.ts splits one
+ * hero's `panorama/images/heroes/<codename>_` art into the Locker-managed
+ * cosmetics VPK in citadel/grimoire, which wins by SearchPaths folder
+ * precedence). This module owns the bindings and keeps the applied card set in
+ * sync as skins toggle.
+ *
+ * Why the main process and not the renderer: skins change from FOUR surfaces
+ * (Locker toggle, Installed toggle, apply-profile, apply-mod-toggle-batch for
+ * launch shuffle / solo). A renderer-side reconcile would silently desync on
+ * three of them, which is exactly the "my icons stopped matching my skin"
+ * failure this feature exists to prevent. reconcileLinkedCards is therefore
+ * called from the IPC layer after every mutation that can change the enabled set.
+ *
+ * INVARIANT (enforced here and in heroCards.ts): for any hero, either a link
+ * owns the card or a manual/custom pick does, never both.
+ *
+ * See docs/locker-hero-card-apply.md for the underlying card apply pipeline.
+ */
+import {
+    lockerLinkKey,
+    loadOrderFromMetaKey,
+    planLinkedCards,
+    selectionsSignature,
+    upsertLink,
+    withoutSkin,
+    type ActiveSkin,
+} from '../../../src/lib/lockerCardLinks';
+import type { LockerCardLink } from '../../../src/types/mod';
+import { getModMetadata } from './metadata';
+import { ensureGrimoireConfigured } from './lockerVpk';
+import { getCardLinks, saveCardLinks } from './lockerCardLinkStore';
+import {
+    currentCardSelections,
+    heroCardPathsForHero,
+    rebuildLockerCosmetics,
+    variantsForHeroPaths,
+} from './heroCards';
+import { codenamesForHero } from './heroPortraits';
+import { scanMods } from './mods';
+import { resolveVpkIdentity } from './vpkIdentity';
+import { vpkmergeBinaryPath } from './modMerger';
+
+export { getCardLinks } from './lockerCardLinkStore';
+
+/** The enabled skins as the planner wants them: stable key + global load order. */
+async function activeSkins(deadlockPath: string): Promise<ActiveSkin[]> {
+    const mods = await scanMods(deadlockPath);
+    const out: ActiveSkin[] = [];
+    for (const mod of mods) {
+        if (!mod.enabled) continue;
+        // gameBananaId / sha256 live in the metadata sidecar, not the scan row.
+        const meta = getModMetadata(mod.metaKey);
+        out.push({
+            key: lockerLinkKey({
+                id: mod.id,
+                gameBananaId: meta?.gameBananaId,
+                sha256: meta?.sha256,
+            }),
+            loadOrder: loadOrderFromMetaKey(mod.metaKey, mod.priority),
+        });
+    }
+    return out;
+}
+
+export interface ReconcileResult {
+    /** True when the cosmetics VPK was actually rebuilt. */
+    rebuilt: boolean;
+    /** Source identities dropped because their VPK was gone at rebuild time. */
+    missing: string[];
+}
+
+/**
+ * Bring the applied card set in line with the bindings and the current enabled
+ * set. Idempotent, and safe to call after any mod mutation.
+ *
+ * Two cheap exits guard the hot path, because this runs after EVERY enable and
+ * disable:
+ *  1. No bindings at all (the overwhelming majority of installs): return before
+ *     touching the disk.
+ *  2. Bindings exist but the resulting selection set is identical to what is
+ *     already applied: return before shelling out to vpkmerge. Toggling an
+ *     unrelated mod therefore costs one scan, not a VPK rebuild.
+ *
+ * `takeOverHeroes` (codenames) clears any manual/custom pick for those heroes
+ * first, so a freshly created link can claim a hero the user had hand-picked in
+ * ONE rebuild instead of two.
+ */
+export async function reconcileLinkedCards(
+    deadlockPath: string,
+    takeOverHeroes: readonly string[] = []
+): Promise<ReconcileResult> {
+    const links = getCardLinks();
+    if (links.length === 0 && takeOverHeroes.length === 0) {
+        return { rebuilt: false, missing: [] };
+    }
+
+    const stored = await currentCardSelections(deadlockPath);
+    const takeOver = new Set(takeOverHeroes);
+    const current = takeOver.size
+        ? stored.filter((sel) => sel.origin === 'link' || !takeOver.has(sel.heroCodename))
+        : stored;
+
+    const next = planLinkedCards({
+        links,
+        current,
+        activeSkins: await activeSkins(deadlockPath),
+        now: new Date().toISOString(),
+    });
+    if (selectionsSignature(next) === selectionsSignature(stored)) {
+        return { rebuilt: false, missing: [] };
+    }
+
+    ensureGrimoireConfigured(deadlockPath);
+    const { missing } = await rebuildLockerCosmetics(deadlockPath, next);
+    return { rebuilt: true, missing };
+}
+
+/**
+ * Reconcile without ever throwing. The IPC mutation handlers use this: a broken
+ * link, a missing vpkmerge binary or an unconfigured gameinfo must never turn a
+ * plain "enable this mod" click into a failure. The applied cards just stay as
+ * they were, and the next successful reconcile catches up.
+ */
+export async function reconcileLinkedCardsQuietly(deadlockPath: string): Promise<void> {
+    try {
+        await reconcileLinkedCards(deadlockPath);
+    } catch (err) {
+        console.warn('[lockerCardLinks] reconcile failed (applied cards left unchanged):', err);
+    }
+}
+
+export interface SetCardLinkArgs {
+    /** Stable Locker skin key (see lockerLinkKey). */
+    skinKey: string;
+    skinName?: string;
+    heroName: string;
+    /** Folder-relative metaKey of the icon mod to bind. */
+    sourceKey: string;
+}
+
+/**
+ * Bind `skinKey` to the icon mod at `sourceKey`, then reconcile so the change is
+ * live immediately when the skin is already enabled.
+ *
+ * Snapshots the source's identity (metaKey + sha256 + name) into the binding so
+ * later rebuilds can relocate it after a rename or an overflow move, the same
+ * recovery the card rebuild already does for manual picks.
+ */
+export async function setCardLink(
+    deadlockPath: string,
+    args: SetCardLinkArgs
+): Promise<ReconcileResult> {
+    vpkmergeBinaryPath(); // surface a clear error early if the binary is missing/old
+    const { skinKey, skinName, heroName, sourceKey } = args;
+    const codename = codenamesForHero(heroName)[0];
+    if (!codename) throw new Error(`Unknown hero: ${heroName}`);
+
+    const mods = await scanMods(deadlockPath);
+    const source = mods.find((m) => m.metaKey === sourceKey);
+    if (!source) throw new Error(`Icon mod not found: ${sourceKey}`);
+
+    const cardPaths = heroCardPathsForHero(source.path, heroName);
+    if (cardPaths.length === 0) {
+        throw new Error(`${source.fileName} has no card art for ${heroName}.`);
+    }
+
+    const identity = await resolveVpkIdentity(source.path);
+    const meta = getModMetadata(source.metaKey);
+    const link: LockerCardLink = {
+        skinKey,
+        skinName,
+        heroName,
+        heroCodename: codename,
+        sourceKey: source.metaKey,
+        sourceModName: meta?.modName,
+        sourceGameBananaId: meta?.gameBananaId,
+        sourceSha256: identity.sha256,
+        variants: variantsForHeroPaths(cardPaths, heroName),
+        linkedAt: new Date().toISOString(),
+    };
+
+    // upsertLink drops any prior binding for this skin AND any other binding for
+    // this hero; takeOverHeroes then drops the hero's manual pick. Together that
+    // leaves exactly one owner for the hero.
+    saveCardLinks(upsertLink(getCardLinks(), link));
+    return reconcileLinkedCards(deadlockPath, [codename]);
+}
+
+/** Remove the binding for one skin and revert whatever it had applied. */
+export async function removeCardLink(
+    deadlockPath: string,
+    skinKey: string
+): Promise<ReconcileResult> {
+    const links = getCardLinks();
+    const next = withoutSkin(links, skinKey);
+    if (next.length === links.length) return { rebuilt: false, missing: [] };
+    saveCardLinks(next);
+    return reconcileLinkedCards(deadlockPath);
+}

--- a/electron/main/services/lockerCardLinks.ts
+++ b/electron/main/services/lockerCardLinks.ts
@@ -15,8 +15,9 @@
  * failure this feature exists to prevent. reconcileLinkedCards is therefore
  * called from the IPC layer after every mutation that can change the enabled set.
  *
- * INVARIANT (enforced here and in heroCards.ts): for any hero, either a link
- * owns the card or a manual/custom pick does, never both.
+ * INVARIANT (enforced here and in heroCards.ts): for any hero, either its link
+ * set owns the card or a manual/custom pick does, never both. Multiple skins
+ * for one hero may each have a link; load order selects the live one.
  *
  * See docs/locker-hero-card-apply.md for the underlying card apply pipeline.
  */
@@ -73,6 +74,18 @@ export interface ReconcileResult {
     missing: string[];
 }
 
+interface ReconcileOptions {
+    /** Codenames whose manual/custom selection a newly-created link set takes
+     * over during this reconcile. */
+    takeOverHeroes?: readonly string[];
+    /** Continue when the stored link set is empty so the final removed link can
+     * also remove its already-applied selection. */
+    allowEmptyLinks?: boolean;
+    /** Rebuild even when the desired manifest is unchanged. Used after deletes
+     * to validate that every selected source still exists. */
+    forceRebuild?: boolean;
+}
+
 /**
  * Bring the applied card set in line with the bindings and the current enabled
  * set. Idempotent, and safe to call after any mod mutation.
@@ -91,10 +104,19 @@ export interface ReconcileResult {
  */
 export async function reconcileLinkedCards(
     deadlockPath: string,
-    takeOverHeroes: readonly string[] = []
+    options: ReconcileOptions = {}
 ): Promise<ReconcileResult> {
+    const {
+        takeOverHeroes = [],
+        allowEmptyLinks = false,
+        forceRebuild = false,
+    } = options;
     const links = getCardLinks();
-    if (links.length === 0 && takeOverHeroes.length === 0) {
+    if (
+        links.length === 0 &&
+        takeOverHeroes.length === 0 &&
+        !allowEmptyLinks
+    ) {
         return { rebuilt: false, missing: [] };
     }
 
@@ -107,10 +129,12 @@ export async function reconcileLinkedCards(
     const next = planLinkedCards({
         links,
         current,
-        activeSkins: await activeSkins(deadlockPath),
+        // Removing a dormant final link needs no mod scan: with no links there
+        // is nothing that can consume the enabled set.
+        activeSkins: links.length > 0 ? await activeSkins(deadlockPath) : [],
         now: new Date().toISOString(),
     });
-    if (selectionsSignature(next) === selectionsSignature(stored)) {
+    if (!forceRebuild && selectionsSignature(next) === selectionsSignature(stored)) {
         return { rebuilt: false, missing: [] };
     }
 
@@ -125,9 +149,12 @@ export async function reconcileLinkedCards(
  * plain "enable this mod" click into a failure. The applied cards just stay as
  * they were, and the next successful reconcile catches up.
  */
-export async function reconcileLinkedCardsQuietly(deadlockPath: string): Promise<void> {
+export async function reconcileLinkedCardsQuietly(
+    deadlockPath: string,
+    options: ReconcileOptions = {}
+): Promise<void> {
     try {
-        await reconcileLinkedCards(deadlockPath);
+        await reconcileLinkedCards(deadlockPath, options);
     } catch (err) {
         console.warn('[lockerCardLinks] reconcile failed (applied cards left unchanged):', err);
     }
@@ -183,11 +210,19 @@ export async function setCardLink(
         linkedAt: new Date().toISOString(),
     };
 
-    // upsertLink drops any prior binding for this skin AND any other binding for
-    // this hero; takeOverHeroes then drops the hero's manual pick. Together that
-    // leaves exactly one owner for the hero.
-    saveCardLinks(upsertLink(getCardLinks(), link));
-    return reconcileLinkedCards(deadlockPath, [codename]);
+    // One binding per skin, but any number of linked skins per hero. The planner
+    // chooses the live one by load order. takeOverHeroes drops a manual/custom
+    // pick so the hero is owned by the link set instead.
+    const previous = getCardLinks();
+    saveCardLinks(upsertLink(previous, link));
+    try {
+        return await reconcileLinkedCards(deadlockPath, { takeOverHeroes: [codename] });
+    } catch (err) {
+        // A failed build must not leave a link persisted over the still-current
+        // manual card. Restore the metadata transaction before surfacing it.
+        saveCardLinks(previous);
+        throw err;
+    }
 }
 
 /** Remove the binding for one skin and revert whatever it had applied. */
@@ -199,5 +234,12 @@ export async function removeCardLink(
     const next = withoutSkin(links, skinKey);
     if (next.length === links.length) return { rebuilt: false, missing: [] };
     saveCardLinks(next);
-    return reconcileLinkedCards(deadlockPath);
+    try {
+        return await reconcileLinkedCards(deadlockPath, { allowEmptyLinks: true });
+    } catch (err) {
+        // Keep the binding when its applied output could not be reverted; the UI
+        // can retry instead of claiming an unlink that never took effect.
+        saveCardLinks(links);
+        throw err;
+    }
 }

--- a/electron/main/services/lockerVpk.ts
+++ b/electron/main/services/lockerVpk.ts
@@ -29,6 +29,10 @@ import { readStash } from './launch';
 /** Synthetic metadata keys for the managed selection sets (decoupled from the
  *  VPK filename so they never collide with a user mod). */
 export const LOCKER_CARDS_KEY = 'locker:cards';
+/** Synthetic key for the skin -> icon bindings. Not a managed VPK of its own:
+ *  links are an INPUT that decides part of the cards VPK's contents, so they
+ *  live beside the card selection set rather than owning a pak slot. */
+export const LOCKER_CARD_LINKS_KEY = 'locker:cardlinks';
 export const LOCKER_SOUNDS_KEY = 'locker:sounds';
 export const LOCKER_COLORS_KEY = 'locker:colors';
 export const LOCKER_TRIPPY_SKINS_KEY = 'locker:trippyskins';

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -79,6 +79,16 @@ export interface ModMetadata {
      *  hero ability/VO sounds, `null` when classified and it has none, and
      *  `undefined` when not yet classified (so enrichMod skips the re-parse). */
     abilitySounds?: import('../../../src/types/mod').AbilitySoundClassification | null;
+    /** Panorama codename when this VPK is a companion ICON mod (nothing but one
+     *  hero's card art; see classifyHeroIconOnly in vpk.ts). Tri-state like
+     *  globalType: a codename when it is one, `null` when classified and it is
+     *  not, `undefined` when not yet classified. Drives which mods the Locker
+     *  offers as the icon half of a skin link. */
+    heroIconOnly?: string | null;
+    /** Set on the synthetic `locker:cardlinks` key: every skin -> icon binding.
+     *  Not a real VPK's metadata; the key is synthetic so the bindings can never
+     *  collide with a user mod that later takes a freed pakNN slot. */
+    lockerCardLinks?: import('../../../src/types/mod').LockerCardLinksInfo;
     /** Set when this VPK was built from a user GLB via the soul-container
      *  import. The orientation/glow transform + tracking status; presence marks
      *  the slot for idempotent re-import (replace the previous build). */

--- a/electron/main/services/vpk.ts
+++ b/electron/main/services/vpk.ts
@@ -793,6 +793,55 @@ export function classifyGlobalModFromVpk(vpkPath: string): GlobalModType | null 
 }
 
 /**
+ * Entries a companion icon addon is allowed to carry besides the hero art
+ * itself. Verified against real published addons: they ship a stray `README.txt`
+ * and the panorama compiler sidecar next to the `.vtex_c` set, and Grimoire's own
+ * imprinting adds `addoninfo.txt` / `modinfo.json`. None of these change what the
+ * game renders, so tolerating them is what keeps real-world addons detectable
+ * instead of "almost matching".
+ */
+const ICON_ADDON_INCIDENTAL =
+    /^(?:readme[^/]*|addoninfo\.txt|modinfo\.json|panorama\/image_compiler\.vdata_c)$/i;
+
+/**
+ * The panorama codename when this VPK is a companion ICON mod: nothing but ONE
+ * hero's `panorama/images/heroes/<codename>_` art. Null for anything else.
+ *
+ * This is the shape of the per-skin icon addons published alongside the big icon
+ * packs (a "<Skin> TOASTED Addon" ships exactly
+ * `panorama/images/heroes/familiar_{card,card_critical,card_gloat,mm,sm,vertical}_psd.vtex_c`),
+ * and it's the signal that makes a mod offerable as the icon half of a skin link.
+ *
+ * Deliberately stricter than "classifyGlobalModType returned null with one hero":
+ * a skin bundle that happens to ship its hero's card also lands there, and
+ * offering a whole skin as somebody's icon source would be nonsense. Requiring
+ * that EVERY substantive entry live under this one hero's card prefix is what
+ * separates "an icon addon" from "a skin that includes icons".
+ */
+export function classifyHeroIconOnly(paths: string[]): string | null {
+    if (paths.length === 0) return null;
+    const codenames = heroImageCodenames(paths);
+    if (codenames.size !== 1) return null;
+    const [codename] = [...codenames];
+    for (const p of paths) {
+        // Any nesting under heroes/ is fine (some packs use heroes/backgrounds/):
+        // heroImageCodenames already proved only ONE hero is referenced across
+        // the whole set, so the folder shape doesn't need re-checking here.
+        if (HERO_IMAGE_PREFIX.test(p)) continue;
+        if (ICON_ADDON_INCIDENTAL.test(p)) continue;
+        return null; // ships something else: a skin, a HUD layout, another hero
+    }
+    return codename;
+}
+
+/** Convenience wrapper over the cached VPK parse; see classifyHeroIconOnly. */
+export function classifyHeroIconOnlyFromVpk(vpkPath: string): string | null {
+    const paths = parseVpkDirectoryCached(vpkPath);
+    if (!paths || paths.length === 0) return null;
+    return classifyHeroIconOnly(paths);
+}
+
+/**
  * Ability-VFX layer roots. A hero's recolorable ability effects live in two
  * particle dirs, keyed by the model/particle codename (Paige = `bookworm`),
  * which is the namespace used by `models/`+`particles/abilities/`, NOT the

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -148,6 +148,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('revert-hero-card', heroName),
     getActiveHeroCard: (heroName: string) =>
         ipcRenderer.invoke('get-active-hero-card', heroName),
+    getCardLinks: () => ipcRenderer.invoke('get-card-links'),
+    setCardLink: (args: {
+        skinKey: string;
+        skinName?: string;
+        heroName: string;
+        sourceKey: string;
+    }) => ipcRenderer.invoke('set-card-link', args),
+    removeCardLink: (skinKey: string) => ipcRenderer.invoke('remove-card-link', skinKey),
     getCustomCardSlots: (heroName: string) =>
         ipcRenderer.invoke('get-custom-card-slots', heroName),
     applyCustomHeroCard: (heroName: string, uploads: { variant: string; dataUrl: string }[]) =>

--- a/src/components/locker/HeroCardPicker.tsx
+++ b/src/components/locker/HeroCardPicker.tsx
@@ -69,6 +69,7 @@ interface PortraitFileGroup {
 export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
   const { t } = useTranslation();
   const loadMods = useAppStore((s) => s.loadMods);
+  const loadCardLinks = useAppStore((s) => s.loadCardLinks);
   // This component is remounted per hero (the parent LockerHeroView is keyed
   // by hero.id), so initial state stands in for the per-hero reset.
   const [portraits, setPortraits] = useState<HeroPortrait[]>([]);
@@ -152,7 +153,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       }
       // Rebuild changed the cosmetics VPK and possibly the load order; refresh
       // the shared mod list so Installed/Locker stay in sync.
-      await loadMods({ silent: true });
+      await Promise.all([loadMods({ silent: true }), loadCardLinks()]);
     } catch (err) {
       setActionError(String(err));
     } finally {
@@ -205,7 +206,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       // Mark these exact picks as applied so the button reads "Applied" until
       // the user changes a slot.
       setAppliedSig(sigAtApply);
-      await loadMods({ silent: true });
+      await Promise.all([loadMods({ silent: true }), loadCardLinks()]);
     } catch (err) {
       setActionError(String(err));
     } finally {
@@ -222,7 +223,7 @@ export default function HeroCardPicker({ heroName }: HeroCardPickerProps) {
       setActiveSource(null);
       setPicks({});
       setAppliedSig(null);
-      await loadMods({ silent: true });
+      await Promise.all([loadMods({ silent: true }), loadCardLinks()]);
     } catch (err) {
       setActionError(String(err));
     } finally {

--- a/src/components/locker/HeroSkinsPanel.tsx
+++ b/src/components/locker/HeroSkinsPanel.tsx
@@ -26,6 +26,8 @@ import ModThumbnail from '../ModThumbnail';
 import AudioPreviewPlayer from '../AudioPreviewPlayer';
 import DownloadableSkinsSection from './DownloadableSkinsSection';
 import { LockerModImagePicker } from './LockerModImagePicker';
+import SkinIconLinkPicker from './SkinIconLinkPicker';
+import { heroIconMods } from '../../lib/lockerCardLinks';
 import { Select } from '../common/forms';
 
 interface SkinGroup {
@@ -379,6 +381,7 @@ function SkinGroupCard({
   shuffleVariantChoice,
   onSetShuffleVariant,
   shuffleArmed,
+  iconCandidates,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -388,6 +391,9 @@ function SkinGroupCard({
   useHeroPortraitThumbnails: boolean;
   heroName?: string;
   soundVolume: number;
+  /** Companion icon mods installed for this hero (see heroIconMods). Empty
+   *  hides the "match icons" control entirely. */
+  iconCandidates: Mod[];
   /** 1-based load-order position, shown as a corner chip. Only set when 2+
    *  skins are active for the hero (otherwise order is meaningless). */
   loadOrderPosition?: number;
@@ -531,78 +537,90 @@ function SkinGroupCard({
         className="absolute inset-0 z-10 cursor-pointer rounded-[10px]"
       />
 
-      {/* Set Locker image (issue #208): pick this skin's view from its gallery
-          or a custom upload. Hover-revealed; z-30 keeps it above the toggle. */}
-      {onPickImage && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onPickImage();
-          }}
-          aria-label={t('locker.modImage.set', { name: primary.name })}
-          title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100 ${
-            onToggleIncluded && onRequestDelete ? 'right-[4.125rem]' : onToggleIncluded || onRequestDelete ? 'right-9' : 'right-1.5'
-          }`}
-        >
-          <ImagePlus className="h-3.5 w-3.5" />
-        </button>
-      )}
+      {/* Corner control cluster. A flex row rather than four independently
+          positioned absolutes: each control is optional, so hand-computed right-*
+          offsets had to enumerate every combination and would only get worse with
+          another button. z-30 keeps the whole cluster above the full-card toggle. */}
+      <div className="absolute right-1.5 top-1.5 z-30 flex items-center gap-1.5">
+        {/* Set Locker image (issue #208): pick this skin's view from its gallery
+            or a custom upload. Hover-revealed. */}
+        {onPickImage && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPickImage();
+            }}
+            aria-label={t('locker.modImage.set', { name: primary.name })}
+            title={t('locker.modImage.set', { name: primary.name })}
+            className="flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/card:opacity-100"
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+          </button>
+        )}
 
-      {/* Delete: removes the whole group (every variant VPK). Hover-revealed so
-          it stays out of the way; z-30 keeps it above the full-card toggle. */}
-      {onRequestDelete && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRequestDelete(
-              group.variants.map((v) => v.id),
-              primary.name
-            );
-          }}
-          aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
-          title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className={`absolute top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100 ${
-            onToggleIncluded ? 'right-9' : 'right-1.5'
-          }`}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      )}
+        {/* Match icons: link a companion icon mod to this skin so its icons
+            follow it on and off. Renders nothing when the hero has none. */}
+        {heroName && primary.sourceSection !== 'Sound' && (
+          <SkinIconLinkPicker
+            skin={primary}
+            skinName={primary.name}
+            heroName={heroName}
+            candidates={iconCandidates}
+          />
+        )}
 
-      {/* Add to shuffle: opt this skin into the launch-shuffle pool. Anchors the
-          top-right corner because it's the only always-visible control here (lit
-          when included, shown on every card while the shuffle switch is armed) -
-          the hover-only image/delete buttons extend leftward from it. */}
-      {onToggleIncluded && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleIncluded();
-          }}
-          aria-pressed={isIncluded}
-          aria-label={
-            isIncluded
-              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
-              : t('locker.randomize.addToShuffle', { name: primary.name })
-          }
-          title={
-            isIncluded
-              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
-              : t('locker.randomize.addToShuffle', { name: primary.name })
-          }
-          className={`absolute right-1.5 top-1.5 z-30 flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/card:opacity-100 ${
-            isIncluded
-              ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
-              : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/65 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
-          }`}
-        >
-          <Shuffle className="h-3.5 w-3.5" />
-        </button>
-      )}
+        {/* Delete: removes the whole group (every variant VPK). Hover-revealed
+            so it stays out of the way. */}
+        {onRequestDelete && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRequestDelete(
+                group.variants.map((v) => v.id),
+                primary.name
+              );
+            }}
+            aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
+            title={t('locker.skins.deleteSkin', { name: primary.name })}
+            className="flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/card:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+
+        {/* Add to shuffle: opt this skin into the launch-shuffle pool. Last in
+            the row (so it anchors the corner) because it's the one control that
+            can be lit while not hovered. */}
+        {onToggleIncluded && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleIncluded();
+            }}
+            aria-pressed={isIncluded}
+            aria-label={
+              isIncluded
+                ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+                : t('locker.randomize.addToShuffle', { name: primary.name })
+            }
+            title={
+              isIncluded
+                ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+                : t('locker.randomize.addToShuffle', { name: primary.name })
+            }
+            className={`flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/card:opacity-100 ${
+              isIncluded
+                ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
+                : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/65 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
+            }`}
+          >
+            <Shuffle className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
 
       {/* Sound preview. All variants of one GameBanana submission share the
           same preview clip, so the group's primary audioUrl is the
@@ -698,6 +716,7 @@ function SkinGroupRow({
   shuffleVariantChoice,
   onSetShuffleVariant,
   shuffleArmed,
+  iconCandidates,
 }: {
   group: SkinGroup;
   onSelect: (modId: string) => void;
@@ -707,6 +726,8 @@ function SkinGroupRow({
   useHeroPortraitThumbnails: boolean;
   heroName?: string;
   soundVolume: number;
+  /** Companion icon mods installed for this hero (see heroIconMods). */
+  iconCandidates: Mod[];
   /** Issue #208: user-chosen Locker image for this skin (data URL), if any. */
   overrideSrc?: string;
   /** Open the image picker for this skin. Omitted for sound mods. */
@@ -735,70 +756,78 @@ function SkinGroupRow({
           : 'border-border bg-bg-secondary/70 hover:border-accent/60 hover:bg-bg-secondary/85'
       } ${isIncluded ? 'ring-2 ring-accent/45' : ''}`}
     >
-      {onPickImage && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onPickImage();
-          }}
-          aria-label={t('locker.modImage.set', { name: primary.name })}
-          title={t('locker.modImage.set', { name: primary.name })}
-          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100 ${
-            onToggleIncluded && onRequestDelete ? 'right-[4.5rem]' : onToggleIncluded || onRequestDelete ? 'right-10' : 'right-2'
-          }`}
-        >
-          <ImagePlus className="h-3.5 w-3.5" />
-        </button>
-      )}
-      {onRequestDelete && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRequestDelete(
-              group.variants.map((v) => v.id),
-              primary.name
-            );
-          }}
-          aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
-          title={t('locker.skins.deleteSkin', { name: primary.name })}
-          className={`absolute top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100 ${
-            onToggleIncluded ? 'right-10' : 'right-2'
-          }`}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      )}
-      {/* Add to shuffle (see SkinGroupCard). Anchors the top-right corner; the
-          hover-only image/delete buttons extend leftward from it. */}
-      {onToggleIncluded && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleIncluded();
-          }}
-          aria-pressed={isIncluded}
-          aria-label={
-            isIncluded
-              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
-              : t('locker.randomize.addToShuffle', { name: primary.name })
-          }
-          title={
-            isIncluded
-              ? t('locker.randomize.removeFromShuffle', { name: primary.name })
-              : t('locker.randomize.addToShuffle', { name: primary.name })
-          }
-          className={`absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/row:opacity-100 ${
-            isIncluded
-              ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
-              : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/55 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
-          }`}
-        >
-          <Shuffle className="h-3.5 w-3.5" />
-        </button>
-      )}
+      {/* Corner control cluster, mirroring SkinGroupCard: one flex row instead of
+          per-button right-* arithmetic that had to enumerate every combination of
+          optional controls. */}
+      <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
+        {onPickImage && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPickImage();
+            }}
+            aria-label={t('locker.modImage.set', { name: primary.name })}
+            title={t('locker.modImage.set', { name: primary.name })}
+            className="flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:opacity-100 group-hover/row:opacity-100"
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {heroName && primary.sourceSection !== 'Sound' && (
+          <SkinIconLinkPicker
+            skin={primary}
+            skinName={primary.name}
+            heroName={heroName}
+            candidates={iconCandidates}
+          />
+        )}
+        {onRequestDelete && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRequestDelete(
+                group.variants.map((v) => v.id),
+                primary.name
+              );
+            }}
+            aria-label={t('locker.skins.deleteSkin', { name: primary.name })}
+            title={t('locker.skins.deleteSkin', { name: primary.name })}
+            className="flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white/90 opacity-0 backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-state-danger/80 hover:text-white focus-visible:opacity-100 group-hover/row:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {/* Add to shuffle (see SkinGroupCard). Last so it anchors the corner. */}
+        {onToggleIncluded && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleIncluded();
+            }}
+            aria-pressed={isIncluded}
+            aria-label={
+              isIncluded
+                ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+                : t('locker.randomize.addToShuffle', { name: primary.name })
+            }
+            title={
+              isIncluded
+                ? t('locker.randomize.removeFromShuffle', { name: primary.name })
+                : t('locker.randomize.addToShuffle', { name: primary.name })
+            }
+            className={`flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/row:opacity-100 ${
+              isIncluded
+                ? 'opacity-100 bg-accent text-accent-foreground hover:bg-accent/80'
+                : `${shuffleArmed ? 'opacity-100' : 'opacity-0'} bg-black/55 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
+            }`}
+          >
+            <Shuffle className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
       <button
         type="button"
         onClick={() => {
@@ -940,6 +969,14 @@ export default function HeroSkinsPanel({
   // The "Locker image" (grid-thumbnail surface) the picker mirrors from.
   const lockerModThumbnails = useAppStore((s) => s.lockerModThumbnails);
   const groups = useMemo(() => groupVariants(mods), [mods]);
+  // Companion icon mods are read from the FULL installed list, not this panel's
+  // `mods`: an icon addon is its own VPK and may be filed under a different
+  // hero pile (or none) than the skins it pairs with.
+  const allMods = useAppStore((s) => s.mods);
+  const iconCandidates = useMemo(
+    () => (heroName ? heroIconMods(allMods, heroName) : []),
+    [allMods, heroName]
+  );
   // Issue #208: which skin's image picker is open (null = none). Skins only;
   // sound mods keep the hero-portrait thumbnail and get no picker.
   const [pickerGroup, setPickerGroup] = useState<SkinGroup | null>(null);
@@ -982,6 +1019,7 @@ export default function HeroSkinsPanel({
     useHeroPortraitThumbnails,
     heroName,
     soundVolume,
+    iconCandidates,
   };
 
   return (

--- a/src/components/locker/SkinIconLinkPicker.tsx
+++ b/src/components/locker/SkinIconLinkPicker.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Images, Loader2 } from 'lucide-react';
+import type { Mod } from '../../types/mod';
+import { lockerLinkKey } from '../../lib/lockerCardLinks';
+import { useAppStore } from '../../stores/appStore';
+import { showToast } from '../../stores/toastStore';
+
+interface SkinIconLinkPickerProps {
+  /** The skin group's representative mod, which the link key is derived from. */
+  skin: Mod;
+  /** Display name for the skin (the group's title, not the VPK filename). */
+  skinName: string;
+  heroName: string;
+  /** Companion icon mods available for this hero (see heroIconMods). */
+  candidates: Mod[];
+  /** Extra classes for the trigger button, so each layout can place it. */
+  className?: string;
+  /** Keep the trigger visible instead of hover-only (used once a link exists). */
+  alwaysVisible?: boolean;
+}
+
+/**
+ * "Match icons" control on a skin card.
+ *
+ * Links this skin to a companion icon mod so the icons follow the skin: turn the
+ * skin on and its icons apply, turn it off and they revert. The alternative
+ * users face today is the instruction those addons actually ship with ("RENAME
+ * THE TOASTED ICON MOD TO pak02_dir.vpk OR A NUMBER BIGGER"), because the addon
+ * has to out-rank both the skin bundle and the icon pack. A link sidesteps load
+ * order entirely: the art is split into the Locker-managed VPK in
+ * citadel/grimoire, which wins by search-path precedence.
+ *
+ * Renders nothing when the hero has no companion icon mods installed, so the
+ * control only appears for users who actually have the pairing to make.
+ */
+export default function SkinIconLinkPicker({
+  skin,
+  skinName,
+  heroName,
+  candidates,
+  className = '',
+  alwaysVisible = false,
+}: SkinIconLinkPickerProps) {
+  const { t } = useTranslation();
+  const cardLinks = useAppStore((s) => s.cardLinks);
+  const linkSkinIcons = useAppStore((s) => s.linkSkinIcons);
+  const unlinkSkinIcons = useAppStore((s) => s.unlinkSkinIcons);
+  const loadMods = useAppStore((s) => s.loadMods);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const skinKey = useMemo(() => lockerLinkKey(skin), [skin]);
+  const activeLink = cardLinks.find((link) => link.skinKey === skinKey);
+  const linkedSourceKey = activeLink?.sourceKey;
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  // Nothing to pair with: stay out of the way entirely.
+  if (candidates.length === 0) return null;
+
+  const choose = async (sourceKey: string | null) => {
+    setBusy(true);
+    try {
+      if (sourceKey === null) {
+        await unlinkSkinIcons(skinKey);
+      } else {
+        await linkSkinIcons({ skinKey, skinName, heroName, sourceKey });
+      }
+      // The applied cards live in a Grimoire-managed VPK the mod list reflects,
+      // and a link can take a hero over from a manual pick, so re-read.
+      await loadMods({ silent: true });
+      setOpen(false);
+    } catch (err) {
+      showToast(String(err), { tone: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const linked = Boolean(activeLink);
+  const label = linked
+    ? t('locker.iconLink.linkedTo', { name: activeLink?.sourceModName ?? activeLink?.sourceKey })
+    : t('locker.iconLink.matchIcons');
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((value) => !value);
+        }}
+        onMouseDown={(event) => event.stopPropagation()}
+        aria-label={label}
+        aria-expanded={open}
+        title={label}
+        className={`flex h-7 w-7 items-center justify-center rounded-full backdrop-blur-sm transition-[opacity,background-color,color] duration-150 focus-visible:opacity-100 group-hover/card:opacity-100 group-hover/row:opacity-100 ${
+          linked
+            ? 'bg-accent text-accent-foreground opacity-100 hover:bg-accent/80'
+            : `${alwaysVisible ? 'opacity-100' : 'opacity-0'} bg-black/65 text-white/90 hover:bg-accent/70 hover:text-accent-foreground`
+        }`}
+      >
+        {busy ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Images className="h-3.5 w-3.5" />
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full z-40 mt-1 w-60 rounded-md border border-white/[0.12] bg-bg-secondary/95 p-1.5 shadow-xl shadow-black/50 backdrop-blur-md"
+          role="menu"
+          onClick={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <div className="px-1.5 pb-1.5 pt-1">
+            <div className="text-[11px] font-semibold text-text-primary">
+              {t('locker.iconLink.title')}
+            </div>
+            <div className="text-[10px] leading-snug text-text-secondary">
+              {t('locker.iconLink.hint')}
+            </div>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {candidates.map((candidate) => {
+              const isActive = candidate.metaKey === linkedSourceKey;
+              return (
+                <button
+                  key={candidate.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  disabled={busy}
+                  onClick={() => choose(isActive ? null : candidate.metaKey)}
+                  className={`flex items-center gap-2 rounded px-1.5 py-1.5 text-left text-[11px] transition-colors disabled:opacity-60 ${
+                    isActive
+                      ? 'bg-accent/15 text-text-primary'
+                      : 'text-text-primary/85 hover:bg-white/[0.06] hover:text-text-primary'
+                  }`}
+                >
+                  <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center">
+                    {isActive && <Check className="h-3.5 w-3.5 text-accent" />}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate" title={candidate.name}>
+                    {candidate.name}
+                  </span>
+                </button>
+              );
+            })}
+            {linked && (
+              <button
+                type="button"
+                role="menuitem"
+                disabled={busy}
+                onClick={() => choose(null)}
+                className="mt-0.5 rounded border-t border-white/[0.08] px-1.5 pb-1 pt-1.5 text-left text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+              >
+                {t('locker.iconLink.unlink')}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/locker/SkinIconLinkPicker.tsx
+++ b/src/components/locker/SkinIconLinkPicker.tsx
@@ -53,7 +53,7 @@ export default function SkinIconLinkPicker({
 
   const skinKey = useMemo(() => lockerLinkKey(skin), [skin]);
   const activeLink = cardLinks.find((link) => link.skinKey === skinKey);
-  const linkedSourceKey = activeLink?.sourceKey;
+  const linked = Boolean(activeLink);
 
   useEffect(() => {
     if (!open) return;
@@ -71,8 +71,10 @@ export default function SkinIconLinkPicker({
     };
   }, [open]);
 
-  // Nothing to pair with: stay out of the way entirely.
-  if (candidates.length === 0) return null;
+  // With neither candidates nor a stored link there is nothing useful to show.
+  // A broken/missing source still renders its linked control so the user always
+  // has a way to remove the binding.
+  if (candidates.length === 0 && !activeLink) return null;
 
   const choose = async (sourceKey: string | null) => {
     setBusy(true);
@@ -93,7 +95,6 @@ export default function SkinIconLinkPicker({
     }
   };
 
-  const linked = Boolean(activeLink);
   const label = linked
     ? t('locker.iconLink.linkedTo', { name: activeLink?.sourceModName ?? activeLink?.sourceKey })
     : t('locker.iconLink.matchIcons');
@@ -140,7 +141,12 @@ export default function SkinIconLinkPicker({
           </div>
           <div className="flex flex-col gap-0.5">
             {candidates.map((candidate) => {
-              const isActive = candidate.metaKey === linkedSourceKey;
+              // Content identity survives the pakNN/addons rename caused by an
+              // enable, disable, or reorder. Fall back to the captured metaKey
+              // for older links that predate source hashes.
+              const isActive = activeLink?.sourceSha256 && candidate.sha256
+                ? activeLink.sourceSha256.toLowerCase() === candidate.sha256.toLowerCase()
+                : candidate.metaKey === activeLink?.sourceKey;
               return (
                 <button
                   key={candidate.id}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, AddMergeSourcesResult, ImprintAllInstalledResult, ImprintInstalledProgress, ImprintPreflightResult, ImprintDetails, PeekImprintResult, ApplyHeroCardResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, ActiveTrippySkin, ApplyTrippySkinResult, ApplyTrippyVfxResult, TrippySpriteOptions, TrippySpriteResult, TrippyVfxChoice, LockerOverview, LockerCardThumbnail, LockerClearScope, AppearanceSurface } from '../types/mod';
+import type { Mod, AppSettings, GlobalModType, UnknownModFilterGuess, UnknownModDetectionProgress, ApplyUnknownModMatchArgs, ApplyUnknownCustomModArgs, AssociateUnknownModArgs, UnknownModFileList, EditLocalModArgs, MergeModsArgs, UnmergeModResult, ExtractMergeSourceResult, AddMergeSourcesResult, ImprintAllInstalledResult, ImprintInstalledProgress, ImprintPreflightResult, ImprintDetails, PeekImprintResult, ApplyHeroCardResult, LockerCardLink, SetCardLinkArgs, CardLinkReconcileResult, HeroAbilitySlot, AbilitySlot, AbilitySoundParams, ActiveHeroSound, ApplyHeroSoundResult, ActiveHeroColor, ApplyHeroColorResult, ApplyHeroPrismResult, ActiveTrippySkin, ApplyTrippySkinResult, ApplyTrippyVfxResult, TrippySpriteOptions, TrippySpriteResult, TrippyVfxChoice, LockerOverview, LockerCardThumbnail, LockerClearScope, AppearanceSurface } from '../types/mod';
 import type { DmmMigrationRequest, DmmMigrationReport } from './dmmMigration';
 import type {
   HeroPortrait,
@@ -191,6 +191,22 @@ export async function getActiveHeroCard(
   heroName: string
 ): Promise<{ sourceFileName: string; variants: string[] } | null> {
   return window.electronAPI.getActiveHeroCard(heroName);
+}
+
+/** Every skin -> icon binding (see LockerCardLink). */
+export async function getCardLinks(): Promise<LockerCardLink[]> {
+  return window.electronAPI.getCardLinks();
+}
+
+/** Bind a skin to a companion icon mod. Applies immediately when the skin is
+ *  already enabled; otherwise it applies the moment the skin is turned on. */
+export async function setCardLink(args: SetCardLinkArgs): Promise<CardLinkReconcileResult> {
+  return window.electronAPI.setCardLink(args);
+}
+
+/** Unbind a skin, reverting whatever card its link had applied. */
+export async function removeCardLink(skinKey: string): Promise<CardLinkReconcileResult> {
+  return window.electronAPI.removeCardLink(skinKey);
 }
 
 /** Uploadable card-variant slots for a hero, derived from the base game art. */

--- a/src/lib/heroCodenames.ts
+++ b/src/lib/heroCodenames.ts
@@ -1,0 +1,98 @@
+/**
+ * Hero display name -> panorama codename, the namespace hero CARD art lives
+ * under as `panorama/images/heroes/<codename>_<variant>`.
+ *
+ * Shared by both processes: the main process uses it to scan and split card art
+ * (heroPortraits.ts re-exports from here), and the renderer uses it to tell
+ * which installed icon mods belong to the hero it is showing. Keeping one table
+ * is what stops the two sides from disagreeing about, say, whether Abrams' cards
+ * are filed under `atlas` or `bull`.
+ *
+ * This deliberately does NOT reuse the sound-codename table
+ * (electron/main/services/heroSoundCodenames.ts). That table is scoped to the
+ * ~35 heroes that ship ability sounds, so it (a) omits heroes whose only modded
+ * art is panorama cards (Doorman, Graves, Rem, Sinclair, Venator, Victor,
+ * Warden, Wraith) and (b) uses the sound-path codename, which diverges from the
+ * panorama/class_name codename for Abrams (sound `abrams` vs panorama `atlas`)
+ * and Mo & Krill (`mokrill` vs `krill`). Both bugs made the card picker silently
+ * return nothing for those heroes.
+ *
+ * Source of truth: assets.deadlock-api.com/v2/heroes `class_name`. Both
+ * "Doorman" (GameBanana's category name) and "The Doorman" (the API/roster name)
+ * are keyed so the lookup works whichever name flows in.
+ */
+const PANORAMA_CODENAME_BY_HERO: Readonly<Record<string, string>> = {
+  Abrams: 'atlas',
+  Apollo: 'fencer',
+  Bebop: 'bebop',
+  Billy: 'punkgoat',
+  Calico: 'nano',
+  Celeste: 'unicorn',
+  Doorman: 'doorman',
+  'The Doorman': 'doorman',
+  Drifter: 'drifter',
+  Dynamo: 'dynamo',
+  Graves: 'necro',
+  'Grey Talon': 'orion',
+  Haze: 'haze',
+  Holliday: 'astro',
+  Infernus: 'inferno',
+  Ivy: 'tengu',
+  Kelvin: 'kelvin',
+  'Lady Geist': 'ghost',
+  Lash: 'lash',
+  McGinnis: 'forge',
+  Mina: 'vampirebat',
+  Mirage: 'mirage',
+  'Mo & Krill': 'krill',
+  Paige: 'bookworm',
+  Paradox: 'chrono',
+  Pocket: 'synth',
+  Rem: 'familiar',
+  Seven: 'gigawatt',
+  Shiv: 'shiv',
+  Silver: 'werewolf',
+  Sinclair: 'magician',
+  Venator: 'priest',
+  Victor: 'frank',
+  Vindicta: 'hornet',
+  Viscous: 'viscous',
+  Vyper: 'viper',
+  Warden: 'warden',
+  Wraith: 'wraith',
+  Yamato: 'yamato',
+};
+
+/**
+ * LEGACY panorama codenames. Six heroes were renamed during development; the
+ * deadlock-api `class_name` (above) is the current name, but a lot of shipped
+ * community icon packs (catlock, irl_hero_icons, "did you see that", ...) still
+ * author their card art under the OLD codename. Verified against real installed
+ * packs: e.g. "did_you_see_that_icons" ships `archer`/`engineer`/`bull`/
+ * `spectre`/`digger`/`sumo`, never `orion`/`forge`/`atlas`/`ghost`/`krill`/
+ * `dynamo`. We match BOTH so cards from old and new packs both show.
+ */
+const PANORAMA_CODENAME_ALIASES: Readonly<Record<string, string[]>> = {
+  'Grey Talon': ['archer'],
+  McGinnis: ['engineer'],
+  Abrams: ['bull'],
+  'Lady Geist': ['spectre'],
+  'Mo & Krill': ['digger'],
+  Dynamo: ['sumo'],
+};
+
+/** Resolve a hero display name (e.g. "Vindicta") to its primary panorama
+ *  codename (e.g. "hornet"), or undefined when the name is unknown. */
+export function codenameForHero(heroName: string): string | undefined {
+  return PANORAMA_CODENAME_BY_HERO[heroName];
+}
+
+/** Every panorama codename a hero's card art might be filed under: the current
+ *  class_name first, then any legacy aliases. Empty when the name is unknown.
+ *  Card scanning, apply and the icon-link picker all iterate this so neither old
+ *  nor new packs are missed. */
+export function codenamesForHero(heroName: string): string[] {
+  const primary = PANORAMA_CODENAME_BY_HERO[heroName];
+  if (!primary) return [];
+  return [primary, ...(PANORAMA_CODENAME_ALIASES[heroName] ?? [])];
+}

--- a/src/lib/lockerCardLinks.test.ts
+++ b/src/lib/lockerCardLinks.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import {
+  lockerLinkKey,
+  planLinkedCards,
+  selectionsSignature,
+  upsertLink,
+  withoutHero,
+  withoutSkin,
+  type ActiveSkin,
+} from './lockerCardLinks';
+import type { LockerCardLink, LockerCardSelection } from '../types/mod';
+
+const NOW = '2026-07-30T00:00:00.000Z';
+
+function link(over: Partial<LockerCardLink> = {}): LockerCardLink {
+  return {
+    skinKey: 'gamebanana:111',
+    skinName: 'Ralsei Rem',
+    heroName: 'Rem',
+    heroCodename: 'familiar',
+    sourceKey: 'pak04_dir.vpk',
+    sourceModName: 'Ralsei Rem Toasted Compatibility Icons',
+    sourceSha256: 'abc',
+    variants: ['card', 'mm'],
+    linkedAt: NOW,
+    ...over,
+  };
+}
+
+function manual(over: Partial<LockerCardSelection> = {}): LockerCardSelection {
+  return {
+    heroCodename: 'hornet',
+    heroName: 'Vindicta',
+    variants: ['card'],
+    source: { kind: 'mod', fileName: 'pak09_dir.vpk', sha256AtApplyTime: 'zzz' },
+    origin: 'manual',
+    addedAt: NOW,
+    ...over,
+  };
+}
+
+const active = (...keys: string[]): ActiveSkin[] =>
+  keys.map((key, i) => ({ key, loadOrder: i + 1 }));
+
+describe('lockerLinkKey', () => {
+  it('prefers the GameBanana id so the key survives pakNN renames', () => {
+    expect(lockerLinkKey({ id: 'md5a', gameBananaId: 680646, sha256: 'aa' })).toBe(
+      'gamebanana:680646'
+    );
+  });
+
+  it('falls back to content hash for local imports', () => {
+    expect(lockerLinkKey({ id: 'md5a', sha256: 'deadbeef' })).toBe('sha256:deadbeef');
+  });
+
+  it('falls back to the mod id only when there is no stable identity', () => {
+    expect(lockerLinkKey({ id: 'md5a' })).toBe('mod:md5a');
+  });
+
+  it('ignores a zero/negative GameBanana id', () => {
+    expect(lockerLinkKey({ id: 'md5a', gameBananaId: 0, sha256: 'bb' })).toBe('sha256:bb');
+  });
+
+  it('is stable across the rename a toggle causes (id changes, key does not)', () => {
+    const before = lockerLinkKey({ id: 'md5-pak07', gameBananaId: 42 });
+    const after = lockerLinkKey({ id: 'md5-pak12', gameBananaId: 42 });
+    expect(before).toBe(after);
+  });
+});
+
+describe('planLinkedCards', () => {
+  it('applies a linked icon when its skin is enabled', () => {
+    const next = planLinkedCards({
+      links: [link()],
+      current: [],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({
+      heroCodename: 'familiar',
+      origin: 'link',
+      linkedSkinKey: 'gamebanana:111',
+      source: { fileName: 'pak04_dir.vpk', sha256AtApplyTime: 'abc' },
+    });
+  });
+
+  it('applies nothing when the linked skin is disabled', () => {
+    const next = planLinkedCards({
+      links: [link()],
+      current: [],
+      activeSkins: [],
+      now: NOW,
+    });
+    expect(next).toEqual([]);
+  });
+
+  it('drops the link selection when its skin is turned off', () => {
+    const applied = planLinkedCards({
+      links: [link()],
+      current: [],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    const reverted = planLinkedCards({
+      links: [link()],
+      current: applied,
+      activeSkins: [],
+      now: NOW,
+    });
+    expect(reverted).toEqual([]);
+  });
+
+  it('keeps manual selections for other heroes untouched', () => {
+    const next = planLinkedCards({
+      links: [link()],
+      current: [manual()],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(next).toHaveLength(2);
+    expect(next.find((s) => s.heroCodename === 'hornet')).toEqual(manual());
+  });
+
+  it('keeps a custom upload for another hero untouched', () => {
+    const custom = manual({
+      heroCodename: 'lash',
+      heroName: 'Lash',
+      origin: undefined,
+      source: { kind: 'custom', fileName: 'custom:lash', sha256AtApplyTime: '' },
+    });
+    const next = planLinkedCards({
+      links: [link()],
+      current: [custom],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(next.find((s) => s.heroCodename === 'lash')).toEqual(custom);
+  });
+
+  it('never clobbers a manual pick for the SAME hero', () => {
+    const manualRem = manual({ heroCodename: 'familiar', heroName: 'Rem' });
+    const next = planLinkedCards({
+      links: [link()],
+      current: [manualRem],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(next).toEqual([manualRem]);
+  });
+
+  it('treats a legacy selection with no origin as manual and leaves it alone', () => {
+    const legacy = manual({ heroCodename: 'familiar', heroName: 'Rem', origin: undefined });
+    const next = planLinkedCards({
+      links: [link()],
+      current: [legacy],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(next).toEqual([legacy]);
+  });
+
+  it('resolves two enabled linked skins for one hero by load order', () => {
+    const loser = link({ skinKey: 'gamebanana:111', sourceKey: 'loser.vpk' });
+    const winner = link({ skinKey: 'gamebanana:222', sourceKey: 'winner.vpk' });
+    const next = planLinkedCards({
+      links: [loser, winner],
+      current: [],
+      activeSkins: [
+        { key: 'gamebanana:222', loadOrder: 3 },
+        { key: 'gamebanana:111', loadOrder: 9 },
+      ],
+      now: NOW,
+    });
+    expect(next).toHaveLength(1);
+    expect(next[0].source.fileName).toBe('winner.vpk');
+  });
+
+  it('uses the lowest load order when a skin has several enabled variant VPKs', () => {
+    const next = planLinkedCards({
+      links: [link(), link({ skinKey: 'gamebanana:222', sourceKey: 'other.vpk' })],
+      current: [],
+      activeSkins: [
+        { key: 'gamebanana:111', loadOrder: 12 },
+        { key: 'gamebanana:111', loadOrder: 4 },
+        { key: 'gamebanana:222', loadOrder: 8 },
+      ],
+      now: NOW,
+    });
+    expect(next.map((s) => s.source.fileName)).toEqual(['pak04_dir.vpk']);
+  });
+
+  it('applies links for different heroes side by side', () => {
+    const next = planLinkedCards({
+      links: [link(), link({ skinKey: 'gamebanana:222', heroCodename: 'lash', heroName: 'Lash' })],
+      current: [],
+      activeSkins: active('gamebanana:111', 'gamebanana:222'),
+      now: NOW,
+    });
+    expect(next.map((s) => s.heroCodename).sort()).toEqual(['familiar', 'lash']);
+  });
+
+  it('preserves addedAt for an already-applied link so unrelated toggles are no-ops', () => {
+    const applied = planLinkedCards({
+      links: [link()],
+      current: [],
+      activeSkins: active('gamebanana:111'),
+      now: '2026-01-01T00:00:00.000Z',
+    });
+    const again = planLinkedCards({
+      links: [link()],
+      current: applied,
+      activeSkins: active('gamebanana:111'),
+      now: '2026-09-09T00:00:00.000Z',
+    });
+    expect(again[0].addedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(selectionsSignature(again)).toBe(selectionsSignature(applied));
+  });
+
+  it('re-points a hero when the link swaps to a different icon source', () => {
+    const applied = planLinkedCards({
+      links: [link()],
+      current: [],
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    const swapped = planLinkedCards({
+      links: [link({ sourceKey: 'pak22_dir.vpk' })],
+      current: applied,
+      activeSkins: active('gamebanana:111'),
+      now: NOW,
+    });
+    expect(swapped[0].source.fileName).toBe('pak22_dir.vpk');
+    expect(selectionsSignature(swapped)).not.toBe(selectionsSignature(applied));
+  });
+});
+
+describe('selectionsSignature', () => {
+  it('is order independent', () => {
+    const a = manual();
+    const b = manual({ heroCodename: 'lash', heroName: 'Lash' });
+    expect(selectionsSignature([a, b])).toBe(selectionsSignature([b, a]));
+  });
+
+  it('distinguishes a manual pick from a link on the same source', () => {
+    const asManual = manual({ heroCodename: 'familiar' });
+    const asLink = manual({
+      heroCodename: 'familiar',
+      origin: 'link',
+      linkedSkinKey: 'gamebanana:111',
+    });
+    expect(selectionsSignature([asManual])).not.toBe(selectionsSignature([asLink]));
+  });
+});
+
+describe('link set edits', () => {
+  it('upsert replaces a prior binding for the same skin', () => {
+    const next = upsertLink([link()], link({ sourceKey: 'new.vpk' }));
+    expect(next).toHaveLength(1);
+    expect(next[0].sourceKey).toBe('new.vpk');
+  });
+
+  it('upsert replaces another skin binding for the same hero (one owner per hero)', () => {
+    const next = upsertLink([link()], link({ skinKey: 'gamebanana:999', sourceKey: 'new.vpk' }));
+    expect(next).toHaveLength(1);
+    expect(next[0].skinKey).toBe('gamebanana:999');
+  });
+
+  it('upsert leaves bindings for other heroes alone', () => {
+    const other = link({ skinKey: 'gamebanana:222', heroCodename: 'lash', heroName: 'Lash' });
+    const next = upsertLink([other], link());
+    expect(next).toHaveLength(2);
+  });
+
+  it('withoutHero clears every binding that owns the hero', () => {
+    expect(withoutHero([link(), link({ skinKey: 'gamebanana:222' })], 'familiar')).toEqual([]);
+  });
+
+  it('withoutSkin clears only that skin binding', () => {
+    const other = link({ skinKey: 'gamebanana:222', heroCodename: 'lash' });
+    expect(withoutSkin([link(), other], 'gamebanana:111')).toEqual([other]);
+  });
+});

--- a/src/lib/lockerCardLinks.test.ts
+++ b/src/lib/lockerCardLinks.test.ts
@@ -225,7 +225,7 @@ describe('planLinkedCards', () => {
       now: NOW,
     });
     const swapped = planLinkedCards({
-      links: [link({ sourceKey: 'pak22_dir.vpk' })],
+      links: [link({ sourceKey: 'pak22_dir.vpk', sourceSha256: 'different-content' })],
       current: applied,
       activeSkins: active('gamebanana:111'),
       now: NOW,
@@ -251,6 +251,28 @@ describe('selectionsSignature', () => {
     });
     expect(selectionsSignature([asManual])).not.toBe(selectionsSignature([asLink]));
   });
+
+  it('changes when source content changes under the same metaKey', () => {
+    const before = manual({
+      source: { kind: 'mod', fileName: 'pak04_dir.vpk', sha256AtApplyTime: 'old' },
+    });
+    const after = manual({
+      source: { kind: 'mod', fileName: 'pak04_dir.vpk', sha256AtApplyTime: 'new' },
+    });
+    expect(selectionsSignature([before])).not.toBe(selectionsSignature([after]));
+  });
+
+  it('ignores a pakNN rename when the source content identity is unchanged', () => {
+    const before = manual({
+      variants: ['vertical', 'card'],
+      source: { kind: 'mod', fileName: 'pak04_dir.vpk', sha256AtApplyTime: 'same' },
+    });
+    const after = manual({
+      variants: ['card', 'vertical'],
+      source: { kind: 'mod', fileName: 'addons2/pak19_dir.vpk', sha256AtApplyTime: 'same' },
+    });
+    expect(selectionsSignature([before])).toBe(selectionsSignature([after]));
+  });
 });
 
 describe('link set edits', () => {
@@ -260,10 +282,10 @@ describe('link set edits', () => {
     expect(next[0].sourceKey).toBe('new.vpk');
   });
 
-  it('upsert replaces another skin binding for the same hero (one owner per hero)', () => {
+  it('keeps another skin binding for the same hero', () => {
     const next = upsertLink([link()], link({ skinKey: 'gamebanana:999', sourceKey: 'new.vpk' }));
-    expect(next).toHaveLength(1);
-    expect(next[0].skinKey).toBe('gamebanana:999');
+    expect(next).toHaveLength(2);
+    expect(next.map((item) => item.skinKey)).toEqual(['gamebanana:111', 'gamebanana:999']);
   });
 
   it('upsert leaves bindings for other heroes alone', () => {

--- a/src/lib/lockerCardLinks.ts
+++ b/src/lib/lockerCardLinks.ts
@@ -1,0 +1,223 @@
+/**
+ * Skin -> icon links: the pure decision layer.
+ *
+ * The Deadlock icon ecosystem is built on companion mods. A global pack (e.g.
+ * DEADLOCK TOASTED) restyles every hero's card, then per-skin addons restyle ONE
+ * hero's card to match a specific skin. Loading both correctly by hand means
+ * winning a three-way pakNN fight against the skin bundle AND the pack, which is
+ * literally what those addons' install instructions ask users to do ("RENAME THE
+ * TOASTED ICON MOD TO pak02_dir.vpk OR A NUMBER BIGGER").
+ *
+ * A link says "whenever this skin is on, apply that hero's card from that mod",
+ * and the existing hero-card pipeline does the rest: the art is split into the
+ * Locker-managed cosmetics VPK in citadel/grimoire, which wins by SearchPaths
+ * folder precedence, so load order stops mattering entirely.
+ *
+ * Everything here is pure so it can be unit-tested and shared: the main process
+ * (services/lockerCardLinks.ts) supplies the live enabled set and performs the
+ * rebuild, the renderer uses the same key function so both sides agree on
+ * identity.
+ */
+import type { LockerCardLink, LockerCardSelection, Mod } from '../types/mod';
+import { codenamesForHero } from './heroCodenames';
+
+/** The identity fields a stable skin key is derived from. Structural so both a
+ *  renderer `Mod` and a main-process scan row can be passed directly. */
+export interface LinkKeyFields {
+  gameBananaId?: number;
+  sha256?: string;
+  id: string;
+}
+
+/**
+ * Stable key for the skin half of a link.
+ *
+ * The fallback chain matters. `mod.id` is `md5(metaKey)` and EVERY enable,
+ * disable and reorder renames the VPK (pak07 -> pak12, addons -> .disabled),
+ * which changes the metaKey and therefore the id. A link keyed on id alone would
+ * break on exactly the toggles it exists to survive. GameBanana id is stable and
+ * group-scoped (so it matches the Locker's own skin grouping, covering
+ * multi-variant submissions with one link); sha256 is stable content identity
+ * for local imports; the id is a last resort for a mod with neither.
+ *
+ * Mirrors shuffleSkinKey (lockerRandomizer.ts) on purpose: same problem, same
+ * answer, so a skin pooled for shuffle and linked to an icon agree on identity.
+ */
+export function lockerLinkKey(mod: LinkKeyFields): string {
+  if (typeof mod.gameBananaId === 'number' && mod.gameBananaId > 0) {
+    return `gamebanana:${mod.gameBananaId}`;
+  }
+  if (mod.sha256) return `sha256:${mod.sha256}`;
+  return `mod:${mod.id}`;
+}
+
+/**
+ * Global load-order rank from a metaKey: lower = higher priority (loads as
+ * pak01, wins file conflicts). With overflow folders the pakNN repeats per
+ * folder, so the folder index from `addons{N}/...` is folded in to get a single
+ * monotonic order; base citadel/addons (and .disabled) is folder 0.
+ *
+ * Lives here rather than in lockerUtils because the main process needs the same
+ * formula to rank linked skins and cannot import lockerUtils (which reaches for
+ * renderer-only asset paths). lockerUtils.modLoadOrder delegates to this so
+ * there is exactly one definition.
+ */
+export function loadOrderFromMetaKey(metaKey: string, priority: number): number {
+  const match = metaKey.match(/^addons(\d+)\//);
+  const folderIndex = match ? parseInt(match[1], 10) : 0;
+  return folderIndex * 100 + priority;
+}
+
+/** One currently-enabled skin, as the planner sees it. */
+export interface ActiveSkin {
+  key: string;
+  /** Global load order (lower = wins file conflicts). Breaks ties when two
+   *  linked skins for the SAME hero are enabled at once. */
+  loadOrder: number;
+}
+
+/** Turn a link into the card selection it implies. */
+function selectionForLink(link: LockerCardLink, addedAt: string): LockerCardSelection {
+  return {
+    heroCodename: link.heroCodename,
+    heroName: link.heroName,
+    variants: link.variants,
+    source: {
+      kind: 'mod',
+      fileName: link.sourceKey,
+      modName: link.sourceModName,
+      gameBananaId: link.sourceGameBananaId,
+      sha256AtApplyTime: link.sourceSha256 ?? '',
+    },
+    origin: 'link',
+    linkedSkinKey: link.skinKey,
+    addedAt,
+  };
+}
+
+/**
+ * The card selection set implied by `links` given which skins are enabled.
+ *
+ * Rules, in order:
+ *  1. Every non-link selection (manual pick, custom upload, legacy entry with no
+ *     `origin`) is kept verbatim. Reconcile never touches a card the user chose
+ *     by hand.
+ *  2. A hero that already has a non-link selection is skipped entirely, so a
+ *     manual pick can't be clobbered by a link. In practice this is unreachable
+ *     because linking and manual-applying each clear the other side, but the
+ *     planner enforces the invariant rather than trusting it.
+ *  3. Otherwise each link whose skin is currently enabled contributes its
+ *     hero's card. Two enabled linked skins for the same hero resolve by load
+ *     order: the skin that wins in-game is the one whose icons apply.
+ *  4. Link selections whose skin is no longer enabled simply aren't re-added,
+ *     which is how disabling a skin reverts its icons.
+ */
+export function planLinkedCards(input: {
+  links: readonly LockerCardLink[];
+  current: readonly LockerCardSelection[];
+  activeSkins: readonly ActiveSkin[];
+  /** Timestamp for newly added selections. Injected so the result is
+   *  deterministic under test (and because Date.now is unavailable in some
+   *  execution contexts). */
+  now: string;
+}): LockerCardSelection[] {
+  const { links, current, activeSkins, now } = input;
+
+  const orderByKey = new Map<string, number>();
+  for (const skin of activeSkins) {
+    const prior = orderByKey.get(skin.key);
+    if (prior === undefined || skin.loadOrder < prior) orderByKey.set(skin.key, skin.loadOrder);
+  }
+
+  // Rule 1 + 2: manual/custom entries survive and claim their hero.
+  const next = current.filter((sel) => sel.origin !== 'link');
+  const ownedHeroes = new Set(next.map((sel) => sel.heroCodename));
+
+  // Rule 3: best live link per hero.
+  const bestByHero = new Map<string, { link: LockerCardLink; loadOrder: number }>();
+  for (const link of links) {
+    const loadOrder = orderByKey.get(link.skinKey);
+    if (loadOrder === undefined) continue; // rule 4: skin not enabled
+    if (ownedHeroes.has(link.heroCodename)) continue;
+    const best = bestByHero.get(link.heroCodename);
+    if (!best || loadOrder < best.loadOrder) bestByHero.set(link.heroCodename, { link, loadOrder });
+  }
+
+  for (const { link } of bestByHero.values()) {
+    // Carry the previous addedAt when this exact link was already applied, so an
+    // unrelated toggle doesn't churn the timestamp (and with it the signature).
+    const prior = current.find(
+      (sel) =>
+        sel.origin === 'link' &&
+        sel.heroCodename === link.heroCodename &&
+        sel.linkedSkinKey === link.skinKey &&
+        sel.source.fileName === link.sourceKey
+    );
+    next.push(selectionForLink(link, prior?.addedAt ?? now));
+  }
+
+  return next;
+}
+
+/**
+ * Order-independent fingerprint of a selection set, used to skip the (expensive,
+ * vpkmerge-shelling) rebuild when a toggle changed nothing relevant. Covers
+ * everything that affects the built VPK plus the owner, so a manual -> link
+ * handover of the same source still counts as a change.
+ */
+export function selectionsSignature(selections: readonly LockerCardSelection[]): string {
+  return selections
+    .map(
+      (sel) =>
+        `${sel.heroCodename}|${sel.origin ?? 'manual'}|${sel.source.kind ?? 'mod'}|${
+          sel.source.fileName
+        }|${sel.linkedSkinKey ?? ''}`
+    )
+    .sort()
+    .join('\n');
+}
+
+/** Links minus every entry for `heroCodename`. Used to enforce the one-owner-
+ *  per-hero invariant when a manual pick or revert takes the hero over. */
+export function withoutHero(
+  links: readonly LockerCardLink[],
+  heroCodename: string
+): LockerCardLink[] {
+  return links.filter((link) => link.heroCodename !== heroCodename);
+}
+
+/** Links minus the binding for `skinKey` (unlinking one skin). */
+export function withoutSkin(links: readonly LockerCardLink[], skinKey: string): LockerCardLink[] {
+  return links.filter((link) => link.skinKey !== skinKey);
+}
+
+/**
+ * Upsert `link`, replacing any prior binding for the same skin AND any other
+ * binding for the same hero. Both are required by the one-owner invariant: a
+ * skin links to at most one icon mod, and a hero's card has at most one source.
+ */
+export function upsertLink(
+  links: readonly LockerCardLink[],
+  link: LockerCardLink
+): LockerCardLink[] {
+  const kept = links.filter(
+    (existing) => existing.skinKey !== link.skinKey && existing.heroCodename !== link.heroCodename
+  );
+  return [...kept, link];
+}
+
+/**
+ * Companion icon mods installed for `heroName`: VPKs that carry nothing but this
+ * hero's card art (see classifyHeroIconOnly). That is the shape of the per-skin
+ * icon addons published alongside the big icon packs, and they are the only
+ * things worth offering as a skin's icon source. Enabled and disabled mods both
+ * qualify: the apply pipeline splits the art out of the file directly, so a
+ * linked addon never needs a load-order slot of its own.
+ */
+export function heroIconMods(mods: Mod[], heroName: string): Mod[] {
+  const codenames = new Set(codenamesForHero(heroName));
+  if (codenames.size === 0) return [];
+  return mods
+    .filter((mod) => mod.heroIconOnly && codenames.has(mod.heroIconOnly))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/lib/lockerCardLinks.ts
+++ b/src/lib/lockerCardLinks.ts
@@ -95,6 +95,22 @@ function selectionForLink(link: LockerCardLink, addedAt: string): LockerCardSele
   };
 }
 
+/** Stable identity for the icon source behind a selection. A content hash wins
+ * over its current metaKey so enable/disable and overflow renames do not make an
+ * unchanged source look new. */
+function selectionSourceIdentity(selection: LockerCardSelection): string {
+  return selection.source.sha256AtApplyTime
+    ? `sha256:${selection.source.sha256AtApplyTime.toLowerCase()}`
+    : `key:${selection.source.fileName}`;
+}
+
+/** Stable identity for the icon source captured by a link. */
+function linkSourceIdentity(link: LockerCardLink): string {
+  return link.sourceSha256
+    ? `sha256:${link.sourceSha256.toLowerCase()}`
+    : `key:${link.sourceKey}`;
+}
+
 /**
  * The card selection set implied by `links` given which skins are enabled.
  *
@@ -151,7 +167,7 @@ export function planLinkedCards(input: {
         sel.origin === 'link' &&
         sel.heroCodename === link.heroCodename &&
         sel.linkedSkinKey === link.skinKey &&
-        sel.source.fileName === link.sourceKey
+        selectionSourceIdentity(sel) === linkSourceIdentity(link)
     );
     next.push(selectionForLink(link, prior?.addedAt ?? now));
   }
@@ -169,9 +185,9 @@ export function selectionsSignature(selections: readonly LockerCardSelection[]):
   return selections
     .map(
       (sel) =>
-        `${sel.heroCodename}|${sel.origin ?? 'manual'}|${sel.source.kind ?? 'mod'}|${
-          sel.source.fileName
-        }|${sel.linkedSkinKey ?? ''}`
+        `${sel.heroCodename}|${sel.origin ?? 'manual'}|${sel.source.kind ?? 'mod'}|${selectionSourceIdentity(
+          sel
+        )}|${sel.linkedSkinKey ?? ''}|${[...sel.variants].sort().join(',')}`
     )
     .sort()
     .join('\n');
@@ -192,17 +208,16 @@ export function withoutSkin(links: readonly LockerCardLink[], skinKey: string): 
 }
 
 /**
- * Upsert `link`, replacing any prior binding for the same skin AND any other
- * binding for the same hero. Both are required by the one-owner invariant: a
- * skin links to at most one icon mod, and a hero's card has at most one source.
+ * Upsert `link`, replacing the prior binding for the same skin. A hero may have
+ * several linked skins: planLinkedCards chooses the enabled skin that wins load
+ * order, while the one-owner invariant only prevents a manual card and the link
+ * set from fighting over that hero.
  */
 export function upsertLink(
   links: readonly LockerCardLink[],
   link: LockerCardLink
 ): LockerCardLink[] {
-  const kept = links.filter(
-    (existing) => existing.skinKey !== link.skinKey && existing.heroCodename !== link.heroCodename
-  );
+  const kept = links.filter((existing) => existing.skinKey !== link.skinKey);
   return [...kept, link];
 }
 

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react';
 import type { GameBananaCategoryNode } from '../types/gamebanana';
 import type { AppearanceBg, AppearanceSurface, AppSettings, GlobalModType, Mod } from '../types/mod';
 import { getAssetPath } from './assetPath';
+import { loadOrderFromMetaKey } from './lockerCardLinks';
 import {
   HERO_NAMES as SHARED_HERO_NAMES,
   HERO_ALIASES as SHARED_HERO_ALIASES,
@@ -392,9 +393,7 @@ export function getLockerSkinKey(mod: Mod): string {
  * math stays consistent across both surfaces.
  */
 export function modLoadOrder(mod: Mod): number {
-  const match = mod.metaKey.match(/^addons(\d+)\//);
-  const folderIndex = match ? parseInt(match[1], 10) : 0;
-  return folderIndex * 100 + mod.priority;
+  return loadOrderFromMetaKey(mod.metaKey, mod.priority);
 }
 
 /**

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1706,6 +1706,13 @@
       "exportDialogTitle": "Export {{hero}} custom card",
       "exportedToast": "Exported to {{path}}"
     },
+    "iconLink": {
+      "matchIcons": "Match icons",
+      "linkedTo": "Icons: {{name}}",
+      "title": "Link card icons",
+      "hint": "Pick a companion icon mod for this skin. While the skin is enabled, the hero's card art is applied from it automatically, no load order needed.",
+      "unlink": "Remove link"
+    },
     "trippy": {
       "loading": "Loading...",
       "description": "Paint {{hero}}'s body and gun textures with a flowing procedural pattern: the paint scrolls in game. This composes with anything applied on the Abilities surface.",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2128,
+  "totalKeys": 2133,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2128,
+      "translatedKeys": 2133,
       "pct": 100
     },
     {

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -230,7 +230,7 @@ function FacetSheenDefs() {
 
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages, shuffleOnLaunch, setShuffleOnLaunch, shuffleIncluded, toggleShuffleIncluded, shuffleVariants, setShuffleVariant } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, loadCardLinks, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages, shuffleOnLaunch, setShuffleOnLaunch, shuffleIncluded, toggleShuffleIncluded, shuffleVariants, setShuffleVariant } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(
@@ -320,8 +320,12 @@ export default function Locker() {
   useEffect(() => {
     if (activeDeadlockPath) {
       loadMods({ silent: useAppStore.getState().modsLoaded });
+      // Bindings live in main-process metadata and survive app restarts. Load
+      // them with the Locker so linked badges and unlink controls reflect disk,
+      // not just edits made during this renderer session.
+      loadCardLinks();
     }
-  }, [activeDeadlockPath, loadMods]);
+  }, [activeDeadlockPath, loadMods, loadCardLinks]);
 
   // Refresh on any completed download so a newly-installed mod (and its
   // freshly-classified globalType) surfaces here without leaving the page,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Mod, AppSettings, AppearanceSurface, EditLocalModArgs, GlobalModType } from '../types/mod';
+import type { Mod, AppSettings, AppearanceSurface, EditLocalModArgs, GlobalModType, LockerCardLink } from '../types/mod';
 import type { ImportCustomModArgs, ImportCustomModResult } from '../types/electron';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { setDateFormat } from '../lib/dateFormat';
@@ -291,6 +291,12 @@ interface AppState {
   // settings.appearanceBackgrounds; this only holds the custom image bytes.
   appearanceImages: Partial<Record<AppearanceSurface, string>>;
 
+  // Skin -> icon links: "when this skin is on, apply that hero's icons too."
+  // The bindings themselves live in the main process (which reconciles them on
+  // every enable/disable/profile/shuffle); this is the renderer's read model for
+  // showing which skins are linked. Loaded lazily when the Locker opens.
+  cardLinks: LockerCardLink[];
+
   // Actions
   loadSettings: () => Promise<void>;
   saveSettings: (settings: AppSettings) => Promise<void>;
@@ -363,6 +369,19 @@ interface AppState {
   /** Hide (or show) the hero name label over this skin's grid thumbnail. */
   setLockerModThumbnailHideName: (skinKey: string, hide: boolean) => Promise<void>;
 
+  /** Load the skin -> icon bindings from the main process. */
+  loadCardLinks: () => Promise<void>;
+  /** Bind a skin to a companion icon mod. The main process applies it right
+   *  away when the skin is enabled, so callers refresh mods afterwards. */
+  linkSkinIcons: (args: {
+    skinKey: string;
+    skinName?: string;
+    heroName: string;
+    sourceKey: string;
+  }) => Promise<void>;
+  /** Unbind a skin, reverting whatever card its link had applied. */
+  unlinkSkinIcons: (skinKey: string) => Promise<void>;
+
   /** Load all custom launcher / sidebar background images from the main process. */
   loadAppearanceImages: () => Promise<void>;
   /** Store a custom image (baked data URL) for a surface and refresh the map. */
@@ -410,6 +429,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   lockerModThumbnails: {},
   lockerThumbHideHeroName: {},
   appearanceImages: {},
+  cardLinks: [],
 
   // Load settings from backend
   loadSettings: async () => {
@@ -555,6 +575,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       else delete nextFlags[skinKey];
       return { lockerThumbHideHeroName: nextFlags };
     });
+  },
+
+  // Skin -> icon links. The main process owns the bindings and does the applying
+  // (it has to: profile switches and launch shuffle change skins without the
+  // renderer involved). These actions only edit them and re-read the result.
+  loadCardLinks: async () => {
+    try {
+      set({ cardLinks: await api.getCardLinks() });
+    } catch {
+      // Non-fatal: skins simply show as unlinked.
+    }
+  },
+  linkSkinIcons: async (args) => {
+    await api.setCardLink(args);
+    set({ cardLinks: await api.getCardLinks() });
+  },
+  unlinkSkinIcons: async (skinKey: string) => {
+    await api.removeCardLink(skinKey);
+    set({ cardLinks: await api.getCardLinks() });
   },
 
   // Custom launcher / sidebar background images (issue: unify launcher backgrounds).

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -20,6 +20,9 @@ import type {
     ImprintDetails,
     PeekImprintResult,
     ApplyHeroCardResult,
+    CardLinkReconcileResult,
+    LockerCardLink,
+    SetCardLinkArgs,
     HeroAbilitySlot,
     AbilitySlot,
     AbilitySoundParams,
@@ -634,6 +637,12 @@ export interface ElectronAPI {
     getActiveHeroCard: (
         heroName: string
     ) => Promise<{ sourceFileName: string; variants: string[] } | null>;
+    /** Every skin -> icon binding (see LockerCardLink). */
+    getCardLinks: () => Promise<LockerCardLink[]>;
+    /** Bind a skin to an icon mod, applying it right away when the skin is on. */
+    setCardLink: (args: SetCardLinkArgs) => Promise<CardLinkReconcileResult>;
+    /** Unbind a skin, reverting whatever its link had applied. */
+    removeCardLink: (skinKey: string) => Promise<CardLinkReconcileResult>;
     getCustomCardSlots: (heroName: string) => Promise<CustomCardSlot[]>;
     applyCustomHeroCard: (
         heroName: string,

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -93,9 +93,10 @@ export interface LockerCardSelection {
  * cosmetics VPK in citadel/grimoire, which wins by SearchPaths folder
  * precedence rather than load order.
  *
- * INVARIANT: for any hero, either a link owns the card or a manual/custom pick
- * does, never both. Every explicit action (link, manual apply, revert) clears
- * the other side, so a hero's card always has exactly one owner.
+ * INVARIANT: for any hero, either its link set owns the card or a manual/custom
+ * pick does, never both. A hero may have one link per skin; when several linked
+ * skins are enabled, load order chooses the active card. Manual apply/revert
+ * clears the hero's whole link set so the two ownership modes never fight.
  */
 export interface LockerCardLink {
   /** Stable Locker skin key this icon is bound to (see lockerLinkKey):

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -66,7 +66,84 @@ export interface LockerCardSelection {
     gameBananaId?: number;
     sha256AtApplyTime: string;
   };
+  /**
+   * Who owns this hero's card. `manual` (the default, and what an absent value
+   * means for selections written before links existed) is a direct pick in the
+   * Cards tab. `link` means it was applied automatically because a linked skin
+   * is enabled (see LockerCardLink), and reconcileLinkedCards may replace or
+   * drop it as skins toggle. Nothing else touches a `manual` entry.
+   */
+  origin?: 'manual' | 'link';
+  /** Set only when `origin` is `link`: the skin key that pulled this card in,
+   *  so the picker can label it and reconcile can tell whose it is. */
+  linkedSkinKey?: string;
   addedAt: string;
+}
+
+/**
+ * A skin -> icon binding: "whenever this skin is enabled, also apply this hero's
+ * card art from that mod."
+ *
+ * This exists because the icon ecosystem is built on companion mods: a global
+ * icon pack (DEADLOCK TOASTED and friends) plus a per-skin addon that restyles
+ * ONE hero's card to match a specific skin. Loading those correctly by hand is a
+ * three-way pakNN fight (the addon must beat both the skin bundle and the icon
+ * pack), which is what the addons' own install instructions ask users to do.
+ * A link turns that into one click: the art is split into the Locker-managed
+ * cosmetics VPK in citadel/grimoire, which wins by SearchPaths folder
+ * precedence rather than load order.
+ *
+ * INVARIANT: for any hero, either a link owns the card or a manual/custom pick
+ * does, never both. Every explicit action (link, manual apply, revert) clears
+ * the other side, so a hero's card always has exactly one owner.
+ */
+export interface LockerCardLink {
+  /** Stable Locker skin key this icon is bound to (see lockerLinkKey):
+   *  `gamebanana:<id>`, else `sha256:<sha>`, else `mod:<id>`. Deliberately NOT
+   *  keyed on mod id alone: `mod.id` is md5(metaKey) and every enable / disable
+   *  / reorder renames the VPK, so an id-keyed link would break on exactly the
+   *  toggles it exists to survive. */
+  skinKey: string;
+  /** Display name of the linked skin, for UI labels. */
+  skinName?: string;
+  heroName: string;
+  heroCodename: string;
+  /** Folder-relative metaKey of the icon mod the card art is split from. */
+  sourceKey: string;
+  sourceModName?: string;
+  sourceGameBananaId?: number;
+  /** Content identity of the icon mod at link time, so a renamed or
+   *  overflow-moved source still resolves (same recovery the card rebuild uses). */
+  sourceSha256?: string;
+  /** Variant tokens captured at link time (informational; the split takes the
+   *  whole per-hero prefix regardless). */
+  variants: string[];
+  linkedAt: string;
+}
+
+/** The full set of skin -> icon bindings, stored under the synthetic metadata
+ *  key `locker:cardlinks` (decoupled from any VPK filename). */
+export interface LockerCardLinksInfo {
+  links: LockerCardLink[];
+  updatedAt: string;
+}
+
+/** Arguments for creating (or replacing) one skin -> icon binding. */
+export interface SetCardLinkArgs {
+  /** Stable Locker skin key (see lockerLinkKey in lib/lockerCardLinks). */
+  skinKey: string;
+  /** Display name of the skin, stored for UI labels. */
+  skinName?: string;
+  heroName: string;
+  /** Folder-relative metaKey of the icon mod to bind. */
+  sourceKey: string;
+}
+
+/** Outcome of a link edit: whether the applied cards actually changed, and any
+ *  source whose VPK had vanished by rebuild time. */
+export interface CardLinkReconcileResult {
+  rebuilt: boolean;
+  missing: string[];
 }
 
 /**
@@ -645,6 +722,12 @@ export interface Mod {
    *  not yet classified or the mod has no recognized hero ability sounds.
    *  Drives the per-ability sound picker. */
   abilitySounds?: AbilitySoundClassification;
+  /** Panorama codename when this VPK is a companion ICON mod: nothing but one
+   *  hero's `panorama/images/heroes/<codename>_` art (no models, no particles,
+   *  no other hero). That is the shape of the per-skin icon addons published
+   *  alongside the big icon packs, and it's what makes a mod offerable as the
+   *  icon half of a skin link. Undefined when the mod is anything else. */
+  heroIconOnly?: string;
   /** Set when this VPK was built from a user GLB via the soul-container import.
    *  Carries the orientation/glow transform so the build is reproducible and the
    *  UI can label it as a local soul-container import. */


### PR DESCRIPTION
## What

Skins in the Locker can now be linked to their matching card icon mods, so the hero card follows the skin automatically.

The Deadlock icon ecosystem is built on companion mods: a global pack (e.g. DEADLOCK TOASTED) restyles every hero's card, then per-skin addons restyle one hero's card to match a specific skin. Those addons' own install instructions tell users to win a pakNN rename fight by hand. A link replaces that: whenever the linked skin is enabled, that hero's card art is split out of the icon mod into the Locker-managed cosmetics VPK (`citadel/grimoire`), which wins by SearchPaths folder precedence, so load order stops mattering.

- Pure decision layer (`src/lib/lockerCardLinks.ts`) shared by the renderer and the main process. Link identity is keyed on GameBanana id, then sha256, then mod id, so links survive the pakNN renames every toggle causes (mirrors `shuffleSkinKey`).
- `classifyHeroIconOnly` tags icon-only VPKs during scans; the skins panel offers them per hero via the new `SkinIconLinkPicker`.
- `reconcileLinkedCards` runs in the IPC layer after every mutation that can change the enabled set (Locker toggle, Installed toggle, apply-profile, toggle batches), preventing renderer-side desync.
- One-owner invariant: for any hero, either a link owns the card or a manual/custom pick does, never both.

## Provenance

Recovered and finished from WIP: the tracked half was in a stash made on `fix/catalog-freshness`, the new files were untracked in the working tree. Deliberately excluded from that stash: stale crosshair geometry hunks (superseded by the preview-accuracy branch) and the Browse load-more guard (pairs with `browsePaging.ts`, still in the tree for its own PR).

Finishing touches added in this commit:

- The five `locker.iconLink.*` en strings were missing; wrote them and regenerated the locale manifest. Please review the copy.
- Moved `heroIconMods` from the picker component into `src/lib/lockerCardLinks.ts` to satisfy `react-refresh/only-export-components`.
- The service docstring referenced `docs/locker-skin-icon-links.md`, which was never written; retargeted it to `docs/locker-hero-card-apply.md`. If the skin-icon-links doc exists as a draft somewhere, it can land in a follow-up.

## Release note

For the next tag, under **New Features**:

> **Skins can link to their matching card icons.** Per-skin icon addons (the companions to the big icon packs) no longer need manual pakNN renames: link one to a skin in the Locker and the hero's card follows the skin automatically whenever it is enabled.

## Verification

- `tsc -b`, `eslint`, `vitest run` (791 tests across 62 files, including the new pure `lockerCardLinks`, main-process lifecycle, and `heroIconOnly` suites), `i18n:check`, and the manifest check all pass locally.
- Not exercised in the running app in this pass: the flow itself is recovered WIP. Worth a manual check of link, unlink, and a skin toggle from Installed before merging.

