### PR TITLE
fix(stats): keep salt-contribution copy honest about the client tag

### DIFF
--- a/electron/main/services/saltIngest.ts
+++ b/electron/main/services/saltIngest.ts
@@ -8,9 +8,9 @@
 //
 // This service reimplements what the official deadlock-api-ingest tool does,
 // minus its two privacy leaks: the "username" field carries a constant client
-// tag instead of the player's name, and we never ping statlocker.gg. The only
-// thing that leaves the machine is match_id, cluster_id and the two salts:
-// numbers that describe the match, not the player.
+// tag instead of the player's name, and we never ping statlocker.gg. What
+// leaves the machine is match_id, cluster_id, the two salts, and the constant
+// "grimoire" tag: data that describes the match and the client, never the player.
 //
 // Cache-file format note: the host and path are stored as null-separated
 // fields in a small binary header (not a literal http:// URL), always within

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -896,7 +896,7 @@
       "confirmProfileUpdate": "Confirm before overwriting a profile's saved mods. Off overwrites immediately.",
       "ignoreConflicts": "Hide all conflicts from the Conflicts page. Off shows them.",
       "discordRpc": "Show your current Grimoire activity on your Discord profile. Talks only to your local Discord app and sends nothing to Grimoire.",
-      "contributeSalts": "Share the replay keys Steam already caches for matches you view in-game. Sends only the match id, server cluster, and two download keys: no account id, no username, nothing about you or your mods.",
+      "contributeSalts": "Share the replay keys Steam already caches for matches you view in-game. Sends only the match id, server cluster, two download keys, and a fixed \"grimoire\" client tag: no account id, no player name, nothing about you or your mods.",
       "fixUnknown": "Match unknown local VPKs against GameBanana to recover names and thumbnails. May hit rate limits on large libraries.",
       "vpkImprint": "Give each newly installed mod a small identity imprint so an orphaned file can be recognized offline. Adds an Imprint installed mods button on the Installed page to imprint mods you already have.",
       "deadworks": "Add a Servers tab to browse and join Deadworks community servers. Required content downloads before connecting.",


### PR DESCRIPTION
Follow-up to #340, which added a constant "grimoire" username tag to submitted salts while the settings toggle still promised "no username".

- Reword `settings.toggles.contributeSalts` to name the fixed client tag: sends match id, server cluster, two download keys, and a fixed "grimoire" client tag; no account id, no player name, nothing about the user.
- Update the stale sentence in the `saltIngest.ts` header comment the same way.

No behavior change; i18n gates pass and the locale manifest is unchanged (key set identical).