### PR TITLE
feat(mods): Global priority root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Design docs and references live in `docs/`:
 - `design-overhaul-brief.md` - UI design language reference
 - `social-architecture.md` + `social-architecture-decisions.md` - Architecture and ADRs for the planned `grimoire-social` companion service (see below)
 - `ability-vfx-recolor.md` - Hero ability VFX layer extraction + in app recoloring. Read before touching `detectVfxLayer`/`extractVfxLayer` (in `vpk.ts`/`modMerger.ts`) or building the recolor/Locker surface. Covers why particle recolor must use an in place scalar patch, not a KV3 re-encode.
+- `locker-global-mods.md` - "Global" mods: the `citadel/grimoire` priority root that outranks every other mod. Read before touching grimoire-folder handling, the `modLoadOrder` helpers, or the shuffle planner. Covers the deliberate split between `globalType` (classification, labelled "General") and `priorityMod` (placement, labelled "Global").
 - `deadworks-servers.md` - The Deadworks server browser: relay data flow, content provisioning, and (critically) how the deadworks content path is woven into grimoire's canonical `gameinfo.gi` block so Fix Configuration never erases it. Read before touching `deadworksServers.ts`, `ipc/servers.ts`, or the gameinfo handling in `system.ts`/`deadlock.ts`.
 
 ## Companion Service: grimoire-social

--- a/docs/locker-global-mods.md
+++ b/docs/locker-global-mods.md
@@ -1,0 +1,153 @@
+# Global Mods (the priority root)
+
+Status: shipped. Read this before touching `citadel/grimoire` handling in
+`deadlock.ts` / `mods.ts`, the `modLoadOrder` helpers, or the shuffle planner.
+
+A **Global** mod lives in `citadel/grimoire` instead of `citadel/addons`. That
+folder is the first `Game` line in the canonical SearchPaths block
+(`electron/main/services/system.ts`), and earlier lines win, so a Global mod
+beats every other mod on any file they share. The launch shuffle also never
+disables one.
+
+Origin: a Discord report asking for a mod "lock" that keeps a mod on and on top
+while other skins re-roll, so the reporter would stop merging that mod into
+every skin by hand.
+
+## The word "Global" means two things, on purpose
+
+This is the single most confusable thing in this area, so it is worth stating
+flatly:
+
+| Concept | Code | UI label | What it answers |
+|---|---|---|---|
+| Classification axis (Soul Containers, HUD, Announcer, ...) | `globalType`, `GlobalModType` | **General** | "What kind of mod is this?" |
+| Precedence / placement | `priorityMod`, `PRIORITY_TAB` | **Global** | "Does this mod win?" |
+
+The code names and the UI labels deliberately do NOT match. `globalType` is a
+**persisted sidecar field**: renaming it would need a metadata migration for
+every existing install, for zero user benefit. So the classification axis keeps
+its code name and got a new label ("General"), while the new precedence feature
+took the "Global" label the users already use for it and a distinct code name
+(`priorityMod` / "priority root").
+
+`PRIORITY_TAB` is a separate sentinel from `GlobalModType` specifically so a
+Global mod can never be written into the classification field by accident.
+
+They are also independent: Global is placement, so unlike a `globalType` tag it
+does **not** pull a mod off the hero axis. A Global hero skin still shows in
+that hero's Locker pile; it just also wins every collision.
+
+## Folder layout
+
+```
+citadel/grimoire/          <- first Game line, outranks everything
+  pak01_dir.vpk            RESERVED: Locker cards      (lockerVpk.ts)
+  pak02_dir.vpk            RESERVED: Locker sounds
+  pak03_dir.vpk            RESERVED: Locker colors
+  pak04_dir.vpk            RESERVED: Locker trippy skins
+  pak05_dir.vpk ...        user Global mods (95 slots)
+citadel/addons/            <- normal mods, pak01-pak99
+citadel/addons1..9/        <- overflow roots
+```
+
+Reserved-first is not arbitrary: a lower pakNN loads first, so the Locker's own
+managed artifacts still outrank a user's Global mod. `PRIORITY_FIRST_SLOT` (5)
+and `isReservedPriorityVpk` in `deadlock.ts` own that split; `lockerVpk.ts` owns
+the four filenames. Adding a fifth managed artifact means bumping both.
+
+There is no overflow for the priority root. It is one folder with one
+SearchPaths line, and minting siblings would mean rewriting gameinfo for what is
+meant to be a small curated set. At capacity, `PRIORITY_LIMIT_MESSAGE` tells the
+user to remove one.
+
+## The invariants
+
+**The sidecar flag is the source of truth, not the folder.** A disabled mod sits
+in `.disabled/` under a free-form name with no folder to read. Without
+`metadata.priorityMod`, disabling a Global mod and re-enabling it would silently
+demote it to `citadel/addons`. `enableModImpl` consults the flag for exactly
+this reason, and it is the case
+`priorityFolderMove.test.ts` exists to pin.
+
+**Scanning and allocating are deliberately different views.**
+`getModScanRootPaths` (grimoire first, then the addon roots) is what `scanMods`
+walks, so a Global mod stays visible and manageable. `getAddonFolderPaths`
+(addon roots only) stays the *allocation* view: slot allocation, overflow
+minting, and the gameinfo rewrite must never treat the priority root as
+somewhere a mod can spill into. A mod only lands there via
+`setModPriorityFolder`.
+
+**The scan skips the reserved range.** The managed VPKs are keyed by synthetic
+metadata keys (`locker:cards` and friends), so surfacing them would invent
+phantom mods the user never installed and let them delete a Locker artifact.
+
+**`metaKeyFor` namespaces the folder** as `grimoire/<file>`, so a Global `pak05`
+cannot collide with an addons `pak05` in the metadata sidecar. Base addons and
+`.disabled` keep bare filenames, so existing installs need no migration.
+
+**Load order goes through one helper per side.** `addonFolderIndex`
+(`mods.ts`, main) and `modLoadOrder` (`lockerUtils.ts`, renderer) both rank the
+priority root below zero. Any third copy of this math is a bug waiting to
+happen: the Conflicts page used to hand-roll its own and would have reported the
+wrong conflict winner, so it now imports `modLoadOrder`.
+
+**Reorder skips priority-root mods.** They win by search-path position, not slot
+number, so including one in `reorderModsImpl` would pack it back into
+`citadel/addons` and silently strip its Global status. This is what keeps a
+per-hero reorder and an `applyProfile` from demoting a Global mod. As a
+consequence, Global survives profile switches (`priorityMod` is not carried in
+the portable profile format, same as `globalType`).
+
+## Shuffle interaction
+
+Three rules in `planRandomization` (`src/lib/lockerRandomizer.ts`):
+
+1. A Global mod is never added to `disableIds`. This is the whole point of the
+   feature.
+2. A Global skin is dropped from the eligible pool: it is already always on, so
+   offering it as a re-roll candidate is contradictory. A hero whose only pooled
+   skin is Global is therefore skipped, which is correct (nothing left to
+   re-roll).
+3. Global mods are excluded from the `activeLockerSkin` lookup that drives the
+   avoid-current bias. `activeLockerSkin` returns the lowest load order, and a
+   Global mod sorts first by construction, so without this one Global mod would
+   make every hero's bias compare against the wrong skin.
+
+Rule 3 is easy to lose in a refactor and has no visible symptom except the
+shuffle occasionally re-picking the skin already on screen.
+
+## UI surfaces
+
+- **Locker > General > Global tab** (`src/pages/Locker.tsx`): last tab in the
+  rail, with a live count. Cards are ordinary multi-toggle cards, never the
+  prop-container single-select 3D treatment (`isPropContainer` is forced false).
+  The card kebab offers **Remove from Global** instead of the seven
+  classification destinations.
+- **Add mods picker** (`src/components/locker/GlobalModPicker.tsx`): search over
+  name / filename / hero tag / category, multi-select, enabled mods first. Its
+  own file per the chip-away policy for the god pages.
+- **Installed kebab**: per-mod **Make Global** / **Remove from Global**, plus a
+  "Global" chip on the card. Reachable for any mod, not just Locker-managed
+  ones. There is no bulk path here on purpose: the picker covers the bulk case
+  from the Locker side.
+
+## Tests
+
+- `priorityFolderMove.test.ts` drives the real service against a temp sandbox
+  (electron mocked to `app.getPath` only, same pattern as
+  `dmmMigration.nondestructive.test.ts`): reserved slots hidden, allocation
+  starts at pak05, sidecar follows the rename with nothing left under the old
+  key, disable/enable round trip, and move-out with no flag resurrection.
+- `priorityFolder.test.ts` pins the pure helpers (reserved-slot split, folder
+  match, metaKey namespacing).
+- `lockerUtils.test.ts` pins the folder-beats-number ordering rule.
+- `lockerRandomizer.test.ts` covers the three shuffle rules above.
+
+## Known gaps
+
+- No bulk "Make Global" in the Installed multi-select menu (deliberate, above).
+- `priorityMod` is not carried by profile export / `mp1:` share codes.
+- The picker's selection is keyed by mod id, which changes when a mod moves.
+  Nothing re-scans between opening and confirming the dialog, so the ids stay
+  valid for its lifetime, but a future background rescan would need to
+  re-resolve them.

--- a/docs/locker-global-mods.md
+++ b/docs/locker-global-mods.md
@@ -75,7 +75,10 @@ walks, so a Global mod stays visible and manageable. `getAddonFolderPaths`
 (addon roots only) stays the *allocation* view: slot allocation, overflow
 minting, and the gameinfo rewrite must never treat the priority root as
 somewhere a mod can spill into. A mod only lands there via
-`setModPriorityFolder`.
+`setModPriorityFolder`. Features that inspect the complete installed library
+(metadata identity, Locker cards/sounds/portraits) go through
+`listInstalledUserVpks` in `modLibrary.ts`, which adds `.disabled` and filters
+the reserved priority range once for every consumer.
 
 **The scan skips the reserved range.** The managed VPKs are keyed by synthetic
 metadata keys (`locker:cards` and friends), so surfacing them would invent
@@ -97,6 +100,22 @@ number, so including one in `reorderModsImpl` would pack it back into
 per-hero reorder and an `applyProfile` from demoting a Global mod. As a
 consequence, Global survives profile switches (`priorityMod` is not carried in
 the portable profile format, same as `globalType`).
+
+**Placement changes are failure-atomic.** Destination allocation happens before
+metadata changes. Moving into Global renames first and stamps the destination
+key afterward; if the app stops between those steps, the priority-root scan
+self-heals the flag. Moving out clears the flag before the rename so the
+migrated row is already correct; a failed rename immediately restores it, with
+the scan as the durable fallback. Renderer actions rethrow failures so pickers
+and menus stay open with contextual feedback.
+
+## Vanilla launch interaction
+
+Launch Vanilla stashes user Global VPKs alongside ordinary addon VPKs, including
+their chunk siblings, and restores each file to its recorded root. The reserved
+Locker artifacts in pak01-pak04 keep their established lifecycle and are not
+part of the user-mod stash. `isReservedPriorityVpkArtifact` owns the broader
+directory-plus-chunk reserved check used by this path.
 
 ## Shuffle interaction
 
@@ -142,6 +161,11 @@ shuffle occasionally re-picking the skin already on screen.
   match, metaKey namespacing).
 - `lockerUtils.test.ts` pins the folder-beats-number ordering rule.
 - `lockerRandomizer.test.ts` covers the three shuffle rules above.
+- `priorityFolderFailure.test.ts` pins full-root and failed-rename metadata
+  atomicity.
+- `modLibrary.test.ts`, `metadata.backfill.test.ts`, and
+  `launchVanilla.test.ts` cover complete Global discovery, hash backfill, and
+  Vanilla stash/restore without moving reserved Locker artifacts.
 
 ## Known gaps
 

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -853,7 +853,7 @@ ipcMain.handle(
     }
 );
 
-// set-mod-priority — mark a mod Global (or clear it). Global mods move to the
+// set-mod-priority: mark a mod Global (or clear it). Global mods move to the
 // priority root citadel/grimoire, which gameinfo.gi lists ahead of
 // citadel/addons, so they win every file collision without any load-order
 // bookkeeping and the launch shuffle leaves them alone. Moving a mod is a

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -12,6 +12,7 @@ import {
     reorderMods,
     swapModPriority,
     setModsEnabledBatch,
+    setModPriorityFolder,
     allocateEnabledVpkPath,
     runExclusiveModMutation,
     type Mod,
@@ -265,6 +266,7 @@ function enrichMod(mod: Mod): WireMod {
             soulImport: metadata.soulImport,
             urnImport: metadata.urnImport,
             ignoreUpdates: metadata.ignoreUpdates,
+            priorityMod: metadata.priorityMod,
             imprinted: metadata.imprinted,
             imprintStale: metadata.imprintStale,
         };
@@ -848,6 +850,27 @@ ipcMain.handle(
             ignoreUpdates: ignore ? true : undefined,
         });
         return enrichMod(target);
+    }
+);
+
+// set-mod-priority — mark a mod Global (or clear it). Global mods move to the
+// priority root citadel/grimoire, which gameinfo.gi lists ahead of
+// citadel/addons, so they win every file collision without any load-order
+// bookkeeping and the launch shuffle leaves them alone. Moving a mod is a
+// folder mutation, so setModPriorityFolder takes the mutation lock.
+ipcMain.handle(
+    'set-mod-priority-folder',
+    async (_, modId: string, priority: boolean): Promise<Mod> => {
+        const deadlockPath = getActiveDeadlockPath();
+        if (!deadlockPath) {
+            throw new Error('No Deadlock path configured');
+        }
+        // enrichMod, like every sibling handler: the service returns a raw
+        // scanned Mod, and the renderer's copy must carry the projected
+        // sidecar fields (priorityMod included) or the card would drop its
+        // Global chip until the next full reload.
+        const mod = await setModPriorityFolder(deadlockPath, modId, priority);
+        return enrichMod(mod);
     }
 );
 

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -179,9 +179,21 @@ export function getDisabledPath(deadlockPath: string): string {
  * Get the Grimoire-managed addon folder path, creating it if necessary.
  *
  * This is a SECOND addon search path (sibling of citadel/addons), listed FIRST
- * in gameinfo.gi's SearchPaths so it outranks every user mod. It holds only the
- * Locker-managed override VPKs (hero cards + ability sounds), keeping them off
- * the user's 99-slot citadel/addons budget while still winning every collision.
+ * in gameinfo.gi's SearchPaths so it outranks every user mod, and it does not
+ * consume the user's 99-slot citadel/addons budget.
+ *
+ * Two kinds of VPK live here:
+ *
+ * - Slots pak01-pak04 are RESERVED for the Locker-managed override VPKs (hero
+ *   cards, ability sounds, ability colors, trippy skins). They are written by
+ *   lockerVpk.ts under synthetic metadata keys and are never user mods.
+ * - Slots pak05-pak99 hold user mods the user marked "Global" (see
+ *   PRIORITY_FIRST_SLOT). Being here IS the whole feature: the engine's search
+ *   path order makes them win every file collision with no load-order
+ *   bookkeeping, and the launch shuffle leaves them alone.
+ *
+ * Reserved-first ordering is deliberate: a lower pakNN loads first and wins, so
+ * the Locker's own managed artifacts still outrank a user's Global mod.
  */
 export function getGrimoirePath(deadlockPath: string): string {
     const grimoirePath = join(deadlockPath, 'game', 'citadel', 'grimoire');
@@ -191,6 +203,33 @@ export function getGrimoirePath(deadlockPath: string): string {
     }
 
     return grimoirePath;
+}
+
+/** Folder name of the priority root, as it appears under citadel/. */
+export const PRIORITY_FOLDER_NAME = 'grimoire';
+
+/**
+ * First pakNN slot in citadel/grimoire available to user mods. Slots 1-4 are
+ * the Locker-managed VPKs (cards, sounds, colors, trippy skins); see
+ * lockerVpk.ts, which owns those filenames. Keep this in sync if a fifth
+ * managed artifact is ever added.
+ */
+export const PRIORITY_FIRST_SLOT = 5;
+
+/**
+ * True for a citadel/grimoire filename in the reserved pak01-pak04 range. The
+ * scan uses this to skip the Locker-managed VPKs, which are keyed by synthetic
+ * metadata keys (locker:cards and friends) and must never surface as user mods.
+ */
+export function isReservedPriorityVpk(fileName: string): boolean {
+    const match = fileName.match(/^pak(\d+)_dir\.vpk$/i);
+    if (!match) return false;
+    return parseInt(match[1], 10) < PRIORITY_FIRST_SLOT;
+}
+
+/** True when this absolute VPK path sits in the priority root. */
+export function isPriorityFolderPath(vpkPath: string): boolean {
+    return basename(dirname(vpkPath)).toLowerCase() === PRIORITY_FOLDER_NAME;
 }
 
 /**
@@ -228,6 +267,19 @@ export function getAddonFolderPaths(deadlockPath: string): string[] {
         // citadel/ unreadable: base-only is the safe fallback.
     }
     return folders;
+}
+
+/**
+ * Every enabled-mod root the scan walks, in engine search-path order: the
+ * priority root (citadel/grimoire) first, then the addon roots.
+ *
+ * Deliberately separate from getAddonFolderPaths, which stays the *allocation*
+ * view: slot allocation, overflow minting, and the gameinfo SearchPaths rewrite
+ * must never treat the priority root as somewhere a mod can spill into. A mod
+ * only lands there by explicit user action (setModPriorityFolder).
+ */
+export function getModScanRootPaths(deadlockPath: string): string[] {
+    return [getGrimoirePath(deadlockPath), ...getAddonFolderPaths(deadlockPath)];
 }
 
 /**
@@ -275,13 +327,17 @@ export function createNextOverflowFolder(deadlockPath: string): string | null {
  * Mods in the base citadel/addons folder and in .disabled/ key to their BARE
  * filename, exactly as they always have, so existing installs need no migration.
  * Mods in an overflow folder key to `addons{N}/<filename>` so a pak01_dir.vpk in
- * addons1 can't collide with the pak01_dir.vpk in the base folder. This is the
+ * addons1 can't collide with the pak01_dir.vpk in the base folder. Mods in the
+ * priority root key to `grimoire/<filename>` for the same reason. This is the
  * single source of truth for the rule; metadata access and id generation both
  * route through it.
  */
 export function metaKeyFor(vpkPath: string): string {
     const fileName = basename(vpkPath);
     const parentName = basename(dirname(vpkPath));
+    if (parentName.toLowerCase() === PRIORITY_FOLDER_NAME) {
+        return `${PRIORITY_FOLDER_NAME}/${fileName}`;
+    }
     return OVERFLOW_FOLDER_RE.test(parentName) ? `${parentName}/${fileName}` : fileName;
 }
 

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -227,9 +227,25 @@ export function isReservedPriorityVpk(fileName: string): boolean {
     return parseInt(match[1], 10) < PRIORITY_FIRST_SLOT;
 }
 
+/**
+ * True for any VPK artifact owned by a reserved priority slot. Vanilla launch
+ * moves chunk siblings as well as *_dir.vpk files, so its filter must recognize
+ * pak01_000.vpk in addition to pak01_dir.vpk.
+ */
+export function isReservedPriorityVpkArtifact(fileName: string): boolean {
+    const match = fileName.match(/^pak(\d+)_(?:dir|\d{3})\.vpk$/i);
+    if (!match) return false;
+    return parseInt(match[1], 10) < PRIORITY_FIRST_SLOT;
+}
+
 /** True when this absolute VPK path sits in the priority root. */
 export function isPriorityFolderPath(vpkPath: string): boolean {
     return basename(dirname(vpkPath)).toLowerCase() === PRIORITY_FOLDER_NAME;
+}
+
+/** True when an absolute path is one of the Locker-managed priority VPKs. */
+export function isReservedPriorityVpkPath(vpkPath: string): boolean {
+    return isPriorityFolderPath(vpkPath) && isReservedPriorityVpk(basename(vpkPath));
 }
 
 /**

--- a/electron/main/services/heroCards.ts
+++ b/electron/main/services/heroCards.ts
@@ -17,12 +17,10 @@ import { basename, join } from 'path';
 import { randomUUID, createHash } from 'crypto';
 import { app } from 'electron';
 import {
-    getAddonFolderPaths,
     getCitadelPath,
-    getDisabledPath,
     getGrimoirePath,
-    metaKeyFor,
 } from './deadlock';
+import { listInstalledUserVpks } from './modLibrary';
 import { parseVpkDirectoryCached, invalidateVpkParseCache } from './vpk';
 import {
     runVpkmerge,
@@ -82,30 +80,10 @@ interface VpkRef {
     enabled: boolean;
 }
 
-/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
- *  overflow addonsN) plus the ones parked in `.disabled/`, so a card source that
- *  overflowed past slot 99 is still found at apply/rebuild time. */
+/** User VPKs across Global, every addon folder, and `.disabled`, so a source
+ *  remains discoverable after any placement or enable-state change. */
 async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
-    const out: VpkRef[] = [];
-    const folders: Array<[string, boolean]> = [
-        ...getAddonFolderPaths(deadlockPath).map((p) => [p, true] as [string, boolean]),
-        [getDisabledPath(deadlockPath), false],
-    ];
-    for (const [dir, enabled] of folders) {
-        let entries: string[];
-        try {
-            entries = await fs.readdir(dir);
-        } catch {
-            continue; // .disabled may not exist
-        }
-        for (const entry of entries) {
-            if (entry.toLowerCase().endsWith('_dir.vpk')) {
-                const path = join(dir, entry);
-                out.push({ fileName: entry, path, metaKey: metaKeyFor(path), enabled });
-            }
-        }
-    }
-    return out;
+    return listInstalledUserVpks(deadlockPath);
 }
 
 /** The single Locker cosmetics VPK (the one whose metadata carries the

--- a/electron/main/services/heroPortraits.ts
+++ b/electron/main/services/heroPortraits.ts
@@ -14,7 +14,8 @@
 import { promises as fs } from 'fs';
 import { basename, join } from 'path';
 import { app } from 'electron';
-import { getAddonFolderPaths, getDisabledPath, metaKeyFor } from './deadlock';
+import { metaKeyFor } from './deadlock';
+import { listInstalledUserVpks } from './modLibrary';
 import { parseVpkDirectoryCached } from './vpk';
 import { vpkmergeBinaryPath, runVpkmerge } from './modMerger';
 import { getModMetadata } from './metadata';
@@ -113,23 +114,10 @@ function sanitize(value: string): string {
     return value.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }
 
-/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
- *  overflow addonsN) plus the ones parked in `.disabled/`, so a source that
- *  overflowed past slot 99 still surfaces in the picker. */
+/** User VPKs across Global, every addon folder, and `.disabled`, so a source
+ *  remains discoverable after any placement or enable-state change. */
 async function listAddonVpks(deadlockPath: string): Promise<string[]> {
-    const vpks: string[] = [];
-    for (const dir of [...getAddonFolderPaths(deadlockPath), getDisabledPath(deadlockPath)]) {
-        let entries: string[];
-        try {
-            entries = await fs.readdir(dir);
-        } catch {
-            continue; // .disabled may not exist
-        }
-        for (const entry of entries) {
-            if (entry.endsWith('_dir.vpk')) vpks.push(join(dir, entry));
-        }
-    }
-    return vpks;
+    return (await listInstalledUserVpks(deadlockPath)).map((vpk) => vpk.path);
 }
 
 interface PortraitManifest {
@@ -145,7 +133,7 @@ interface PortraitManifest {
 /**
  * Decode every hero portrait/card the installed mods ship for `heroName`.
  *
- * Scans enabled + disabled addon VPKs, cheaply pre-filters by the VPK file
+ * Scans every installed user VPK, cheaply pre-filters by the VPK file
  * tree (reusing the cached parser so we don't re-read every pak), then shells
  * out to `vpkmerge portrait` only for VPKs that actually carry this hero's
  * panorama art.

--- a/electron/main/services/heroSounds.ts
+++ b/electron/main/services/heroSounds.ts
@@ -21,7 +21,8 @@ import { promises as fs, existsSync } from 'fs';
 import { basename, join } from 'path';
 import { randomUUID } from 'crypto';
 import { app } from 'electron';
-import { getAddonFolderPaths, getDisabledPath, getCitadelPath, getGrimoirePath, metaKeyFor } from './deadlock';
+import { getCitadelPath, getGrimoirePath } from './deadlock';
+import { listInstalledUserVpks } from './modLibrary';
 import { invalidateVpkParseCache } from './vpk';
 import { runVpkmerge, runVpkmergeStdout, vpkmergeBinaryPath, verifyVpkOutput } from './modMerger';
 import {
@@ -51,30 +52,10 @@ interface VpkRef {
     enabled: boolean;
 }
 
-/** Enabled addon VPKs across every addon folder (base citadel/addons plus any
- *  overflow addonsN) plus the ones parked in `.disabled/`, so a sound source that
- *  overflowed past slot 99 is still found at apply/rebuild time. */
+/** User VPKs across Global, every addon folder, and `.disabled`, so a source
+ *  remains discoverable after any placement or enable-state change. */
 async function listAddonVpks(deadlockPath: string): Promise<VpkRef[]> {
-    const out: VpkRef[] = [];
-    const folders: Array<[string, boolean]> = [
-        ...getAddonFolderPaths(deadlockPath).map((p) => [p, true] as [string, boolean]),
-        [getDisabledPath(deadlockPath), false],
-    ];
-    for (const [dir, enabled] of folders) {
-        let entries: string[];
-        try {
-            entries = await fs.readdir(dir);
-        } catch {
-            continue;
-        }
-        for (const entry of entries) {
-            if (entry.toLowerCase().endsWith('_dir.vpk')) {
-                const path = join(dir, entry);
-                out.push({ fileName: entry, path, metaKey: metaKeyFor(path), enabled });
-            }
-        }
-    }
-    return out;
+    return listInstalledUserVpks(deadlockPath);
 }
 
 /** The single Locker sound VPK (metadata carries `lockerSounds`), or null. Only

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -3,7 +3,14 @@ import { join, basename, dirname } from 'path';
 import { spawn } from 'child_process';
 import { shell } from 'electron';
 import { getUserDataPath } from '../utils/paths';
-import { getAddonsPath, getDisabledPath, getAddonFolderPaths, getCitadelPath } from './deadlock';
+import {
+    getAddonsPath,
+    getDisabledPath,
+    getModScanRootPaths,
+    getCitadelPath,
+    isReservedPriorityVpkArtifact,
+    PRIORITY_FOLDER_NAME,
+} from './deadlock';
 import { loadSettings } from './settings';
 import { writeLaunchOptions, readLaunchOptions, isSteamRunning } from './launchOptions';
 
@@ -39,15 +46,15 @@ export interface VanillaStash {
     version: 1;
     status: 'pending' | 'active';
     startedAt: string;
-    /** Each stashed VPK plus the addon folder it came from, so restore returns
-     *  it to the right place. `folder` is the addon root basename: "addons" for
-     *  the base folder, "addonsN" for an overflow folder. Absent on stashes
-     *  written before multi-folder overflow existed; those are all base addons. */
+    /** Each stashed VPK plus the enabled-mod root it came from, so restore
+     *  returns it to the right place. `folder` is "grimoire", "addons", or an
+     *  overflow "addonsN" basename. Absent on stashes written before
+     *  multi-folder overflow existed; those are all base addons. */
     mods: Array<{ fileName: string; folder?: string }>;
 }
 
-/** Absolute path of an addon root folder from the basename recorded in the
- *  stash ("addons" -> base citadel/addons, "addonsN" -> citadel/addonsN). */
+/** Absolute path of an enabled-mod root from the basename recorded in the
+ *  stash ("addons" -> base citadel/addons; others are siblings under citadel). */
 function originFolderPath(deadlockPath: string, folder: string): string {
     return folder === 'addons'
         ? getAddonsPath(deadlockPath)
@@ -201,25 +208,24 @@ export async function stopDeadlockGame(): Promise<StopDeadlockResult> {
 }
 
 /**
- * Stash every VPK across every addon folder (base citadel/addons plus any
- * overflow addonsN): record them to the stash file first (so a crash mid-move
- * leaves a recoverable breadcrumb that knows each file's origin folder), then
- * move the files into disabled/. Mark the stash 'active' only once all moves
- * succeed.
+ * Stash every user VPK across every enabled-mod root (priority, base addons,
+ * and overflow addonsN): record them to the stash file first (so a crash
+ * mid-move leaves a recoverable breadcrumb that knows each file's origin),
+ * then move the files into disabled/. Locker-managed priority slots pak01-pak04
+ * retain their established lifecycle and are deliberately left in place.
  *
  * If a move fails mid-operation, we leave the stash at 'pending' and rethrow.
  * The caller (or next app startup) can then invoke restoreFromStash to
  * reassemble whatever state made it to disk.
  */
-async function stashEnabledMods(deadlockPath: string): Promise<VanillaStash> {
+export async function stashEnabledMods(deadlockPath: string): Promise<VanillaStash> {
     const disabledPath = getDisabledPath(deadlockPath);
 
-    // Enumerate every addon root (base citadel/addons first, then overflow
-    // addons1, addons2, ...) and record each enabled VPK with its origin folder
-    // BEFORE moving anything, so a crash mid-move leaves a recoverable breadcrumb
-    // that knows where each file belongs.
+    // Enumerate every enabled-mod root and record each user VPK with its origin
+    // BEFORE moving anything, so a crash mid-move leaves a recoverable
+    // breadcrumb that knows where each file belongs.
     const mods: Array<{ fileName: string; folder: string }> = [];
-    for (const folder of getAddonFolderPaths(deadlockPath)) {
+    for (const folder of getModScanRootPaths(deadlockPath)) {
         const name = basename(folder);
         let entries: string[];
         try {
@@ -229,7 +235,14 @@ async function stashEnabledMods(deadlockPath: string): Promise<VanillaStash> {
         }
         // Stash only VPK files (addon folders may contain other junk).
         for (const fileName of entries) {
-            if (fileName.toLowerCase().endsWith('.vpk')) mods.push({ fileName, folder: name });
+            if (!fileName.toLowerCase().endsWith('.vpk')) continue;
+            if (
+                name.toLowerCase() === PRIORITY_FOLDER_NAME &&
+                isReservedPriorityVpkArtifact(fileName)
+            ) {
+                continue;
+            }
+            mods.push({ fileName, folder: name });
         }
     }
 
@@ -267,10 +280,9 @@ export interface RestoreResult {
 }
 
 /**
- * Move stashed VPKs from disabled/ back to each one's origin addon folder (base
- * addons or an overflow addonsN, per the stash record), with retries for
- * transient Windows file locks. Deletes the stash only if every file is
- * accounted for.
+ * Move stashed VPKs from disabled/ back to each one's origin enabled-mod root
+ * (priority, base addons, or overflow addonsN), with retries for transient
+ * Windows file locks. Deletes the stash only if every file is accounted for.
  *
  * Hazard notes:
  * - If the game is still running and holds a handle on the _dir.vpk, Windows
@@ -467,8 +479,10 @@ export async function launchModded({
 }
 
 /**
- * Launch the game WITHOUT any mods active. Stashes every VPK in addons/,
- * triggers Steam, then schedules a background restore after the game mounts.
+ * Launch the game without user mods active. Stashes every user VPK in the
+ * priority/addon roots, triggers Steam, then schedules a background restore
+ * after the game mounts. Locker-managed priority artifacts keep their existing
+ * lifecycle and are not part of the user-mod stash.
  *
  * If the Steam launch itself fails, we immediately restore from the stash
  * we just wrote, leaving the user in exactly the state they were in before.

--- a/electron/main/services/launchVanilla.test.ts
+++ b/electron/main/services/launchVanilla.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const harness = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({
+    app: { getPath: () => harness.userData },
+    shell: { openExternal: vi.fn() },
+}));
+
+import { restoreFromStash, stashEnabledMods } from './launch';
+
+describe('Vanilla user-mod stash', () => {
+    beforeEach(() => {
+        harness.userData = mkdtempSync(join(tmpdir(), 'vanilla-userdata-'));
+    });
+
+    it('stashes and restores Global user VPKs while preserving reserved Locker artifacts', async () => {
+        const root = mkdtempSync(join(tmpdir(), 'vanilla-game-'));
+        const citadel = join(root, 'game', 'citadel');
+        const grimoire = join(citadel, 'grimoire');
+        const addons = join(citadel, 'addons');
+        const disabled = join(addons, '.disabled');
+        mkdirSync(grimoire, { recursive: true });
+        mkdirSync(disabled, { recursive: true });
+
+        const managedDir = join(grimoire, 'pak01_dir.vpk');
+        const managedChunk = join(grimoire, 'pak01_000.vpk');
+        const globalDir = join(grimoire, 'pak05_dir.vpk');
+        const globalChunk = join(grimoire, 'pak05_000.vpk');
+        const addonDir = join(addons, 'pak02_dir.vpk');
+        for (const path of [managedDir, managedChunk, globalDir, globalChunk, addonDir]) {
+            writeFileSync(path, path);
+        }
+
+        const stash = await stashEnabledMods(root);
+
+        expect(stash.status).toBe('active');
+        expect(stash.mods.map(({ fileName, folder }) => `${folder}/${fileName}`).sort()).toEqual([
+            'addons/pak02_dir.vpk',
+            'grimoire/pak05_000.vpk',
+            'grimoire/pak05_dir.vpk',
+        ]);
+        expect(existsSync(managedDir)).toBe(true);
+        expect(existsSync(managedChunk)).toBe(true);
+        expect(existsSync(globalDir)).toBe(false);
+        expect(existsSync(globalChunk)).toBe(false);
+        expect(existsSync(addonDir)).toBe(false);
+        expect(existsSync(join(disabled, 'grimoire', 'pak05_dir.vpk'))).toBe(true);
+        expect(existsSync(join(disabled, 'grimoire', 'pak05_000.vpk'))).toBe(true);
+        expect(existsSync(join(disabled, 'pak02_dir.vpk'))).toBe(true);
+
+        const restored = await restoreFromStash(root, stash);
+
+        expect(restored).toEqual({ restored: 3, skipped: 0, failed: [] });
+        expect(existsSync(globalDir)).toBe(true);
+        expect(existsSync(globalChunk)).toBe(true);
+        expect(existsSync(addonDir)).toBe(true);
+        expect(existsSync(join(harness.userData, 'vanilla-stash.json'))).toBe(false);
+    });
+});

--- a/electron/main/services/metadata.backfill.test.ts
+++ b/electron/main/services/metadata.backfill.test.ts
@@ -25,12 +25,14 @@ import { resolveVpkIdentity } from './vpkIdentity';
 
 const hash = (letter: string) => letter.repeat(64);
 
-function createDeadlockRoot(): { root: string; addons: string; disabled: string } {
+function createDeadlockRoot(): { root: string; addons: string; disabled: string; grimoire: string } {
     const root = mkdtempSync(join(tmpdir(), 'metadata-backfill-game-'));
     const addons = join(root, 'game', 'citadel', 'addons');
     const disabled = join(addons, '.disabled');
+    const grimoire = join(root, 'game', 'citadel', 'grimoire');
     mkdirSync(disabled, { recursive: true });
-    return { root, addons, disabled };
+    mkdirSync(grimoire, { recursive: true });
+    return { root, addons, disabled, grimoire };
 }
 
 beforeEach(() => {
@@ -74,6 +76,23 @@ describe('backfillMissingMetadataHashes', () => {
 
         expect(getModMetadata('local_skin_dir.vpk')).toEqual({ sha256: hash('c') });
         expect(resolveVpkIdentity).toHaveBeenCalledWith(imprintedPath);
+    });
+
+    it('backfills Global user VPKs and ignores reserved Locker artifacts', async () => {
+        const { root, grimoire } = createDeadlockRoot();
+        const managedPath = join(grimoire, 'pak01_dir.vpk');
+        const globalPath = join(grimoire, 'pak05_dir.vpk');
+        writeFileSync(managedPath, 'managed');
+        writeFileSync(globalPath, 'global');
+        harness.identities.set(globalPath, hash('e'));
+
+        const updated = await backfillMissingMetadataHashes(root);
+
+        expect(updated).toBe(1);
+        expect(getModMetadata('grimoire/pak05_dir.vpk')).toEqual({ sha256: hash('e') });
+        expect(getModMetadata('grimoire/pak01_dir.vpk')).toBeUndefined();
+        expect(resolveVpkIdentity).toHaveBeenCalledTimes(1);
+        expect(resolveVpkIdentity).toHaveBeenCalledWith(globalPath);
     });
 
     it('migrates a minimal hash row with its mod across a metaKey rename', () => {

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -116,6 +116,12 @@ export interface ModMetadata {
      *  when the user wants to stay on a specific version after the author
      *  replaces or rearranges files. */
     ignoreUpdates?: boolean;
+    /** User marked this mod Global: it lives in the priority root
+     *  (citadel/grimoire), which the engine searches before citadel/addons, so
+     *  it wins every file collision and the launch shuffle leaves it enabled.
+     *  Source of truth for placement, because a disabled mod sits in .disabled/
+     *  where the folder can't tell us. Undefined (not false) when unset. */
+    priorityMod?: boolean;
 }
 
 export type ModMetadataMap = Record<string, ModMetadata>;

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'crypto';
 import { createReadStream, readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, statSync, mkdirSync, copyFileSync, readdirSync } from 'fs';
-import { promises as fs } from 'fs';
 import { join, dirname } from 'path';
-import { getAddonFolderPaths, getDisabledPath, metaKeyFor } from './deadlock';
+import { metaKeyFor } from './deadlock';
+import { listInstalledUserVpks } from './modLibrary';
 import { resolveVpkIdentity } from './vpkIdentity';
 import { getMetadataPath } from '../utils/paths';
 
@@ -288,20 +288,16 @@ export async function backfillMissingMetadataHashes(deadlockPath: string): Promi
     return updated;
 }
 
-// Map every installed VPK to its absolute path, keyed by metaKey (lowercased) so
-// it lines up with the metaKey-keyed metadata entries. Scans every addon folder
-// (base + overflow) plus .disabled; for base/.disabled the key is the bare
-// filename, for overflow it's addons{N}/<file>.
+// Map every installed user VPK to its absolute path, keyed by metaKey
+// (lowercased) so it lines up with the metaKey-keyed metadata entries. The
+// shared inventory includes Global, addons/overflow, and .disabled while
+// excluding the Locker-managed reserved priority VPKs.
 async function collectInstalledVpkPaths(deadlockPath: string): Promise<Map<string, string>> {
     const filesByKey = new Map<string, string>();
 
-    for (const folder of [...getAddonFolderPaths(deadlockPath), getDisabledPath(deadlockPath)]) {
-        for (const entry of await fs.readdir(folder, { withFileTypes: true }).catch(() => [])) {
-            if (!entry.isFile() || !entry.name.toLowerCase().endsWith('_dir.vpk')) continue;
-            const full = join(folder, entry.name);
-            const key = metaKeyFor(full).toLowerCase();
-            if (!filesByKey.has(key)) filesByKey.set(key, full);
-        }
+    for (const vpk of await listInstalledUserVpks(deadlockPath)) {
+        const key = vpk.metaKey.toLowerCase();
+        if (!filesByKey.has(key)) filesByKey.set(key, vpk.path);
     }
 
     return filesByKey;

--- a/electron/main/services/modLibrary.test.ts
+++ b/electron/main/services/modLibrary.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { listInstalledUserVpks } from './modLibrary';
+
+describe('listInstalledUserVpks', () => {
+    it('covers every user-mod root and excludes reserved Locker VPKs', async () => {
+        const root = mkdtempSync(join(tmpdir(), 'mod-library-'));
+        const citadel = join(root, 'game', 'citadel');
+        const grimoire = join(citadel, 'grimoire');
+        const addons = join(citadel, 'addons');
+        const overflow = join(citadel, 'addons1');
+        const disabled = join(addons, '.disabled');
+        for (const dir of [grimoire, addons, overflow, disabled]) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        writeFileSync(join(grimoire, 'pak01_dir.vpk'), 'managed');
+        writeFileSync(join(grimoire, 'pak05_dir.vpk'), 'global');
+        writeFileSync(join(addons, 'pak02_dir.vpk'), 'base');
+        writeFileSync(join(overflow, 'pak03_dir.vpk'), 'overflow');
+        writeFileSync(join(disabled, 'parked_dir.vpk'), 'disabled');
+        writeFileSync(join(grimoire, 'notes.txt'), 'not a vpk');
+
+        const vpks = await listInstalledUserVpks(root);
+        expect(vpks.map(({ metaKey, enabled }) => ({ metaKey, enabled }))).toEqual([
+            { metaKey: 'grimoire/pak05_dir.vpk', enabled: true },
+            { metaKey: 'pak02_dir.vpk', enabled: true },
+            { metaKey: 'addons1/pak03_dir.vpk', enabled: true },
+            { metaKey: 'parked_dir.vpk', enabled: false },
+        ]);
+    });
+});

--- a/electron/main/services/modLibrary.ts
+++ b/electron/main/services/modLibrary.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import {
+    getDisabledPath,
+    getModScanRootPaths,
+    isReservedPriorityVpkPath,
+    metaKeyFor,
+} from './deadlock';
+
+/** A user-installed directory VPK found in an enabled root or .disabled. */
+export interface InstalledUserVpk {
+    fileName: string;
+    path: string;
+    metaKey: string;
+    enabled: boolean;
+}
+
+/**
+ * List every user-installed directory VPK, regardless of placement.
+ *
+ * This is the inventory view shared by features that inspect source VPKs
+ * (metadata identity, Locker cards/sounds/portraits). It deliberately differs
+ * from getAddonFolderPaths, which is allocation-only and must never hand out
+ * slots in citadel/grimoire.
+ *
+ * The priority root also contains Locker-managed artifacts in pak01-pak04.
+ * Those use synthetic metadata keys and are not user mods, so they are filtered
+ * once here rather than at every consumer.
+ */
+export async function listInstalledUserVpks(deadlockPath: string): Promise<InstalledUserVpk[]> {
+    const roots: Array<{ path: string; enabled: boolean }> = [
+        ...getModScanRootPaths(deadlockPath).map((path) => ({ path, enabled: true })),
+        { path: getDisabledPath(deadlockPath), enabled: false },
+    ];
+    const vpks: InstalledUserVpk[] = [];
+
+    for (const root of roots) {
+        const entries = await fs.readdir(root.path, { withFileTypes: true }).catch(() => []);
+        for (const entry of entries) {
+            if (!entry.isFile() || !entry.name.toLowerCase().endsWith('_dir.vpk')) continue;
+            const path = join(root.path, entry.name);
+            if (isReservedPriorityVpkPath(path)) continue;
+            vpks.push({
+                fileName: entry.name,
+                path,
+                metaKey: metaKeyFor(path),
+                enabled: root.enabled,
+            });
+        }
+    }
+
+    return vpks;
+}

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { createHash, randomBytes } from 'crypto';
-import { getAddonsPath, getDisabledPath, getAddonFolderPaths, getModScanRootPaths, getGrimoirePath, createNextOverflowFolder, overflowAddonsPath, MAX_ADDON_FOLDERS, metaKeyFor, isPriorityFolderPath, isReservedPriorityVpk, PRIORITY_FIRST_SLOT } from './deadlock';
+import { getAddonsPath, getDisabledPath, getAddonFolderPaths, getModScanRootPaths, getGrimoirePath, createNextOverflowFolder, overflowAddonsPath, MAX_ADDON_FOLDERS, metaKeyFor, isPriorityFolderPath, isReservedPriorityVpkPath, PRIORITY_FIRST_SLOT } from './deadlock';
 import { fixGameinfo } from './system';
 import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
 import { compareFileContents } from './fileMatch';
@@ -324,7 +324,7 @@ async function scanFolder(folder: string, enabled: boolean): Promise<Mod[]> {
         // Locker's own managed VPKs. They are keyed by synthetic metadata keys
         // (locker:cards and friends), so surfacing them here would invent
         // phantom user mods for artifacts the user never installed.
-        if (isPriorityFolderPath(fullPath) && isReservedPriorityVpk(entry)) continue;
+        if (isReservedPriorityVpkPath(fullPath)) continue;
 
         try {
             const stats = await fs.stat(fullPath);
@@ -832,14 +832,11 @@ export function setModPriorityFolder(deadlockPath: string, modId: string, priori
             assertCanMoveLoadedGameMod(target);
         }
 
-        // Record the intent before any rename, so a crash mid-move leaves the
-        // flag and the next enable heals the placement.
-        setModMetadata(target.metaKey, { priorityMod: priority ? true : undefined });
-
         if (!target.enabled) {
             // Nothing to move: the file is parked in .disabled/ under a
             // free-form name. The flag alone decides where the next enable
             // puts it.
+            setModMetadata(target.metaKey, { priorityMod: priority ? true : undefined });
             return target;
         }
 
@@ -854,7 +851,38 @@ export function setModPriorityFolder(deadlockPath: string, modId: string, priori
             });
         }
 
-        const moved = await moveModToFolderAs(target, destination.folder, destination.fileName, true);
+        // Keep placement and metadata atomic from the caller's perspective.
+        //
+        // Moving IN: rename first, then stamp the destination key. If the app
+        // crashes between those steps, scanMods sees a user VPK in grimoire and
+        // self-heals the missing flag. Allocation/rename failures leave the
+        // original metadata untouched.
+        //
+        // Moving OUT: clear first so the migrated row is already correct when
+        // the rename lands. If the rename fails (or the app crashes before it),
+        // scanMods sees the still-resident priority VPK and restores the flag.
+        if (!priority) {
+            setModMetadata(target.metaKey, { priorityMod: undefined });
+        }
+
+        let moved: Mod;
+        try {
+            moved = await moveModToFolderAs(target, destination.folder, destination.fileName, true);
+        } catch (err) {
+            if (!priority) {
+                // Best-effort immediate rollback; scanMods is the durable
+                // fallback if persisting this restoration itself fails.
+                try {
+                    setModMetadata(target.metaKey, { priorityMod: true });
+                } catch {
+                    // Preserve the original filesystem error.
+                }
+            }
+            throw err;
+        }
+        if (priority) {
+            setModMetadata(moved.metaKey, { priorityMod: true });
+        }
         modTrace(
             `priority: "${target.name}" ${target.metaKey} -> ${moved.metaKey} (global=${priority})`
         );

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { createHash, randomBytes } from 'crypto';
-import { getAddonsPath, getDisabledPath, getAddonFolderPaths, createNextOverflowFolder, overflowAddonsPath, MAX_ADDON_FOLDERS, metaKeyFor } from './deadlock';
+import { getAddonsPath, getDisabledPath, getAddonFolderPaths, getModScanRootPaths, getGrimoirePath, createNextOverflowFolder, overflowAddonsPath, MAX_ADDON_FOLDERS, metaKeyFor, isPriorityFolderPath, isReservedPriorityVpk, PRIORITY_FIRST_SLOT } from './deadlock';
 import { fixGameinfo } from './system';
 import { getModMetadata, setModMetadata, removeModMetadata, migrateModMetadata } from './metadata';
 import { compareFileContents } from './fileMatch';
@@ -138,6 +138,10 @@ export interface Mod {
     /** User opted out of the "update available" flag for this mod. The
      *  enricher reads this from the mod metadata sidecar. */
     ignoreUpdates?: boolean;
+    /** User marked this mod Global: it lives in the citadel/grimoire priority
+     *  root, which the engine searches ahead of citadel/addons. The enricher
+     *  reads this from the mod metadata sidecar. */
+    priorityMod?: boolean;
 }
 
 /**
@@ -243,11 +247,20 @@ function slugify(value: string): string {
 }
 
 /**
- * Folder index of an addon VPK from its on-disk path: 0 for the base
+ * Folder index of an addon VPK from its on-disk path, ordered the way the
+ * engine searches: PRIORITY_FOLDER_INDEX for citadel/grimoire, 0 for the base
  * citadel/addons, N for an overflow citadel/addonsN. Anything else (e.g. a
  * .disabled file) reports 0; callers that care gate on mod.enabled first.
+ *
+ * The priority root sorts BELOW zero because it is the first Game line in the
+ * canonical SearchPaths block (system.ts), and earlier lines win. That single
+ * fact is what makes a Global mod outrank every addons mod without any pakNN
+ * bookkeeping, so every load-order consumer must go through this function.
  */
+const PRIORITY_FOLDER_INDEX = -1;
+
 function addonFolderIndex(vpkPath: string): number {
+    if (isPriorityFolderPath(vpkPath)) return PRIORITY_FOLDER_INDEX;
     const match = basename(dirname(vpkPath)).match(/^addons(\d+)$/i);
     return match ? parseInt(match[1], 10) : 0;
 }
@@ -306,6 +319,12 @@ async function scanFolder(folder: string, enabled: boolean): Promise<Mod[]> {
 
     for (const entry of entries) {
         const fullPath = join(folder, entry);
+
+        // Reserved priority slots (pak01-pak04 in citadel/grimoire) are the
+        // Locker's own managed VPKs. They are keyed by synthetic metadata keys
+        // (locker:cards and friends), so surfacing them here would invent
+        // phantom user mods for artifacts the user never installed.
+        if (isPriorityFolderPath(fullPath) && isReservedPriorityVpk(entry)) continue;
 
         try {
             const stats = await fs.stat(fullPath);
@@ -369,7 +388,10 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
     // Scan every enabled addon folder (base citadel/addons plus any overflow
     // addons1, addons2, ...) and the single shared .disabled parking lot. Each
     // mod's metaKey is stamped in scanFolder from its folder location.
-    const enabledFolders = getAddonFolderPaths(deadlockPath);
+    // Scan roots include the priority root (citadel/grimoire) ahead of the
+    // addon roots, so a mod the user marked Global stays visible and fully
+    // manageable in the list instead of vanishing when it moves there.
+    const enabledFolders = getModScanRootPaths(deadlockPath);
     await cleanupStaleMergeRebuildArtifacts(enabledFolders);
     const scanned = await Promise.all([
         ...enabledFolders.map((folder) => scanFolder(folder, true)),
@@ -738,6 +760,92 @@ export async function allocateEnabledVpkPath(deadlockPath: string): Promise<stri
 }
 
 /**
+ * Message for a full priority root. Distinct from ENABLE_LIMIT_MESSAGE because
+ * the remedy is different (un-Global something, not disable something) and
+ * because the priority root has no overflow: it is one folder with one
+ * SearchPaths line, and minting siblings would mean rewriting gameinfo for what
+ * is meant to be a small curated set.
+ */
+export const PRIORITY_LIMIT_MESSAGE =
+    'You can have at most 95 Global mods. Remove one from Global to make room.';
+
+/**
+ * Find a free user slot in the priority root. Slots below PRIORITY_FIRST_SLOT
+ * belong to the Locker's managed VPKs and are never handed out, which is also
+ * what keeps those artifacts loading ahead of user Global mods.
+ */
+async function allocatePrioritySlot(deadlockPath: string): Promise<AllocatedSlot> {
+    const folder = getGrimoirePath(deadlockPath);
+    const used = await folderPakNumbers(folder);
+    for (let slot = PRIORITY_FIRST_SLOT; slot <= MAX_VPK_PRIORITY; slot++) {
+        if (!used.has(slot)) {
+            return { folder, fileName: `pak${String(slot).padStart(2, '0')}_dir.vpk` };
+        }
+    }
+    throw new Error(PRIORITY_LIMIT_MESSAGE);
+}
+
+/**
+ * Move a mod into or out of the priority root (the "Global" affordance).
+ *
+ * The metadata flag is the source of truth rather than the current folder,
+ * because a disabled mod lives in .disabled/ and has no folder to read: without
+ * the flag, disabling a Global mod and re-enabling it would silently demote it
+ * back to citadel/addons. enableModImpl consults the flag for exactly that
+ * reason.
+ *
+ * A disabled mod can still be marked Global; the flag is recorded and the move
+ * happens on the next enable.
+ */
+export function setModPriorityFolder(deadlockPath: string, modId: string, priority: boolean): Promise<Mod> {
+    return withModMutationLock(async () => {
+        const mods = await scanMods(deadlockPath);
+        await syncRunningGameModSnapshotFromMods(mods);
+        const target = mods.find((m) => m.id === modId);
+        if (!target) throw new Error(`Mod not found: ${modId}`);
+
+        const alreadyThere = isPriorityFolderPath(target.path);
+        if (alreadyThere === priority) {
+            // Folder already correct; just make sure the flag agrees so a
+            // later disable/enable round trip preserves the choice.
+            setModMetadata(target.metaKey, { priorityMod: priority ? true : undefined });
+            return target;
+        }
+
+        // Record the intent before any rename, so a crash mid-move leaves the
+        // flag and the next enable heals the placement.
+        setModMetadata(target.metaKey, { priorityMod: priority ? true : undefined });
+
+        if (!target.enabled) {
+            // Nothing to move: the file is parked in .disabled/ under a
+            // free-form name. The flag alone decides where the next enable
+            // puts it.
+            return target;
+        }
+
+        assertCanMoveLoadedGameMod(target);
+
+        let destination: AllocatedSlot;
+        if (priority) {
+            destination = await allocatePrioritySlot(deadlockPath);
+        } else {
+            const disabledForbidden = await folderPakNumbers(getDisabledPath(deadlockPath));
+            destination = await allocateSlot(deadlockPath, {
+                disabledForbidden,
+                preferred: [getModMetadata(target.metaKey)?.lastPriority],
+            });
+        }
+
+        const moved = await moveModToFolderAs(target, destination.folder, destination.fileName, true);
+        modTrace(
+            `priority: "${target.name}" ${target.metaKey} -> ${moved.metaKey} (global=${priority})`
+        );
+        return moved;
+    });
+}
+
+
+/**
  * Serialize every mod-folder mutation (enable / disable / delete / reorder /
  * priority) through one in-process queue.
  *
@@ -908,7 +1016,21 @@ async function enableModImpl(deadlockPath: string, modId: string): Promise<Mod> 
     // allocateSlot fills the base addons folder first, then each overflow folder
     // in order, minting a new one (and patching gameinfo) only when all are full.
     const meta = getModMetadata(targetMod.metaKey);
-    const { folder, fileName } = await allocateSlot(deadlockPath, {
+    // A mod the user marked Global returns to the priority root, not to
+    // citadel/addons. Without this, disabling and re-enabling a Global mod
+    // would silently demote it. If the priority root is full we fall back to a
+    // normal slot rather than refusing the enable outright: losing the Global
+    // status is recoverable and visible, a failed enable is neither.
+    let allocated: AllocatedSlot | null = null;
+    if (meta?.priorityMod) {
+        try {
+            allocated = await allocatePrioritySlot(deadlockPath);
+        } catch {
+            setModMetadata(targetMod.metaKey, { priorityMod: undefined });
+            modTrace(`enable: priority root full, demoting "${meta?.modName ?? targetMod.name}" to addons`);
+        }
+    }
+    const { folder, fileName } = allocated ?? await allocateSlot(deadlockPath, {
         disabledForbidden: disabledUsed,
         preferred: [meta?.lastPriority, ownNumber ?? undefined],
     });
@@ -1090,7 +1212,12 @@ async function reorderModsImpl(deadlockPath: string, orderedIds: string[]): Prom
     for (const id of orderedIds) {
         const mod = modById.get(id);
         if (!mod) throw new Error(`Mod not in list: ${id}`);
-        if (mod.enabled) targets.push(mod);
+        // Priority-root mods are outside the addons pakNN ordering entirely:
+        // they win by search-path position, not by slot number. Including one
+        // here would pack it into citadel/addons and silently strip its Global
+        // status. Callers pass the full enabled list, so filter rather than
+        // throw.
+        if (mod.enabled && !isPriorityFolderPath(mod.path)) targets.push(mod);
     }
     if (targets.length === 0) return;
     const targetIds = new Set(targets.map((m) => m.id));

--- a/electron/main/services/mods.ts
+++ b/electron/main/services/mods.ts
@@ -400,6 +400,18 @@ export async function scanMods(deadlockPath: string): Promise<Mod[]> {
 
     const mods = scanned.flat();
 
+    // Self-heal: an enabled user VPK living in the priority root must carry
+    // the priorityMod flag, or the Global surfaces can't see it and the next
+    // disable/enable silently demotes it to addons. Also adopts hand-placed
+    // VPKs. (Reserved Locker-managed slots never reach this list.)
+    for (const m of mods) {
+        if (!m.enabled || !isPriorityFolderPath(m.path)) continue;
+        if (!getModMetadata(m.metaKey)?.priorityMod) {
+            setModMetadata(m.metaKey, { priorityMod: true });
+            modTrace(`scanMods: healed missing priorityMod flag on ${m.metaKey}`);
+        }
+    }
+
     // Sort by global load order: folder first (base, then addons1, addons2, ...),
     // then pakNN within a folder, so the list reflects real load priority.
     mods.sort(
@@ -812,6 +824,14 @@ export function setModPriorityFolder(deadlockPath: string, modId: string, priori
             return target;
         }
 
+        // Refuse before touching metadata: writing the flag first would let a
+        // remove blocked by this guard clear the flag while the VPK stays in
+        // the priority root, stranding an unflagged Global mod (invisible to
+        // the Global surfaces, demoted to addons on its next enable).
+        if (target.enabled) {
+            assertCanMoveLoadedGameMod(target);
+        }
+
         // Record the intent before any rename, so a crash mid-move leaves the
         // flag and the next enable heals the placement.
         setModMetadata(target.metaKey, { priorityMod: priority ? true : undefined });
@@ -822,8 +842,6 @@ export function setModPriorityFolder(deadlockPath: string, modId: string, priori
             // puts it.
             return target;
         }
-
-        assertCanMoveLoadedGameMod(target);
 
         let destination: AllocatedSlot;
         if (priority) {

--- a/electron/main/services/priorityFolder.test.ts
+++ b/electron/main/services/priorityFolder.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isReservedPriorityVpk, isPriorityFolderPath, metaKeyFor, PRIORITY_FIRST_SLOT } from './deadlock';
+
+/**
+ * The priority root (citadel/grimoire) mixes two populations: the Locker's own
+ * managed VPKs in pak01-pak04, keyed by synthetic metadata keys, and user
+ * "Global" mods in pak05+. Confusing the two is the failure that would surface
+ * as phantom mods in the user's list (managed VPKs scanned as user mods) or as
+ * a destroyed Locker override (a user mod allocated over pak01), so the split
+ * is pinned here rather than left to the call sites.
+ */
+describe('isReservedPriorityVpk', () => {
+    it('reserves the four Locker-managed slots', () => {
+        expect(isReservedPriorityVpk('pak01_dir.vpk')).toBe(true);
+        expect(isReservedPriorityVpk('pak02_dir.vpk')).toBe(true);
+        expect(isReservedPriorityVpk('pak03_dir.vpk')).toBe(true);
+        expect(isReservedPriorityVpk('pak04_dir.vpk')).toBe(true);
+    });
+
+    it('leaves the user range free', () => {
+        expect(isReservedPriorityVpk('pak05_dir.vpk')).toBe(false);
+        expect(isReservedPriorityVpk('pak99_dir.vpk')).toBe(false);
+    });
+
+    it('agrees with PRIORITY_FIRST_SLOT', () => {
+        const first = `pak${String(PRIORITY_FIRST_SLOT).padStart(2, '0')}_dir.vpk`;
+        const last = `pak${String(PRIORITY_FIRST_SLOT - 1).padStart(2, '0')}_dir.vpk`;
+        expect(isReservedPriorityVpk(first)).toBe(false);
+        expect(isReservedPriorityVpk(last)).toBe(true);
+    });
+
+    it('ignores non-pakNN names', () => {
+        expect(isReservedPriorityVpk('something.vpk')).toBe(false);
+        expect(isReservedPriorityVpk('pak01.vpk')).toBe(false);
+    });
+});
+
+describe('isPriorityFolderPath', () => {
+    it('matches only the grimoire root', () => {
+        expect(isPriorityFolderPath('/game/citadel/grimoire/pak05_dir.vpk')).toBe(true);
+        expect(isPriorityFolderPath('/game/citadel/addons/pak05_dir.vpk')).toBe(false);
+        expect(isPriorityFolderPath('/game/citadel/addons1/pak05_dir.vpk')).toBe(false);
+        expect(isPriorityFolderPath('/game/citadel/.disabled/whatever.vpk')).toBe(false);
+    });
+});
+
+describe('metaKeyFor', () => {
+    // A priority-root mod must not share a key with a base-addons mod holding
+    // the same pakNN, or moving a mod into Global would collide with an
+    // unrelated mod's metadata and swap their identities.
+    it('namespaces priority-root mods', () => {
+        expect(metaKeyFor('/game/citadel/grimoire/pak05_dir.vpk')).toBe('grimoire/pak05_dir.vpk');
+    });
+
+    it('leaves base addons and .disabled keys bare (no migration for existing installs)', () => {
+        expect(metaKeyFor('/game/citadel/addons/pak05_dir.vpk')).toBe('pak05_dir.vpk');
+        expect(metaKeyFor('/game/citadel/.disabled/pak05_dir.vpk')).toBe('pak05_dir.vpk');
+    });
+
+    it('still namespaces overflow folders', () => {
+        expect(metaKeyFor('/game/citadel/addons1/pak05_dir.vpk')).toBe('addons1/pak05_dir.vpk');
+    });
+});

--- a/electron/main/services/priorityFolder.test.ts
+++ b/electron/main/services/priorityFolder.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isReservedPriorityVpk, isPriorityFolderPath, metaKeyFor, PRIORITY_FIRST_SLOT } from './deadlock';
+import {
+    isReservedPriorityVpk,
+    isReservedPriorityVpkArtifact,
+    isReservedPriorityVpkPath,
+    isPriorityFolderPath,
+    metaKeyFor,
+    PRIORITY_FIRST_SLOT,
+} from './deadlock';
 
 /**
  * The priority root (citadel/grimoire) mixes two populations: the Locker's own
@@ -33,6 +40,12 @@ describe('isReservedPriorityVpk', () => {
         expect(isReservedPriorityVpk('something.vpk')).toBe(false);
         expect(isReservedPriorityVpk('pak01.vpk')).toBe(false);
     });
+
+    it('recognizes reserved chunk siblings for Vanilla stashing', () => {
+        expect(isReservedPriorityVpkArtifact('pak01_000.vpk')).toBe(true);
+        expect(isReservedPriorityVpkArtifact('pak04_999.vpk')).toBe(true);
+        expect(isReservedPriorityVpkArtifact('pak05_000.vpk')).toBe(false);
+    });
 });
 
 describe('isPriorityFolderPath', () => {
@@ -41,6 +54,12 @@ describe('isPriorityFolderPath', () => {
         expect(isPriorityFolderPath('/game/citadel/addons/pak05_dir.vpk')).toBe(false);
         expect(isPriorityFolderPath('/game/citadel/addons1/pak05_dir.vpk')).toBe(false);
         expect(isPriorityFolderPath('/game/citadel/.disabled/whatever.vpk')).toBe(false);
+    });
+
+    it('combines folder and reserved filename checks for inventory scans', () => {
+        expect(isReservedPriorityVpkPath('/game/citadel/grimoire/pak01_dir.vpk')).toBe(true);
+        expect(isReservedPriorityVpkPath('/game/citadel/grimoire/pak05_dir.vpk')).toBe(false);
+        expect(isReservedPriorityVpkPath('/game/citadel/addons/pak01_dir.vpk')).toBe(false);
     });
 });
 

--- a/electron/main/services/priorityFolderFailure.test.ts
+++ b/electron/main/services/priorityFolderFailure.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const harness = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => harness.userData } }));
+vi.mock('./launch', () => ({
+    isDeadlockRunning: async () => false,
+    readStash: async () => null,
+}));
+
+import {
+    PRIORITY_LIMIT_MESSAGE,
+    scanMods,
+    setModPriorityFolder,
+} from './mods';
+import { getModMetadata, saveMetadata } from './metadata';
+
+function writeVpk(path: string): void {
+    const header = Buffer.alloc(64);
+    header.writeUInt32LE(0x55aa1234, 0);
+    header.writeUInt32LE(2, 4);
+    writeFileSync(path, header);
+}
+
+function createGame(): { root: string; addons: string; grimoire: string } {
+    const root = mkdtempSync(join(tmpdir(), 'priority-failure-'));
+    const addons = join(root, 'game', 'citadel', 'addons');
+    const grimoire = join(root, 'game', 'citadel', 'grimoire');
+    mkdirSync(join(addons, '.disabled'), { recursive: true });
+    mkdirSync(grimoire, { recursive: true });
+    return { root, addons, grimoire };
+}
+
+describe('setModPriorityFolder failure atomicity', () => {
+    beforeEach(() => {
+        harness.userData = mkdtempSync(join(tmpdir(), 'priority-failure-userdata-'));
+        saveMetadata({});
+        vi.restoreAllMocks();
+    });
+
+    it('does not set the flag when the Global root is full', async () => {
+        const { root, addons, grimoire } = createGame();
+        const source = join(addons, 'pak01_dir.vpk');
+        writeVpk(source);
+        for (let slot = 5; slot <= 99; slot++) {
+            writeVpk(join(grimoire, `pak${String(slot).padStart(2, '0')}_dir.vpk`));
+        }
+        const target = (await scanMods(root)).find((mod) => mod.path === source)!;
+
+        await expect(setModPriorityFolder(root, target.id, true)).rejects.toThrow(
+            PRIORITY_LIMIT_MESSAGE
+        );
+
+        expect(existsSync(source)).toBe(true);
+        expect(getModMetadata(target.metaKey)?.priorityMod).toBeUndefined();
+    });
+
+    it('leaves an addons mod unflagged when the move into Global fails', async () => {
+        const { root, addons } = createGame();
+        const source = join(addons, 'pak01_dir.vpk');
+        writeVpk(source);
+        const target = (await scanMods(root)).find((mod) => mod.path === source)!;
+        vi.spyOn(fs, 'rename').mockRejectedValueOnce(
+            Object.assign(new Error('rename failed'), { code: 'EIO' })
+        );
+
+        await expect(setModPriorityFolder(root, target.id, true)).rejects.toThrow('rename failed');
+
+        expect(existsSync(source)).toBe(true);
+        expect(getModMetadata(target.metaKey)?.priorityMod).toBeUndefined();
+    });
+
+    it('restores the flag when the move out of Global fails', async () => {
+        const { root, grimoire } = createGame();
+        const source = join(grimoire, 'pak05_dir.vpk');
+        writeVpk(source);
+        const target = (await scanMods(root)).find((mod) => mod.path === source)!;
+        expect(getModMetadata(target.metaKey)?.priorityMod).toBe(true);
+        vi.spyOn(fs, 'rename').mockRejectedValueOnce(
+            Object.assign(new Error('rename failed'), { code: 'EIO' })
+        );
+
+        await expect(setModPriorityFolder(root, target.id, false)).rejects.toThrow('rename failed');
+
+        expect(existsSync(source)).toBe(true);
+        expect(getModMetadata(target.metaKey)?.priorityMod).toBe(true);
+    });
+});

--- a/electron/main/services/priorityFolderMove.test.ts
+++ b/electron/main/services/priorityFolderMove.test.ts
@@ -20,13 +20,13 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync } from '
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-const h = vi.hoisted(() => ({ userData: '' }));
+const h = vi.hoisted(() => ({ userData: '', gameRunning: false }));
 vi.mock('electron', () => ({ app: { getPath: () => h.userData } }));
 // The loaded-mod guard asks the real process table (pgrep/tasklist) whether
 // Deadlock is running, so an unmocked run fails on any machine where the game
-// is open. Pin the sandbox's truth: no game, no vanilla stash.
+// is open. Pin it to the flag so the blocked-move test can flip it.
 vi.mock('./launch', () => ({
-  isDeadlockRunning: async () => false,
+  isDeadlockRunning: async () => h.gameRunning,
   readStash: async () => null,
 }));
 
@@ -117,6 +117,24 @@ describe('setModPriorityFolder', () => {
     expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk', 'pak05_dir.vpk']);
   });
 
+  // Regression: the flag write used to run before the game-running guard, so a
+  // blocked remove cleared priorityMod while the VPK stayed in the priority
+  // root: an unflagged Global mod invisible to the Global surfaces, demoted to
+  // addons on its next enable.
+  it('a remove blocked by the game-running guard keeps the flag and the file', async () => {
+    const mods = await scanMods(dl);
+    const global = mods.find((m) => m.metaKey === 'grimoire/pak05_dir.vpk')!;
+
+    h.gameRunning = true;
+    try {
+      await expect(setModPriorityFolder(dl, global.id, false)).rejects.toThrow('Game is running');
+    } finally {
+      h.gameRunning = false;
+    }
+    expect(getModMetadata('grimoire/pak05_dir.vpk')?.priorityMod).toBe(true);
+    expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk', 'pak05_dir.vpk']);
+  });
+
   it('moves a mod back out to the addons folder', async () => {
     const mods = await scanMods(dl);
     const global = mods.find((m) => m.metaKey === 'grimoire/pak05_dir.vpk')!;
@@ -131,5 +149,18 @@ describe('setModPriorityFolder', () => {
     const off = await disableMod(dl, cleared.id);
     const back = await enableMod(dl, off.id);
     expect(back.metaKey).not.toContain('grimoire/');
+  });
+
+  // scanMods self-heal: an enabled non-reserved VPK found in the priority root
+  // without the flag (stranded by the pre-guard-fix remove path, or hand-placed)
+  // gets priorityMod stamped so the Global surfaces see it and the next
+  // disable/enable round trip cannot demote it.
+  it('heals a flagless resident of the priority root on scan', async () => {
+    writeVpk(join(dl, ...GRIMOIRE, 'pak06_dir.vpk'));
+    expect(getModMetadata('grimoire/pak06_dir.vpk')?.priorityMod).toBeUndefined();
+
+    const mods = await scanMods(dl);
+    expect(mods.some((m) => m.metaKey === 'grimoire/pak06_dir.vpk')).toBe(true);
+    expect(getModMetadata('grimoire/pak06_dir.vpk')?.priorityMod).toBe(true);
   });
 });

--- a/electron/main/services/priorityFolderMove.test.ts
+++ b/electron/main/services/priorityFolderMove.test.ts
@@ -22,6 +22,13 @@ import { join } from 'path';
 
 const h = vi.hoisted(() => ({ userData: '' }));
 vi.mock('electron', () => ({ app: { getPath: () => h.userData } }));
+// The loaded-mod guard asks the real process table (pgrep/tasklist) whether
+// Deadlock is running, so an unmocked run fails on any machine where the game
+// is open. Pin the sandbox's truth: no game, no vanilla stash.
+vi.mock('./launch', () => ({
+  isDeadlockRunning: async () => false,
+  readStash: async () => null,
+}));
 
 import { scanMods, setModPriorityFolder, disableMod, enableMod } from './mods';
 import { getModMetadata } from './metadata';

--- a/electron/main/services/priorityFolderMove.test.ts
+++ b/electron/main/services/priorityFolderMove.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration test for the Global (priority root) placement, run against a real
+ * temp sandbox rather than mocks, because every risk in this feature is a
+ * filesystem risk: a VPK moved to the wrong folder, a metadata row left behind
+ * under the old key, or a slot allocated over one of the Locker's own managed
+ * VPKs.
+ *
+ * The move dep chain is electron/sqlite-free except app.getPath(), so we mock
+ * just that (same pattern as dmmMigration.nondestructive.test.ts) and drive the
+ * real service.
+ *
+ * The round trip is the case worth pinning: a Global mod that is disabled lands
+ * in .disabled/ under a free-form name with no folder left to read, so the
+ * metadata flag is the only thing that can put it back in the priority root on
+ * the next enable. Get that wrong and marking a mod Global appears to work
+ * until the first time the user toggles it off and on.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const h = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => h.userData } }));
+
+import { scanMods, setModPriorityFolder, disableMod, enableMod } from './mods';
+import { getModMetadata } from './metadata';
+
+/** A VPK header the scanner accepts, padded so the file has a plausible size. */
+function writeVpk(path: string): void {
+  const header = Buffer.alloc(4096);
+  header.writeUInt32LE(0x55aa1234, 0); // VPK magic
+  header.writeUInt32LE(2, 4); // version
+  writeFileSync(path, header);
+}
+
+const GRIMOIRE = ['game', 'citadel', 'grimoire'];
+const ADDONS = ['game', 'citadel', 'addons'];
+
+describe('setModPriorityFolder', () => {
+  let dl: string;
+  const names = (parts: string[]) => {
+    const dir = join(dl, ...parts);
+    return existsSync(dir) ? readdirSync(dir).filter((n) => n.endsWith('.vpk')).sort() : [];
+  };
+
+  beforeAll(() => {
+    const root = mkdtempSync(join(tmpdir(), 'prio-'));
+    dl = join(root, 'dl');
+    const userData = join(root, 'userdata');
+    const addons = join(dl, ...ADDONS);
+    const grimoire = join(dl, ...GRIMOIRE);
+    for (const d of [addons, join(addons, '.disabled'), grimoire, userData]) {
+      mkdirSync(d, { recursive: true });
+    }
+    writeFileSync(join(dl, 'game', 'citadel', 'gameinfo.gi'), 'GameInfo {}\n');
+    h.userData = userData;
+
+    // Two ordinary mods in addons, plus the Locker's managed cards VPK
+    // occupying the first reserved priority slot.
+    writeVpk(join(addons, 'pak01_dir.vpk'));
+    writeVpk(join(addons, 'pak02_dir.vpk'));
+    writeVpk(join(grimoire, 'pak01_dir.vpk'));
+  });
+
+  it('hides the Locker-managed reserved slots from the mod list', async () => {
+    const mods = await scanMods(dl);
+    // grimoire/pak01 is the managed cards VPK. Surfacing it would invent a mod
+    // the user never installed and let them delete a Locker artifact.
+    expect(mods.map((m) => m.metaKey).sort()).toEqual(['pak01_dir.vpk', 'pak02_dir.vpk']);
+  });
+
+  it('moves a mod into the priority root above the reserved slots', async () => {
+    const before = await scanMods(dl);
+    const target = before.find((m) => m.metaKey === 'pak02_dir.vpk')!;
+    const moved = await setModPriorityFolder(dl, target.id, true);
+
+    expect(moved.metaKey).toBe('grimoire/pak05_dir.vpk');
+    // Allocation starts at PRIORITY_FIRST_SLOT, so the managed pak01 survives.
+    expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk', 'pak05_dir.vpk']);
+    expect(names(ADDONS)).toEqual(['pak01_dir.vpk']);
+  });
+
+  // scanMods is the raw filesystem view; the priorityMod field is projected by
+  // enrichMod at the ipc layer. What must hold HERE is that the sidecar row
+  // followed the rename to the new key, since that flag is what survives a
+  // disable and drives the next enable.
+  it('carries the sidecar flag to the new metadata key', async () => {
+    const mods = await scanMods(dl);
+    const global = mods.find((m) => m.metaKey === 'grimoire/pak05_dir.vpk');
+    expect(global?.enabled).toBe(true);
+    expect(getModMetadata('grimoire/pak05_dir.vpk')?.priorityMod).toBe(true);
+    // and nothing was left behind under the pre-move key
+    expect(getModMetadata('pak02_dir.vpk')?.priorityMod).toBeUndefined();
+  });
+
+  it('restores the priority root across a disable/enable round trip', async () => {
+    const mods = await scanMods(dl);
+    const global = mods.find((m) => m.metaKey === 'grimoire/pak05_dir.vpk')!;
+
+    const off = await disableMod(dl, global.id);
+    expect(off.enabled).toBe(false);
+    // Parked in .disabled/, so the folder no longer says anything about intent.
+    expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk']);
+
+    const back = await enableMod(dl, off.id);
+    // The metadata flag, not the folder, is what put it back.
+    expect(back.metaKey).toBe('grimoire/pak05_dir.vpk');
+    expect(getModMetadata('grimoire/pak05_dir.vpk')?.priorityMod).toBe(true);
+    expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk', 'pak05_dir.vpk']);
+  });
+
+  it('moves a mod back out to the addons folder', async () => {
+    const mods = await scanMods(dl);
+    const global = mods.find((m) => m.metaKey === 'grimoire/pak05_dir.vpk')!;
+    const cleared = await setModPriorityFolder(dl, global.id, false);
+
+    expect(cleared.metaKey).not.toContain('grimoire/');
+    expect(getModMetadata(cleared.metaKey)?.priorityMod).toBeUndefined();
+    expect(names(GRIMOIRE)).toEqual(['pak01_dir.vpk']);
+    expect(names(ADDONS).length).toBe(2);
+
+    // And the flag is really gone: a later disable/enable must not resurrect it.
+    const off = await disableMod(dl, cleared.id);
+    const back = await enableMod(dl, off.id);
+    expect(back.metaKey).not.toContain('grimoire/');
+  });
+});

--- a/electron/main/services/system.ts
+++ b/electron/main/services/system.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { join, extname } from 'path';
-import { getGameinfoPath, getDisabledPath, getCitadelPath, getGrimoirePath, getOverflowFolderNames, getAddonFolderPaths, hasDeadworksContentRoot, DEADWORKS_SEARCH_PATH } from './deadlock';
+import { getGameinfoPath, getDisabledPath, getCitadelPath, getGrimoirePath, getOverflowFolderNames, getModScanRootPaths, hasDeadworksContentRoot, DEADWORKS_SEARCH_PATH } from './deadlock';
 import { ensureReplayFolderLink } from './replayFolder';
 
 // The canonical SearchPaths block for Deadlock with mod support
@@ -379,10 +379,10 @@ export function cleanupAddons(deadlockPath: string): CleanupResult {
 
     const disabledPath = getDisabledPath(deadlockPath);
 
-    // Process every enabled addon folder (base citadel/addons plus any overflow
-    // addonsN) and the shared .disabled parking lot, so leftover archives are
+    // Process every enabled user-mod root (priority, base addons, and overflow
+    // addonsN) plus the shared .disabled parking lot, so leftover archives are
     // removed wherever a mod ended up.
-    for (const folder of [...getAddonFolderPaths(deadlockPath), disabledPath]) {
+    for (const folder of [...getModScanRootPaths(deadlockPath), disabledPath]) {
         if (!existsSync(folder)) continue;
 
         const files = readdirSync(folder);

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -234,6 +234,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('set-mod-global-type', modId, globalType),
     setModIgnoreUpdates: (modId: string, ignore: boolean) =>
         ipcRenderer.invoke('set-mod-ignore-updates', modId, ignore),
+    setModPriorityFolder: (modId: string, priority: boolean) =>
+        ipcRenderer.invoke('set-mod-priority-folder', modId, priority),
     backfillGameBananaFileId: (
         modId: string,
         payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/components/locker/GlobalModPicker.tsx
+++ b/src/components/locker/GlobalModPicker.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowUpToLine, Check, Search, X } from 'lucide-react';
+import type { Mod } from '../../types/mod';
+import { Modal } from '../common/Modal';
+import { Button } from '../common/ui';
+
+interface GlobalModPickerProps {
+  /** Every installed mod. Ones already Global are filtered out here rather than
+   *  by the caller, so the list can say so in its empty state. */
+  mods: Mod[];
+  hideNsfwPreviews: boolean;
+  onClose: () => void;
+  /** Mark the chosen mods Global. Resolves once every move has been applied. */
+  onConfirm: (modIds: string[]) => Promise<void>;
+}
+
+/**
+ * "Add mods to Global": search installed mods and move the chosen ones into the
+ * citadel/grimoire priority root.
+ *
+ * Lives in its own file rather than inside Locker.tsx: the page is already one
+ * of the two god pages, and the chip-away policy is that new surfaces start as
+ * their own component.
+ *
+ * Selection is keyed by mod id. Ids are derived from the pakNN filename and
+ * change when a mod moves, but nothing here re-scans between opening and
+ * confirming, so the ids stay valid for the life of the dialog. The caller
+ * refreshes the list afterwards.
+ */
+export function GlobalModPicker({ mods, hideNsfwPreviews, onClose, onConfirm }: GlobalModPickerProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Candidates are every installed mod that isn't already Global. Locker-managed
+  // artifacts (the cards/sounds/colors VPKs) never appear in the mod list, so
+  // there is nothing to exclude for them here.
+  const candidates = useMemo(() => mods.filter((m) => !m.priorityMod), [mods]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const pool = q
+      ? candidates.filter(
+          (m) =>
+            m.name.toLowerCase().includes(q) ||
+            m.fileName.toLowerCase().includes(q) ||
+            m.lockerHero?.toLowerCase().includes(q) ||
+            m.categoryName?.toLowerCase().includes(q)
+        )
+      : candidates;
+    // Enabled first, then alphabetical: the mod someone wants to pin is
+    // overwhelmingly one they already have on.
+    return [...pool].sort((a, b) => {
+      if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [candidates, query]);
+
+  const toggle = (modId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(modId)) next.delete(modId);
+      else next.add(modId);
+      return next;
+    });
+  };
+
+  const confirm = async () => {
+    if (selected.size === 0 || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onConfirm([...selected]);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      onClose={onClose}
+      size="lg"
+      dismissable={!busy}
+      labelledBy="global-mod-picker-title"
+      panelClassName="flex max-h-[80vh] flex-col"
+    >
+      <div className="flex items-start justify-between gap-4 border-b border-border p-4">
+        <div className="min-w-0">
+          <h2 id="global-mod-picker-title" className="text-base font-semibold text-text-primary">
+            {t('locker.globalPicker.title')}
+          </h2>
+          <p className="mt-1 text-xs text-text-secondary">{t('locker.globalPicker.description')}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={busy}
+          aria-label={t('common.actions.close')}
+          className="flex-shrink-0 rounded p-1 text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-50"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="border-b border-border p-4">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
+          <input
+            ref={searchRef}
+            type="text"
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('locker.globalPicker.searchPlaceholder')}
+            className="w-full rounded-lg border border-border bg-bg-input py-2 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {filtered.length === 0 ? (
+          <p className="px-2 py-8 text-center text-sm text-text-secondary">
+            {candidates.length === 0
+              ? t('locker.globalPicker.allGlobal')
+              : t('locker.globalPicker.noMatches')}
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {filtered.map((mod) => {
+              const isSelected = selected.has(mod.id);
+              const showArt = mod.thumbnailUrl && !(mod.nsfw && hideNsfwPreviews);
+              return (
+                <li key={mod.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggle(mod.id)}
+                    disabled={busy}
+                    aria-pressed={isSelected}
+                    className={`flex w-full items-center gap-3 rounded-lg border px-2.5 py-2 text-left transition-colors disabled:opacity-50 ${
+                      isSelected
+                        ? 'border-accent bg-accent/10'
+                        : 'border-transparent hover:border-white/10 hover:bg-bg-tertiary'
+                    }`}
+                  >
+                    <span
+                      className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+                        isSelected ? 'border-accent bg-accent text-accent-foreground' : 'border-white/25'
+                      }`}
+                    >
+                      {isSelected && <Check className="h-3 w-3" />}
+                    </span>
+                    <span className="h-9 w-16 flex-shrink-0 overflow-hidden rounded border border-white/[0.08] bg-bg-tertiary">
+                      {showArt && (
+                        <img src={mod.thumbnailUrl} alt="" className="h-full w-full object-cover" draggable={false} />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm text-text-primary">{mod.name}</span>
+                      <span className="block truncate text-xs text-text-secondary">
+                        {mod.lockerHero ?? mod.categoryName ?? mod.fileName}
+                      </span>
+                    </span>
+                    {!mod.enabled && (
+                      <span className="flex-shrink-0 rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-secondary">
+                        {t('locker.globalPicker.disabled')}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {error && (
+        <p className="border-t border-border px-4 py-2 text-xs text-state-danger">{error}</p>
+      )}
+
+      <div className="flex items-center justify-between gap-3 border-t border-border p-4">
+        <span className="text-xs text-text-secondary">
+          {t('locker.globalPicker.selectedCount', { count: selected.size })}
+        </span>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={busy}>
+            {t('common.actions.cancel')}
+          </Button>
+          <Button onClick={() => void confirm()} disabled={selected.size === 0 || busy}>
+            <ArrowUpToLine className="h-4 w-4" />
+            {busy ? t('locker.globalPicker.adding') : t('locker.globalPicker.add')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default GlobalModPicker;

--- a/src/components/locker/GlobalModPicker.tsx
+++ b/src/components/locker/GlobalModPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowUpToLine, Check, Search, X } from 'lucide-react';
 import type { Mod } from '../../types/mod';
@@ -39,6 +39,17 @@ export function GlobalModPicker({ mods, hideNsfwPreviews, onClose, onConfirm }: 
   // artifacts (the cards/sounds/colors VPKs) never appear in the mod list, so
   // there is nothing to exclude for them here.
   const candidates = useMemo(() => mods.filter((m) => !m.priorityMod), [mods]);
+
+  // A multi-move can make partial progress before a later item fails. Successful
+  // moves receive new ids and disappear from candidates; prune those stale ids
+  // so retrying submits only the remaining visible selections.
+  useEffect(() => {
+    const candidateIds = new Set(candidates.map((mod) => mod.id));
+    setSelected((prev) => {
+      const next = new Set([...prev].filter((id) => candidateIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [candidates]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/src/components/locker/GlobalModPicker.tsx
+++ b/src/components/locker/GlobalModPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowUpToLine, Check, Search, X } from 'lucide-react';
 import type { Mod } from '../../types/mod';
@@ -25,8 +25,8 @@ interface GlobalModPickerProps {
  *
  * Selection is keyed by mod id. Ids are derived from the pakNN filename and
  * change when a mod moves, but nothing here re-scans between opening and
- * confirming, so the ids stay valid for the life of the dialog. The caller
- * refreshes the list afterwards.
+ * confirming, so the ids stay valid for the life of the dialog. The store
+ * action behind onConfirm updates the mod list as each move lands.
  */
 export function GlobalModPicker({ mods, hideNsfwPreviews, onClose, onConfirm }: GlobalModPickerProps) {
   const { t } = useTranslation();
@@ -34,7 +34,6 @@ export function GlobalModPicker({ mods, hideNsfwPreviews, onClose, onConfirm }: 
   const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const searchRef = useRef<HTMLInputElement>(null);
 
   // Candidates are every installed mod that isn't already Global. Locker-managed
   // artifacts (the cards/sounds/colors VPKs) never appear in the mod list, so
@@ -113,7 +112,6 @@ export function GlobalModPicker({ mods, hideNsfwPreviews, onClose, onConfirm }: 
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
           <input
-            ref={searchRef}
             type="text"
             autoFocus
             value={query}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -434,6 +434,13 @@ export async function setModIgnoreUpdates(
   return window.electronAPI.setModIgnoreUpdates(modId, ignore);
 }
 
+export async function setModPriorityFolder(
+  modId: string,
+  priority: boolean
+): Promise<Mod> {
+  return window.electronAPI.setModPriorityFolder(modId, priority);
+}
+
 export async function backfillGameBananaFileId(
   modId: string,
   payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/lib/lockerRandomizer.test.ts
+++ b/src/lib/lockerRandomizer.test.ts
@@ -385,6 +385,67 @@ describe('planRandomization', () => {
     });
     expect(plan).toEqual({ enableIds: [], disableIds: [], changedHeroes: [] });
   });
+
+  // The reported bug: a mod the user wants kept on was turned off every time
+  // the hero's skins re-rolled, forcing them to merge it into each skin.
+  it('never disables a Global mod when the hero re-rolls', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [
+        1,
+        [
+          mod({ id: 'keep', gameBananaId: 9, enabled: true, priority: 1, priorityMod: true }),
+          mod({ id: 'a', gameBananaId: 1, enabled: true, priority: 2 }),
+          mod({ id: 'b', gameBananaId: 2, priority: 3 }),
+        ],
+      ],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.disableIds).not.toContain('keep');
+    // The ordinary enabled skin still gets swapped out, so the shuffle keeps
+    // working around the Global mod rather than being disabled by it.
+    expect(plan.disableIds).toContain('a');
+    expect(plan.enableIds).toEqual(['b']);
+  });
+
+  it('never picks a Global mod as the re-rolled skin, even when pooled', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [
+        1,
+        [
+          mod({ id: 'glob', gameBananaId: 1, enabled: true, priority: 1, priorityMod: true }),
+          mod({ id: 'b', gameBananaId: 2, priority: 2 }),
+        ],
+      ],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1', 'gamebanana:2']),
+      rng: fixedRng(0),
+    });
+    expect(plan.enableIds).toEqual(['b']);
+    expect(plan.disableIds).toEqual([]);
+  });
+
+  // Pin beats pool: with nothing left to re-roll, the hero is skipped rather
+  // than the Global mod being cycled with itself.
+  it('skips a hero whose only pooled skin is Global', () => {
+    const heroSkins = new Map<number, Mod[]>([
+      [1, [mod({ id: 'glob', gameBananaId: 1, enabled: true, priority: 1, priorityMod: true })]],
+    ]);
+    const plan = planRandomization({
+      heroSkins,
+      heroIds: [1],
+      included: new Set(['gamebanana:1']),
+      rng: fixedRng(0),
+    });
+    expect(plan).toEqual({ enableIds: [], disableIds: [], changedHeroes: [] });
+  });
 });
 
 describe('planLaunchShuffle', () => {

--- a/src/lib/lockerRandomizer.ts
+++ b/src/lib/lockerRandomizer.ts
@@ -182,12 +182,25 @@ export function planRandomization(options: RandomizePlanOptions): RandomizePlan 
     if (!mods || mods.length === 0) continue;
 
     const skins = groupLockerSkins(mods);
-    const eligible = skins.filter((skin) => included.has(shuffleSkinKey(skin.primary)));
+    // A Global mod is pinned by construction: it lives in the priority root and
+    // outranks everything, so offering it as a shuffle candidate is
+    // contradictory (it is already always on). Dropping it from the pool also
+    // means a hero whose only pooled skin is Global is skipped entirely, which
+    // is the right outcome: there is nothing left to re-roll.
+    const eligible = skins.filter(
+      (skin) => included.has(shuffleSkinKey(skin.primary)) && !skin.primary.priorityMod
+    );
     if (eligible.length === 0) continue;
 
     // Bias away from the currently-active skin so each launch changes the look.
     // Only when there's an alternative left to pick.
-    const activeMod = activeLockerSkin(mods);
+    //
+    // Global mods are excluded from the "active" lookup: activeLockerSkin picks
+    // the lowest load order, and a Global mod lives in the priority root, so it
+    // sorts ahead of every addons mod by construction. Without this filter one
+    // Global mod would make every hero's avoid-current bias compare against the
+    // wrong skin, and the shuffle could re-pick the skin already on screen.
+    const activeMod = activeLockerSkin(mods.filter((m) => !m.priorityMod));
     const activeKey = activeMod ? shuffleSkinKey(activeMod) : undefined;
     let pool = eligible;
     if (avoidCurrent && eligible.length > 1 && activeKey) {
@@ -230,6 +243,10 @@ export function planRandomization(options: RandomizePlanOptions): RandomizePlan 
       explicitChoice ? [chosenVariant.id] : chosen.variants.map((variant) => variant.id)
     );
     for (const mod of mods) {
+      // Global mods survive every re-roll. This is the whole point of the
+      // feature: without it, marking a mod Global would keep it winning file
+      // collisions right up until the next launch turned it off.
+      if (mod.priorityMod) continue;
       if (mod.enabled && !chosenVariantIds.has(mod.id)) {
         disableIds.push(mod.id);
         heroChanged = true;

--- a/src/lib/lockerUtils.test.ts
+++ b/src/lib/lockerUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { Mod } from '../types/mod';
+import { modLoadOrder, activeLockerSkin } from './lockerUtils';
+
+function mod(over: Partial<Mod> & { id: string; metaKey: string; priority: number }): Mod {
+  return {
+    name: over.id,
+    fileName: `pak${String(over.priority).padStart(2, '0')}_dir.vpk`,
+    path: `/addons/${over.id}.vpk`,
+    enabled: true,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+/**
+ * Load order decides which mod wins when two cover the same file, so it drives
+ * the Locker's "active skin", the Conflicts page's winner column, and the
+ * per-hero reorder strip. The citadel/grimoire priority root is the first Game
+ * line in the canonical SearchPaths block, so it must outrank every addons
+ * folder; this used to be mirrored by hand on the Conflicts page and went stale.
+ */
+describe('modLoadOrder', () => {
+  it('ranks the priority root ahead of base addons', () => {
+    const global = mod({ id: 'g', metaKey: 'grimoire/pak99_dir.vpk', priority: 99 });
+    const base = mod({ id: 'b', metaKey: 'pak01_dir.vpk', priority: 1 });
+    // Even the LAST priority slot beats the FIRST base slot: the folder wins,
+    // not the number.
+    expect(modLoadOrder(global)).toBeLessThan(modLoadOrder(base));
+  });
+
+  it('orders within the priority root by pakNN', () => {
+    const first = mod({ id: 'a', metaKey: 'grimoire/pak05_dir.vpk', priority: 5 });
+    const second = mod({ id: 'b', metaKey: 'grimoire/pak06_dir.vpk', priority: 6 });
+    expect(modLoadOrder(first)).toBeLessThan(modLoadOrder(second));
+  });
+
+  it('keeps base addons ahead of overflow folders', () => {
+    const base = mod({ id: 'b', metaKey: 'pak99_dir.vpk', priority: 99 });
+    const overflow = mod({ id: 'o', metaKey: 'addons1/pak01_dir.vpk', priority: 1 });
+    expect(modLoadOrder(base)).toBeLessThan(modLoadOrder(overflow));
+  });
+});
+
+describe('activeLockerSkin', () => {
+  // The Locker's hero card art follows the active skin. A Global mod sorts
+  // first by construction, so it would hijack every hero card it is grouped
+  // under if callers did not filter it out (the shuffle planner does).
+  it('returns the lowest load order among enabled mods', () => {
+    const mods = [
+      mod({ id: 'late', metaKey: 'pak09_dir.vpk', priority: 9 }),
+      mod({ id: 'early', metaKey: 'pak02_dir.vpk', priority: 2 }),
+      mod({ id: 'off', metaKey: 'pak01_dir.vpk', priority: 1, enabled: false }),
+    ];
+    expect(activeLockerSkin(mods)?.id).toBe('early');
+  });
+
+  it('is undefined when nothing is enabled', () => {
+    expect(activeLockerSkin([mod({ id: 'x', metaKey: 'pak01_dir.vpk', priority: 1, enabled: false })])).toBeUndefined();
+  });
+});

--- a/src/lib/lockerUtils.ts
+++ b/src/lib/lockerUtils.ts
@@ -392,6 +392,12 @@ export function getLockerSkinKey(mod: Mod): string {
  * math stays consistent across both surfaces.
  */
 export function modLoadOrder(mod: Mod): number {
+  // The priority root (citadel/grimoire) is the FIRST Game line in the
+  // canonical SearchPaths block, so it outranks every addons folder. Ranking it
+  // -1 is what makes a Global mod sort ahead of pak01 in the base folder. Keep
+  // in step with addonFolderIndex in electron/main/services/mods.ts, which
+  // applies the same rule on the main-process side.
+  if (mod.metaKey.startsWith('grimoire/')) return -100 + mod.priority;
   const match = mod.metaKey.match(/^addons(\d+)\//);
   const folderIndex = match ? parseInt(match[1], 10) : 0;
   return folderIndex * 100 + mod.priority;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1307,15 +1307,22 @@
       "mergeCombineHint_other": "Combine {{count}} mods into one VPK",
       "tag": "Tag",
       "tagEmptyHint": "Select mods to tag for the Locker",
-      "tagCountHint_one": "Tag {{count}} mod for a hero or Global category in the Locker",
-      "tagCountHint_other": "Tag {{count}} mods for a hero or Global category in the Locker",
+      "tagCountHint_one": "Tag {{count}} mod for a hero or General category in the Locker",
+      "tagCountHint_other": "Tag {{count}} mods for a hero or General category in the Locker",
       "tagDialogLabel": "Tag selected mods for the Locker"
     },
     "tag": {
       "clearLockerTag": "Clear Locker tag",
       "setLockerTag": "Set Locker tag",
-      "global": "Global",
+      "global": "General",
       "hero": "Hero"
+    },
+    "priority": {
+      "make": "Make Global",
+      "clear": "Remove from Global",
+      "chip": "Global",
+      "hint": "Global mods load before every other mod, so they always win when two mods change the same file. Shuffling skins never turns them off.",
+      "busy": "Moving..."
     },
     "card": {
       "soundPreview": "Sound Preview",
@@ -1455,6 +1462,20 @@
       "useLockerImage": "Use Locker image",
       "hideHeroName": "Hide hero name label",
       "hideHeroNameHint": "Turn on when the image already shows the hero's name."
+    },
+    "globalPicker": {
+      "title": "Add mods to Global",
+      "description": "Global mods load before everything else, so they always win when two mods change the same file. Shuffling skins never turns them off.",
+      "trigger": "Add mods",
+      "searchPlaceholder": "Search installed mods...",
+      "selectedCount_one": "{{count}} selected",
+      "selectedCount_other": "{{count}} selected",
+      "add": "Add to Global",
+      "adding": "Adding...",
+      "disabled": "Off",
+      "noMatches": "No installed mods match that search.",
+      "allGlobal": "Every installed mod is already Global.",
+      "empty": "Nothing is Global yet. Add a mod here to keep it on and winning over everything else."
     },
     "global": {
       "activeBadgeTitle": "This soul container is active and loaded in-game",
@@ -1810,7 +1831,7 @@
       "gallery": "Gallery",
       "list": "List",
       "noHeroCategoriesFound": "No hero categories found.",
-      "global": "Global",
+      "global": "General",
       "globalEmptyHint": "Import soul containers & spirit urns",
       "unassigned": "Unassigned",
       "unassignedDescription": "These mods couldn't be matched to a hero automatically. Tag one to move it into that hero's locker pile.",
@@ -1823,10 +1844,10 @@
       "back": "Back",
       "changeCategory": "Change category",
       "changeCategoryForNamed": "Change category for {{name}}",
-      "changeGlobalCategory": "Change global category",
+      "changeGlobalCategory": "Change General category",
       "moveToCategory": "Move to category",
-      "removeFromGlobal": "Remove from Global",
-      "noGlobalNonHeroCosmeticsInstalledYet": "No global (non-hero) cosmetics installed yet.",
+      "removeFromGlobal": "Remove from General",
+      "noGlobalNonHeroCosmeticsInstalledYet": "No general (non-hero) cosmetics installed yet.",
       "disableNamed": "Disable {{name}}",
       "enableNamed": "Enable {{name}}",
       "clickToDisable": "Click to disable",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,24 +1,24 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2128,
+  "totalKeys": 2145,
   "languages": [
     {
       "code": "bg",
       "name": "български",
       "translatedKeys": 1954,
-      "pct": 92
+      "pct": 91
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2128,
+      "translatedKeys": 2145,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
       "translatedKeys": 1848,
-      "pct": 87
+      "pct": 86
     },
     {
       "code": "ru",

--- a/src/pages/Conflicts.tsx
+++ b/src/pages/Conflicts.tsx
@@ -23,6 +23,7 @@ import {
 import type { ModConflict } from '../lib/api';
 import type { Mod } from '../types/mod';
 import { useAppStore } from '../stores/appStore';
+import { modLoadOrder } from '../lib/lockerUtils';
 import { Button } from '../components/common/ui';
 import { PageHeader, EmptyState, ConfirmModal, ViewModeToggle, PageLayout, type ViewMode } from '../components/common/PageComponents';
 import ConflictReorderActions from '../components/conflicts/ConflictReorderActions';
@@ -60,15 +61,10 @@ function ModThumbMenu({
   );
 }
 
-/** Global load-order rank of a mod: lower = loads first. The pakNN (mod.priority)
- *  repeats per overflow folder, so fold in the folder index from metaKey
- *  (addons{N}/...) for a single monotonic order. Mirrors modLoadOrder in
- *  Installed.tsx so the conflict reorder matches the load-order list. */
-function modLoadOrder(mod: Mod): number {
-  const match = mod.metaKey.match(/^addons(\d+)\//);
-  const folderIndex = match ? parseInt(match[1], 10) : 0;
-  return folderIndex * 100 + mod.priority;
-}
+// Load-order rank comes from lockerUtils rather than a local copy: this page
+// used to mirror the math by hand, which silently went stale when the
+// citadel/grimoire priority root was added (a Global mod outranks every addons
+// mod, so a hand-rolled addons-only rank reports the wrong conflict winner).
 interface ModWithThumbnail {
   id: string;
   name: string;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -67,6 +67,7 @@ import {
   Copy,
   ExternalLink,
   Star,
+  ArrowUpToLine,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MenuContent, MenuItem, MenuRoot, MenuSeparator, MenuTrigger } from '../components/common/menu';
@@ -529,6 +530,8 @@ interface InstalledEntryCardProps {
   onViewImprint: (mod: Mod) => void;
   onTagLocker: (entry: ModEntry, heroName: string | null) => Promise<void>;
   onTagGlobal: (entry: ModEntry, globalType: GlobalModType | null) => Promise<void>;
+  /** Move an entry into or out of the citadel/grimoire priority root. */
+  onSetPriority: (entry: ModEntry, priority: boolean) => Promise<void>;
   onFixUnknown: (mod: Mod) => void;
   onCommitPriority: (modId: string, newPosition: number) => Promise<void>;
   onUnmerge: (mod: Mod) => void;
@@ -577,6 +580,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
   onViewImprint,
   onTagLocker,
   onTagGlobal,
+  onSetPriority,
   onFixUnknown,
   onCommitPriority,
   onUnmerge,
@@ -612,6 +616,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
         onViewImprint={mod.imprinted ? () => onViewImprint(mod) : undefined}
         onTagLocker={(heroName) => onTagLocker(entry, heroName)}
         onTagGlobal={(globalType) => onTagGlobal(entry, globalType)}
+        onSetPriority={(priority) => onSetPriority(entry, priority)}
         onFixUnknown={
           // Any local (unlinked, non-merged) mod can search GameBanana and
           // link, not just ones flagged "unknown": naming a local mod via
@@ -672,6 +677,7 @@ const InstalledEntryCard = memo(function InstalledEntryCard({
       onDelete={() => onDelete(entry)}
       onTagLocker={(heroName) => onTagLocker(entry, heroName)}
       onTagGlobal={(globalType) => onTagGlobal(entry, globalType)}
+      onSetPriority={(priority) => onSetPriority(entry, priority)}
       loadPosition={loadPosition}
       loadCount={loadCount}
       onCommitPriority={(p) => onCommitPriority(entry.primary.id, p)}
@@ -800,6 +806,7 @@ export default function Installed() {
     editLocalMod,
     setModLockerHero,
     setModGlobalType,
+    setModPriorityFolder,
     setVariantLabel,
     soundVolume,
     setInstalledScrollTop,
@@ -3354,6 +3361,17 @@ export default function Installed() {
       await setModGlobalType(entry.mod.id, globalType);
     }
   });
+  // Marking a grouped entry Global moves every variant, so a submission whose
+  // files co-require each other (model plus voice lines) doesn't end up half in
+  // the priority root. Sequential, like the other per-variant loops here: each
+  // move renames a VPK under the main-process mutation lock.
+  const setEntryPriority = useStableCallback(async (entry: ModEntry, priority: boolean) => {
+    if (entry.kind === 'group') {
+      for (const variant of entry.variants) await setModPriorityFolder(variant.id, priority);
+    } else {
+      await setModPriorityFolder(entry.mod.id, priority);
+    }
+  });
   const fixUnknownEntry = useStableCallback((mod: Mod) => openUnknownModFix(mod, 'single'));
   // commitLoadPosition is declared after the early returns (it reads the
   // compact order built there); bridge it through the same synchronous-ref
@@ -3804,6 +3822,7 @@ export default function Installed() {
     onViewImprint: viewEntryImprint,
     onTagLocker: tagEntryLocker,
     onTagGlobal: tagEntryGlobal,
+    onSetPriority: setEntryPriority,
     onFixUnknown: fixUnknownEntry,
     onCommitPriority: commitEntryPriority,
     onUnmerge: unmergeEntry,
@@ -6962,6 +6981,9 @@ interface ModCardProps {
     lockerHero?: string;
     lockerHeroSource?: Mod['lockerHeroSource'];
     globalType?: GlobalModType;
+    /** Lives in the citadel/grimoire priority root: wins every file collision
+     *  and is never disabled by the launch shuffle. */
+    priorityMod?: boolean;
     merged?: import('../types/mod').MergedModInfo;
   };
   viewMode: ViewMode;
@@ -6989,6 +7011,8 @@ interface ModCardProps {
   onViewImprint?: () => void;
   onTagLocker?: (heroName: string | null) => void | Promise<void>;
   onTagGlobal?: (globalType: GlobalModType | null) => void | Promise<void>;
+  /** Toggle this mod's Global (priority root) placement. */
+  onSetPriority?: (priority: boolean) => void | Promise<void>;
   onFixUnknown?: () => void;
   fixingUnknown?: boolean;
   /** Reposition commit. Passed through to PriorityEditor; the argument is a
@@ -7642,6 +7666,7 @@ function ModCard({
   onViewImprint,
   onTagLocker,
   onTagGlobal,
+  onSetPriority,
   onFixUnknown,
   fixingUnknown,
   onCommitPriority,
@@ -7767,6 +7792,24 @@ function ModCard({
       setTagPickerOpen(false);
     } catch (err) {
       console.error('[Installed] Failed to set global locker tag:', err);
+      setMenuError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMenuBusy(false);
+    }
+  };
+
+  // Toggle the Global (priority root) placement. The move renames the VPK, so
+  // the resulting mod carries a new id; the store refreshes the list, and this
+  // card is re-rendered from the new entry rather than trying to patch itself.
+  const togglePriority = async () => {
+    if (!onSetPriority || menuBusy) return;
+    setMenuBusy(true);
+    setMenuError(null);
+    try {
+      await onSetPriority(!mod.priorityMod);
+      setMenuOpen(false);
+    } catch (err) {
+      console.error('[Installed] Failed to change Global placement:', err);
       setMenuError(err instanceof Error ? err.message : String(err));
     } finally {
       setMenuBusy(false);
@@ -8051,6 +8094,28 @@ function ModCard({
               >
                 <Beaker className="w-3.5 h-3.5" />
                 {t('installed.card.soloLaunch')}
+              </button>
+            )}
+            {onSetPriority && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void togglePriority();
+                }}
+                disabled={menuBusy}
+                title={t('installed.priority.hint')}
+                className={`${menuItemClasses} disabled:cursor-not-allowed disabled:opacity-50 ${
+                  mod.priorityMod ? 'text-accent' : ''
+                }`}
+              >
+                <ArrowUpToLine className="w-3.5 h-3.5" />
+                {menuBusy
+                  ? t('installed.priority.busy')
+                  : mod.priorityMod
+                    ? t('installed.priority.clear')
+                    : t('installed.priority.make')}
               </button>
             )}
             {(onTagLocker || onTagGlobal) && (
@@ -8414,6 +8479,13 @@ function ModCard({
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             <div className={`flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary ${gridTagsClasses}`}>
+              {mod.priorityMod && (
+                <MetaTextChip
+                  label={t('installed.priority.chip')}
+                  className={manualTagChipClasses}
+                  title={t('installed.priority.hint')}
+                />
+              )}
               <LockerHeroChip
                 mod={mod}
                 manualTagChipClasses={manualTagChipClasses}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -92,7 +92,7 @@ import PriorityEditor from '../components/PriorityEditor';
 import { IMAGE_EXTS, deriveModNameFromPath } from '../lib/customModImport';
 import { Modal } from '../components/common/Modal';
 import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
-import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType } from '../lib/lockerUtils';
+import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType, modLoadOrder } from '../lib/lockerUtils';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
@@ -290,16 +290,6 @@ function isEntryEnabled(entry: ModEntry): boolean {
 /** Sort key for ordering enabled/disabled sections. Uses the primary's
  *  priority for groups so reorder math stays consistent with the existing
  *  per-mod priority system. */
-/** Global load-order rank of a mod: lower = higher priority. With overflow
- *  folders the pakNN (mod.priority) repeats per folder, so we fold in the folder
- *  index from metaKey (addons{N}/...) to get a single monotonic order. Base
- *  citadel/addons (and disabled) is folder 0, addons1 is 1, etc. */
-function modLoadOrder(mod: Mod): number {
-  const match = mod.metaKey.match(/^addons(\d+)\//);
-  const folderIndex = match ? parseInt(match[1], 10) : 0;
-  return folderIndex * 100 + mod.priority;
-}
-
 function entrySortPriority(entry: ModEntry): number {
   return modLoadOrder(entry.kind === 'single' ? entry.mod : entry.primary);
 }
@@ -426,6 +416,26 @@ function entryRepresentativeId(entry: ModEntry): string {
 
 function entryDisabledPreferenceKey(entry: ModEntry): string {
   return modPreferenceKey(entry.kind === 'single' ? entry.mod : entry.primary);
+}
+
+/** Stand-in for PriorityEditor on Global (priority-root) cards. They load
+ *  before every numbered mod and reorderMods filters them out of reposition
+ *  batches, so a position number would be both a lie and dead UI. Echoes the
+ *  PriorityEditor chip geometry, accent-tinted so Global reads as its own
+ *  tier rather than position zero. */
+function GlobalLoadBadge({ variant }: { variant: 'overlay' | 'inline' }) {
+  const { t } = useTranslation();
+  return (
+    <span
+      title={t('installed.priority.hint')}
+      aria-label={t('installed.priority.chip')}
+      className={`inline-flex h-[22px] min-w-[30px] items-center justify-center rounded-md border border-accent/60 px-2 text-accent ${
+        variant === 'overlay' ? 'bg-black/70' : 'bg-bg-tertiary'
+      }`}
+    >
+      <ArrowUpToLine className="h-3 w-3" strokeWidth={2.5} />
+    </span>
+  );
 }
 
 /**
@@ -3487,8 +3497,13 @@ export default function Installed() {
   const enabledByLoadOrder = visibleMods
     .filter((m) => m.enabled)
     .sort((a, b) => modLoadOrder(a) - modLoadOrder(b));
-  const enabledModCount = enabledByLoadOrder.length;
-  const loadPositionById = new Map(enabledByLoadOrder.map((m, i) => [m.id, i + 1] as const));
+  // Priority-root (Global) mods sit outside the pakNN ordering: they win by
+  // search-path position and reorderMods filters them out. Numbering only the
+  // rest keeps positions 1..N meaningful and editable, while Global cards get
+  // their own badge.
+  const numberedByLoadOrder = enabledByLoadOrder.filter((m) => !m.priorityMod);
+  const enabledModCount = numberedByLoadOrder.length;
+  const loadPositionById = new Map(numberedByLoadOrder.map((m, i) => [m.id, i + 1] as const));
 
   const handleCopyEnabledMods = async () => {
     // Use the same enabled list the UI shows (visibleMods / load order), not the
@@ -3767,7 +3782,7 @@ export default function Installed() {
    * modsError.
    */
   const commitLoadPosition = async (modId: string, newPosition: number): Promise<void> => {
-    const ordered = enabledByLoadOrder.slice();
+    const ordered = numberedByLoadOrder.slice();
     const fromIdx = ordered.findIndex((m) => m.id === modId);
     if (fromIdx === -1) throw new Error('Mod not found');
     // The editor validates 1..N, but a stale render could submit out of range;
@@ -7519,7 +7534,9 @@ function ModListRowContent({
   return (
     <>
       <div className="flex min-w-0 items-center justify-start">
-        {mod.enabled ? (
+        {mod.enabled && mod.priorityMod ? (
+          <GlobalLoadBadge variant="inline" />
+        ) : mod.enabled ? (
           <span data-card-action="true">
             <PriorityEditor
               modName={mod.name}
@@ -8304,7 +8321,7 @@ function ModCard({
       <MenuTrigger asChild disabled={selectMode}>
     <div
       data-mod-entry-key={entryKey}
-      className={`group/card relative rounded-xl border transform-gpu ${isList ? 'transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ' + stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : ''}`}
+      className={`group/card relative rounded-xl border transform-gpu ${isList ? 'transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ' + stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : mod.priorityMod ? 'ring-1 ring-accent/40' : ''}`}
     >
       <div className={isList ? 'contents' : ''}>
         {selectMode && (
@@ -8376,6 +8393,11 @@ function ModCard({
         const overlayBadges = (
           <>
             {mod.enabled && !selectMode && (
+              mod.priorityMod ? (
+                <div className="absolute top-2 left-2 z-10 flex h-5 items-start">
+                  <GlobalLoadBadge variant="overlay" />
+                </div>
+              ) : (
               <div className="absolute top-2 left-2 z-10 flex h-5 items-start" data-card-action="true">
                 <PriorityEditor
                   modName={mod.name}
@@ -8385,6 +8407,7 @@ function ModCard({
                   onCommit={onCommitPriority}
                 />
               </div>
+              )
             )}
             {!mod.enabled && !selectMode && (
               <div className="absolute top-2 left-2 z-10 flex h-5 items-start">

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Images, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Shuffle, Sparkles, Star, Trash2 } from 'lucide-react';
+import { ArrowLeft, ArrowUpToLine, Box, Check, ChevronDown, ChevronsDownUp, ChevronsUpDown, ExternalLink, Filter, Ghost, Images, Layers, MoreVertical, Music, Palette, PowerOff, Shield, Shirt, Shuffle, Sparkles, Star, Trash2 } from 'lucide-react';
 import { useAppStore } from '../stores/appStore';
 import {
   getGamebananaCategories,
@@ -10,10 +10,12 @@ import {
   getLockerOverview,
   setModGlobalType,
   setModLockerHero,
+  setModPriorityFolder,
 } from '../lib/api';
 import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { getAssetPath } from '../lib/assetPath';
 import HeroSkinsPanel from '../components/locker/HeroSkinsPanel';
+import GlobalModPicker from '../components/locker/GlobalModPicker';
 import { LockerHeroView } from './LockerHero';
 import ModThumbnail from '../components/ModThumbnail';
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
@@ -470,8 +472,23 @@ export default function Locker() {
     () => mods.filter((m) => isLockerManagedSound(m) && !getEffectiveGlobalType(m)),
     [mods]
   );
+  // Global (priority-root) mods are a placement axis, not a classification, so
+  // they are NOT filtered out of the hero grouping: a Global hero skin still
+  // belongs in that hero's pile, it just also wins every collision. This list
+  // only feeds the General view's Global tab.
+  const priorityMods = useMemo(
+    () => mods.filter((m) => m.priorityMod).sort((a, b) => a.name.localeCompare(b.name)),
+    [mods]
+  );
   const globalGroups = useMemo(() => groupGlobalMods(mods), [mods]);
   const globalCount = useMemo(() => countGlobalMods(mods), [mods]);
+  const [globalPickerOpen, setGlobalPickerOpen] = useState(false);
+  // Sequential on purpose: each call renames a VPK under the main-process
+  // mutation lock, so firing them concurrently would just queue anyway, and
+  // serially means a mid-batch failure leaves a coherent partial result.
+  const addModsToGlobal = async (modIds: string[]) => {
+    for (const modId of modIds) await setModPriorityFolder(modId, true);
+  };
   const globalTypeCount = useMemo(
     () => GLOBAL_MOD_TYPE_ORDER.filter((type) => globalGroups[type].length > 0).length,
     [globalGroups]
@@ -1421,8 +1438,20 @@ export default function Locker() {
             onRequestDelete={(ids, name) => setDeletePrompt({ ids, name })}
             onImportSoul={() => setSoulImportOpen(true)}
             onImportUrn={() => setUrnImportOpen(true)}
+            priorityMods={priorityMods}
+            onAddGlobal={() => setGlobalPickerOpen(true)}
+            onRemoveGlobal={(modId) => setModPriorityFolder(modId, false)}
           />
         </div>
+      )}
+
+      {globalPickerOpen && (
+        <GlobalModPicker
+          mods={mods}
+          hideNsfwPreviews={shouldBlurNsfw(settings)}
+          onClose={() => setGlobalPickerOpen(false)}
+          onConfirm={addModsToGlobal}
+        />
       )}
 
       {soulImportOpen && (
@@ -1569,6 +1598,21 @@ function GlobalGalleryCard({ count, typeCount, onNavigate, typeaheadClassName = 
   );
 }
 
+/**
+ * Synthetic tab id for the Global (precedence) tab in the General view. It is
+ * NOT a GlobalModType: those seven are the classification axis stored in the
+ * metadata sidecar's `globalType`, while Global is folder placement
+ * (Mod.priorityMod). Keeping it a separate sentinel is what stops a Global mod
+ * from ever being written into the classification field.
+ */
+const PRIORITY_TAB = 'priority' as const;
+type GeneralTabId = GlobalModType | typeof PRIORITY_TAB;
+
+/** Display label for a General-view tab: builtin type labels, plus Global. */
+function generalTabLabel(tab: GeneralTabId, t: (key: string) => string): string {
+  return tab === PRIORITY_TAB ? t('installed.priority.chip') : GLOBAL_MOD_TYPE_LABELS[tab];
+}
+
 interface LockerGlobalViewProps {
   groups: GlobalModGroups;
   hideNsfw: boolean;
@@ -1582,6 +1626,12 @@ interface LockerGlobalViewProps {
   onImportSoul: () => void;
   /** Open the Spirit Urn GLB import modal (shown on the spirit-urn tab). */
   onImportUrn: () => void;
+  /** Mods living in the citadel/grimoire priority root (the "Global" tab). */
+  priorityMods: Mod[];
+  /** Open the picker that adds installed mods to Global. */
+  onAddGlobal: () => void;
+  /** Move a mod back out of the priority root. */
+  onRemoveGlobal: (modId: string) => void | Promise<unknown>;
 }
 
 /**
@@ -1589,7 +1639,7 @@ interface LockerGlobalViewProps {
  * frosted-glass carousel of cosmetic types (echoing the LockerHeroView shell's
  * art + blur language). Selecting a tile reveals that type's toggleable mods.
  */
-function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onRequestDelete, onImportSoul, onImportUrn }: LockerGlobalViewProps) {
+function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType, onRequestDelete, onImportSoul, onImportUrn, priorityMods, onAddGlobal, onRemoveGlobal }: LockerGlobalViewProps) {
   const { t } = useTranslation();
   const soundVolume = useAppStore((s) => s.soundVolume);
   // Every tab is selectable, empty or not. We still default the landing tab to
@@ -1598,13 +1648,20 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
   const firstPopulated = GLOBAL_MOD_TYPE_ORDER.filter(
     (type) => groups[type].length > 0 || isPropContainerType(type)
   );
-  const [selectedType, setSelectedType] = useState<GlobalModType>(
+  const [selectedType, setSelectedType] = useState<GeneralTabId>(
     () => firstPopulated[0] ?? 'soul-container'
   );
+  // Tab order: the seven classification types, then Global (the precedence
+  // axis). Global is deliberately last and visually separated: it answers a
+  // different question ("does this mod win?") than the types above it ("what
+  // kind of mod is this?").
+  const tabIds: readonly GeneralTabId[] = [...GLOBAL_MOD_TYPE_ORDER, PRIORITY_TAB];
+  const countForTab = (tab: GeneralTabId) =>
+    tab === PRIORITY_TAB ? priorityMods.length : groups[tab].length;
   // Sliding active-tab highlight, mirroring the main sidebar's glide: one
   // indicator element animates between the tab rows rather than each row
   // toggling its own background (which snaps). Refs feed its measured position.
-  const tabRefs = useRef<Map<GlobalModType, HTMLButtonElement | null>>(new Map());
+  const tabRefs = useRef<Map<GeneralTabId, HTMLButtonElement | null>>(new Map());
   const [tabIndicator, setTabIndicator] = useState<{ top: number; height: number } | null>(null);
   // Open retag menu, anchored in viewport coords (fixed-positioned) so it never
   // clips against the scrolling card pane. Null when closed.
@@ -1629,7 +1686,8 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
   // Any type is a valid selection now (empty tabs render their own empty
   // state), so the active tab is simply whatever the user picked.
   const activeType = selectedType;
-  const activeMods = groups[activeType] ?? [];
+  const isPriorityTab = activeType === PRIORITY_TAB;
+  const activeMods = isPriorityTab ? priorityMods : groups[activeType] ?? [];
   // Track the active row's box so the highlight can glide to it. Measured in a
   // layout effect (pre-paint) to avoid a one-frame jump on first mount.
   useLayoutEffect(() => {
@@ -1638,8 +1696,11 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
   }, [activeType]);
   // Soul containers and spirit urns share the single-select + live-3D-tile
   // treatment (frosted glass, content-stable key, active badge, import button).
-  const isPropContainer = isPropContainerType(activeType);
-  const total = GLOBAL_MOD_TYPE_ORDER.reduce((sum, type) => sum + groups[type].length, 0);
+  // Never true for the Global tab: priority mods are ordinary multi-toggle
+  // cards, never the single-select live-3D treatment.
+  const isPropContainer = !isPriorityTab && isPropContainerType(activeType);
+  const total =
+    GLOBAL_MOD_TYPE_ORDER.reduce((sum, type) => sum + groups[type].length, 0) + priorityMods.length;
   // The scrollable card pane: the shared soul-container canvas clamps each
   // card's render rect to this element so models never bleed past the pane.
   const paneRef = useRef<HTMLDivElement>(null);
@@ -1740,10 +1801,10 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
               }}
             />
           )}
-          {GLOBAL_MOD_TYPE_ORDER.map((type) => {
-            const items = groups[type];
+          {tabIds.map((type) => {
+            const count = countForTab(type);
             const isActive = type === activeType;
-            const isEmpty = items.length === 0;
+            const isEmpty = count === 0;
             // Every tab is clickable, empty or not: an empty tab opens its own
             // empty state (the importer for prop containers, a Browse hint for
             // the rest), which is more discoverable than a dead disabled row.
@@ -1760,9 +1821,9 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                 }`}
               >
                 <span className={`flex-1 truncate text-sm font-medium text-white ${isEmpty && !isActive ? 'opacity-50' : ''}`}>
-                  {GLOBAL_MOD_TYPE_LABELS[type]}
+                  {generalTabLabel(type, t)}
                 </span>
-                <span className="text-xs text-white/50">{items.length}</span>
+                <span className="text-xs text-white/50">{count}</span>
               </button>
             );
           })}
@@ -1778,11 +1839,22 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             <>
               <div className="flex items-baseline gap-2">
                 <h3 className="text-base font-semibold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)]">
-                  {GLOBAL_MOD_TYPE_LABELS[activeType]}
+                  {generalTabLabel(activeType, t)}
                 </h3>
                 <span className="text-xs text-white/60">
                   {t('locker.page.modCount', { count: activeMods.length })}
                 </span>
+                {isPriorityTab && (
+                  <button
+                    type="button"
+                    onClick={onAddGlobal}
+                    className="ml-auto inline-flex items-center gap-1.5 self-center rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:border-accent/60 hover:bg-accent/20"
+                    title={t('locker.globalPicker.description')}
+                  >
+                    <ArrowUpToLine className="h-3.5 w-3.5" />
+                    {t('locker.globalPicker.trigger')}
+                  </button>
+                )}
                 {isPropContainer && (
                   <button
                     type="button"
@@ -1816,6 +1888,19 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                     {activeType === 'spirit-urn' ? t('locker.urnImport.trigger.label') : t('locker.soulImport.trigger.label')}
                   </button>
                 </div>
+              ) : activeMods.length === 0 && isPriorityTab ? (
+                <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/15 bg-bg-sunken/30 px-6 py-12 text-center">
+                  <ArrowUpToLine className="h-8 w-8 text-white/40" />
+                  <p className="max-w-sm text-sm text-white/70">{t('locker.globalPicker.empty')}</p>
+                  <button
+                    type="button"
+                    onClick={onAddGlobal}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:border-accent/60 hover:bg-accent/20"
+                  >
+                    <ArrowUpToLine className="h-3.5 w-3.5" />
+                    {t('locker.globalPicker.trigger')}
+                  </button>
+                </div>
               ) : activeMods.length === 0 ? (
                 // Non-prop types can't be imported, so the empty state just
                 // points the user at Browse instead of an import button.
@@ -1823,7 +1908,7 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                   <Layers className="h-8 w-8 text-white/40" />
                   <p className="max-w-sm text-sm text-white/70">
                     {t('locker.global.typeEmpty', {
-                      type: GLOBAL_MOD_TYPE_LABELS[activeType],
+                      type: generalTabLabel(activeType, t),
                     })}
                   </p>
                 </div>
@@ -2111,6 +2196,24 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             className="fixed z-[80] w-52 rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
             style={{ top: retagMenu.y, left: retagMenu.x }}
           >
+            {/* The Global tab is folder placement, not classification, so its
+                cards get the one action that makes sense there. Offering the
+                seven classification types would write `globalType` on a mod
+                whose whole point is where its VPK lives. */}
+            {isPriorityTab ? (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  void onRemoveGlobal(retagMenu.id);
+                  setRetagMenu(null);
+                }}
+                className="w-full rounded px-2 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-tertiary hover:text-text-primary cursor-pointer"
+              >
+                {t('installed.priority.clear')}
+              </button>
+            ) : (
+            <>
             <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
               {t('locker.page.moveToCategory')}
             </div>
@@ -2148,6 +2251,8 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
             >
               {t('locker.page.removeFromGlobal')}
             </button>
+            </>
+            )}
           </div>
         </>
       )}

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -10,7 +10,6 @@ import {
   getLockerOverview,
   setModGlobalType,
   setModLockerHero,
-  setModPriorityFolder,
 } from '../lib/api';
 import { getActiveDeadlockPath, shouldBlurNsfw } from '../lib/appSettings';
 import { getAssetPath } from '../lib/assetPath';
@@ -232,7 +231,7 @@ function FacetSheenDefs() {
 
 export default function Locker() {
   const { t } = useTranslation();
-  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages, shuffleOnLaunch, setShuffleOnLaunch, shuffleIncluded, toggleShuffleIncluded, shuffleVariants, setShuffleVariant } =
+  const { settings, mods, modsLoading, modsError, loadSettings, loadMods, toggleMod, reorderMods, deleteMod, setModPriorityFolder, setBrowseUi, setLockerHeroName, lockerModImages, lockerHideHeroName, lockerModThumbnails, lockerThumbHideHeroName, loadLockerModImages, shuffleOnLaunch, setShuffleOnLaunch, shuffleIncluded, toggleShuffleIncluded, shuffleVariants, setShuffleVariant } =
     useAppStore();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const [categories, setCategories] = useState<GameBananaCategoryNode[]>(

--- a/src/pages/Locker.tsx
+++ b/src/pages/Locker.tsx
@@ -45,7 +45,6 @@ import {
   activeLockerSkin,
   buildHeroList,
   canonicalHeroName,
-  countGlobalMods,
   countLockerSkins,
   getLockerSkinKey,
   getEffectiveGlobalType,
@@ -480,7 +479,15 @@ export default function Locker() {
     [mods]
   );
   const globalGroups = useMemo(() => groupGlobalMods(mods), [mods]);
-  const globalCount = useMemo(() => countGlobalMods(mods), [mods]);
+  // The General tile is the entry point for both independent axes. Count each
+  // mod once even when it has a General classification and Global placement.
+  const globalCount = useMemo(
+    () => mods.reduce(
+      (count, mod) => count + (getEffectiveGlobalType(mod) || mod.priorityMod ? 1 : 0),
+      0
+    ),
+    [mods]
+  );
   const [globalPickerOpen, setGlobalPickerOpen] = useState(false);
   // Sequential on purpose: each call renames a VPK under the main-process
   // mutation lock, so firing them concurrently would just queue anyway, and
@@ -489,8 +496,10 @@ export default function Locker() {
     for (const modId of modIds) await setModPriorityFolder(modId, true);
   };
   const globalTypeCount = useMemo(
-    () => GLOBAL_MOD_TYPE_ORDER.filter((type) => globalGroups[type].length > 0).length,
-    [globalGroups]
+    () =>
+      GLOBAL_MOD_TYPE_ORDER.filter((type) => globalGroups[type].length > 0).length +
+      (priorityMods.length > 0 ? 1 : 0),
+    [globalGroups, priorityMods]
   );
 
   // Calculate heroMods, passing heroList for name-based category inference
@@ -1665,6 +1674,12 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
   // Open retag menu, anchored in viewport coords (fixed-positioned) so it never
   // clips against the scrolling card pane. Null when closed.
   const [retagMenu, setRetagMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [priorityActionBusy, setPriorityActionBusy] = useState(false);
+  const [priorityActionError, setPriorityActionError] = useState<string | null>(null);
+  useEffect(() => {
+    setPriorityActionBusy(false);
+    setPriorityActionError(null);
+  }, [retagMenu?.id]);
   // Close the menu on any scroll / resize / Escape — a fixed menu would
   // otherwise float away from its anchor once the pane scrolls.
   useEffect(() => {
@@ -1698,8 +1713,10 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
   // Never true for the Global tab: priority mods are ordinary multi-toggle
   // cards, never the single-select live-3D treatment.
   const isPropContainer = !isPriorityTab && isPropContainerType(activeType);
-  const total =
-    GLOBAL_MOD_TYPE_ORDER.reduce((sum, type) => sum + groups[type].length, 0) + priorityMods.length;
+  const total = new Set([
+    ...GLOBAL_MOD_TYPE_ORDER.flatMap((type) => groups[type].map((mod) => mod.id)),
+    ...priorityMods.map((mod) => mod.id),
+  ]).size;
   // The scrollable card pane: the shared soul-container canvas clamps each
   // card's render rect to this element so models never bleed past the pane.
   const paneRef = useRef<HTMLDivElement>(null);
@@ -2200,17 +2217,36 @@ function LockerGlobalView({ groups, hideNsfw, onBack, onToggle, onSetGlobalType,
                 seven classification types would write `globalType` on a mod
                 whose whole point is where its VPK lives. */}
             {isPriorityTab ? (
+              <>
               <button
                 type="button"
                 role="menuitem"
+                disabled={priorityActionBusy}
                 onClick={() => {
-                  void onRemoveGlobal(retagMenu.id);
-                  setRetagMenu(null);
+                  if (priorityActionBusy) return;
+                  setPriorityActionBusy(true);
+                  setPriorityActionError(null);
+                  void (async () => {
+                    try {
+                      await onRemoveGlobal(retagMenu.id);
+                      setRetagMenu(null);
+                    } catch (err) {
+                      setPriorityActionError(err instanceof Error ? err.message : String(err));
+                    } finally {
+                      setPriorityActionBusy(false);
+                    }
+                  })();
                 }}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-tertiary hover:text-text-primary cursor-pointer"
+                className="w-full rounded px-2 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-tertiary hover:text-text-primary cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {t('installed.priority.clear')}
+                {priorityActionBusy ? t('installed.priority.busy') : t('installed.priority.clear')}
               </button>
+              {priorityActionError && (
+                <p role="alert" className="px-2 py-1 text-[11px] text-state-danger">
+                  {priorityActionError}
+                </p>
+              )}
+              </>
             ) : (
             <>
             <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -326,6 +326,9 @@ interface AppState {
   editLocalMod: (modId: string, args: EditLocalModArgs) => Promise<void>;
   setModLockerHero: (modId: string, heroName: string | null) => Promise<void>;
   setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<void>;
+  /** Mark a mod Global (priority root) or clear it. Moves the VPK, so it goes
+   *  through the toggle queue like every other folder mutation. */
+  setModPriorityFolder: (modId: string, priority: boolean) => Promise<void>;
   setVariantLabel: (modId: string, label: string) => Promise<void>;
   /** Batch local import. Resolves with one result per source, in request order. */
   importCustomMods: (items: ImportCustomModArgs[]) => Promise<ImportCustomModResult[]>;
@@ -861,6 +864,22 @@ export const useAppStore = create<AppState>((set, get) => ({
     const updated = await api.setModGlobalType(modId, globalType);
     set({
       mods: get().mods.map((m) => (m.id === modId ? updated : m)),
+    });
+  },
+
+  // Marking a mod Global renames its VPK into citadel/grimoire, which changes
+  // its id (ids derive from the filename). Route through enqueueToggle so the
+  // move can't interleave with a Locker/Installed toggle and work off a stale
+  // id, the same hazard documented on the mutation queue in mods.ts.
+  setModPriorityFolder: async (modId: string, priority: boolean) => {
+    await enqueueToggle(async () => {
+      try {
+        const updated = await api.setModPriorityFolder(modId, priority);
+        set({ mods: get().mods.map((m) => (m.id === modId ? updated : m)) });
+      } catch (err) {
+        if (!isGameRunningModLockError(err)) set({ modsError: String(err) });
+        await get().loadMods();
+      }
     });
   },
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -877,8 +877,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         const updated = await api.setModPriorityFolder(modId, priority);
         set({ mods: get().mods.map((m) => (m.id === modId ? updated : m)) });
       } catch (err) {
-        if (!isGameRunningModLockError(err)) set({ modsError: String(err) });
-        await get().loadMods();
+        // Reconcile any partial batch progress, then preserve the rejection for
+        // the initiating surface. The picker and card menus own contextual
+        // errors; swallowing here made them close as if a failed move worked.
+        await get().loadMods({ silent: true });
+        throw err;
       }
     });
   },

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -724,6 +724,10 @@ export interface ElectronAPI {
     clearLockerOverrides: (scope: LockerClearScope) => Promise<void>;
     setModGlobalType: (modId: string, globalType: GlobalModType | null) => Promise<Mod>;
     setModIgnoreUpdates: (modId: string, ignore: boolean) => Promise<Mod>;
+    /** Mark a mod Global (moves it to the citadel/grimoire priority root) or
+     *  clear it. See Mod.priorityMod. Distinct from setModPriority, which sets
+     *  a mod's pakNN slot within citadel/addons. */
+    setModPriorityFolder: (modId: string, priority: boolean) => Promise<Mod>;
     backfillGameBananaFileId: (
       modId: string,
       payload: { gameBananaFileId: number; fileDescription?: string; sourceFileName?: string }

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -656,6 +656,12 @@ export interface Mod {
   /** User opted out of the "update available" flag for this mod. Persisted
    *  in metadata; toggled from the mod details modal. */
   ignoreUpdates?: boolean;
+  /** User marked this mod Global. It lives in citadel/grimoire, the search
+   *  path the engine reads before citadel/addons, so it wins every file
+   *  collision and the launch shuffle never disables it. Note this is the
+   *  *precedence* axis and has nothing to do with `globalType`, which is the
+   *  Locker's non-hero *classification* axis (labelled "General" in the UI). */
+  priorityMod?: boolean;
   /** True once this VPK has been re-packed in place with a self-identifying
    *  `addoninfo.txt` embed (path B imprinting). A UI hint only: it does NOT
    *  affect canonical identity (sha256 stays the original). Projected from


### PR DESCRIPTION
Adds a Global placement axis for mods: marking a mod Global moves its VPK into the `citadel/grimoire` priority root, which `gameinfo.gi` lists ahead of `citadel/addons`, so Global mods win every file collision with no load-order bookkeeping. Includes the Locker General > Global tab surface (picker, kebab remove), Installed-page tagging, shuffle and profile integration, and `docs/locker-global-mods.md`.

Review follow-ups: Locker now routes add/remove through the store action so the Global tab refreshes immediately (and gets the stale-id toggle queue), the move integration test mocks the game-running probe (the suite failed if Deadlock was open), plus an em-dash and a dead ref.

Final review follow-up makes Global moves failure-atomic, includes user Global VPKs in Launch Vanilla and all installed-library scanners, propagates action errors to their initiating UI, and adds focused regression coverage.

Gates: typecheck, lint, i18n:check, manifest check, vitest 782/782, all green.

## Test checklist

Run from this branch (`pnpm dev`), game closed unless a step says otherwise.

**Core moves (the follow-up fix: watch for instant UI refresh, no page reload)**
- [x] Locker > General > Global tab > Add mods: pick two or more installed mods, confirm. They appear in the Global tab immediately.
- [x] The moved VPKs are in `game/citadel/grimoire/` at `pak05` or higher (`pak01`-`pak04` stay reserved for Locker-managed VPKs).
- [x] Kebab on a Global card > clear: the card leaves the tab immediately and the VPK is back in `citadel/addons`.

**Placement survives lifecycle**
- [x] Disable a Global mod, then re-enable it: it returns to `citadel/grimoire`, not addons (the metadata flag is the only thing that can restore it).
- [x] Restart the app: the Global tab still lists the same mods.
- [x] Switch to another profile and back: Global placement intact.
- [x] With launch shuffle on, Launch Modded: shuffle never disables or moves Global mods.

**Priority actually wins**
- [x] Enable a normal mod that overlaps files with a Global mod: the Conflicts page shows the Global mod winning, and in game the Global mod's files are the ones loaded.

**Guards**
- [x] With Deadlock running, try to remove an enabled Global mod: it refuses with visible feedback (contextual error in the menu), and the VPK does not move.
- [x] Fix Configuration / the gameinfo banner does not strip or fight the `citadel/grimoire` search path.

**Installed page**
- [x] Per-mod Global tagging works from Installed; bulk placement works through the Locker picker, and both surfaces stay in sync.