### PR TITLE
chore(release): v1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the v1.27.0 tag.

Gates on this tree: `tsc -b`, `eslint .`, `vitest run` (920 tests, 69 files), `i18n:check` (1904 referenced keys present), `gen-locale-manifest --check`. Linux AppImage built and booted clean.

Release notes are drafted and go on the GitHub Release body after the tag builds.