### PR TITLE
feat(packaging): add flatpak packaging

### DIFF
--- a/flatpak/com.grimoiremods.Grimoire.desktop
+++ b/flatpak/com.grimoiremods.Grimoire.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Grimoire
+Exec=grimoire %U
+Terminal=false
+Type=Application
+Icon=com.grimoiremods.Grimoire
+StartupWMClass=Grimoire
+Comment=Mod manager for Deadlock
+MimeType=x-scheme-handler/grimoire;
+Categories=Game;

--- a/flatpak/com.grimoiremods.Grimoire.metainfo.xml
+++ b/flatpak/com.grimoiremods.Grimoire.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.grimoiremods.Grimoire</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Grimoire</name>
+  <summary>Mod manager for Deadlock</summary>
+  <description>
+    <p>
+      Grimoire is a mod manager and companion tool for Deadlock. Browse and
+      install mods from GameBanana, manage load order and conflicts, organize
+      skins in the Hero Locker, design crosshairs, edit your autoexec, and
+      track player stats.
+    </p>
+  </description>
+  <developer id="com.grimoiremods">
+    <name>Slush97</name>
+  </developer>
+  <launchable type="desktop-id">com.grimoiremods.Grimoire.desktop</launchable>
+  <url type="homepage">https://grimoiremods.com</url>
+  <url type="bugtracker">https://github.com/Slush97/grimoire/issues</url>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="1.26.0" date="2026-07-30"/>
+  </releases>
+</component>

--- a/flatpak/com.grimoiremods.Grimoire.yml
+++ b/flatpak/com.grimoiremods.Grimoire.yml
@@ -1,0 +1,64 @@
+# Flatpak manifest for Grimoire.
+# Repackages the released deb (same binaries users already run) on top of the
+# Electron base app. Bump the url/sha256 and the metainfo release entry when
+# cutting a new version.
+#
+# Build:
+#   flatpak run org.flatpak.Builder --user --force-clean \
+#     --install-deps-from=flathub --repo=repo builddir flatpak/com.grimoiremods.Grimoire.yml
+#   flatpak build-bundle repo Grimoire-<version>.flatpak com.grimoiremods.Grimoire
+
+app-id: com.grimoiremods.Grimoire
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: grimoire
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --share=network
+  - --device=dri
+  # Grimoire's whole job is editing game files (gameinfo.gi, addons, configs)
+  # inside Steam libraries, which can live on any drive per libraryfolders.vdf.
+  # Host access mirrors what the AppImage and deb already have. A future
+  # Flathub submission should narrow this to specific paths.
+  - --filesystem=host
+  # Flatpak Steam keeps its library under its own app dir, which host excludes.
+  - --filesystem=~/.var/app/com.valvesoftware.Steam
+  # Electron safeStorage talks to the Secret Service (planned social session token).
+  - --talk-name=org.freedesktop.secrets
+  # Tray icons on KDE/StatusNotifier desktops.
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+modules:
+  - name: grimoire
+    buildsystem: simple
+    build-commands:
+      - ar x grimoire_1.26.0_amd64.deb
+      - tar xf data.tar.xz
+      - cp -a opt/Grimoire /app/grimoire
+      - install -Dm755 grimoire.sh /app/bin/grimoire
+      - install -Dm644 com.grimoiremods.Grimoire.desktop /app/share/applications/com.grimoiremods.Grimoire.desktop
+      - install -Dm644 com.grimoiremods.Grimoire.metainfo.xml /app/share/metainfo/com.grimoiremods.Grimoire.metainfo.xml
+      - |
+        for f in usr/share/icons/hicolor/*/apps/grimoire.png; do
+          size=$(basename $(dirname $(dirname "$f")))
+          # flatpak export rejects icons above 512x512
+          case "$size" in 1024x1024) continue ;; esac
+          install -Dm644 "$f" "/app/share/icons/hicolor/${size}/apps/com.grimoiremods.Grimoire.png"
+        done
+    sources:
+      - type: file
+        url: https://github.com/Slush97/grimoire/releases/download/v1.26.0/grimoire_1.26.0_amd64.deb
+        sha256: 631f885bb01a3970a7995783e0d84b6c9f71ab9406a850a68df392aa1002c2a7
+      - type: file
+        path: grimoire.sh
+      - type: file
+        path: com.grimoiremods.Grimoire.desktop
+      - type: file
+        path: com.grimoiremods.Grimoire.metainfo.xml

--- a/flatpak/grimoire.sh
+++ b/flatpak/grimoire.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# zypak-wrapper (from org.electronjs.Electron2.BaseApp) provides the Chromium
+# sandbox inside the flatpak sandbox; chrome-sandbox setuid does not work here.
+exec zypak-wrapper /app/grimoire/grimoire "$@"


### PR DESCRIPTION
## Summary
- Adds `flatpak/`: manifest, desktop entry, AppStream metainfo, and zypak wrapper for building a Flatpak of the desktop client (app id `com.grimoiremods.Grimoire`)
- The manifest repackages the released deb (same binaries users already run) on top of `org.electronjs.Electron2.BaseApp//24.08`; cutting a new version means bumping the deb url/sha256 and the metainfo release entry
- First bundle built from this and shipped on the v1.26.0 release, with SHA256SUMS and release notes updated

## Notes
- `finish-args` grants `--filesystem=host` (Steam libraries can live on any drive per libraryfolders.vdf; matches what the AppImage effectively has) plus the flatpak-Steam app dir and Secret Service access for safeStorage
- In-app updates are already disabled under flatpak: `getInstallSource()` returns 'managed' for exec paths under `/app/`
- flatpak export rejects icons above 512x512, so the install loop skips the 1024x1024 icon

## Test plan
- Built with `org.flatpak.Builder`, installed the bundle user-scope
- Headless launch under Xvfb with a CDP port: renderer mounted, welcome screen rendered with all three setup checks green (Deadlock detected on a second drive via the Steam manifest, gameinfo.gi search paths read, autoexec found)
- Desktop export verified: `x-scheme-handler/grimoire` MimeType and hicolor icons present
- Launched on a live desktop session and confirmed working