### PR TITLE
fix(crosshair): rasterize the preview the way the game does

### DIFF
--- a/docs/crosshair-geometry.md
+++ b/docs/crosshair-geometry.md
@@ -1,0 +1,196 @@
+# Crosshair geometry: how Deadlock actually draws it
+
+Reference for `src/components/crosshair/drawCrosshair.ts` and
+`src/lib/crosshair.ts`. Read this before touching the preview renderer.
+
+Everything below was recovered from the shipped game, not guessed:
+
+- `game/citadel/pak01_dir.vpk` -> `panorama/styles/ability_hud_elements/element_gun.vcss_c`
+  (the crosshair's stylesheet)
+- `game/citadel/bin/win64/client.dll` -> the gun HUD element's constructor and
+  per-frame style update (the C++ that owns the geometry)
+
+VPK entries were listed and extracted with `vpkmerge-core`'s dev examples
+(`find_entry`, `extract_entry`, `decodetex`). Re-run those after a game patch to
+confirm nothing moved.
+
+## Where the crosshair lives
+
+It is **not** a texture and **not** a standalone panel. It is part of the *gun
+ability HUD element*, built in C++ out of plain Panorama panels found by name:
+
+```
+GunGrosshair            container (typo is Valve's)
+  TopArc     BottomArc     LeftArc     RightArc
+  TopPip     BottomPip     LeftPip     RightPip          <- the four lines
+  TopPipOutline  ... x4                                  <- their outlines
+  TopPipBlack    ... x4                                  <- hidden by default
+  Dot
+  DotOutline
+```
+
+Base styling comes from `.crosshair__pip`, `.crosshair__pipborder`,
+`.crosshair__dot`, `.crosshair__dotborder` in `element_gun.vcss`. Each frame the
+C++ overwrites size, opacity, colour and `border-width` from the
+`citadel_crosshair_*` convars. Pips are solid `background-color`, no image and no
+`border-radius`, so they are sharp rectangles. The dot and dot outline carry
+`border-radius: 50%`, so they are circles.
+
+The per hero reticles at the bottom of that stylesheet (`.viper .crosshair__pip`
+and friends) swap in `background-image` textures and hard-code sizes. They ignore
+the convars entirely, which is what
+`citadel_crosshair_disable_hero_specific_crosshairs` turns off.
+
+## Positioning
+
+The four pips are positioned by one helper that walks a 4-panel array applying a
+rotation of `index * 90deg` plus a per-group offset angle (0 for pips, 45 for
+arcs) and a translation of `D` along the rotated axis. So:
+
+- each pip's **centre** sits `D` from screen centre
+- the panel itself is rotated, so the left/right pair is the top/bottom pair with
+  width and height swapped
+
+```
+D = cppArcDefaultOffset + citadel_crosshair_pip_gap
+  = 4 + pip_gap
+```
+
+`cppArcDefaultOffset: 4.0` is an `@define` in `element_gun.vcss`, read once at
+construction. (`cppPipDefaultOffset: 7` is defined in the same file but the
+shipped code path never reads it. Do not "fix" this by using 7.)
+
+When `citadel_crosshair_pip_gap_static` is `false` (the game's default) live
+weapon spread is added to `D` every frame. A static editor cannot show that, so
+Grimoire models the static shape only.
+
+## Integer truncation
+
+This is the single easiest thing to get wrong. `pip_width`, `pip_height` and
+`dot_size` are **float** convars, and the in-game sliders persist raw floats into
+`machine_convars.vcfg` (`citadel_crosshair_dot_size "8.301266"` is a real value).
+But the HUD runs every one of them through `cvttss2si` (truncate toward zero)
+before applying it:
+
+| convar | type | truncated before use |
+|---|---|---|
+| `pip_width` | float | yes |
+| `pip_height` | float | yes |
+| `dot_size` | float | yes |
+| `pip_outline_gap` | int | yes |
+| `dot_outline_gap` | int | yes |
+| `pip_outline_border` | int | read as int |
+| `dot_outline_border` | int | read as int |
+| `pip_gap` | int | read as int |
+| all four `*_opacity` | float | no, used as-is |
+
+So `dot_size 8.301266` renders as an 8px dot. Half-step sliders in the editor
+are a lie: the preview and the game both round them down.
+
+## Outlines and the Panorama box model
+
+The outline panels are sized to the **outer** box and their border is painted
+**inward**:
+
+```
+pipOutlineWidth  = pip_width  + pip_outline_gap + 2 * pip_outline_border
+pipOutlineHeight = pip_height + pip_outline_gap + 2 * pip_outline_border
+dotOutlineSize   = dot_size   + dot_outline_gap + 2 * dot_outline_border
+border-width     = *_outline_border
+```
+
+Because the border eats into that box, the hole left in the middle is
+`pip_dim + gap`, and the pip is centred in it. **Clearance between the pip edge
+and the outline is `gap / 2` per side, not a full `gap`.**
+
+Evidence for borders being drawn inward rather than outward: the concentric ammo
+rings in the same stylesheet only line up under that reading. `#clip_bg_progress_bar`
+(98px / 8px border), `#clip_progress_bar` (94px / 4px) and `#clip_bullet`
+(96px / 6px) all land on a border centreline diameter of exactly 90 when the
+border is inside the box, and on nothing in common otherwise.
+
+## Rasterization: whole device pixels, composed in layout units
+
+The game rasterizes the crosshair on **whole device pixels**. Measured from a
+1440p screenshot with `pip_width 1`, a pip is exactly one pixel of
+`rgb(5,254,254)` with untouched background on both sides. A canvas drawing the
+same pip at its true fractional width (1 x 4/3 = 1.333px) antialiases it into
+two pixels at about 78% coverage each, which reads as a line twice as thick,
+blurry, and visibly dimmer (`rgb(9,200,199)`). That was the single largest
+remaining mismatch after the geometry above was fixed.
+
+Two rules matter, and they interact:
+
+1. **Compose in layout units, snap once.** The C++ builds each panel's size in
+   1080p layout px (`SetWidth(gap + pip_width + 2 * border)`) and Panorama
+   converts to device px afterwards. So a 3px outline box at 1440p is
+   `round(3 * 4/3) = 4` device px. Snapping the parts first and adding them
+   would give `1 + 2 = 3`, one pixel narrower, and it is wrong.
+2. **The centre is not snapped.** The stylesheet uses
+   `horizontal-align: center_nopixelsnap` / `vertical-align: center_nopixelsnap`,
+   so a box with an odd device size straddles the centre and its leading edge
+   rounds half-up. This is why an odd-height outline box is not symmetric about
+   the centre: at 1440p the top cap lands 12px above centre and the bottom cap
+   12px below, from an 11px-tall box. `Math.round` on the leading edge
+   reproduces it.
+
+Verified against the same screenshot: the bottom pip and its outline match the
+renderer pixel for pixel across rows +6 to +12 (outline flanks, 1px pip, the pip
+ending one row before the outline, and the 4px end cap).
+
+## Opacity and colour
+
+Opacity is a panel property, applied by the C++ via `SetOpacity`, not baked into
+the colour:
+
+- pip panel opacity = `pip_opacity`, background colour = `color_r/g/b`
+- pip outline panel opacity = `pip_outline_opacity`, border colour = `outline_color_r/g/b`
+- dot / dot outline the same with their own convars
+
+Multiplying the colour's alpha instead is equivalent for a flat draw, which is
+what the canvas renderer does.
+
+## Convar defaults
+
+These are the defaults `client.dll` registers, i.e. what a fresh install looks
+like. They are **not** the same as `CROSSHAIR_DEFAULTS` in `src/lib/crosshair.ts`,
+which is Grimoire's editor starting point. Both are exported so the difference
+stays deliberate; see `CROSSHAIR_GAME_DEFAULTS`.
+
+| convar | game default | Grimoire default |
+|---|---|---|
+| `pip_gap` | 4 | 5 |
+| `pip_gap_static` | false | true |
+| `pip_width` | 2.0 | 2 |
+| `pip_height` | 16.0 | 10 |
+| `pip_opacity` | 0.5 | 1 |
+| `pip_outline_border` | 1 | 1 |
+| `pip_outline_gap` | 1 | 0 |
+| `pip_outline_opacity` | 0.7 | 1 |
+| `dot_size` | 4.0 | 8 |
+| `dot_opacity` | 0.7 | 0 |
+| `dot_outline_border` | 2 | 2 |
+| `dot_outline_gap` | 2 | 0 |
+| `dot_outline_opacity` | 0.7 | 0 |
+| `color_r/g/b` | 255/255/255 | 0/255/0 |
+| `outline_color_r/g/b` | 0/0/0 | 0/0/0 |
+
+## Convars Grimoire does not model
+
+`citadel_crosshair_clip_angle` (90), `citadel_crosshair_clip_bullet_gap` (0.5) and
+`citadel_crosshair_clip_offset_angle` (180) drive the ammo ring around the
+crosshair, not its shape. `citadel_crosshair_hit_marker_duration` (0.1) and
+`citadel_crosshair_out_of_range_dist` are behavioural. None belong in the preset
+format.
+
+## What is still assumed
+
+The scale factor. Grimoire draws in 1080p reference pixels and multiplies by
+`display height / 1080`, matching Panorama's ui-scale convention. That has not
+been re-derived from the binary, but a 1440p screenshot measured against it fits
+to the pixel, so it is now corroborated rather than merely assumed.
+
+Antialiasing of the round parts. The dot and dot outline are drawn as canvas
+arcs, which feather their rim the way Panorama feathers a `border-radius: 50%`
+panel. The exact filter is not the same, so a 3px dot may differ by a shade at
+the edge. The straight parts, which are what you actually aim with, are exact.

--- a/src/components/crosshair/CrosshairControls.tsx
+++ b/src/components/crosshair/CrosshairControls.tsx
@@ -113,11 +113,13 @@ export default function CrosshairControls() {
           <div className="space-y-5">
             <Slider editable label={<Tx k="crosshair.controls.gap" fallback="Gap" />} value={pipGap} min={-10} max={50} onChange={setPipGap} />
             <Slider editable label={<Tx k="crosshair.controls.height" fallback="Height" />} value={pipHeight} min={0} max={50} onChange={setPipHeight} />
-            <Slider editable label={<Tx k="crosshair.controls.width" fallback="Width" />} value={pipWidth} min={0} max={10} step={0.5} onChange={setPipWidth} />
+            {/* Whole steps only: the HUD truncates the size convars toward
+                zero, so 2.5 and 2 are the same crosshair in game. */}
+            <Slider editable label={<Tx k="crosshair.controls.width" fallback="Width" />} value={pipWidth} min={0} max={10} onChange={setPipWidth} />
             <Slider editable label={<Tx k="crosshair.controls.opacity" fallback="Opacity" />} value={pipOpacity} min={0} max={1} step={0.05} onChange={setPipOpacity} />
             <SubGroup title={<Tx k="crosshair.sections.outline" fallback="Outline" />}>
               <Slider editable label={<Tx k="crosshair.controls.outlineWidth" fallback="Outline Width" />} value={pipOutlineBorder} min={0} max={5} onChange={setPipOutlineBorder} />
-              <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={pipOutlineGap} min={0} max={10} step={0.5} onChange={setPipOutlineGap} />
+              <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={pipOutlineGap} min={0} max={10} onChange={setPipOutlineGap} />
               <Slider editable label={<Tx k="crosshair.controls.outlineOpacity" fallback="Outline Opacity" />} value={pipOutlineOpacity} min={0} max={1} step={0.05} onChange={setPipOutlineOpacity} />
             </SubGroup>
           </div>
@@ -125,7 +127,7 @@ export default function CrosshairControls() {
 
         {tab === 'dot' && (
           <div className="space-y-5">
-            <Slider editable label={<Tx k="crosshair.controls.size" fallback="Size" />} value={dotSize} min={0} max={20} step={0.5} onChange={setDotSize} />
+            <Slider editable label={<Tx k="crosshair.controls.size" fallback="Size" />} value={dotSize} min={0} max={20} onChange={setDotSize} />
             <Slider editable label={<Tx k="crosshair.controls.opacity" fallback="Opacity" />} value={dotOpacity} min={0} max={1} step={0.05} onChange={setDotOpacity} />
             {dotOpacity === 0 && (
               <p className="rounded-sm border border-white/5 bg-black/20 px-3 py-2 text-xs text-text-secondary">
@@ -134,7 +136,7 @@ export default function CrosshairControls() {
             )}
             <SubGroup title={<Tx k="crosshair.sections.outline" fallback="Outline" />}>
               <Slider editable label={<Tx k="crosshair.controls.outlineWidth" fallback="Outline Width" />} value={dotOutlineBorder} min={0} max={5} onChange={setDotOutlineBorder} />
-              <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={dotOutlineGap} min={0} max={10} step={0.5} onChange={setDotOutlineGap} />
+              <Slider editable label={<Tx k="crosshair.controls.outlineGap" fallback="Outline Gap" />} value={dotOutlineGap} min={0} max={10} onChange={setDotOutlineGap} />
               <Slider editable label={<Tx k="crosshair.controls.outlineOpacity" fallback="Outline Opacity" />} value={dotOutlineOpacity} min={0} max={1} step={0.05} onChange={setDotOutlineOpacity} />
             </SubGroup>
           </div>

--- a/src/components/crosshair/CrosshairPresetRail.tsx
+++ b/src/components/crosshair/CrosshairPresetRail.tsx
@@ -144,11 +144,15 @@ export default function CrosshairPresetRail({
                   {preset.name}
                 </span>
 
-                <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-1.5 bg-black/65 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                {/* The overlay itself never takes the pointer: only the two
+                    buttons do. If the whole layer went pointer-events-auto on
+                    hover it would sit over the load button and swallow every
+                    click on the tile (and its cursor). */}
+                <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-1.5 bg-black/65 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                   <button
                     type="button"
                     onClick={() => onApply(preset.id)}
-                    className="cursor-pointer rounded-sm border border-accent/40 bg-accent/10 p-1.5 text-text-primary transition-colors hover:border-accent/60 hover:bg-accent/20"
+                    className="pointer-events-auto cursor-pointer rounded-sm border border-accent/40 bg-accent/10 p-1.5 text-text-primary transition-colors hover:border-accent/60 hover:bg-accent/20"
                     title={t('crosshair.actions.applyToGame')}
                     aria-label={t('crosshair.actions.applyToGame')}
                   >
@@ -157,7 +161,7 @@ export default function CrosshairPresetRail({
                   <button
                     type="button"
                     onClick={() => onDelete(preset.id)}
-                    className="cursor-pointer rounded-sm bg-red-500/20 p-1.5 text-state-danger transition-colors hover:bg-red-500/40"
+                    className="pointer-events-auto cursor-pointer rounded-sm bg-red-500/20 p-1.5 text-state-danger transition-colors hover:bg-red-500/40"
                     title={t('common.actions.delete')}
                     aria-label={t('common.actions.delete')}
                   >

--- a/src/components/crosshair/CrosshairPreview.tsx
+++ b/src/components/crosshair/CrosshairPreview.tsx
@@ -5,7 +5,12 @@ import { drawCrosshair } from './drawCrosshair';
 
 interface CrosshairPreviewProps {
     size?: number;
+    // Resolution factor (display height / 1080): the device grid the
+    // crosshair is pixel-snapped to.
     scale?: number;
+    // Magnification applied after snapping; enlarges device pixels instead of
+    // re-rasterizing the crosshair finer.
+    zoom?: number;
     // Optional override settings (for displaying saved presets/profiles;
     // legacy shapes are normalized inside the renderer)
     settings?: Partial<CrosshairSettings>;
@@ -13,7 +18,7 @@ interface CrosshairPreviewProps {
     transparent?: boolean;
 }
 
-export default function CrosshairPreview({ size = 200, scale = 1, settings, transparent }: CrosshairPreviewProps) {
+export default function CrosshairPreview({ size = 200, scale = 1, zoom = 1, settings, transparent }: CrosshairPreviewProps) {
     const storeSettings = useCrosshairStore();
     const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -32,8 +37,8 @@ export default function CrosshairPreview({ size = 200, scale = 1, settings, tran
         canvas.height = Math.round(size * dpr);
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-        drawCrosshair(ctx, s, { size, scale, background: transparent ? null : '#555' });
-    }, [s, size, scale, transparent]);
+        drawCrosshair(ctx, s, { size, scale, zoom, background: transparent ? null : '#555' });
+    }, [s, size, scale, zoom, transparent]);
 
     return (
         <canvas

--- a/src/components/crosshair/CrosshairStage.tsx
+++ b/src/components/crosshair/CrosshairStage.tsx
@@ -1,15 +1,20 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCrosshairStore } from '../../stores/crosshairStore';
+import { crosshairReach } from '../../lib/crosshair';
 import CrosshairPreview from './CrosshairPreview';
-import { STAGE_BACKGROUNDS, type StageBackground } from './stageBackgrounds';
+import { STAGE_BACKGROUNDS, STAGE_CAPTURE_HEIGHT, type StageBackground } from './stageBackgrounds';
 
 /** How long the crosshair takes to glide back to center after the pointer leaves. */
 const RECENTER_MS = 260;
 
 interface CrosshairStageProps {
-  /** Total draw scale (resolution factor x zoom). */
+  /** Resolution factor (display height / 1080): the pixel-snap grid. Changing
+   *  it re-rasterizes the crosshair on the new grid; it does NOT resize the
+   *  scene, because switching resolution doesn't make a monitor bigger. */
   scale: number;
+  /** Magnification of the whole stage (scene and crosshair together). */
+  zoom: number;
   background: StageBackground;
 }
 
@@ -30,7 +35,7 @@ interface CrosshairStageProps {
  * the scene, the crosshair, and the hint. `inset-0` resolves against the
  * parent's used size, so it holds regardless of how that height was arrived at.
  */
-export default function CrosshairStage({ scale, background }: CrosshairStageProps) {
+export default function CrosshairStage({ scale, zoom, background }: CrosshairStageProps) {
   const { t } = useTranslation();
   const stageRef = useRef<HTMLDivElement>(null);
   const followRef = useRef<HTMLDivElement>(null);
@@ -41,17 +46,20 @@ export default function CrosshairStage({ scale, background }: CrosshairStageProp
   const settings = useCrosshairStore();
   const bg = STAGE_BACKGROUNDS.find((b) => b.id === background) ?? STAGE_BACKGROUNDS[0];
 
+  // The simulated screen is the capture: CAPTURE_HEIGHT device-ish px tall,
+  // shown at zoom CSS px each, regardless of the selected resolution. The
+  // crosshair rasterizes on the selected resolution's grid (1080 * scale
+  // device px per screen height), so one of its device px occupies this many
+  // CSS px. At 1440p on a 1440p monitor this is exactly `zoom`; at 1080p the
+  // coarser pixels draw proportionally fatter, at 4K finer, which is the only
+  // visible difference switching resolution SHOULD make.
+  const deviceToCss = (STAGE_CAPTURE_HEIGHT * zoom) / (1080 * scale);
+
   // Size the canvas to what the crosshair actually needs at this scale, so a
-  // wide gap at 4K/3x zoom isn't clipped by a fixed-size backing store (and a
-  // tiny dot doesn't allocate a huge one). Mirrors drawCrosshair's geometry:
-  // pips sit centered on a gap boundary D away from the middle.
-  const pipDistance = Math.max(0, (9 + settings.pipGap * 2.5) / 2);
-  const reach =
-    Math.max(
-      pipDistance + settings.pipHeight / 2 + settings.pipOutlineGap + settings.pipOutlineBorder,
-      settings.dotSize / 2 + settings.dotOutlineGap + settings.dotOutlineBorder
-    ) + 4;
-  const canvasSize = Math.min(1400, Math.max(120, Math.ceil(reach * 2 * scale)));
+  // wide gap at 3x zoom isn't clipped by a fixed-size backing store (and a
+  // tiny dot doesn't allocate a huge one). Kept EVEN so the canvas centre sits
+  // on a whole pixel and the snapped device pixels land crisp.
+  const canvasSize = Math.min(1400, Math.max(120, 2 * Math.ceil(crosshairReach(settings) * scale * deviceToCss)));
 
   const write = useCallback(() => {
     frameRef.current = null;
@@ -110,6 +118,11 @@ export default function CrosshairStage({ scale, background }: CrosshairStageProp
       {/* The gradient always sits underneath, so a screenshot that fails to
           load degrades to the plain surface instead of a broken-image gap. */}
       <div aria-hidden className="absolute inset-0 bg-gradient-to-br from-bg-tertiary to-bg-secondary" />
+      {/* The scene is a 1:1 centre crop of the native 2560x1440 capture,
+          scaled only by zoom: never by the selected resolution (a monitor
+          doesn't grow when you switch resolution) and never cover-fitted
+          (which squeezed the scene to ~half size and made every crosshair
+          read about twice as thick as in game). */}
       {bg.src && (
         <img
           key={bg.id}
@@ -118,7 +131,8 @@ export default function CrosshairStage({ scale, background }: CrosshairStageProp
           aria-hidden
           draggable={false}
           onError={(e) => { e.currentTarget.style.display = 'none'; }}
-          className="absolute inset-0 h-full w-full object-cover"
+          className="absolute left-1/2 top-1/2 max-w-none -translate-x-1/2 -translate-y-1/2"
+          style={{ height: STAGE_CAPTURE_HEIGHT * zoom, width: 'auto' }}
         />
       )}
 
@@ -131,7 +145,7 @@ export default function CrosshairStage({ scale, background }: CrosshairStageProp
           transitionDuration: `${RECENTER_MS}ms`,
         }}
       >
-        <CrosshairPreview size={canvasSize} scale={scale} transparent />
+        <CrosshairPreview size={canvasSize} scale={scale} zoom={deviceToCss} transparent />
       </div>
 
       {/* Fades out on hover: once the crosshair is tracking, the hint has done

--- a/src/components/crosshair/drawCrosshair.ts
+++ b/src/components/crosshair/drawCrosshair.ts
@@ -3,27 +3,32 @@
 // never drift apart (the old DOM preview and SVG thumbnail disagreed on dot
 // size and outline z-order).
 //
-// Geometry is computed in 1080p-reference pixels (the same unit the
-// citadel_crosshair_* convars use) and multiplied by `scale`
-// (display resolution height / 1080, times any preview zoom).
+// Geometry comes from computeCrosshairLayout in src/lib/crosshair.ts, which
+// reproduces the game's rasterization: sizes composed in 1080p layout units,
+// snapped once to whole device px at `scale` (display height / 1080), centres
+// unsnapped. Drawing on that grid is what keeps a 1px pip one crisp pixel at
+// 1440p instead of two antialiased ones; see docs/crosshair-geometry.md.
 
 import type { CrosshairSettings } from '../../types/electron';
-import { normalizeCrosshairSettings } from '../../lib/crosshair';
+import {
+    computeCrosshairLayout,
+    normalizeCrosshairSettings,
+    type CrosshairRect,
+} from '../../lib/crosshair';
 
 export interface DrawCrosshairOptions {
     /** Canvas logical (CSS) size in px; the crosshair is centered in it. */
     size: number;
-    /** 1080p-px to display-px multiplier. */
+    /** 1080p-layout-px to display-px multiplier (resolution / 1080). This is
+     *  the device grid the crosshair is snapped to. */
     scale: number;
+    /** CSS px one snapped device px occupies (default 1). Applied AFTER
+     *  snapping, so magnifying shows the same whole device pixels bigger
+     *  instead of re-rasterizing finer. The stage also uses this to draw a
+     *  coarser grid's pixels physically fatter (1080p) or finer (4K). */
+    zoom?: number;
     /** Background fill; null/undefined leaves the canvas transparent. */
     background?: string | null;
-}
-
-interface Rect {
-    x: number;
-    y: number;
-    w: number;
-    h: number;
 }
 
 export function drawCrosshair(
@@ -33,6 +38,7 @@ export function drawCrosshair(
 ): void {
     const s = normalizeCrosshairSettings(raw);
     const { size, scale } = opts;
+    const zoom = opts.zoom ?? 1;
 
     ctx.clearRect(0, 0, size, size);
     if (opts.background) {
@@ -42,67 +48,57 @@ export function drawCrosshair(
 
     const cx = size / 2;
     const cy = size / 2;
-    const px = (v: number) => v * scale;
+    const layout = computeCrosshairLayout(s, scale);
 
-    // Gap formula carried over from the previous DOM preview (calibrated
-    // against the game; re-verify after any in-game crosshair update).
-    // D = distance from screen center to each pip's center line.
-    const D = Math.max(0, (9 + s.pipGap * 2.5) / 2);
+    // Device px -> canvas px; snapping already happened in device space.
+    const rect = (r: CrosshairRect) =>
+        [cx + r.x * zoom, cy + r.y * zoom, r.w * zoom, r.h * zoom] as const;
 
-    // Pip rects in 1080p units, relative to center; pips are centered on the
-    // gap boundary (half extends inward, half outward), matching the game.
-    const pips: Rect[] =
-        s.pipWidth > 0 && s.pipHeight > 0
-            ? [
-                  { x: -s.pipWidth / 2, y: -D - s.pipHeight / 2, w: s.pipWidth, h: s.pipHeight }, // top
-                  { x: -s.pipWidth / 2, y: D - s.pipHeight / 2, w: s.pipWidth, h: s.pipHeight }, // bottom
-                  { x: -D - s.pipHeight / 2, y: -s.pipWidth / 2, w: s.pipHeight, h: s.pipWidth }, // left
-                  { x: D - s.pipHeight / 2, y: -s.pipWidth / 2, w: s.pipHeight, h: s.pipWidth }, // right
-              ]
-            : [];
-
+    // Opacity is a panel property in the game (SetOpacity); multiplying it
+    // into the fill colour is equivalent for these flat draws.
     const fillColor = `rgba(${s.colorR}, ${s.colorG}, ${s.colorB}, ${s.pipOpacity})`;
     const dotColor = `rgba(${s.colorR}, ${s.colorG}, ${s.colorB}, ${s.dotOpacity})`;
     const outlineColor = (opacity: number) =>
         `rgba(${s.outlineColorR}, ${s.outlineColorG}, ${s.outlineColorB}, ${opacity})`;
 
-    // 1. Pip outlines (stroked fully outside the pip, offset by the gap)
-    if (s.pipOutlineBorder > 0 && s.pipOutlineOpacity > 0) {
-        ctx.strokeStyle = outlineColor(s.pipOutlineOpacity);
-        ctx.lineWidth = px(s.pipOutlineBorder);
-        const off = s.pipOutlineGap + s.pipOutlineBorder / 2;
-        for (const r of pips) {
-            ctx.strokeRect(
-                cx + px(r.x - off),
-                cy + px(r.y - off),
-                px(r.w + 2 * off),
-                px(r.h + 2 * off)
-            );
+    // 1. Pip outlines: the outer box with a punched-out hole, because the
+    //    game's border paints inward from the outer box edge.
+    if (layout.pipOutlineBorder > 0 && s.pipOutlineOpacity > 0) {
+        ctx.fillStyle = outlineColor(s.pipOutlineOpacity);
+        const b = layout.pipOutlineBorder * zoom;
+        for (const o of layout.pipOutlines) {
+            const [x, y, w, h] = rect(o);
+            ctx.beginPath();
+            ctx.rect(x, y, w, h);
+            if (w > 2 * b && h > 2 * b) ctx.rect(x + b, y + b, w - 2 * b, h - 2 * b);
+            ctx.fill('evenodd');
         }
     }
 
-    // 2. Dot outline ring (outside the dot, offset by the gap)
-    if (s.dotOutlineBorder > 0 && s.dotOutlineOpacity > 0) {
-        ctx.strokeStyle = outlineColor(s.dotOutlineOpacity);
-        ctx.lineWidth = px(s.dotOutlineBorder);
+    // 2. Dot outline: an annulus, border likewise inward from the outer circle
+    if (layout.dotOutlineBorder > 0 && s.dotOutlineOpacity > 0 && layout.dotOutlineSize > 0) {
+        const outer = layout.dotOutlineSize / 2;
+        const inner = Math.max(0, outer - layout.dotOutlineBorder);
+        ctx.fillStyle = outlineColor(s.dotOutlineOpacity);
         ctx.beginPath();
-        ctx.arc(cx, cy, px(s.dotSize / 2 + s.dotOutlineGap + s.dotOutlineBorder / 2), 0, Math.PI * 2);
-        ctx.stroke();
+        ctx.arc(cx, cy, outer * zoom, 0, Math.PI * 2);
+        if (inner > 0) ctx.arc(cx, cy, inner * zoom, 0, Math.PI * 2, true);
+        ctx.fill('evenodd');
     }
 
     // 3. Pips
     if (s.pipOpacity > 0) {
         ctx.fillStyle = fillColor;
-        for (const r of pips) {
-            ctx.fillRect(cx + px(r.x), cy + px(r.y), px(r.w), px(r.h));
+        for (const p of layout.pips) {
+            ctx.fillRect(...rect(p));
         }
     }
 
     // 4. Center dot (top layer)
-    if (s.dotOpacity > 0 && s.dotSize > 0) {
+    if (s.dotOpacity > 0 && layout.dotSize > 0) {
         ctx.fillStyle = dotColor;
         ctx.beginPath();
-        ctx.arc(cx, cy, px(s.dotSize / 2), 0, Math.PI * 2);
+        ctx.arc(cx, cy, (layout.dotSize / 2) * zoom, 0, Math.PI * 2);
         ctx.fill();
     }
 }

--- a/src/components/crosshair/stageBackgrounds.ts
+++ b/src/components/crosshair/stageBackgrounds.ts
@@ -2,6 +2,11 @@ import { getAssetPath } from '../../lib/assetPath';
 
 export type StageBackground = 'street' | 'sandbox' | 'plain';
 
+/** Native height of the stage captures (both are 2560x1440 screenshots). The
+ *  stage's scene/crosshair scale math is anchored to this: at zoom 1 one
+ *  capture px is one CSS px, so the simulated screen is CAPTURE_HEIGHT tall. */
+export const STAGE_CAPTURE_HEIGHT = 1440;
+
 /**
  * Scenes the crosshair preview can sit on. The two screenshots let you judge
  * contrast against real in-game lighting instead of a flat editor gray;

--- a/src/lib/crosshair.test.ts
+++ b/src/lib/crosshair.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { computeCrosshairLayout } from './crosshair';
+
+// Every expected value below comes from docs/crosshair-geometry.md, which was
+// measured against the shipped game (1440p screenshots + client.dll). If one
+// of these fails after an edit, the preview no longer matches the game.
+
+const SCALE_1440 = 1440 / 1080;
+
+describe('computeCrosshairLayout', () => {
+    it('keeps a 1px pip exactly one device pixel at 1440p', () => {
+        const layout = computeCrosshairLayout({ pipWidth: 1, pipHeight: 6 }, SCALE_1440);
+        expect(layout.pips[0].w).toBe(1);
+    });
+
+    it('composes sizes in layout units and snaps once (3px outline box -> 4 device px)', () => {
+        // Snapping the parts first would give 1 + 2 = 3; the game rounds the
+        // composed 3 * 4/3 = 4.
+        const layout = computeCrosshairLayout(
+            { pipWidth: 1, pipHeight: 6, pipOutlineGap: 0, pipOutlineBorder: 1 },
+            SCALE_1440
+        );
+        expect(layout.pipOutlines[0].w).toBe(4);
+    });
+
+    it('truncates float convars toward zero before use', () => {
+        // citadel_crosshair_dot_size "8.301266" is a real persisted value and
+        // renders as an 8px dot.
+        const layout = computeCrosshairLayout({ dotSize: 8.301266 }, 1);
+        expect(layout.dotSize).toBe(8);
+    });
+
+    it('places pip centres at D = 4 + pip_gap from the screen centre', () => {
+        // Game defaults: gap 4 -> D 8; a 16-tall pip at scale 1 spans -16..0.
+        const layout = computeCrosshairLayout({ pipGap: 4, pipWidth: 2, pipHeight: 16 }, 1);
+        expect(layout.pips[0].y).toBe(-16);
+        expect(layout.pips[0].h).toBe(16);
+    });
+
+    it('rounds the unsnapped leading edge half-up (11px outline box caps at -12/+12)', () => {
+        // The doc's 1440p asymmetry example: D = 5, outline box 8 layout px
+        // tall -> 11 device px; the top box's far cap lands 12 above centre
+        // and the bottom box's 12 below, though the box height is odd.
+        const layout = computeCrosshairLayout(
+            { pipGap: 1, pipWidth: 1, pipHeight: 6, pipOutlineGap: 0, pipOutlineBorder: 1 },
+            SCALE_1440
+        );
+        const top = layout.pipOutlines[0];
+        const bottom = layout.pipOutlines[1];
+        expect(top.h).toBe(11);
+        expect(top.y).toBe(-12);
+        expect(bottom.y + bottom.h).toBe(12);
+    });
+
+    it('swaps width and height for the left/right pair', () => {
+        const layout = computeCrosshairLayout({ pipWidth: 2, pipHeight: 16 }, 1);
+        const [, , left] = layout.pips;
+        expect(left.w).toBe(16);
+        expect(left.h).toBe(2);
+    });
+
+    it('hides the pips entirely when a dimension truncates to zero', () => {
+        const layout = computeCrosshairLayout({ pipWidth: 0.9, pipHeight: 16 }, 1);
+        expect(layout.pips).toHaveLength(0);
+        expect(layout.pipOutlines).toHaveLength(0);
+    });
+});

--- a/src/lib/crosshair.ts
+++ b/src/lib/crosshair.ts
@@ -35,6 +35,35 @@ export const CROSSHAIR_DEFAULTS: CrosshairSettings = {
     pipBorder: true,
 };
 
+/**
+ * The defaults client.dll registers, i.e. a fresh install's crosshair. Kept
+ * separate from CROSSHAIR_DEFAULTS (Grimoire's editor starting point) so the
+ * difference stays deliberate; see docs/crosshair-geometry.md.
+ */
+export const CROSSHAIR_GAME_DEFAULTS: CrosshairSettings = {
+    pipGap: 4,
+    pipGapStatic: false,
+    pipHeight: 16,
+    pipWidth: 2,
+    pipOpacity: 0.5,
+    pipOutlineBorder: 1,
+    pipOutlineGap: 1,
+    pipOutlineOpacity: 0.7,
+    dotOpacity: 0.7,
+    dotSize: 4,
+    dotOutlineBorder: 2,
+    dotOutlineGap: 2,
+    dotOutlineOpacity: 0.7,
+    colorR: 255,
+    colorG: 255,
+    colorB: 255,
+    outlineColorR: 0,
+    outlineColorG: 0,
+    outlineColorB: 0,
+    disableHeroSpecificCrosshairs: false,
+    pipBorder: true,
+};
+
 const num = (v: unknown, fallback: number): number =>
     typeof v === 'number' && Number.isFinite(v) ? v : fallback;
 const bool = (v: unknown, fallback: boolean): boolean =>
@@ -144,6 +173,111 @@ const CONVAR_FIELDS: Array<[string, keyof CrosshairSettings, 'number' | 'boolean
     ['citadel_crosshair_outline_color_b', 'outlineColorB', 'number'],
     ['citadel_crosshair_disable_hero_specific_crosshairs', 'disableHeroSpecificCrosshairs', 'boolean'],
 ];
+
+// ---------------------------------------------------------------------------
+// Geometry. Mirrors how the game's gun HUD element lays its panels out,
+// recovered from client.dll + element_gun.vcss; the full derivation and the
+// screenshot evidence live in docs/crosshair-geometry.md. Read that before
+// changing anything below.
+
+/** cppArcDefaultOffset in element_gun.vcss: the base offset the C++ adds to
+ *  citadel_crosshair_pip_gap when positioning each pip's centre. */
+const PIP_BASE_OFFSET = 4;
+
+/** Axis-aligned box in whole device px, relative to the screen centre. */
+export interface CrosshairRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+export interface CrosshairLayout {
+    /** Pip rectangles: top, bottom, left, right. Empty when width/height is 0. */
+    pips: CrosshairRect[];
+    /** Outer boxes of the pip outline panels; the border paints inward. */
+    pipOutlines: CrosshairRect[];
+    /** Pip outline border width, device px. */
+    pipOutlineBorder: number;
+    /** Dot diameter, device px (the dot panel carries border-radius: 50%). */
+    dotSize: number;
+    /** Dot outline outer diameter, device px; its border also paints inward. */
+    dotOutlineSize: number;
+    /** Dot outline border width, device px. */
+    dotOutlineBorder: number;
+}
+
+/**
+ * Rasterize the crosshair the way the game does: sizes composed in 1080p
+ * layout units and snapped ONCE to whole device px (`scale` = display height
+ * / 1080), centres never snapped (center_nopixelsnap), so a panel's leading
+ * edge rounds half-up. The HUD truncates every size convar toward zero
+ * (cvttss2si) before use, so dot_size 8.3 is an 8px dot here too.
+ */
+export function computeCrosshairLayout(
+    raw: Partial<CrosshairSettings>,
+    scale: number
+): CrosshairLayout {
+    const s = normalizeCrosshairSettings(raw);
+
+    const pipWidth = Math.trunc(s.pipWidth);
+    const pipHeight = Math.trunc(s.pipHeight);
+    const pipGap = Math.trunc(s.pipGap);
+    const pipOutlineGap = Math.trunc(s.pipOutlineGap);
+    const pipOutlineBorder = Math.trunc(s.pipOutlineBorder);
+    const dotSize = Math.trunc(s.dotSize);
+    const dotOutlineGap = Math.trunc(s.dotOutlineGap);
+    const dotOutlineBorder = Math.trunc(s.dotOutlineBorder);
+
+    // Snap a composed layout size to device px. Snapping the parts and adding
+    // them instead is off by a pixel (round(3 * 4/3) = 4, but 1 + 2 = 3).
+    const dev = (v: number) => Math.round(v * scale);
+    // Leading edge of a panel of snapped size `size` centred (unsnapped) at
+    // layout coordinate `centre`.
+    const edge = (centre: number, size: number) => Math.round(centre * scale - size / 2);
+
+    // Each pip's centre sits D from the screen centre.
+    const D = PIP_BASE_OFFSET + pipGap;
+
+    // (cx, cy, w, h) in layout units; the left/right pair is the top/bottom
+    // pair rotated 90deg, i.e. width and height swapped.
+    const pipSpecs: Array<[number, number, number, number]> =
+        pipWidth > 0 && pipHeight > 0
+            ? [
+                  [0, -D, pipWidth, pipHeight],
+                  [0, D, pipWidth, pipHeight],
+                  [-D, 0, pipHeight, pipWidth],
+                  [D, 0, pipHeight, pipWidth],
+              ]
+            : [];
+
+    const box = ([cx, cy, w, h]: [number, number, number, number], grow: number): CrosshairRect => {
+        const dw = dev(w + grow);
+        const dh = dev(h + grow);
+        return { x: edge(cx, dw), y: edge(cy, dh), w: dw, h: dh };
+    };
+
+    return {
+        pips: pipSpecs.map((p) => box(p, 0)),
+        // Outline panels are sized to the outer box and their border eats
+        // inward, leaving gap/2 clearance per side of the pip.
+        pipOutlines: pipSpecs.map((p) => box(p, pipOutlineGap + 2 * pipOutlineBorder)),
+        pipOutlineBorder: dev(pipOutlineBorder),
+        dotSize: dev(dotSize),
+        dotOutlineSize: dev(dotSize + dotOutlineGap + 2 * dotOutlineBorder),
+        dotOutlineBorder: dev(dotOutlineBorder),
+    };
+}
+
+/** How far from the centre the crosshair can reach, in 1080p layout px (with
+ *  a small margin), for sizing preview canvases. */
+export function crosshairReach(raw: Partial<CrosshairSettings>): number {
+    const s = normalizeCrosshairSettings(raw);
+    const D = Math.abs(PIP_BASE_OFFSET + Math.trunc(s.pipGap));
+    const pipReach = D + s.pipHeight / 2 + s.pipOutlineGap / 2 + s.pipOutlineBorder;
+    const dotReach = (s.dotSize + s.dotOutlineGap) / 2 + s.dotOutlineBorder;
+    return Math.max(pipReach, dotReach) + 4;
+}
 
 /**
  * Extract crosshair convars from machine_convars.vcfg content (the KV file

--- a/src/pages/Crosshair.tsx
+++ b/src/pages/Crosshair.tsx
@@ -12,8 +12,11 @@ import { Button, SegmentedControl } from '../components/common/ui';
 import { PageHeader } from '../components/common/PageComponents';
 import Tx from '../components/translation/Tx';
 
-// The in-game crosshair is authored in 1080p-reference px and scaled by
-// screen height, so the preview multiplies by (resolution / 1080).
+// The in-game crosshair is authored in 1080p-reference px, scaled by screen
+// height and snapped to whole device pixels. The picker chooses that snap
+// grid; the stage keeps the scene (and the crosshair's physical size) fixed,
+// so switching resolution shows only the real rasterization differences,
+// e.g. a width-1 pip rounding thinner at 1440p than at 1080p or 4K.
 const RESOLUTIONS = [
     { label: '1080p', height: 1080 },
     { label: '1440p', height: 1440 },
@@ -217,7 +220,7 @@ export default function Crosshair() {
                         the window instead of collapsing. From xl it goes back to
                         taking whatever the row leaves over. */}
                     <div className="relative h-[clamp(220px,42vh,560px)] overflow-hidden rounded-sm border border-white/5 xl:h-auto xl:min-h-[280px] xl:flex-1">
-                        <CrosshairStage scale={(resolution / 1080) * zoom} background={background} />
+                        <CrosshairStage scale={resolution / 1080} zoom={zoom} background={background} />
 
                         {/* Both overlay bars share one wrapping row so they move
                             onto separate lines on a narrow window instead of

--- a/src/pages/Profiles.tsx
+++ b/src/pages/Profiles.tsx
@@ -977,7 +977,7 @@ export default function Profiles() {
                                 </Button>
                               </div>
                               <div className="flex items-center gap-4">
-                                <CrosshairPreview size={56} scale={1.3} settings={profile.crosshair} />
+                                <CrosshairPreview size={56} scale={1440 / 1080} settings={profile.crosshair} />
                                 <div className="text-xs text-text-secondary space-y-1">
                                   <div>
                                     <Tx


### PR DESCRIPTION
Two fixes to the Crosshair tab, plus the geometry reference they were derived from.

## Preview rasterization

The preview scaled fractional geometry straight onto the canvas, so it only looked right at 1080p (scale 1). At 1440p every edge antialiased into wider, dimmer lines, the pip distance used an uncalibrated legacy formula, and outlines modelled the gap wrong.

Geometry now lives in `computeCrosshairLayout` (`src/lib/crosshair.ts`), recovered from `client.dll` + `element_gun.vcss` and screenshot-verified against the game:

- `D = 4 + pip_gap`
- float convars truncated toward zero
- sizes composed in 1080p layout units, snapped once to whole device px
- centres left unsnapped (leading edge rounds half-up)
- outline borders painted inward

The stage now shows the scene as a 1:1 centre crop scaled only by zoom, never cover-fit. Cover-fit was minifying it roughly 2x, which made every crosshair read twice as thick as it does in game. The resolution picker now changes only the snap grid: 1080p pixels draw fatter, 4K finer, same physical size, matching what switching resolution on a real monitor does. Sliders for truncated convars step in whole numbers, since 2.5 and 2 are the same crosshair.

`docs/crosshair-geometry.md` documents the derivation and the measured values. `src/lib/crosshair.test.ts` pins those values (7 tests).

## Preset tile clicks

The hover overlay flipped the whole layer to `pointer-events-auto`, which covered the tile's load button: no pointer cursor, and every click outside the Play/Trash icons was swallowed. The overlay now stays pointer-inert and only its two buttons take the pointer, so clicking a tile loads the preset again.

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm i18n:check`, and the new crosshair tests all pass locally.
