### PR TITLE
fix(installed): unify card action menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-context-menu": "^2.2.16",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.24
+        version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0))(@types/react@19.2.7)(@types/three@0.184.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0)
@@ -861,6 +864,9 @@ packages:
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
   '@radix-ui/react-arrow@1.1.10':
     resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
     peerDependencies:
@@ -874,8 +880,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-arrow@1.1.15':
+    resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.15':
+    resolution: {integrity: sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -918,6 +950,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.5':
+    resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context-menu@2.2.16':
     resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
     peerDependencies:
@@ -949,8 +990,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.2.2':
+    resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.4':
+    resolution: {integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -984,6 +1043,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.19':
+    resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.24':
+    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -991,6 +1076,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.6':
+    resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.16':
+    resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-focus-scope@1.1.7':
@@ -1024,8 +1131,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.4':
+    resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.24':
+    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1063,6 +1192,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.3.7':
+    resolution: {integrity: sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.12':
     resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
     peerDependencies:
@@ -1076,8 +1218,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.1.17':
+    resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.10':
+    resolution: {integrity: sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1104,6 +1272,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.6':
     resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.10':
+    resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1154,6 +1335,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.19':
+    resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -1165,6 +1359,15 @@ packages:
 
   '@radix-ui/react-slot@1.3.0':
     resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.3':
+    resolution: {integrity: sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1203,6 +1406,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.4':
+    resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
@@ -1214,6 +1426,15 @@ packages:
 
   '@radix-ui/react-use-controllable-state@1.2.3':
     resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1239,6 +1460,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
@@ -1250,6 +1480,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.2':
     resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.3':
+    resolution: {integrity: sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1275,6 +1514,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -1286,6 +1534,15 @@ packages:
 
   '@radix-ui/react-use-rect@1.1.2':
     resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.4':
+    resolution: {integrity: sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1311,6 +1568,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-size@1.1.4':
+    resolution: {integrity: sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-visually-hidden@1.2.6':
     resolution: {integrity: sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==}
     peerDependencies:
@@ -1329,6 +1595,9 @@ packages:
 
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
+
+  '@radix-ui/rect@1.1.3':
+    resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
   '@react-three/drei@10.7.7':
     resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
@@ -3541,6 +3810,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -3998,10 +4268,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -5167,6 +5439,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.4': {}
 
+  '@radix-ui/primitive@1.1.7': {}
+
   '@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5176,9 +5450,30 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -5204,6 +5499,12 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -5235,7 +5536,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-context@1.2.2(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-direction@1.1.4(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -5267,11 +5580,56 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -5298,6 +5656,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-id@1.1.4(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5316,6 +5681,32 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.3)
       aria-hidden: 1.2.6
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -5360,6 +5751,24 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-rect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5370,10 +5779,29 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -5393,6 +5821,15 @@ snapshots:
   '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -5434,6 +5871,25 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
@@ -5444,6 +5900,13 @@ snapshots:
   '@radix-ui/react-slot@1.3.0(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-slot@1.3.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
@@ -5480,6 +5943,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.7)(react@19.2.3)
@@ -5492,6 +5961,15 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
@@ -5510,6 +5988,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
@@ -5524,6 +6009,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-is-hydrated@0.1.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -5531,6 +6022,12 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -5550,6 +6047,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-rect@1.1.4(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
@@ -5560,6 +6064,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.2(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-size@1.1.4(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
@@ -5576,6 +6087,8 @@ snapshots:
   '@radix-ui/rect@1.1.1': {}
 
   '@radix-ui/rect@1.1.2': {}
+
+  '@radix-ui/rect@1.1.3': {}
 
   '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0))(@types/react@19.2.7)(@types/three@0.184.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.184.0)':
     dependencies:

--- a/src/components/ImageContextMenu.tsx
+++ b/src/components/ImageContextMenu.tsx
@@ -1,43 +1,24 @@
 import { type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, ExternalLink, Fingerprint, FolderOpen, ImageDown, Link, Loader2 } from 'lucide-react';
+import { Check, ExternalLink, ImageDown, Link, Loader2 } from 'lucide-react';
 import { MenuContent, MenuItem, MenuLabel, MenuRoot, MenuSeparator, MenuTrigger } from './common/menu';
+import { canOpenImageSource, copyImageToClipboard, resolveImageSource } from '../lib/imageActions';
 
 interface ImageContextMenuProps {
   src: string;
   alt: string;
   copySrc?: string;
-  /** When set, appends a "Reveal mod in folder" item. The image menu swallows
-   *  right-clicks (its trigger stops propagation), so card surfaces that offer
-   *  reveal-in-folder pass it down here too to keep the action reachable. */
-  onRevealInFolder?: () => void;
-  /** When set, appends a "View imprint" item (Fingerprint icon). Same rationale
-   *  as onRevealInFolder: mod cards offer this on right-click, and the image
-   *  menu swallows those clicks. Callers pass it only for imprinted mods. */
-  onViewImprint?: () => void;
-  /** Extra menu items appended below the reveal/imprint block (the Installed
-   *  card's "Add to list" submenu). Same rationale as onRevealInFolder: this
-   *  menu swallows the card's right-clicks, so card-level actions have to be
-   *  threaded through to stay reachable from the thumbnail. */
-  extraItems?: ReactNode;
   children: ReactNode;
 }
 
 type CopyState = 'idle' | 'copying' | 'copied' | 'failed';
 
-export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, onViewImprint, extraItems, children }: ImageContextMenuProps) {
+export default function ImageContextMenu({ src, alt, copySrc, children }: ImageContextMenuProps) {
   const { t } = useTranslation();
   const [imageCopyState, setImageCopyState] = useState<CopyState>('idle');
   const [urlCopyState, setUrlCopyState] = useState<CopyState>('idle');
   const source = useMemo(() => resolveImageSource(copySrc ?? src), [copySrc, src]);
-  const canOpenImage = useMemo(() => {
-    try {
-      const protocol = new URL(source).protocol;
-      return protocol === 'http:' || protocol === 'https:';
-    } catch {
-      return false;
-    }
-  }, [source]);
+  const canOpenImage = useMemo(() => canOpenImageSource(source), [source]);
 
   const resetTransientState = () => {
     setImageCopyState('idle');
@@ -53,11 +34,7 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
   const copyImage = async () => {
     setImageCopyState('copying');
     try {
-      if (typeof window.electronAPI.copyImageToClipboard === 'function') {
-        await window.electronAPI.copyImageToClipboard(source);
-      } else {
-        await copyImageWithWebClipboard(source);
-      }
+      await copyImageToClipboard(source);
       setImageCopyState('copied');
       finishAndClose();
     } catch (err) {
@@ -155,53 +132,7 @@ export default function ImageContextMenu({ src, alt, copySrc, onRevealInFolder, 
               </MenuItem>
             </>
           )}
-          {(onRevealInFolder || onViewImprint) && (
-            <>
-              <MenuSeparator />
-              {onRevealInFolder && (
-                <MenuItem icon={FolderOpen} onSelect={onRevealInFolder}>
-                  {t('imageContextMenu.revealModInFolder')}
-                </MenuItem>
-              )}
-              {onViewImprint && (
-                <MenuItem icon={Fingerprint} onSelect={onViewImprint}>
-                  {t('installed.imprintDetails.menuEntry')}
-                </MenuItem>
-              )}
-            </>
-          )}
-          {extraItems && (
-            <>
-              <MenuSeparator />
-              {extraItems}
-            </>
-          )}
       </MenuContent>
     </MenuRoot>
   );
-}
-
-function resolveImageSource(src: string): string {
-  try {
-    return new URL(src, window.location.href).toString();
-  } catch {
-    return src;
-  }
-}
-
-async function copyImageWithWebClipboard(source: string): Promise<void> {
-  if (!('ClipboardItem' in window) || !navigator.clipboard?.write) {
-    throw new Error('Image clipboard API is unavailable until the Electron preload reloads');
-  }
-  const response = await fetch(source);
-  if (!response.ok) {
-    throw new Error(`Image request failed with status ${response.status}`);
-  }
-  const blob = await response.blob();
-  if (!blob.type.startsWith('image/')) {
-    throw new Error('Clipboard source is not an image');
-  }
-  await navigator.clipboard.write([
-    new ClipboardItem({ [blob.type]: blob }),
-  ]);
 }

--- a/src/components/ModThumbnail.tsx
+++ b/src/components/ModThumbnail.tsx
@@ -24,11 +24,9 @@ interface ModThumbnailProps {
    *  is still used when the user uploaded an override thumbnail (we treat
    *  any non-empty `src` as the explicit choice). */
   mergedSources?: MergedModSource[];
-  /** Forwarded to the image context menu as a "Reveal mod in folder" item. */
-  onRevealInFolder?: () => void;
-  /** Forwarded to the image context menu as a "View imprint" item. Callers
-   *  pass it only for imprinted mods. */
-  onViewImprint?: () => void;
+  /** Disable the image-specific right-click menu when the thumbnail belongs to
+   *  a larger interactive surface with its own context menu. */
+  enableImageContextMenu?: boolean;
 }
 
 export default function ModThumbnail({
@@ -43,8 +41,7 @@ export default function ModThumbnail({
   fallback,
   heroPortrait,
   mergedSources,
-  onRevealInFolder,
-  onViewImprint,
+  enableImageContextMenu = true,
 }: ModThumbnailProps) {
   const { t } = useTranslation();
   const shouldBlur = nsfw && hideNsfw;
@@ -63,8 +60,7 @@ export default function ModThumbnail({
         alt={alt}
         className={className}
         shouldBlur={shouldBlur}
-        onRevealInFolder={onRevealInFolder}
-        onViewImprint={onViewImprint}
+        enableImageContextMenu={enableImageContextMenu}
       />
     );
   }
@@ -102,10 +98,10 @@ export default function ModThumbnail({
     </div>
   );
 
-  if (resolvedBlur) return thumbnail;
+  if (resolvedBlur || !enableImageContextMenu) return thumbnail;
 
   return (
-    <ImageContextMenu src={resolvedSrc} alt={alt} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint}>
+    <ImageContextMenu src={resolvedSrc} alt={alt}>
       {thumbnail}
     </ImageContextMenu>
   );
@@ -116,8 +112,7 @@ interface MergedCollageProps {
   alt: string;
   className: string;
   shouldBlur?: boolean;
-  onRevealInFolder?: () => void;
-  onViewImprint?: () => void;
+  enableImageContextMenu: boolean;
 }
 
 /**
@@ -126,7 +121,7 @@ interface MergedCollageProps {
  * cells. Grid shape is picked to keep cells roughly square on a wide card;
  * with more than 16 thumbnails the last cell becomes a "+N more" tile.
  */
-function MergedCollage({ sources, alt, className, shouldBlur, onRevealInFolder, onViewImprint }: MergedCollageProps) {
+function MergedCollage({ sources, alt, className, shouldBlur, enableImageContextMenu }: MergedCollageProps) {
   const { t } = useTranslation();
   const { cells, cols } = buildCollage(sources);
   return (
@@ -147,8 +142,8 @@ function MergedCollage({ sources, alt, className, shouldBlur, onRevealInFolder, 
                   decoding="async"
                   className="block w-full h-full object-cover blur-xl scale-110"
                 />
-              ) : (
-                <ImageContextMenu src={cell.url} alt={alt} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint}>
+              ) : enableImageContextMenu ? (
+                <ImageContextMenu src={cell.url} alt={alt}>
                   <img
                     src={cell.url}
                     alt=""
@@ -157,6 +152,14 @@ function MergedCollage({ sources, alt, className, shouldBlur, onRevealInFolder, 
                     className="block w-full h-full object-cover"
                   />
                 </ImageContextMenu>
+              ) : (
+                <img
+                  src={cell.url}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  className="block w-full h-full object-cover"
+                />
               )
             ) : (
               <div className="w-full h-full flex items-center justify-center text-xs font-semibold text-text-secondary">

--- a/src/components/ModThumbnail.tsx
+++ b/src/components/ModThumbnail.tsx
@@ -153,11 +153,16 @@ function MergedCollage({ sources, alt, className, shouldBlur, enableImageContext
                   />
                 </ImageContextMenu>
               ) : (
+                // No image menu of its own (the surrounding card owns the
+                // right-click), but the cell still marks its own source so that
+                // menu can act on the tile actually under the pointer rather
+                // than on the merged mod's first source.
                 <img
                   src={cell.url}
                   alt=""
                   loading="lazy"
                   decoding="async"
+                  data-collage-src={cell.url}
                   className="block w-full h-full object-cover"
                 />
               )

--- a/src/components/common/menu.tsx
+++ b/src/components/common/menu.tsx
@@ -1,12 +1,12 @@
-import { type ReactNode } from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 import * as RadixContextMenu from '@radix-ui/react-context-menu';
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, type LucideIcon } from 'lucide-react';
 
-// Shared right-click menu primitives (styled wrappers over Radix
-// context-menu). One source for the menu surface and item styling that was
-// previously copy-pasted between ImageContextMenu, Sidebar, and the
-// Installed card menu. Menus sit at z-[80] (see the z-index scale in
-// index.css).
+// Shared menu primitives (styled wrappers over Radix). One source for the menu
+// surface and item styling that was previously copy-pasted between
+// ImageContextMenu, Sidebar, and the Installed card menu. Menus sit at z-[80]
+// (see the z-index scale in index.css).
 //
 // Usage:
 //   <MenuRoot>
@@ -17,26 +17,100 @@ import { Check, ChevronRight, type LucideIcon } from 'lucide-react';
 //       <MenuSeparator />
 //     </MenuContent>
 //   </MenuRoot>
+//
+// `kind` picks which Radix package backs the menu: 'context' (the default)
+// opens on right-click at the pointer, 'dropdown' opens from a button trigger.
+// Both packages wrap @radix-ui/react-menu and expose structurally identical
+// sub-components, which is what lets one item tree render through either root.
+// The Installed card relies on that: its three-dot button and its right-click
+// menu are the same list of actions, mounted twice.
 
-export const MenuRoot = RadixContextMenu.Root;
-export const MenuTrigger = RadixContextMenu.Trigger;
+export type MenuKind = 'context' | 'dropdown';
+
+// Typed against the dropdown namespace because its Content is the one that
+// accepts positioning props (side/align/sideOffset). A context menu anchors at
+// the pointer and has no use for them, so they are stripped for that kind.
+type MenuNamespace = typeof RadixDropdownMenu;
+
+const NAMESPACES: Record<MenuKind, MenuNamespace> = {
+  context: RadixContextMenu as unknown as MenuNamespace,
+  dropdown: RadixDropdownMenu,
+};
+
+interface MenuImpl {
+  kind: MenuKind;
+  ns: MenuNamespace;
+}
+
+const MenuImplContext = createContext<MenuImpl>({ kind: 'context', ns: NAMESPACES.context });
+
+function useMenuImpl(): MenuImpl {
+  return useContext(MenuImplContext);
+}
+
+interface MenuRootProps {
+  children: ReactNode;
+  kind?: MenuKind;
+  /** Controlled open state. Dropdown menus only: context menus own their own. */
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
+}
+
+export function MenuRoot({ children, kind = 'context', ...props }: MenuRootProps) {
+  const ns = NAMESPACES[kind];
+  const Root = ns.Root;
+  return (
+    <MenuImplContext.Provider value={{ kind, ns }}>
+      <Root {...props}>{children}</Root>
+    </MenuImplContext.Provider>
+  );
+}
+
+interface MenuTriggerProps {
+  children: ReactNode;
+  asChild?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function MenuTrigger({ children, ...props }: MenuTriggerProps) {
+  const { ns } = useMenuImpl();
+  const Trigger = ns.Trigger;
+  return <Trigger {...props}>{children}</Trigger>;
+}
 
 export const MENU_SURFACE_CLASS =
   'z-[80] min-w-52 rounded-lg border border-white/10 bg-bg-secondary/95 p-1.5 text-sm text-text-primary shadow-2xl shadow-black/50 backdrop-blur-md animate-fade-in';
 
-type MenuContentProps = RadixContextMenu.ContextMenuContentProps;
+type MenuContentProps = RadixDropdownMenu.DropdownMenuContentProps;
 
-export function MenuContent({ children, className = '', ...props }: MenuContentProps) {
+export function MenuContent({
+  children,
+  className = '',
+  side = 'bottom',
+  align = 'end',
+  sideOffset = 6,
+  ...props
+}: MenuContentProps) {
+  const { kind, ns } = useMenuImpl();
+  const Portal = ns.Portal;
+  const Content = ns.Content;
+  // Context-menu Content positions itself at the pointer and would forward
+  // these straight to the DOM as unknown attributes.
+  const positioning = kind === 'dropdown' ? { side, align, sideOffset } : {};
   return (
-    <RadixContextMenu.Portal>
-      <RadixContextMenu.Content
+    <Portal>
+      <Content
         collisionPadding={12}
         className={`${MENU_SURFACE_CLASS} ${className}`}
+        {...positioning}
         {...props}
       >
         {children}
-      </RadixContextMenu.Content>
-    </RadixContextMenu.Portal>
+      </Content>
+    </Portal>
   );
 }
 
@@ -57,6 +131,8 @@ const ITEM_GEOMETRY_CLASS =
 const DEFAULT_TONE_CLASS = 'text-text-primary focus:bg-white/10 data-[highlighted]:bg-white/10';
 
 export function MenuItem({ children, icon: Icon, spinning, tone = 'default', disabled, onSelect }: MenuItemProps) {
+  const { ns } = useMenuImpl();
+  const Item = ns.Item;
   const toneClass = tone === 'success'
     ? 'text-state-success focus:bg-state-success/10 data-[highlighted]:bg-state-success/10'
     : tone === 'danger'
@@ -64,7 +140,7 @@ export function MenuItem({ children, icon: Icon, spinning, tone = 'default', dis
       : DEFAULT_TONE_CLASS;
 
   return (
-    <RadixContextMenu.Item
+    <Item
       disabled={disabled}
       onSelect={(event) => {
         event.stopPropagation();
@@ -74,49 +150,62 @@ export function MenuItem({ children, icon: Icon, spinning, tone = 'default', dis
     >
       {Icon && <Icon className={`h-4 w-4 flex-shrink-0 text-current ${spinning ? 'animate-spin' : ''}`} />}
       <span className="min-w-0 flex-1 truncate">{children}</span>
-    </RadixContextMenu.Item>
+    </Item>
   );
 }
 
 export function MenuLabel({ children, className = '' }: { children: ReactNode; className?: string }) {
+  const { ns } = useMenuImpl();
+  const Label = ns.Label;
   return (
-    <RadixContextMenu.Label
+    <Label
       className={`max-w-64 truncate px-2 py-1 text-[11px] uppercase tracking-wide text-text-tertiary ${className}`}
     >
       {children}
-    </RadixContextMenu.Label>
+    </Label>
   );
 }
 
 export function MenuSeparator() {
-  return <RadixContextMenu.Separator className="my-1 h-px bg-white/10" />;
+  const { ns } = useMenuImpl();
+  const Separator = ns.Separator;
+  return <Separator className="my-1 h-px bg-white/10" />;
 }
 
-export const MenuSub = RadixContextMenu.Sub;
+export function MenuSub({ children }: { children: ReactNode }) {
+  const { ns } = useMenuImpl();
+  const Sub = ns.Sub;
+  return <Sub>{children}</Sub>;
+}
 
 export function MenuSubTrigger({ children, icon: Icon }: { children: ReactNode; icon?: LucideIcon }) {
+  const { ns } = useMenuImpl();
+  const SubTrigger = ns.SubTrigger;
   return (
-    <RadixContextMenu.SubTrigger
+    <SubTrigger
       className={`${ITEM_GEOMETRY_CLASS} ${DEFAULT_TONE_CLASS} data-[state=open]:bg-white/10`}
     >
       {Icon && <Icon className="h-4 w-4 flex-shrink-0 text-current" />}
       <span className="min-w-0 flex-1 truncate">{children}</span>
       <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
-    </RadixContextMenu.SubTrigger>
+    </SubTrigger>
   );
 }
 
 export function MenuSubContent({ children, className = '' }: { children: ReactNode; className?: string }) {
+  const { ns } = useMenuImpl();
+  const Portal = ns.Portal;
+  const SubContent = ns.SubContent;
   return (
-    <RadixContextMenu.Portal>
-      <RadixContextMenu.SubContent
+    <Portal>
+      <SubContent
         collisionPadding={12}
         sideOffset={2}
         className={`${MENU_SURFACE_CLASS} ${className}`}
       >
         {children}
-      </RadixContextMenu.SubContent>
-    </RadixContextMenu.Portal>
+      </SubContent>
+    </Portal>
   );
 }
 
@@ -137,8 +226,11 @@ export function MenuCheckboxItem({
   disabled,
   onCheckedChange,
 }: MenuCheckboxItemProps) {
+  const { ns } = useMenuImpl();
+  const CheckboxItem = ns.CheckboxItem;
+  const ItemIndicator = ns.ItemIndicator;
   return (
-    <RadixContextMenu.CheckboxItem
+    <CheckboxItem
       checked={checked}
       disabled={disabled}
       onSelect={(event) => {
@@ -153,11 +245,61 @@ export function MenuCheckboxItem({
           checked ? 'border-accent bg-accent text-accent-foreground' : 'border-border'
         }`}
       >
-        <RadixContextMenu.ItemIndicator>
+        <ItemIndicator>
           <Check className="h-3 w-3" />
-        </RadixContextMenu.ItemIndicator>
+        </ItemIndicator>
       </span>
       <span className="min-w-0 flex-1 truncate">{children}</span>
-    </RadixContextMenu.CheckboxItem>
+    </CheckboxItem>
+  );
+}
+
+interface MenuRadioGroupProps {
+  children: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+/**
+ * Single-choice section (the card's locker tag, where a mod is either untagged,
+ * a Global type, or one hero). Radix gives the rows role="menuitemradio" and
+ * arrow-key navigation, which a list of hand-rolled buttons does not.
+ */
+export function MenuRadioGroup({ children, value, onValueChange }: MenuRadioGroupProps) {
+  const { ns } = useMenuImpl();
+  const RadioGroup = ns.RadioGroup;
+  return (
+    <RadioGroup value={value} onValueChange={onValueChange}>
+      {children}
+    </RadioGroup>
+  );
+}
+
+interface MenuRadioItemProps {
+  children: ReactNode;
+  value: string;
+  disabled?: boolean;
+  /** Colour of the row while it is the selected value. */
+  tone?: 'accent' | 'info';
+}
+
+export function MenuRadioItem({ children, value, disabled, tone = 'accent' }: MenuRadioItemProps) {
+  const { ns } = useMenuImpl();
+  const RadioItem = ns.RadioItem;
+  const ItemIndicator = ns.ItemIndicator;
+  const checkedToneClass = tone === 'info'
+    ? 'data-[state=checked]:text-state-info'
+    : 'data-[state=checked]:text-accent';
+  return (
+    <RadioItem
+      value={value}
+      disabled={disabled}
+      className={`${ITEM_GEOMETRY_CLASS} ${DEFAULT_TONE_CLASS} ${checkedToneClass}`}
+    >
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      <ItemIndicator className="flex-shrink-0">
+        <Check className="h-3.5 w-3.5" />
+      </ItemIndicator>
+    </RadioItem>
   );
 }

--- a/src/lib/imageActions.ts
+++ b/src/lib/imageActions.ts
@@ -1,0 +1,38 @@
+export function resolveImageSource(src: string): string {
+  try {
+    return new URL(src, window.location.href).toString();
+  } catch {
+    return src;
+  }
+}
+
+export function canOpenImageSource(source: string): boolean {
+  try {
+    const protocol = new URL(source).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export async function copyImageToClipboard(source: string): Promise<void> {
+  if (typeof window.electronAPI.copyImageToClipboard === 'function') {
+    await window.electronAPI.copyImageToClipboard(source);
+    return;
+  }
+
+  if (!('ClipboardItem' in window) || !navigator.clipboard?.write) {
+    throw new Error('Image clipboard API is unavailable until the Electron preload reloads');
+  }
+  const response = await fetch(source);
+  if (!response.ok) {
+    throw new Error(`Image request failed with status ${response.status}`);
+  }
+  const blob = await response.blob();
+  if (!blob.type.startsWith('image/')) {
+    throw new Error('Clipboard source is not an image');
+  }
+  await navigator.clipboard.write([
+    new ClipboardItem({ [blob.type]: blob }),
+  ]);
+}

--- a/src/locales/bg/translation.json
+++ b/src/locales/bg/translation.json
@@ -2454,8 +2454,7 @@
     "copyingAddress": "Копиране на адреса",
     "addressCopied": "Адресът е копиран",
     "copyAddressFailed": "Копирането на адреса е неуспешно",
-    "openImage": "Отваряне на изображението",
-    "revealModInFolder": "Показване на мода в папка"
+    "openImage": "Отваряне на изображението"
   },
   "audioPreview": {
     "audioUnavailable": "Аудиото е недостъпно",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2624,8 +2624,7 @@
     "copyingAddress": "Copying address",
     "addressCopied": "Address copied",
     "copyAddressFailed": "Copy address failed",
-    "openImage": "Open image",
-    "revealModInFolder": "Reveal mod in folder"
+    "openImage": "Open image"
   },
   "audioPreview": {
     "audioUnavailable": "Audio unavailable",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2340,8 +2340,7 @@
     "copyingAddress": "Copie de l'adresse",
     "addressCopied": "Adresse copiée",
     "copyAddressFailed": "Échec de la copie de l'adresse",
-    "openImage": "Ouvrir l'image",
-    "revealModInFolder": "Afficher le mod dans le dossier"
+    "openImage": "Ouvrir l'image"
   },
   "audioPreview": {
     "audioUnavailable": "Audio indisponible",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,23 +1,23 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2152,
+  "totalKeys": 2151,
   "languages": [
     {
       "code": "bg",
       "name": "български",
-      "translatedKeys": 1954,
+      "translatedKeys": 1953,
       "pct": 91
     },
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2152,
+      "translatedKeys": 2151,
       "pct": 100
     },
     {
       "code": "fr",
       "name": "français",
-      "translatedKeys": 1848,
+      "translatedKeys": 1847,
       "pct": 86
     },
     {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -68,9 +68,10 @@ import {
   ExternalLink,
   Star,
   ArrowUpToLine,
+  ImageDown,
+  Link,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { MenuContent, MenuItem, MenuRoot, MenuSeparator, MenuTrigger } from '../components/common/menu';
 import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
@@ -82,7 +83,6 @@ import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterG
 import type { GameBananaModDetails, GameBananaMod, GameBananaItemRef } from '../types/gamebanana';
 import { getModThumbnail } from '../types/gamebanana';
 import ModThumbnail from '../components/ModThumbnail';
-import ImageContextMenu from '../components/ImageContextMenu';
 import AudioPreviewPlayer from '../components/AudioPreviewPlayer';
 import ModDetailsModal from '../components/ModDetailsModal';
 import VariantPickerModal from '../components/VariantPickerModal';
@@ -96,6 +96,7 @@ import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChip
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
+import { canOpenImageSource, copyImageToClipboard, resolveImageSource } from '../lib/imageActions';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
 import { createEnabledVpkRestoreSnapshot, shouldRestoreVpkEnabled, type EnabledVpkRestoreSnapshot } from '../lib/vpkRestore';
 import { modRestoreKey } from '../lib/soloRestore';
@@ -121,7 +122,7 @@ import {
   toggleListMembership,
   writeStoredModLists,
 } from '../lib/modLists';
-import { CreateModListModal, ModListSubmenu } from '../components/installed/ModListMenu';
+import { CreateModListModal } from '../components/installed/ModListMenu';
 import { ManageModListsModal } from '../components/installed/ManageModListsModal';
 import { FilterCheckList } from '../components/installed/FilterCheckList';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
@@ -7022,7 +7023,7 @@ interface ModCardProps {
   onRenameLocal?: (newName: string) => Promise<void>;
   /** Open the imprint details modal. Passed only when the mod's wire
    *  `imprinted` flag is true (the parent gates on it); shown in the card's
-   *  right-click menu and the thumbnail image menus. */
+   *  right-click menu. */
   onViewImprint?: () => void;
   onTagLocker?: (heroName: string | null) => void | Promise<void>;
   onTagGlobal?: (globalType: GlobalModType | null) => void | Promise<void>;
@@ -7083,11 +7084,6 @@ interface ModMediaPreviewProps {
   audioPlayerClassName: string;
   onOpenDetails?: () => void;
   isGroupCard: boolean;
-  onRevealInFolder?: () => void;
-  onViewImprint?: () => void;
-  /** The card's "Add to list" submenu, threaded down because the image menu
-   *  rendered here swallows the right-clicks that would reach the card. */
-  listMenu?: ReactNode;
 }
 
 function SoundPlaceholder() {
@@ -7127,9 +7123,6 @@ function ModMediaPreview({
   audioPlayerClassName,
   onOpenDetails,
   isGroupCard,
-  onRevealInFolder,
-  onViewImprint,
-  listMenu,
 }: ModMediaPreviewProps) {
   const { t } = useTranslation();
   const isSound = mod.sourceSection === 'Sound' && !!mod.audioUrl;
@@ -7157,22 +7150,19 @@ function ModMediaPreview({
       nsfw={mod.nsfw}
       hideNsfw={hideNsfwPreviews}
       className="w-full h-full"
+      enableImageContextMenu={false}
       imageClassName="origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
       mergedSources={mod.merged?.sources}
-      onRevealInFolder={onRevealInFolder}
-      onViewImprint={onViewImprint}
     />
   );
   const soundMedia = mod.thumbnailUrl ? image : soundHeroRenderUrl ? (
-    <ImageContextMenu src={soundHeroRenderUrl} alt={soundHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint} extraItems={listMenu}>
-      <img
-        src={soundHeroRenderUrl}
-        alt={soundHeroName ?? mod.name}
-        draggable={false}
-        className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
-        style={{ objectPosition: `${soundHeroFacePosX}% 25%` }}
-      />
-    </ImageContextMenu>
+    <img
+      src={soundHeroRenderUrl}
+      alt={soundHeroName ?? mod.name}
+      draggable={false}
+      className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
+      style={{ objectPosition: `${soundHeroFacePosX}% 25%` }}
+    />
   ) : (
     <SoundPlaceholder />
   );
@@ -7268,11 +7258,6 @@ interface ModListRowContentProps {
   tagIconClassName: string;
   technicalMetaClasses: string;
   actions: ReactNode;
-  onRevealInFolder?: () => void;
-  onViewImprint?: () => void;
-  /** The card's "Add to list" submenu, threaded down for the same reason as in
-   *  ModMediaPreview: the thumbnail's image menu swallows the card's clicks. */
-  listMenu?: ReactNode;
 }
 
 function lockerHeroSourceLabel(source: Mod['lockerHeroSource']): string {
@@ -7518,9 +7503,6 @@ function ModListRowContent({
   tagIconClassName,
   technicalMetaClasses,
   actions,
-  onRevealInFolder,
-  onViewImprint,
-  listMenu,
 }: ModListRowContentProps) {
   const { t } = useTranslation();
   const isSound = mod.sourceSection === 'Sound' && !!mod.audioUrl;
@@ -7569,15 +7551,13 @@ function ModListRowContent({
         onDragStart={stopMediaDrag}
       >
         {listHeroRenderUrl ? (
-          <ImageContextMenu src={listHeroRenderUrl} alt={listHeroName ?? mod.name} onRevealInFolder={onRevealInFolder} onViewImprint={onViewImprint} extraItems={listMenu}>
-            <img
-              src={listHeroRenderUrl}
-              alt={listHeroName ?? mod.name}
-              draggable={false}
-              className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
-              style={{ objectPosition: `${listHeroFacePosX}% 25%` }}
-            />
-          </ImageContextMenu>
+          <img
+            src={listHeroRenderUrl}
+            alt={listHeroName ?? mod.name}
+            draggable={false}
+            className="block h-full w-full object-cover origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
+            style={{ objectPosition: `${listHeroFacePosX}% 25%` }}
+          />
         ) : isSound && !mod.thumbnailUrl ? (
           <SoundPlaceholder />
         ) : (
@@ -7587,8 +7567,7 @@ function ModListRowContent({
             nsfw={mod.nsfw}
             hideNsfw={hideNsfwPreviews}
             className="w-full h-full"
-            onRevealInFolder={onRevealInFolder}
-            onViewImprint={onViewImprint}
+            enableImageContextMenu={false}
             imageClassName="origin-center transition-transform duration-200 group-enabled:group-hover:scale-[1.03]"
             mergedSources={mod.merged?.sources}
           />
@@ -7706,28 +7685,22 @@ function ModCard({
   const { t } = useTranslation();
   const hasConflicts = conflicts.length > 0;
   const isGroupCard = !!group;
-  // Shared by the card's own context menu and the image context menus on the
-  // thumbnail (which swallow right-clicks before they reach the card).
   const handleRevealInFolder = () => {
     revealModInFolder(mod.id).catch((err) => {
       console.error('[Installed] Failed to reveal mod in folder:', err);
     });
   };
-  const revealAction = selectMode ? undefined : handleRevealInFolder;
-  // "View imprint" mirrors reveal-in-folder: offered on the card's right-click
-  // menu and the image menus (which swallow right-clicks), hidden in select mode.
-  const imprintAction = selectMode ? undefined : onViewImprint;
-  // "Add to list" follows the same rules: shared across the card menu and both
-  // image menus, and stood down in select mode where clicks belong to selection.
-  const listSubmenu =
-    !selectMode && lists && onToggleList && onCreateList ? (
-      <ModListSubmenu
-        lists={lists}
-        memberIds={listIds}
-        onToggle={onToggleList}
-        onCreateNew={onCreateList}
-      />
-    ) : null;
+  const hasListActions = !selectMode && !!lists && !!onToggleList && !!onCreateList;
+  const menuHeroName = mod.sourceSection === 'Sound' && !mod.thumbnailUrl
+    ? mod.lockerHero ?? inferHeroFromTitle(mod.name)
+    : null;
+  const rawCardImageSource = mod.thumbnailUrl
+    ?? (menuHeroName ? getHeroRenderPath(menuHeroName) : undefined)
+    ?? mod.merged?.sources.find((source) => !!source.thumbnailUrl)?.thumbnailUrl;
+  const cardImageSource = rawCardImageSource && !(mod.nsfw && hideNsfwPreviews)
+    ? resolveImageSource(rawCardImageSource)
+    : null;
+  const canOpenCardImage = cardImageSource ? canOpenImageSource(cardImageSource) : false;
   const variantStatusLabel = group ? `${group.enabledCount}/${group.variantCount}` : null;
   const enabledTitle = group?.enabledLabels.join(', ') ?? '';
   const variantStatusTitle = group
@@ -7735,6 +7708,9 @@ function ModCard({
     : '';
   const [menuOpen, setMenuOpen] = useState(false);
   const [tagPickerOpen, setTagPickerOpen] = useState(false);
+  const [listPickerOpen, setListPickerOpen] = useState(false);
+  const [imagePickerOpen, setImagePickerOpen] = useState(false);
+  const [imageActionBusy, setImageActionBusy] = useState(false);
   const [menuBusy, setMenuBusy] = useState(false);
   const [menuError, setMenuError] = useState<string | null>(null);
   // The menu (and its tall tag picker) opens upward by default, but for cards
@@ -7749,6 +7725,65 @@ function ModCard({
   const menuRef = useRef<HTMLDivElement>(null);
   const menuPanelRef = useRef<HTMLDivElement>(null);
 
+  const closeActionsMenu = () => {
+    setMenuOpen(false);
+    setTagPickerOpen(false);
+    setListPickerOpen(false);
+    setImagePickerOpen(false);
+  };
+
+  const openActionsMenu = () => {
+    if (!menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    setMenuRect(rect);
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    setMenuPlacement(spaceAbove < 340 && spaceBelow > spaceAbove ? 'down' : 'up');
+    setTagPickerOpen(false);
+    setListPickerOpen(false);
+    setImagePickerOpen(false);
+    setMenuError(null);
+    setMenuOpen(true);
+  };
+
+  const copyCardImage = async () => {
+    if (!cardImageSource || imageActionBusy) return;
+    setImageActionBusy(true);
+    setMenuError(null);
+    try {
+      await copyImageToClipboard(cardImageSource);
+      closeActionsMenu();
+      showToast(t('imageContextMenu.imageCopied'), { tone: 'success', duration: 2200 });
+    } catch (err) {
+      console.error('[Installed] Failed to copy card image:', err);
+      setMenuError(t('imageContextMenu.copyImageFailed'));
+    } finally {
+      setImageActionBusy(false);
+    }
+  };
+
+  const copyCardImageAddress = async () => {
+    if (!cardImageSource || imageActionBusy) return;
+    setImageActionBusy(true);
+    setMenuError(null);
+    try {
+      await navigator.clipboard.writeText(cardImageSource);
+      closeActionsMenu();
+      showToast(t('imageContextMenu.addressCopied'), { tone: 'success', duration: 2200 });
+    } catch (err) {
+      console.error('[Installed] Failed to copy card image address:', err);
+      setMenuError(t('imageContextMenu.copyAddressFailed'));
+    } finally {
+      setImageActionBusy(false);
+    }
+  };
+
+  const openCardImage = () => {
+    if (!cardImageSource) return;
+    closeActionsMenu();
+    window.open(cardImageSource, '_blank', 'noopener,noreferrer');
+  };
+
   useEffect(() => {
     if (!menuOpen) return;
     const onMouseDown = (event: MouseEvent) => {
@@ -7759,11 +7794,15 @@ function ModCard({
       if (menuPanelRef.current?.contains(target)) return;
       setMenuOpen(false);
       setTagPickerOpen(false);
+      setListPickerOpen(false);
+      setImagePickerOpen(false);
     };
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setMenuOpen(false);
         setTagPickerOpen(false);
+        setListPickerOpen(false);
+        setImagePickerOpen(false);
       }
     };
     // Keep the portaled menu anchored to its card as the list scrolls/resizes.
@@ -8009,21 +8048,8 @@ function ModCard({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            setMenuOpen((open) => {
-              const willOpen = !open;
-              if (willOpen && menuRef.current) {
-                const rect = menuRef.current.getBoundingClientRect();
-                setMenuRect(rect);
-                // The menu can grow tall (tag picker). Prefer opening upward,
-                // but flip down when there's clearly more room below.
-                const spaceAbove = rect.top;
-                const spaceBelow = window.innerHeight - rect.bottom;
-                setMenuPlacement(spaceAbove < 340 && spaceBelow > spaceAbove ? 'down' : 'up');
-              }
-              return willOpen;
-            });
-            setTagPickerOpen(false);
-            setMenuError(null);
+            if (menuOpen) closeActionsMenu();
+            else openActionsMenu();
           }}
           className={`${utilityActionClasses} ${selectMode ? 'hidden' : `${isList ? '' : hoverRevealClasses} aria-expanded:opacity-100 aria-expanded:pointer-events-auto`}`}
           title={t('installed.card.moreActions')}
@@ -8097,6 +8123,159 @@ function ModCard({
                 {t('installed.card.viewAuthorPage')}
               </button>
             )}
+            {cardImageSource && (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-expanded={imagePickerOpen}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setImagePickerOpen((open) => !open);
+                    setListPickerOpen(false);
+                    setTagPickerOpen(false);
+                  }}
+                  className={menuItemClasses}
+                >
+                  <ImagePlus className="w-3.5 h-3.5" />
+                  {t('imageContextMenu.image')}
+                </button>
+                {imagePickerOpen && (
+                  <div className="my-1 rounded-md border border-border bg-bg-primary/40 p-1">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={imageActionBusy}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void copyCardImage();
+                      }}
+                      className={menuItemClasses}
+                    >
+                      {imageActionBusy ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      ) : (
+                        <ImageDown className="w-3.5 h-3.5" />
+                      )}
+                      {imageActionBusy ? t('imageContextMenu.copyingImage') : t('imageContextMenu.copyImage')}
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={imageActionBusy}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void copyCardImageAddress();
+                      }}
+                      className={menuItemClasses}
+                    >
+                      <Link className="w-3.5 h-3.5" />
+                      {t('imageContextMenu.copyImageAddress')}
+                    </button>
+                    {canOpenCardImage && (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openCardImage();
+                        }}
+                        className={menuItemClasses}
+                      >
+                        <ExternalLink className="w-3.5 h-3.5" />
+                        {t('imageContextMenu.openImage')}
+                      </button>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+            <div className="my-1 h-px bg-border" />
+            {hasListActions && lists && onToggleList && onCreateList && (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-expanded={listPickerOpen}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setListPickerOpen((open) => !open);
+                    setTagPickerOpen(false);
+                    setImagePickerOpen(false);
+                  }}
+                  className={menuItemClasses}
+                >
+                  <List className="w-3.5 h-3.5" />
+                  {t('installed.lists.menuTrigger')}
+                </button>
+                {listPickerOpen && (
+                  <div className="my-1 max-h-64 overflow-y-auto rounded-md border border-border bg-bg-primary/40 p-1">
+                    {lists.map((list) => {
+                      const checked = listIds.includes(list.id);
+                      return (
+                        <button
+                          key={list.id}
+                          type="button"
+                          role="menuitemcheckbox"
+                          aria-checked={checked}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleList(list.id);
+                          }}
+                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary"
+                        >
+                          <span className="truncate">{list.name}</span>
+                          {checked && <Check className="w-3.5 h-3.5 flex-shrink-0 text-accent" />}
+                        </button>
+                      );
+                    })}
+                    {lists.length > 0 && <div className="my-1 h-px bg-border" />}
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        closeActionsMenu();
+                        onCreateList();
+                      }}
+                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary"
+                    >
+                      <FilePlus className="w-3.5 h-3.5" />
+                      {t('installed.lists.newList')}
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => {
+                e.stopPropagation();
+                closeActionsMenu();
+                handleRevealInFolder();
+              }}
+              className={menuItemClasses}
+            >
+              <FolderOpen className="w-3.5 h-3.5" />
+              {t('installed.card.revealInFolder')}
+            </button>
+            {onViewImprint && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeActionsMenu();
+                  onViewImprint();
+                }}
+                className={menuItemClasses}
+              >
+                <Fingerprint className="w-3.5 h-3.5" />
+                {t('installed.imprintDetails.menuEntry')}
+              </button>
+            )}
+            <div className="my-1 h-px bg-border" />
             {onSoloLaunch && (
               <button
                 type="button"
@@ -8143,6 +8322,8 @@ function ModCard({
                   onClick={(e) => {
                     e.stopPropagation();
                     setTagPickerOpen((open) => !open);
+                    setListPickerOpen(false);
+                    setImagePickerOpen(false);
                   }}
                   className={menuItemClasses}
                 >
@@ -8314,13 +8495,14 @@ function ModCard({
     </div>
   );
   return (
-    <MenuRoot>
-      {/* Disabled in select mode so right-click doesn't fight the full-card
-          select overlay. Thumbnail right-clicks never reach here: the image
-          context menu's trigger stops propagation. */}
-      <MenuTrigger asChild disabled={selectMode}>
     <div
       data-mod-entry-key={entryKey}
+      onContextMenu={(event) => {
+        if (selectMode) return;
+        event.preventDefault();
+        event.stopPropagation();
+        openActionsMenu();
+      }}
       className={`group/card relative rounded-xl border transform-gpu ${isList ? 'transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ' + stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : mod.priorityMod ? 'ring-1 ring-accent/40' : ''}`}
     >
       <div className={isList ? 'contents' : ''}>
@@ -8369,9 +8551,6 @@ function ModCard({
             tagIconClassName={tagIconClassName}
             technicalMetaClasses={technicalMetaClasses}
             actions={actions}
-            onRevealInFolder={revealAction}
-            onViewImprint={imprintAction}
-            listMenu={listSubmenu}
           />
         ) : (
         <>
@@ -8484,9 +8663,6 @@ function ModCard({
             audioPlayerClassName={audioPlayerClassName}
             onOpenDetails={onOpenDetails}
             isGroupCard={isGroupCard}
-            onRevealInFolder={revealAction}
-            onViewImprint={imprintAction}
-            listMenu={listSubmenu}
           />
         );
         })()}
@@ -8565,24 +8741,6 @@ function ModCard({
       </div>
 
     </div>
-      </MenuTrigger>
-      <MenuContent>
-        {listSubmenu && (
-          <>
-            {listSubmenu}
-            <MenuSeparator />
-          </>
-        )}
-        <MenuItem icon={FolderOpen} onSelect={handleRevealInFolder}>
-          {t('installed.card.revealInFolder')}
-        </MenuItem>
-        {onViewImprint && (
-          <MenuItem icon={Fingerprint} onSelect={onViewImprint}>
-            {t('installed.imprintDetails.menuEntry')}
-          </MenuItem>
-        )}
-      </MenuContent>
-    </MenuRoot>
   );
 }
 

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -1,4 +1,4 @@
-import { memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import {
@@ -72,6 +72,19 @@ import {
   Link,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import {
+  MenuContent,
+  MenuItem,
+  MenuLabel,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuRoot,
+  MenuSeparator,
+  MenuSub,
+  MenuSubContent,
+  MenuSubTrigger,
+  MenuTrigger,
+} from '../components/common/menu';
 import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
@@ -122,7 +135,7 @@ import {
   toggleListMembership,
   writeStoredModLists,
 } from '../lib/modLists';
-import { CreateModListModal } from '../components/installed/ModListMenu';
+import { CreateModListModal, ModListSubmenu } from '../components/installed/ModListMenu';
 import { ManageModListsModal } from '../components/installed/ManageModListsModal';
 import { FilterCheckList } from '../components/installed/FilterCheckList';
 import { Button, CheckboxMark, IconButton, ModalHeader, Tag } from '../components/common/ui';
@@ -7694,145 +7707,72 @@ function ModCard({
   const menuHeroName = mod.sourceSection === 'Sound' && !mod.thumbnailUrl
     ? mod.lockerHero ?? inferHeroFromTitle(mod.name)
     : null;
-  const rawCardImageSource = mod.thumbnailUrl
+  // Right-clicking one tile of a merged mod's collage should act on that tile,
+  // not on the merged mod's first source. Captured from the pointer target
+  // before Radix opens the context menu, and cleared both when that menu closes
+  // and when the three-dot button opens the same actions instead.
+  const [pointerImageSrc, setPointerImageSrc] = useState<string | null>(null);
+  const rawCardImageSource = pointerImageSrc
+    ?? mod.thumbnailUrl
     ?? (menuHeroName ? getHeroRenderPath(menuHeroName) : undefined)
     ?? mod.merged?.sources.find((source) => !!source.thumbnailUrl)?.thumbnailUrl;
   const cardImageSource = rawCardImageSource && !(mod.nsfw && hideNsfwPreviews)
     ? resolveImageSource(rawCardImageSource)
     : null;
   const canOpenCardImage = cardImageSource ? canOpenImageSource(cardImageSource) : false;
+  const captureContextImage = (event: ReactMouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement | null;
+    const cell = target?.closest?.('[data-collage-src]');
+    setPointerImageSrc(cell?.getAttribute('data-collage-src') ?? null);
+  };
   const variantStatusLabel = group ? `${group.enabledCount}/${group.variantCount}` : null;
   const enabledTitle = group?.enabledLabels.join(', ') ?? '';
   const variantStatusTitle = group
     ? t('installed.card.variantStatusTitle', { labels: enabledTitle || t('installed.card.noFilesEnabled') })
     : '';
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [tagPickerOpen, setTagPickerOpen] = useState(false);
-  const [listPickerOpen, setListPickerOpen] = useState(false);
-  const [imagePickerOpen, setImagePickerOpen] = useState(false);
-  const [imageActionBusy, setImageActionBusy] = useState(false);
   const [menuBusy, setMenuBusy] = useState(false);
-  const [menuError, setMenuError] = useState<string | null>(null);
-  // The menu (and its tall tag picker) opens upward by default, but for cards
-  // near the top of the scroll area that clips it. Flip downward when there's
-  // little room above. Measured from the trigger on open.
-  const [menuPlacement, setMenuPlacement] = useState<'up' | 'down'>('up');
-  // Trigger rect captured on open (and on scroll/resize) so the menu can be
-  // portaled to <body> and positioned in fixed coordinates. The card sits in an
-  // overflow-auto/transform-gpu subtree that would otherwise clip an absolutely
-  // (or even fixed) positioned menu, hiding its left edge behind the sidebar.
-  const [menuRect, setMenuRect] = useState<DOMRect | null>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const menuPanelRef = useRef<HTMLDivElement>(null);
 
-  const closeActionsMenu = () => {
-    setMenuOpen(false);
-    setTagPickerOpen(false);
-    setListPickerOpen(false);
-    setImagePickerOpen(false);
-  };
-
-  const openActionsMenu = () => {
-    if (!menuRef.current) return;
-    const rect = menuRef.current.getBoundingClientRect();
-    setMenuRect(rect);
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    setMenuPlacement(spaceAbove < 340 && spaceBelow > spaceAbove ? 'down' : 'up');
-    setTagPickerOpen(false);
-    setListPickerOpen(false);
-    setImagePickerOpen(false);
-    setMenuError(null);
-    setMenuOpen(true);
+  // The menu closes on select (Radix default), so outcomes are reported by
+  // toast rather than by a banner inside a panel the user can no longer see.
+  const reportMenuError = (context: string, err: unknown) => {
+    console.error(`[Installed] ${context}:`, err);
+    showToast(err instanceof Error ? err.message : String(err), { tone: 'error', duration: 4000 });
   };
 
   const copyCardImage = async () => {
-    if (!cardImageSource || imageActionBusy) return;
-    setImageActionBusy(true);
-    setMenuError(null);
+    if (!cardImageSource) return;
     try {
       await copyImageToClipboard(cardImageSource);
-      closeActionsMenu();
       showToast(t('imageContextMenu.imageCopied'), { tone: 'success', duration: 2200 });
     } catch (err) {
       console.error('[Installed] Failed to copy card image:', err);
-      setMenuError(t('imageContextMenu.copyImageFailed'));
-    } finally {
-      setImageActionBusy(false);
+      showToast(t('imageContextMenu.copyImageFailed'), { tone: 'error', duration: 4000 });
     }
   };
 
   const copyCardImageAddress = async () => {
-    if (!cardImageSource || imageActionBusy) return;
-    setImageActionBusy(true);
-    setMenuError(null);
+    if (!cardImageSource) return;
     try {
       await navigator.clipboard.writeText(cardImageSource);
-      closeActionsMenu();
       showToast(t('imageContextMenu.addressCopied'), { tone: 'success', duration: 2200 });
     } catch (err) {
       console.error('[Installed] Failed to copy card image address:', err);
-      setMenuError(t('imageContextMenu.copyAddressFailed'));
-    } finally {
-      setImageActionBusy(false);
+      showToast(t('imageContextMenu.copyAddressFailed'), { tone: 'error', duration: 4000 });
     }
   };
 
   const openCardImage = () => {
     if (!cardImageSource) return;
-    closeActionsMenu();
     window.open(cardImageSource, '_blank', 'noopener,noreferrer');
   };
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onMouseDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      // The menu is portaled out of menuRef, so check both the trigger and the
-      // portaled panel before treating a click as "outside".
-      if (menuRef.current?.contains(target)) return;
-      if (menuPanelRef.current?.contains(target)) return;
-      setMenuOpen(false);
-      setTagPickerOpen(false);
-      setListPickerOpen(false);
-      setImagePickerOpen(false);
-    };
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMenuOpen(false);
-        setTagPickerOpen(false);
-        setListPickerOpen(false);
-        setImagePickerOpen(false);
-      }
-    };
-    // Keep the portaled menu anchored to its card as the list scrolls/resizes.
-    // Inner-container scroll doesn't bubble, so listen in the capture phase.
-    const reposition = () => {
-      if (menuRef.current) setMenuRect(menuRef.current.getBoundingClientRect());
-    };
-    window.addEventListener('mousedown', onMouseDown);
-    window.addEventListener('keydown', onKey);
-    window.addEventListener('scroll', reposition, true);
-    window.addEventListener('resize', reposition);
-    return () => {
-      window.removeEventListener('mousedown', onMouseDown);
-      window.removeEventListener('keydown', onKey);
-      window.removeEventListener('scroll', reposition, true);
-      window.removeEventListener('resize', reposition);
-    };
-  }, [menuOpen]);
 
   const applyLockerTag = async (heroName: string | null) => {
     if (!onTagLocker || menuBusy) return;
     setMenuBusy(true);
-    setMenuError(null);
     try {
       await onTagLocker(heroName);
-      setMenuOpen(false);
-      setTagPickerOpen(false);
     } catch (err) {
-      console.error('[Installed] Failed to set locker hero:', err);
-      setMenuError(err instanceof Error ? err.message : String(err));
+      reportMenuError('Failed to set locker hero', err);
     } finally {
       setMenuBusy(false);
     }
@@ -7841,14 +7781,10 @@ function ModCard({
   const applyGlobalTag = async (globalType: GlobalModType) => {
     if (!onTagGlobal || menuBusy) return;
     setMenuBusy(true);
-    setMenuError(null);
     try {
       await onTagGlobal(globalType);
-      setMenuOpen(false);
-      setTagPickerOpen(false);
     } catch (err) {
-      console.error('[Installed] Failed to set global locker tag:', err);
-      setMenuError(err instanceof Error ? err.message : String(err));
+      reportMenuError('Failed to set global locker tag', err);
     } finally {
       setMenuBusy(false);
     }
@@ -7860,13 +7796,10 @@ function ModCard({
   const togglePriority = async () => {
     if (!onSetPriority || menuBusy) return;
     setMenuBusy(true);
-    setMenuError(null);
     try {
       await onSetPriority(!mod.priorityMod);
-      setMenuOpen(false);
     } catch (err) {
-      console.error('[Installed] Failed to change Global placement:', err);
-      setMenuError(err instanceof Error ? err.message : String(err));
+      reportMenuError('Failed to change Global placement', err);
     } finally {
       setMenuBusy(false);
     }
@@ -7875,15 +7808,11 @@ function ModCard({
   const clearLockerTag = async () => {
     if (menuBusy) return;
     setMenuBusy(true);
-    setMenuError(null);
     try {
       await onTagLocker?.(null);
       await onTagGlobal?.(null);
-      setMenuOpen(false);
-      setTagPickerOpen(false);
     } catch (err) {
-      console.error('[Installed] Failed to clear locker tag:', err);
-      setMenuError(err instanceof Error ? err.message : String(err));
+      reportMenuError('Failed to clear locker tag', err);
     } finally {
       setMenuBusy(false);
     }
@@ -7946,8 +7875,6 @@ function ModCard({
   const favoriteVisibilityClasses = favorite
     ? (selectMode ? 'hidden' : '')
     : hoverActionVisibilityClasses;
-  const menuItemClasses = 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary focus:outline-none focus-visible:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50';
-  const dangerMenuItemClasses = 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-state-danger hover:bg-state-danger/10 focus:outline-none focus-visible:bg-state-danger/10 disabled:cursor-not-allowed disabled:opacity-50';
   const toggleHitboxClasses = 'inline-flex h-7 w-12 items-center justify-center rounded-md cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary';
   const toggleTrackClasses = `relative h-6 w-11 rounded-full transition-colors duration-200 ${
     mod.enabled ? 'bg-accent shadow-[0_0_0_1px_rgba(255,122,47,0.25)]' : 'bg-bg-tertiary border border-border group-hover/toggle:border-white/20'
@@ -8009,6 +7936,172 @@ function ModCard({
     : favorite
       ? t('installed.card.removeDisabledFavorite', { name: mod.name })
       : t('installed.card.addDisabledFavorite', { name: mod.name });
+
+  // One canonical list of card actions, mounted twice: once under the
+  // right-click (context) root wrapping the whole card, once under the
+  // dropdown root on the three-dot button. Only one of the two is open at a
+  // time, so this renders once in practice.
+  const hasTopActions = !!onEditLocal || !!onOpenDetails || !!onViewAuthor || !!cardImageSource;
+  const hasSecondaryActions =
+    !!onSoloLaunch || !!onSetPriority || !!onTagLocker || !!onTagGlobal || !!onFixUnknown
+    || !!(mod.merged && (onCopyShareCode || onUnmerge));
+  const cardMenuItems = (
+    <>
+      {onEditLocal && (
+        <MenuItem icon={Pencil} onSelect={onEditLocal}>
+          {t('installed.card.edit')}
+        </MenuItem>
+      )}
+      {onOpenDetails && (
+        <MenuItem icon={Info} onSelect={onOpenDetails}>
+          {t('installed.card.viewDetails')}
+        </MenuItem>
+      )}
+      {onViewAuthor && (
+        <MenuItem icon={Banana} onSelect={onViewAuthor}>
+          {t('installed.card.viewAuthorPage')}
+        </MenuItem>
+      )}
+      {cardImageSource && (
+        <MenuSub>
+          <MenuSubTrigger icon={ImagePlus}>{t('imageContextMenu.image')}</MenuSubTrigger>
+          <MenuSubContent>
+            <MenuItem icon={ImageDown} onSelect={() => void copyCardImage()}>
+              {t('imageContextMenu.copyImage')}
+            </MenuItem>
+            <MenuItem icon={Link} onSelect={() => void copyCardImageAddress()}>
+              {t('imageContextMenu.copyImageAddress')}
+            </MenuItem>
+            {canOpenCardImage && (
+              <MenuItem icon={ExternalLink} onSelect={openCardImage}>
+                {t('imageContextMenu.openImage')}
+              </MenuItem>
+            )}
+          </MenuSubContent>
+        </MenuSub>
+      )}
+      {hasTopActions && <MenuSeparator />}
+      {hasListActions && lists && onToggleList && onCreateList && (
+        <ModListSubmenu
+          lists={lists}
+          memberIds={listIds}
+          onToggle={onToggleList}
+          onCreateNew={onCreateList}
+        />
+      )}
+      <MenuItem icon={FolderOpen} onSelect={handleRevealInFolder}>
+        {t('installed.card.revealInFolder')}
+      </MenuItem>
+      {onViewImprint && (
+        <MenuItem icon={Fingerprint} onSelect={onViewImprint}>
+          {t('installed.imprintDetails.menuEntry')}
+        </MenuItem>
+      )}
+      {hasSecondaryActions && <MenuSeparator />}
+      {onSoloLaunch && (
+        <MenuItem icon={Beaker} disabled={soloBusy} onSelect={onSoloLaunch}>
+          {t('installed.card.soloLaunch')}
+        </MenuItem>
+      )}
+      {onSetPriority && (
+        <MenuItem
+          icon={ArrowUpToLine}
+          disabled={menuBusy}
+          tone={mod.priorityMod ? 'success' : 'default'}
+          onSelect={() => void togglePriority()}
+        >
+          {menuBusy
+            ? t('installed.priority.busy')
+            : mod.priorityMod
+              ? t('installed.priority.clear')
+              : t('installed.priority.make')}
+        </MenuItem>
+      )}
+      {(onTagLocker || onTagGlobal) && (
+        <MenuSub>
+          <MenuSubTrigger icon={TagIcon}>{t('installed.tag.setLockerTag')}</MenuSubTrigger>
+          {/* Cap the height: the hero list is the full roster and would
+              otherwise run taller than the window. */}
+          <MenuSubContent className="max-h-72 overflow-y-auto">
+            <MenuItem
+              disabled={menuBusy || (!mod.lockerHero && !mod.globalType)}
+              onSelect={() => void clearLockerTag()}
+            >
+              {t('installed.tag.clearLockerTag')}
+            </MenuItem>
+            <MenuSeparator />
+            {/* Global type and hero are independent axes (setModGlobalType does
+                not clear lockerHero), so they are two radio groups rather than
+                one. "Clear locker tag" above resets both. */}
+            {onTagGlobal && (
+              <>
+                <MenuLabel>{t('installed.tag.global')}</MenuLabel>
+                <MenuRadioGroup
+                  value={mod.globalType ?? ''}
+                  onValueChange={(value) => void applyGlobalTag(value as GlobalModType)}
+                >
+                  {GLOBAL_MOD_TYPE_ORDER.map((type) => (
+                    <MenuRadioItem key={type} value={type} disabled={menuBusy}>
+                      {GLOBAL_MOD_TYPE_LABELS[type]}
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+                <MenuSeparator />
+              </>
+            )}
+            <MenuLabel>{t('installed.tag.hero')}</MenuLabel>
+            <MenuRadioGroup
+              value={canonicalHeroName(mod.lockerHero) ?? ''}
+              onValueChange={(value) => void applyLockerTag(value)}
+            >
+              {HERO_NAMES_SORTED.map((heroName) => (
+                <MenuRadioItem
+                  key={heroName}
+                  value={heroName}
+                  disabled={menuBusy}
+                  // Inferred tags read as informational, manual ones as chosen.
+                  tone={mod.lockerHeroSource === 'manual' ? 'accent' : 'info'}
+                >
+                  <HeroTagLabel heroName={heroName} />
+                </MenuRadioItem>
+              ))}
+            </MenuRadioGroup>
+          </MenuSubContent>
+        </MenuSub>
+      )}
+      {onFixUnknown && (
+        <MenuItem
+          icon={fixingUnknown ? Loader2 : mod.isUnknown ? Wrench : Link2}
+          spinning={fixingUnknown}
+          onSelect={onFixUnknown}
+        >
+          {mod.isUnknown ? t('installed.card.fixUnknownMatch') : t('installed.unknown.linkToGamebanana')}
+        </MenuItem>
+      )}
+      {mod.merged && onCopyShareCode && (
+        <MenuItem icon={Share2} onSelect={onCopyShareCode}>
+          {t('installed.merge.copyShareCode')}
+        </MenuItem>
+      )}
+      {mod.merged && onUnmerge && (
+        <MenuItem icon={Scissors} onSelect={onUnmerge}>
+          {t('installed.merge.unmerge')}
+        </MenuItem>
+      )}
+      {/* A merged mod is removed via Unmerge (which deletes the merged VPK
+          and restores its sources), so a raw Delete alongside it would be
+          redundant and confusing. Non-merged mods keep Delete. */}
+      {!mod.merged && (
+        <>
+          <MenuSeparator />
+          <MenuItem icon={Trash2} tone="danger" onSelect={onDelete}>
+            {t('common.actions.delete')}
+          </MenuItem>
+        </>
+      )}
+    </>
+  );
+
   const actions = (
     <div className="ml-auto flex items-center gap-1">
       {onToggleFavorite && (
@@ -8043,438 +8136,24 @@ function ModCard({
           <Trash2 className="w-4 h-4" />
         </button>
       )}
-      <div className="relative" ref={menuRef} data-card-action="true">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (menuOpen) closeActionsMenu();
-            else openActionsMenu();
-          }}
-          className={`${utilityActionClasses} ${selectMode ? 'hidden' : `${isList ? '' : hoverRevealClasses} aria-expanded:opacity-100 aria-expanded:pointer-events-auto`}`}
-          title={t('installed.card.moreActions')}
-          aria-label={t('installed.card.moreActionsFor', { name: mod.name })}
-          aria-expanded={menuOpen}
-          data-card-action="true"
-        >
-          <MoreHorizontal className="w-4 h-4" />
-        </button>
-        {menuOpen && menuRect && createPortal(
-          <div
-            ref={menuPanelRef}
-            role="menu"
-            data-card-menu-open
-            className="z-[80] w-56 max-h-[70vh] overflow-y-auto rounded-lg border border-border bg-bg-secondary p-1 shadow-xl animate-fade-in"
-            style={{
-              position: 'fixed',
-              right: Math.max(8, window.innerWidth - menuRect.right),
-              ...(menuPlacement === 'up'
-                ? { bottom: window.innerHeight - menuRect.top + 8 }
-                : { top: menuRect.bottom + 8 }),
-            }}
-          >
-            {menuError && (
-              <div className="mb-1 rounded-md border border-state-danger/30 bg-state-danger/10 px-2 py-1.5 text-xs text-state-danger">
-                {menuError}
-              </div>
-            )}
-            {onEditLocal && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onEditLocal();
-                }}
-                className={menuItemClasses}
-              >
-                <Pencil className="w-3.5 h-3.5" />
-                {t('installed.card.edit')}
-              </button>
-            )}
-            {onOpenDetails && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onOpenDetails();
-                }}
-                className={menuItemClasses}
-              >
-                <Info className="w-3.5 h-3.5" />
-                {t('installed.card.viewDetails')}
-              </button>
-            )}
-            {onViewAuthor && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onViewAuthor();
-                }}
-                className={menuItemClasses}
-              >
-                <Banana className="w-3.5 h-3.5" />
-                {t('installed.card.viewAuthorPage')}
-              </button>
-            )}
-            {cardImageSource && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  aria-expanded={imagePickerOpen}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setImagePickerOpen((open) => !open);
-                    setListPickerOpen(false);
-                    setTagPickerOpen(false);
-                  }}
-                  className={menuItemClasses}
-                >
-                  <ImagePlus className="w-3.5 h-3.5" />
-                  {t('imageContextMenu.image')}
-                </button>
-                {imagePickerOpen && (
-                  <div className="my-1 rounded-md border border-border bg-bg-primary/40 p-1">
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={imageActionBusy}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void copyCardImage();
-                      }}
-                      className={menuItemClasses}
-                    >
-                      {imageActionBusy ? (
-                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                      ) : (
-                        <ImageDown className="w-3.5 h-3.5" />
-                      )}
-                      {imageActionBusy ? t('imageContextMenu.copyingImage') : t('imageContextMenu.copyImage')}
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={imageActionBusy}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void copyCardImageAddress();
-                      }}
-                      className={menuItemClasses}
-                    >
-                      <Link className="w-3.5 h-3.5" />
-                      {t('imageContextMenu.copyImageAddress')}
-                    </button>
-                    {canOpenCardImage && (
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openCardImage();
-                        }}
-                        className={menuItemClasses}
-                      >
-                        <ExternalLink className="w-3.5 h-3.5" />
-                        {t('imageContextMenu.openImage')}
-                      </button>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-            <div className="my-1 h-px bg-border" />
-            {hasListActions && lists && onToggleList && onCreateList && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  aria-expanded={listPickerOpen}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setListPickerOpen((open) => !open);
-                    setTagPickerOpen(false);
-                    setImagePickerOpen(false);
-                  }}
-                  className={menuItemClasses}
-                >
-                  <List className="w-3.5 h-3.5" />
-                  {t('installed.lists.menuTrigger')}
-                </button>
-                {listPickerOpen && (
-                  <div className="my-1 max-h-64 overflow-y-auto rounded-md border border-border bg-bg-primary/40 p-1">
-                    {lists.map((list) => {
-                      const checked = listIds.includes(list.id);
-                      return (
-                        <button
-                          key={list.id}
-                          type="button"
-                          role="menuitemcheckbox"
-                          aria-checked={checked}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onToggleList(list.id);
-                          }}
-                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary"
-                        >
-                          <span className="truncate">{list.name}</span>
-                          {checked && <Check className="w-3.5 h-3.5 flex-shrink-0 text-accent" />}
-                        </button>
-                      );
-                    })}
-                    {lists.length > 0 && <div className="my-1 h-px bg-border" />}
-                    <button
-                      type="button"
-                      role="menuitem"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        closeActionsMenu();
-                        onCreateList();
-                      }}
-                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-text-primary hover:bg-bg-tertiary"
-                    >
-                      <FilePlus className="w-3.5 h-3.5" />
-                      {t('installed.lists.newList')}
-                    </button>
-                  </div>
-                )}
-              </>
-            )}
+      <div className="relative" data-card-action="true">
+        <MenuRoot kind="dropdown" onOpenChange={(open) => { if (open) setPointerImageSrc(null); }}>
+          <MenuTrigger asChild disabled={selectMode}>
             <button
               type="button"
-              role="menuitem"
-              onClick={(e) => {
-                e.stopPropagation();
-                closeActionsMenu();
-                handleRevealInFolder();
-              }}
-              className={menuItemClasses}
+              onClick={(e) => e.stopPropagation()}
+              className={`${utilityActionClasses} ${selectMode ? 'hidden' : `${isList ? '' : hoverRevealClasses} aria-expanded:opacity-100 aria-expanded:pointer-events-auto`}`}
+              title={t('installed.card.moreActions')}
+              aria-label={t('installed.card.moreActionsFor', { name: mod.name })}
+              data-card-action="true"
             >
-              <FolderOpen className="w-3.5 h-3.5" />
-              {t('installed.card.revealInFolder')}
+              <MoreHorizontal className="w-4 h-4" />
             </button>
-            {onViewImprint && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  closeActionsMenu();
-                  onViewImprint();
-                }}
-                className={menuItemClasses}
-              >
-                <Fingerprint className="w-3.5 h-3.5" />
-                {t('installed.imprintDetails.menuEntry')}
-              </button>
-            )}
-            <div className="my-1 h-px bg-border" />
-            {onSoloLaunch && (
-              <button
-                type="button"
-                role="menuitem"
-                disabled={soloBusy}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onSoloLaunch();
-                }}
-                className={menuItemClasses}
-              >
-                <Beaker className="w-3.5 h-3.5" />
-                {t('installed.card.soloLaunch')}
-              </button>
-            )}
-            {onSetPriority && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void togglePriority();
-                }}
-                disabled={menuBusy}
-                title={t('installed.priority.hint')}
-                className={`${menuItemClasses} disabled:cursor-not-allowed disabled:opacity-50 ${
-                  mod.priorityMod ? 'text-accent' : ''
-                }`}
-              >
-                <ArrowUpToLine className="w-3.5 h-3.5" />
-                {menuBusy
-                  ? t('installed.priority.busy')
-                  : mod.priorityMod
-                    ? t('installed.priority.clear')
-                    : t('installed.priority.make')}
-              </button>
-            )}
-            {(onTagLocker || onTagGlobal) && (
-              <>
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setTagPickerOpen((open) => !open);
-                    setListPickerOpen(false);
-                    setImagePickerOpen(false);
-                  }}
-                  className={menuItemClasses}
-                >
-                  <TagIcon className="w-3.5 h-3.5" />
-                  {t('installed.tag.setLockerTag')}
-                </button>
-                {tagPickerOpen && (
-                  <div className="my-1 max-h-64 overflow-y-auto rounded-md border border-border bg-bg-primary/40 p-1">
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void clearLockerTag();
-                      }}
-                      disabled={menuBusy || (!mod.lockerHero && !mod.globalType)}
-                      className="w-full rounded px-2 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {t('installed.tag.clearLockerTag')}
-                    </button>
-                    <div className="my-1 h-px bg-border" />
-                    {onTagGlobal && (
-                      <>
-                        <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
-                          {t('installed.tag.global')}
-                        </div>
-                        {GLOBAL_MOD_TYPE_ORDER.map((type) => (
-                          <button
-                            key={type}
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void applyGlobalTag(type);
-                            }}
-                            disabled={menuBusy}
-                            className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50 ${
-                              mod.globalType === type ? 'text-accent' : 'text-text-primary'
-                            }`}
-                          >
-                            <span className="truncate">{GLOBAL_MOD_TYPE_LABELS[type]}</span>
-                            {mod.globalType === type && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
-                          </button>
-                        ))}
-                        <div className="my-1 h-px bg-border" />
-                      </>
-                    )}
-                    <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
-                      {t('installed.tag.hero')}
-                    </div>
-                    {HERO_NAMES_SORTED.map((heroName) => {
-                      const tagged = canonicalHeroName(mod.lockerHero) === heroName;
-                      return (
-                      <button
-                        key={heroName}
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          void applyLockerTag(heroName);
-                        }}
-                        disabled={menuBusy}
-                        className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50 ${
-                          tagged
-                            ? mod.lockerHeroSource === 'manual'
-                              ? 'text-accent'
-                              : 'text-sky-200'
-                            : 'text-text-primary'
-                        }`}
-                      >
-                        <HeroTagLabel heroName={heroName} />
-                        {tagged && <Check className="w-3.5 h-3.5 flex-shrink-0" />}
-                      </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </>
-            )}
-            {onFixUnknown && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onFixUnknown();
-                }}
-                className={menuItemClasses}
-              >
-                {fixingUnknown ? (
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                ) : mod.isUnknown ? (
-                  <Wrench className="w-3.5 h-3.5" />
-                ) : (
-                  <Link2 className="w-3.5 h-3.5" />
-                )}
-                {mod.isUnknown ? t('installed.card.fixUnknownMatch') : t('installed.unknown.linkToGamebanana')}
-              </button>
-            )}
-            {mod.merged && onCopyShareCode && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onCopyShareCode();
-                }}
-                className={menuItemClasses}
-              >
-                <Share2 className="w-3.5 h-3.5" />
-                {t('installed.merge.copyShareCode')}
-              </button>
-            )}
-            {mod.merged && onUnmerge && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onUnmerge();
-                }}
-                className={menuItemClasses}
-              >
-                <Scissors className="w-3.5 h-3.5" />
-                {t('installed.merge.unmerge')}
-              </button>
-            )}
-            {/* A merged mod is removed via Unmerge (which deletes the merged VPK
-                and restores its sources), so a raw Delete alongside it would be
-                redundant and confusing. Non-merged mods keep Delete. */}
-            {!mod.merged && (
-              <>
-                <div className="my-1 h-px bg-border" />
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setMenuOpen(false);
-                    onDelete();
-                  }}
-                  className={dangerMenuItemClasses}
-                >
-                  <Trash2 className="w-3.5 h-3.5" />
-                  {t('common.actions.delete')}
-                </button>
-              </>
-            )}
-          </div>,
-          document.body
-        )}
+          </MenuTrigger>
+          <MenuContent className="max-h-[70vh] overflow-y-auto" data-card-menu-open>
+            {cardMenuItems}
+          </MenuContent>
+        </MenuRoot>
       </div>
         <button
           onClick={onToggle}
@@ -8495,14 +8174,15 @@ function ModCard({
     </div>
   );
   return (
+    <MenuRoot onOpenChange={(open) => { if (!open) setPointerImageSrc(null); }}>
+      {/* Disabled in select mode so right-click doesn't fight the full-card
+          select overlay. The thumbnail's own image menu is switched off on
+          cards (enableImageContextMenu={false}), so artwork right-clicks reach
+          this one rather than a second, image-only menu. */}
+      <MenuTrigger asChild disabled={selectMode}>
     <div
       data-mod-entry-key={entryKey}
-      onContextMenu={(event) => {
-        if (selectMode) return;
-        event.preventDefault();
-        event.stopPropagation();
-        openActionsMenu();
-      }}
+      onContextMenu={captureContextImage}
       className={`group/card relative rounded-xl border transform-gpu ${isList ? 'transition-[transform,box-shadow,border-color,background-color,opacity] duration-200 ease-out ' + stateClasses : glassStateClasses} ${mergedStackShadow} ${updateAvailable ? 'update-stripes' : ''} ${shellClasses} ${selected ? 'ring-2 ring-accent ring-offset-2 ring-offset-bg-primary' : mod.priorityMod ? 'ring-1 ring-accent/40' : ''}`}
     >
       <div className={isList ? 'contents' : ''}>
@@ -8741,6 +8421,11 @@ function ModCard({
       </div>
 
     </div>
+      </MenuTrigger>
+      <MenuContent className="max-h-[70vh] overflow-y-auto" data-card-menu-open>
+        {cardMenuItems}
+      </MenuContent>
+    </MenuRoot>
   );
 }
 


### PR DESCRIPTION
## Summary

- use one canonical Installed card action menu for the three-dot button and right-clicks anywhere on the card
- back that menu with Radix rather than the hand-rolled portal, so it keeps cursor anchoring, keyboard navigation, and collision handling (`docs/ui-conventions.md`: "context menus use the `Menu` family")
- fold list, reveal, imprint, and image utilities into clearly grouped sections of that menu
- keep the generic image context menu image-only and share its clipboard helpers

## How the two triggers share one menu

`common/menu.tsx` is now namespace-parameterized. Radix's context-menu and dropdown-menu packages expose structurally identical sub-components, so a single item tree renders through either root: `MenuRoot kind="context"` wraps the card (right-click, anchored at the pointer) and `MenuRoot kind="dropdown"` sits on the three-dot button. Adds `@radix-ui/react-dropdown-menu`.

This deletes the hand-rolled portal along with its trigger-rect measurement, its `spaceAbove < 340` placement guess, and its outside-mousedown/Escape handlers.

## Behavior changes worth calling out

- The locker tag picker is two radio groups (global type and hero are independent axes: `setModGlobalType` does not clear `lockerHero`), so those rows get `role="menuitemradio"` and arrow-key navigation instead of being non-menu children inside `role="menu"`.
- Card menu feedback is toast-only. The menu closes on select, so the previous in-menu `menuError` banner and the image-action spinner could not be seen once an action fired.
- Merged-mod collage cells carry their own source, and the menu reads it off the pointer target. Right-clicking the 7th tile acts on the 7th tile, not on the mod's first source. Still behind the existing NSFW gate.
- `Copy image` and `Copy image address` no longer share one busy flag (copying the address used to spin the *image* row and read "Copying image").
- `ModListSubmenu` is rendered by the card again rather than reimplemented inline, which also drops the `List`/`ListPlus` and `FilePlus`/`Plus` icon drift.

## Validation

- pnpm typecheck
- pnpm lint
- pnpm i18n:check (1885 referenced keys, no new orphans) + locale manifest check
- vitest run (65 files, 842 tests)
- electron-vite build

## Manual test

The Electron dev build was exercised against a real mod library: right-clicks on card artwork, on card background, and on individual collage tiles, plus the three-dot trigger, in both grid and list view; submenu fly-outs, keyboard navigation, and select mode (where the trigger stays disabled).