### PR TITLE
feat(macos): CrossOver bottle support and mac build target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Grimoire
 
-Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux).
+Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux shipped; macOS runs from source for development, see `docs/macos.md`).
 
 ## What It Does
 
@@ -98,6 +98,7 @@ Design docs and references live in `docs/`:
 - `social-architecture.md` + `social-architecture-decisions.md` - Architecture and ADRs for the planned `grimoire-social` companion service (see below)
 - `ability-vfx-recolor.md` - Hero ability VFX layer extraction + in app recoloring. Read before touching `detectVfxLayer`/`extractVfxLayer` (in `vpk.ts`/`modMerger.ts`) or building the recolor/Locker surface. Covers why particle recolor must use an in place scalar patch, not a KV3 re-encode.
 - `locker-global-mods.md` - "Global" mods: the `citadel/grimoire` priority root that outranks every other mod. Read before touching grimoire-folder handling, the `modLoadOrder` helpers, or the shuffle planner. Covers the deliberate split between `globalType` (classification, labelled "General") and `priorityMod` (placement, labelled "Global").
+- `macos.md` - Why macOS needs a CrossOver bottle, how Steam roots are discovered there, and how launching differs. Read before touching `steamRoots.ts`, `bottleLaunch.ts`, or any per-platform Steam path list. Covers why the three old hardcoded path lists were collapsed into one module.
 - `deadworks-servers.md` - The Deadworks server browser: relay data flow, content provisioning, and (critically) how the deadworks content path is woven into grimoire's canonical `gameinfo.gi` block so Fix Configuration never erases it. Read before touching `deadworksServers.ts`, `ipc/servers.ts`, or the gameinfo handling in `system.ts`/`deadlock.ts`.
 
 ## Companion Service: grimoire-social

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,87 @@
+# macOS support
+
+Grimoire runs on macOS for development and local mod testing. This document
+covers what is different about the platform and why, because almost none of it
+is obvious from the code alone.
+
+## Why macOS is not just "another desktop"
+
+Deadlock ships **no macOS depot**. The native Steam client at
+`~/Library/Application Support/Steam` can never install it, no matter what the
+user does. The only way the game exists on a Mac is inside a Wine prefix (in
+practice a CrossOver bottle) where a *Windows* Steam installed the *Windows*
+depot.
+
+Every platform assumption that holds on Windows and Linux breaks here:
+
+| Assumption | Reality on macOS |
+| --- | --- |
+| Steam lives at a known per-platform path | Steam lives inside a user-named bottle |
+| `libraryfolders.vdf` holds host paths | It holds Windows paths (`C:\...`) |
+| `steam://` URLs reach the right Steam | They reach the native client, which lacks the game |
+| The game is a host process | It is a Windows process under Wine |
+
+## Prerequisites
+
+1. **CrossOver** at `/Applications/CrossOver.app` or `~/Applications/CrossOver.app`.
+   Set `GRIMOIRE_WINE` to a Wine binary to override the search.
+2. **A bottle containing Windows Steam**, with Deadlock installed into it.
+3. **Rosetta 2**, since CrossOver's `wineloader` is x86_64 only.
+
+### Bottle graphics backend
+
+A bottle created with `cxbottle --create` gets **no graphics backend** and falls
+back to wined3d over OpenGL, which macOS caps at GL 4.1. Source 2 does not
+survive that. Append to `[EnvironmentVariables]` in the bottle's
+`cxbottle.conf`, then restart the bottle's wineserver:
+
+```
+"CX_GRAPHICS_BACKEND" = "d3dmetal"
+"WINEMSYNC" = "1"
+```
+
+Bottles created through the CrossOver GUI's application database get this
+automatically. Valid values are `d3dmetal` and `dxvk`.
+
+## How detection works
+
+`electron/main/services/steamRoots.ts` is the single source of truth for "where
+is Steam". It replaced three separate hardcoded per-platform path lists (game
+detection, `loginusers.vdf`, `localconfig.vdf`), all of which were wrong on
+macOS in the same way.
+
+On darwin it enumerates `~/Library/Application Support/CrossOver/Bottles/*`,
+treats any bottle containing `drive_c/Program Files (x86)/Steam` (or the
+non-x86 variant) as a Steam root, and puts those ahead of the native location.
+
+Windows paths read out of a bottle's VDF files are mapped back to host paths
+through that bottle's `dosdevices/` symlinks. This matters for users with more
+than one Steam library: a `D:\SteamLibrary` entry is meaningless to the host
+until it is resolved through `dosdevices/d:`. Note that `z:` conventionally maps
+to `/`, so a Windows path can legitimately point back out at native files. A
+library on an unmapped drive letter is dropped rather than guessed at.
+
+## How launching works
+
+`electron/main/services/bottleLaunch.ts` drives the bottle's own `steam.exe`:
+
+```
+<CrossOver>/bin/wine --bottle <name> -- <bottle>/steam.exe -applaunch 1422450
+```
+
+`triggerSteamLaunch` in `launch.ts` picks this path only when the configured
+Deadlock install actually resolves to a bottle, so a hypothetical future native
+macOS install would still take the normal `steam://` route.
+
+Process control (`isDeadlockRunning`, `requestDeadlockStop`) shares the Linux
+branch: the game is a Windows process under a translation layer, so the host
+only ever sees it via the full cmdline, and `pgrep -f` / `pkill -f` are correct.
+
+## What is not supported
+
+- **No packaged macOS build.** `electron-builder.yml` has no `mac` target and
+  there is no `package:mac` script. Adding one requires decisions about signing
+  and notarization, and the auto-updater expects a signed build.
+- **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only. The bottle
+  discovery, drive mapping, and launch-argument tests are all
+  platform-independent and do run there.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -55,6 +55,23 @@ win:
     - nsis
     - portable
   icon: resources/icon.ico
+# macOS runs Deadlock through a CrossOver bottle (see docs/macos.md), so the
+# audience is Apple Silicon only in practice.
+#
+# There is no Developer ID cert. identity is pinned to null so electron-builder
+# never auto-discovers the local Apple Development cert (which is not valid for
+# distribution and would fail on every other machine). Skipping electron-builder
+# signing leaves the bundle with an INVALID signature, which macOS reports as
+# "damaged", so scripts/adhoc-sign-mac.mjs re-signs ad-hoc afterwards. Users
+# still get the "unidentified developer" prompt on first launch.
+mac:
+  target:
+    - dmg
+    - zip
+  category: public.app-category.games
+  icon: resources/icon.png
+  identity: null
+afterPack: scripts/adhoc-sign-mac.mjs
 nsis:
   oneClick: false
   perMachine: false

--- a/electron/main/services/bottleLaunch.test.ts
+++ b/electron/main/services/bottleLaunch.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { launchAppInBottle, findBottleRunner, BottleRunnerMissingError } from './bottleLaunch';
+import type { SteamBottle } from './steamRoots';
+
+// Rather than mock child_process, point GRIMOIRE_WINE at a real script that
+// records its argv. That exercises the actual spawn call, so a broken argument
+// order or a missing separator shows up here instead of at runtime.
+let root: string;
+let fakeWine: string;
+let argvLog: string;
+let bottle: SteamBottle;
+
+beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'grimoire-launch-'));
+    argvLog = join(root, 'argv.txt');
+    fakeWine = join(root, 'fake-wine');
+    writeFileSync(fakeWine, `#!/bin/sh\nprintf '%s\\n' "$@" > "${argvLog}"\n`);
+    chmodSync(fakeWine, 0o755);
+
+    const steamRoot = join(root, 'Bottles', 'Deadlock', 'drive_c', 'Program Files (x86)', 'Steam');
+    mkdirSync(steamRoot, { recursive: true });
+    writeFileSync(join(steamRoot, 'steam.exe'), 'stub');
+    bottle = { name: 'Deadlock', bottlePath: join(root, 'Bottles', 'Deadlock'), steamRoot };
+});
+
+afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+});
+
+afterEach(() => {
+    delete process.env.GRIMOIRE_WINE;
+});
+
+/** Wait for the detached child to write its log, since spawn is async. */
+async function readArgv(): Promise<string[]> {
+    for (let attempt = 0; attempt < 50; attempt++) {
+        if (existsSync(argvLog)) {
+            const lines = readFileSync(argvLog, 'utf-8').trim().split('\n');
+            if (lines.length > 1) return lines;
+        }
+        await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error('fake wine never ran');
+}
+
+describe('launchAppInBottle', () => {
+    it('invokes the runner with the bottle, a separator, and the app id', async () => {
+        process.env.GRIMOIRE_WINE = fakeWine;
+        launchAppInBottle(bottle, 1422450);
+
+        expect(await readArgv()).toEqual([
+            '--bottle',
+            'Deadlock',
+            '--',
+            join(bottle.steamRoot, 'steam.exe'),
+            '-applaunch',
+            '1422450',
+        ]);
+    });
+
+    it('fails loudly when no Wine runner is available', () => {
+        process.env.GRIMOIRE_WINE = join(root, 'nope');
+        expect(() => launchAppInBottle(bottle, 1422450)).toThrow(BottleRunnerMissingError);
+    });
+
+    it('fails when the bottle has no steam.exe', () => {
+        process.env.GRIMOIRE_WINE = fakeWine;
+        const empty: SteamBottle = { ...bottle, steamRoot: join(root, 'empty') };
+        expect(() => launchAppInBottle(empty, 1422450)).toThrow(/No steam\.exe/);
+    });
+});
+
+describe('findBottleRunner', () => {
+    it('honours the GRIMOIRE_WINE override', () => {
+        process.env.GRIMOIRE_WINE = fakeWine;
+        expect(findBottleRunner()).toBe(fakeWine);
+    });
+
+    it('reports nothing rather than a bad path when the override does not exist', () => {
+        process.env.GRIMOIRE_WINE = join(root, 'nope');
+        expect(findBottleRunner()).toBeNull();
+    });
+});

--- a/electron/main/services/bottleLaunch.ts
+++ b/electron/main/services/bottleLaunch.ts
@@ -1,0 +1,80 @@
+// Launching Windows Steam inside a CrossOver bottle (macOS only).
+//
+// On Windows and Linux we hand Steam a steam:// URL and the OS routes it. That
+// cannot work on macOS: the URL handler is the native Steam client, which has
+// no Deadlock depot and would simply do nothing. The game only exists inside a
+// Wine prefix, so we have to invoke that prefix's steam.exe directly.
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { spawn } from 'child_process';
+import type { SteamBottle } from './steamRoots';
+
+/**
+ * CrossOver's Wine loader, relative to the app bundle. This is the supported
+ * CLI entry point (a Perl wrapper that sets up CX_ROOT, the bottle env, and the
+ * graphics backend) rather than the raw wineloader binary.
+ */
+const CROSSOVER_WINE_SUBPATH = 'Contents/SharedSupport/CrossOver/bin/wine';
+
+/** Locations to look for CrossOver, in priority order. */
+function crossOverCandidates(): string[] {
+    return [
+        '/Applications/CrossOver.app',
+        join(homedir(), 'Applications/CrossOver.app'),
+    ];
+}
+
+/**
+ * Absolute path to CrossOver's wine wrapper, or null when CrossOver is not
+ * installed. `GRIMOIRE_WINE` overrides the search, which is how a user on a
+ * different Wine build (or a non-standard install location) opts in.
+ */
+export function findBottleRunner(): string | null {
+    const override = process.env.GRIMOIRE_WINE;
+    if (override) return existsSync(override) ? override : null;
+
+    for (const app of crossOverCandidates()) {
+        const wine = join(app, CROSSOVER_WINE_SUBPATH);
+        if (existsSync(wine)) return wine;
+    }
+    return null;
+}
+
+/** Thrown when we know the game is in a bottle but cannot drive that bottle. */
+export class BottleRunnerMissingError extends Error {
+    constructor() {
+        super(
+            'Deadlock is installed inside a CrossOver bottle, but CrossOver could not be found. ' +
+            'Install CrossOver, or set GRIMOIRE_WINE to your Wine binary.'
+        );
+        this.name = 'BottleRunnerMissingError';
+    }
+}
+
+/**
+ * Ask the bottle's Steam to launch an app, and return once the request has been
+ * handed off. Deliberately does not wait for the game: callers poll for the
+ * process separately, exactly as they do on the other platforms.
+ *
+ * The child is detached and its stdio discarded so a long-lived Wine process
+ * tree does not keep a handle on Grimoire (and so quitting Grimoire mid-session
+ * cannot take the game down with it).
+ */
+export function launchAppInBottle(bottle: SteamBottle, appId: string | number): void {
+    const runner = findBottleRunner();
+    if (!runner) throw new BottleRunnerMissingError();
+
+    const steamExe = join(bottle.steamRoot, 'steam.exe');
+    if (!existsSync(steamExe)) {
+        throw new Error(`No steam.exe in bottle "${bottle.name}" at ${bottle.steamRoot}`);
+    }
+
+    const child = spawn(
+        runner,
+        ['--bottle', bottle.name, '--', steamExe, '-applaunch', String(appId)],
+        { detached: true, stdio: 'ignore' }
+    );
+    child.unref();
+}

--- a/electron/main/services/deadlock.ts
+++ b/electron/main/services/deadlock.ts
@@ -1,69 +1,31 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import { join, basename, dirname } from 'path';
-import { homedir } from 'os';
-import { execFileSync } from 'child_process';
+import {
+    getSteamRoots,
+    findBottleForPath,
+    readBottleDriveMap,
+    resolveBottleWindowsPath,
+} from './steamRoots';
 
 const DEADLOCK_APP_ID = '1422450';
 
 /**
- * Steam install locations to probe (the directory that contains steamapps/),
- * in priority order. On Windows we ask the registry first so users with
- * Steam installed off the C: default are handled correctly.
- */
-function getSteamInstallPaths(): string[] {
-    const home = homedir();
-
-    if (process.platform === 'linux') {
-        return [
-            join(home, '.steam/steam'),
-            join(home, '.local/share/Steam'),
-            join(home, '.var/app/com.valvesoftware.Steam/.steam/steam'),
-        ];
-    }
-
-    if (process.platform === 'darwin') {
-        return [join(home, 'Library/Application Support/Steam')];
-    }
-
-    if (process.platform === 'win32') {
-        const paths: string[] = [];
-        const push = (p: string | null) => {
-            if (!p) return;
-            const norm = p.replace(/\//g, '\\').replace(/\\+$/, '');
-            if (!paths.some((existing) => existing.toLowerCase() === norm.toLowerCase())) {
-                paths.push(norm);
-            }
-        };
-        push(queryWindowsRegistry('HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam', 'InstallPath'));
-        push(queryWindowsRegistry('HKCU\\SOFTWARE\\Valve\\Steam', 'SteamPath'));
-        push('C:\\Program Files (x86)\\Steam');
-        push('C:\\Program Files\\Steam');
-        return paths;
-    }
-
-    return [];
-}
-
-function queryWindowsRegistry(key: string, value: string): string | null {
-    try {
-        const stdout = execFileSync('reg', ['query', key, '/v', value], {
-            stdio: ['ignore', 'pipe', 'ignore'],
-            timeout: 2000,
-        }).toString();
-        const match = stdout.match(/REG_SZ\s+(.+?)\s*$/m);
-        return match ? match[1].trim() : null;
-    } catch {
-        return null;
-    }
-}
-
-/**
  * Read every "path" entry from a Steam libraryfolders.vdf so we discover
  * every Steam library on the machine, not just the default install dir.
+ *
+ * Returns host paths. On macOS the Steam root can live inside a CrossOver
+ * bottle, and a Windows Steam records Windows paths ("D:\\SteamLibrary") that
+ * mean nothing to the host filesystem, so those are mapped back through the
+ * prefix's dosdevices links. A library on a drive letter the prefix no longer
+ * maps is dropped rather than guessed at.
  */
 function readSteamLibraries(steamInstallPath: string): string[] {
     const vdfPath = join(steamInstallPath, 'steamapps', 'libraryfolders.vdf');
     if (!existsSync(vdfPath)) return [];
+
+    const bottle = process.platform === 'darwin' ? findBottleForPath(steamInstallPath) : null;
+    const driveMap = bottle ? readBottleDriveMap(bottle.bottlePath) : null;
+
     try {
         const content = readFileSync(vdfPath, 'utf-8');
         const libraries: string[] = [];
@@ -71,7 +33,13 @@ function readSteamLibraries(steamInstallPath: string): string[] {
         let match: RegExpExecArray | null;
         while ((match = re.exec(content)) !== null) {
             // VDF escapes backslashes; "C:\\SteamLibrary" -> "C:\SteamLibrary"
-            libraries.push(match[1].replace(/\\\\/g, '\\'));
+            const raw = match[1].replace(/\\\\/g, '\\');
+            if (driveMap) {
+                const mapped = resolveBottleWindowsPath(raw, driveMap);
+                if (mapped) libraries.push(mapped);
+                continue;
+            }
+            libraries.push(raw);
         }
         return libraries;
     } catch {
@@ -106,7 +74,7 @@ export function looksLikeDeadlockPath(path: string): boolean {
  * Deadlock are preferred, as that is Steam's authoritative record.
  */
 export function detectDeadlockPath(): string | null {
-    const steamInstalls = getSteamInstallPaths();
+    const steamInstalls = getSteamRoots();
     const visited = new Set<string>();
     const fallback: string[] = [];
 

--- a/electron/main/services/launch.ts
+++ b/electron/main/services/launch.ts
@@ -13,8 +13,11 @@ import {
 } from './deadlock';
 import { loadSettings } from './settings';
 import { writeLaunchOptions, readLaunchOptions, isSteamRunning } from './launchOptions';
+import { findBottleForPath } from './steamRoots';
+import { launchAppInBottle } from './bottleLaunch';
 
-// Deadlock's Steam AppID — used for the steam://rungameid/... URI scheme.
+// Deadlock's Steam AppID. Used for the steam://rungameid/... URI scheme on
+// Windows and Linux, and for steam.exe -applaunch inside a bottle on macOS.
 const DEADLOCK_STEAM_APP_ID = 1422450;
 const DEADLOCK_PROCESS_NAME = 'deadlock.exe';
 
@@ -134,7 +137,10 @@ export async function isDeadlockRunning(): Promise<boolean> {
             ]);
             return /deadlock\.exe/i.test(result.stdout);
         }
-        if (process.platform === 'linux') {
+        // macOS behaves like Linux here: the game runs as a Windows process
+        // under a translation layer (Wine/CrossOver rather than Proton), so the
+        // host only ever sees it via the full cmdline.
+        if (process.platform === 'linux' || process.platform === 'darwin') {
             const result = await runCommand('pgrep', ['-f', DEADLOCK_PROCESS_NAME]);
             return result.code === 0 && result.stdout.trim().length > 0;
         }
@@ -178,7 +184,7 @@ async function requestDeadlockStop(force: boolean): Promise<CommandResult> {
                 : ['/IM', DEADLOCK_PROCESS_NAME, '/T']
         );
     }
-    if (process.platform === 'linux') {
+    if (process.platform === 'linux' || process.platform === 'darwin') {
         return runCommand('pkill', [force ? '-KILL' : '-TERM', '-f', DEADLOCK_PROCESS_NAME]);
     }
     return { code: 0, stdout: '', stderr: '' };
@@ -434,8 +440,20 @@ async function syncLaunchOptionsToSteam(): Promise<void> {
 
 /**
  * Trigger Steam to launch Deadlock. Doesn't wait for the game to actually start.
+ *
+ * When the install lives inside a CrossOver bottle (the only way Deadlock
+ * exists on macOS, since it ships no macOS depot) the steam:// URL is useless:
+ * the host handler is the native Steam client, which does not have the game.
+ * Drive that bottle's own steam.exe instead.
  */
-async function triggerSteamLaunch(): Promise<void> {
+async function triggerSteamLaunch(deadlockPath: string): Promise<void> {
+    if (process.platform === 'darwin') {
+        const bottle = findBottleForPath(deadlockPath);
+        if (bottle) {
+            launchAppInBottle(bottle, DEADLOCK_STEAM_APP_ID);
+            return;
+        }
+    }
     await shell.openExternal(`steam://rungameid/${DEADLOCK_STEAM_APP_ID}`);
 }
 
@@ -472,7 +490,7 @@ export async function launchModded({
         }
         await beforeLaunch?.();
         await syncLaunchOptionsToSteam();
-        await triggerSteamLaunch();
+        await triggerSteamLaunch(deadlockPath);
     } finally {
         launchInFlight = false;
     }
@@ -523,7 +541,7 @@ export async function launchVanilla({
     try {
         await beforeLaunch?.();
         await syncLaunchOptionsToSteam();
-        await triggerSteamLaunch();
+        await triggerSteamLaunch(deadlockPath);
     } catch (err) {
         // Steam URL failed — immediately restore so the user isn't left with
         // no mods AND no game.

--- a/electron/main/services/launchOptions.ts
+++ b/electron/main/services/launchOptions.ts
@@ -22,8 +22,8 @@
 
 import { promises as fs, existsSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { spawn } from 'child_process';
+import { getSteamRoots } from './steamRoots';
 
 export const DEADLOCK_STEAM_APP_ID = '1422450';
 
@@ -36,21 +36,13 @@ export interface LaunchOptionsLookup {
     currentValue: string | null;
 }
 
-/** Per-platform candidate locations for Steam's `userdata` root. */
+/**
+ * Candidate locations for Steam's `userdata` root, one per discovered Steam
+ * root. On macOS that includes the Steam inside each CrossOver bottle, whose
+ * localconfig.vdf is the one that actually governs Deadlock. See steamRoots.ts.
+ */
 function getSteamUserdataRoots(): string[] {
-    const paths: string[] = [];
-    const home = homedir();
-    if (process.platform === 'linux') {
-        paths.push(join(home, '.steam/steam/userdata'));
-        paths.push(join(home, '.local/share/Steam/userdata'));
-        paths.push(join(home, '.var/app/com.valvesoftware.Steam/.steam/steam/userdata'));
-    } else if (process.platform === 'win32') {
-        paths.push('C:\\Program Files (x86)\\Steam\\userdata');
-        paths.push('C:\\Program Files\\Steam\\userdata');
-    } else if (process.platform === 'darwin') {
-        paths.push(join(home, 'Library/Application Support/Steam/userdata'));
-    }
-    return paths;
+    return getSteamRoots().map((root) => join(root, 'userdata'));
 }
 
 /**

--- a/electron/main/services/steamDetect.ts
+++ b/electron/main/services/steamDetect.ts
@@ -3,7 +3,7 @@
 
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
+import { getSteamRoots } from './steamRoots'
 
 export interface SteamUser {
     steamId64: string
@@ -13,24 +13,14 @@ export interface SteamUser {
 }
 
 /**
- * Get platform-specific Steam config paths
+ * Steam config folders to probe, one per discovered Steam root.
+ *
+ * On macOS this includes the Steam inside each CrossOver bottle, which is the
+ * only place a Deadlock player's loginusers.vdf can actually be, since the
+ * native macOS client cannot install the game. See steamRoots.ts.
  */
 function getSteamConfigPaths(): string[] {
-    const paths: string[] = []
-    const home = homedir()
-
-    if (process.platform === 'linux') {
-        paths.push(join(home, '.steam/steam/config'))
-        paths.push(join(home, '.local/share/Steam/config'))
-        paths.push(join(home, '.var/app/com.valvesoftware.Steam/.steam/steam/config'))
-    } else if (process.platform === 'win32') {
-        paths.push('C:\\Program Files (x86)\\Steam\\config')
-        paths.push('C:\\Program Files\\Steam\\config')
-    } else if (process.platform === 'darwin') {
-        paths.push(join(home, 'Library/Application Support/Steam/config'))
-    }
-
-    return paths
+    return getSteamRoots().map((root) => join(root, 'config'))
 }
 
 /**

--- a/electron/main/services/steamRoots.test.ts
+++ b/electron/main/services/steamRoots.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+    findSteamBottles,
+    findBottleForPath,
+    readBottleDriveMap,
+    resolveBottleWindowsPath,
+} from './steamRoots';
+
+// A fixture that mirrors a real CrossOver bottles directory:
+//
+//   Deadlock/      Steam under "Program Files (x86)" (the usual case)
+//   Deadlock2/     name-prefixed sibling, to catch sloppy startsWith matching
+//   Office/        a bottle with no Steam at all
+//   Legacy/        Steam under "Program Files" (64-bit installer layout)
+//   notabottle     a plain file sitting in the bottles dir
+let bottlesDir: string;
+let hostLibrary: string;
+
+beforeAll(() => {
+    const root = mkdtempSync(join(tmpdir(), 'grimoire-bottles-'));
+    bottlesDir = join(root, 'Bottles');
+    hostLibrary = join(root, 'HostGames');
+    mkdirSync(hostLibrary, { recursive: true });
+
+    const makeBottle = (name: string, steamSubPath: string | null) => {
+        const bottle = join(bottlesDir, name);
+        const driveC = join(bottle, 'drive_c');
+        mkdirSync(driveC, { recursive: true });
+        if (steamSubPath) mkdirSync(join(driveC, steamSubPath), { recursive: true });
+
+        const dosdevices = join(bottle, 'dosdevices');
+        mkdirSync(dosdevices, { recursive: true });
+        // Wine writes c: as a RELATIVE link, which is the case that breaks a
+        // naive readlink consumer.
+        symlinkSync('../drive_c', join(dosdevices, 'c:'));
+        symlinkSync('/', join(dosdevices, 'z:'));
+        // A non-drive link that must be ignored.
+        symlinkSync('/dev/null', join(dosdevices, 'com1'));
+        return bottle;
+    };
+
+    makeBottle('Deadlock', join('Program Files (x86)', 'Steam'));
+    makeBottle('Deadlock2', join('Program Files (x86)', 'Steam'));
+    makeBottle('Office', null);
+    makeBottle('Legacy', join('Program Files', 'Steam'));
+    writeFileSync(join(bottlesDir, 'notabottle'), 'stray file');
+
+    // A second Steam library on its own drive letter, living outside drive_c.
+    symlinkSync(hostLibrary, join(bottlesDir, 'Deadlock', 'dosdevices', 'd:'));
+});
+
+afterAll(() => {
+    rmSync(join(bottlesDir, '..'), { recursive: true, force: true });
+});
+
+describe('findSteamBottles', () => {
+    it('finds only bottles that actually contain a Steam install', () => {
+        const names = findSteamBottles(bottlesDir).map((b) => b.name);
+        expect(names).toEqual(['Deadlock', 'Deadlock2', 'Legacy']);
+    });
+
+    it('handles the 64-bit "Program Files" layout as well as x86', () => {
+        const legacy = findSteamBottles(bottlesDir).find((b) => b.name === 'Legacy')!;
+        expect(legacy.steamRoot).toBe(
+            join(bottlesDir, 'Legacy', 'drive_c', 'Program Files', 'Steam')
+        );
+    });
+
+    it('returns empty rather than throwing when the bottles dir is absent', () => {
+        expect(findSteamBottles(join(bottlesDir, 'does-not-exist'))).toEqual([]);
+    });
+});
+
+describe('readBottleDriveMap', () => {
+    it('resolves relative drive links against the dosdevices dir', () => {
+        const map = readBottleDriveMap(join(bottlesDir, 'Deadlock'));
+        expect(map['c:']).toBe(join(bottlesDir, 'Deadlock', 'drive_c'));
+    });
+
+    it('keeps absolute drive links as-is and ignores non-drive links', () => {
+        const map = readBottleDriveMap(join(bottlesDir, 'Deadlock'));
+        expect(map['z:']).toBe('/');
+        expect(map).not.toHaveProperty('com1');
+    });
+});
+
+describe('resolveBottleWindowsPath', () => {
+    const map = () => readBottleDriveMap(join(bottlesDir, 'Deadlock'));
+
+    it('maps a drive_c Windows path to its host path', () => {
+        expect(resolveBottleWindowsPath('C:\\Program Files (x86)\\Steam', map())).toBe(
+            join(bottlesDir, 'Deadlock', 'drive_c', 'Program Files (x86)', 'Steam')
+        );
+    });
+
+    it('maps a library on another drive letter out to its real location', () => {
+        expect(resolveBottleWindowsPath('D:\\SteamLibrary', map())).toBe(
+            join(hostLibrary, 'SteamLibrary')
+        );
+    });
+
+    it('is case-insensitive about the drive letter', () => {
+        expect(resolveBottleWindowsPath('c:\\Games', map())).toBe(
+            join(bottlesDir, 'Deadlock', 'drive_c', 'Games')
+        );
+    });
+
+    it('returns the drive root itself for a bare drive path', () => {
+        expect(resolveBottleWindowsPath('C:\\', map())).toBe(
+            join(bottlesDir, 'Deadlock', 'drive_c')
+        );
+    });
+
+    it('returns null for a drive the prefix does not map', () => {
+        expect(resolveBottleWindowsPath('E:\\SteamLibrary', map())).toBeNull();
+    });
+
+    it('returns null for something that is not a Windows path', () => {
+        expect(resolveBottleWindowsPath('/usr/local/games', map())).toBeNull();
+    });
+});
+
+describe('findBottleForPath', () => {
+    it('finds the bottle containing a deep game path', () => {
+        const gamePath = join(
+            bottlesDir,
+            'Deadlock',
+            'drive_c',
+            'Program Files (x86)',
+            'Steam',
+            'steamapps',
+            'common',
+            'Deadlock'
+        );
+        expect(findBottleForPath(gamePath, bottlesDir)?.name).toBe('Deadlock');
+    });
+
+    it('does not match a bottle whose name is a prefix of another', () => {
+        const gamePath = join(bottlesDir, 'Deadlock2', 'drive_c', 'Program Files (x86)', 'Steam');
+        expect(findBottleForPath(gamePath, bottlesDir)?.name).toBe('Deadlock2');
+    });
+
+    it('returns null for a path outside any bottle', () => {
+        expect(findBottleForPath(hostLibrary, bottlesDir)).toBeNull();
+    });
+});

--- a/electron/main/services/steamRoots.ts
+++ b/electron/main/services/steamRoots.ts
@@ -1,0 +1,207 @@
+// Steam install root discovery, shared by every service that needs to find
+// Steam's data on disk (game detection, loginusers.vdf, localconfig.vdf).
+//
+// A "Steam root" is the directory that directly contains steamapps/, config/
+// and userdata/. Callers append whichever subfolder they care about.
+//
+// macOS is the interesting platform. Deadlock ships no macOS depot, so the
+// native Steam client at ~/Library/Application Support/Steam can never hold it.
+// The only way the game exists on a Mac is inside a Wine prefix, in practice a
+// CrossOver bottle, where a Windows Steam installed the Windows depot. So on
+// darwin we enumerate CrossOver bottles and treat each Steam we find inside one
+// as a first-class Steam root. The native location is still probed (harmless,
+// and correct the day Valve ships a macOS build).
+
+import { existsSync, readdirSync, readlinkSync, statSync } from 'fs';
+import { join, resolve, isAbsolute } from 'path';
+import { homedir } from 'os';
+import { execFileSync } from 'child_process';
+
+/** A Wine/CrossOver prefix that contains a Windows Steam installation. */
+export interface SteamBottle {
+    /** Bottle folder name, as shown in CrossOver ("Deadlock"). */
+    name: string;
+    /** Absolute host path of the bottle root (the dir holding drive_c/). */
+    bottlePath: string;
+    /** Absolute host path of the Steam install inside the bottle. */
+    steamRoot: string;
+}
+
+/** Default CrossOver bottles directory on macOS. */
+export function defaultBottlesDir(): string {
+    return join(homedir(), 'Library/Application Support/CrossOver/Bottles');
+}
+
+/**
+ * Windows-side Steam install directories to probe inside a bottle, relative to
+ * drive_c. Ordered as Steam's own installer prefers them.
+ */
+const BOTTLE_STEAM_SUBPATHS = [
+    join('Program Files (x86)', 'Steam'),
+    join('Program Files', 'Steam'),
+];
+
+/**
+ * Map a bottle's DOS drive letters to host paths by reading the symlinks in
+ * dosdevices/. Returns lowercase keys with the colon included ("c:").
+ *
+ * Note that z: conventionally maps to the host filesystem root, so a Windows
+ * path recorded inside the bottle can legitimately point back out at native
+ * files. That is why we resolve through this map rather than assuming every
+ * Windows path lives under drive_c.
+ */
+export function readBottleDriveMap(bottlePath: string): Record<string, string> {
+    const dosdevices = join(bottlePath, 'dosdevices');
+    const map: Record<string, string> = {};
+    let entries: string[];
+    try {
+        entries = readdirSync(dosdevices);
+    } catch {
+        return map;
+    }
+    for (const entry of entries) {
+        // Drive links only ("c:"). Skip port links like "com1" and the
+        // "c::" device variants Wine also creates.
+        if (!/^[a-z]:$/i.test(entry)) continue;
+        const linkPath = join(dosdevices, entry);
+        try {
+            const target = readlinkSync(linkPath);
+            map[entry.toLowerCase()] = isAbsolute(target)
+                ? target
+                : resolve(dosdevices, target);
+        } catch {
+            // Not a symlink (some prefixes use real dirs); use it as-is.
+            if (existsSync(linkPath)) map[entry.toLowerCase()] = linkPath;
+        }
+    }
+    return map;
+}
+
+/**
+ * Translate a Windows path recorded inside a bottle ("C:\\Program Files
+ * (x86)\\Steam") into a host path, using that bottle's drive map. Returns null
+ * when the drive letter is not mapped, which is the honest answer for a library
+ * on a drive the prefix no longer has.
+ *
+ * Accepts an already-unescaped path: VDF doubles its backslashes, and callers
+ * are expected to have collapsed those first.
+ */
+export function resolveBottleWindowsPath(
+    windowsPath: string,
+    driveMap: Record<string, string>
+): string | null {
+    const match = windowsPath.match(/^([a-z]:)[\\/]*(.*)$/i);
+    if (!match) return null;
+    const root = driveMap[match[1].toLowerCase()];
+    if (!root) return null;
+    const rest = match[2].replace(/\\/g, '/');
+    return rest ? join(root, rest) : root;
+}
+
+/**
+ * Every CrossOver bottle that contains a Windows Steam install.
+ *
+ * `bottlesDir` is injectable so tests can point at a fixture tree; production
+ * callers use the default.
+ */
+export function findSteamBottles(bottlesDir: string = defaultBottlesDir()): SteamBottle[] {
+    let entries: string[];
+    try {
+        entries = readdirSync(bottlesDir);
+    } catch {
+        return [];
+    }
+
+    const bottles: SteamBottle[] = [];
+    for (const name of entries) {
+        const bottlePath = join(bottlesDir, name);
+        try {
+            if (!statSync(bottlePath).isDirectory()) continue;
+        } catch {
+            continue;
+        }
+        for (const sub of BOTTLE_STEAM_SUBPATHS) {
+            const steamRoot = join(bottlePath, 'drive_c', sub);
+            if (existsSync(steamRoot)) {
+                bottles.push({ name, bottlePath, steamRoot });
+                break;
+            }
+        }
+    }
+    // Stable order so detection is deterministic across runs.
+    return bottles.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The bottle a given host path lives inside, or null when the path is not in a
+ * bottle. Used by the launch path to decide whether the game must be started
+ * through Wine and, if so, which prefix.
+ */
+export function findBottleForPath(
+    hostPath: string,
+    bottlesDir: string = defaultBottlesDir()
+): SteamBottle | null {
+    const normalized = resolve(hostPath);
+    for (const bottle of findSteamBottles(bottlesDir)) {
+        const root = resolve(bottle.bottlePath);
+        if (normalized === root || normalized.startsWith(root + '/')) return bottle;
+    }
+    return null;
+}
+
+function queryWindowsRegistry(key: string, value: string): string | null {
+    try {
+        const stdout = execFileSync('reg', ['query', key, '/v', value], {
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 2000,
+        }).toString();
+        const match = stdout.match(/REG_SZ\s+(.+?)\s*$/m);
+        return match ? match[1].trim() : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Steam install roots to probe, in priority order, deduplicated.
+ *
+ * On Windows we ask the registry first so users with Steam installed off the
+ * C: default are handled correctly. On macOS bottle Steams come before the
+ * native location, because the native one cannot hold Deadlock.
+ */
+export function getSteamRoots(bottlesDir: string = defaultBottlesDir()): string[] {
+    const home = homedir();
+    const roots: string[] = [];
+    const push = (p: string | null) => {
+        if (!p) return;
+        const norm = process.platform === 'win32'
+            ? p.replace(/\//g, '\\').replace(/\\+$/, '')
+            : p.replace(/\/+$/, '');
+        if (!roots.some((existing) => existing.toLowerCase() === norm.toLowerCase())) {
+            roots.push(norm);
+        }
+    };
+
+    if (process.platform === 'linux') {
+        push(join(home, '.steam/steam'));
+        push(join(home, '.local/share/Steam'));
+        push(join(home, '.var/app/com.valvesoftware.Steam/.steam/steam'));
+        return roots;
+    }
+
+    if (process.platform === 'darwin') {
+        for (const bottle of findSteamBottles(bottlesDir)) push(bottle.steamRoot);
+        push(join(home, 'Library/Application Support/Steam'));
+        return roots;
+    }
+
+    if (process.platform === 'win32') {
+        push(queryWindowsRegistry('HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam', 'InstallPath'));
+        push(queryWindowsRegistry('HKCU\\SOFTWARE\\Valve\\Steam', 'SteamPath'));
+        push('C:\\Program Files (x86)\\Steam');
+        push('C:\\Program Files\\Steam');
+        return roots;
+    }
+
+    return roots;
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "i18n:extract-unwired": "node scripts/extract-unwired-i18n.mjs",
     "package": "electron-vite build && electron-builder",
     "package:linux": "electron-vite build && electron-builder --linux",
-    "package:win": "electron-vite build && electron-builder --win"
+    "package:win": "electron-vite build && electron-builder --win",
+    "package:mac": "electron-vite build && electron-builder --mac"
   },
   "dependencies": {
     "7zip-bin": "^5.2.0",

--- a/scripts/adhoc-sign-mac.mjs
+++ b/scripts/adhoc-sign-mac.mjs
@@ -1,0 +1,39 @@
+// electron-builder afterPack hook: ad-hoc sign the macOS app bundle.
+//
+// Why this exists: we have no Developer ID certificate, so electron-builder is
+// configured with `identity: null` and skips signing. That is NOT the same as
+// leaving the app unsigned. electron-builder rewrites the bundle (injects
+// app.asar, rewrites Info.plist, renames the executable), which INVALIDATES the
+// linker-signed ad-hoc signature Electron ships with. macOS treats an invalid
+// signature on a quarantined download as "damaged and can't be opened", which
+// the user cannot click past. A valid ad-hoc signature instead produces the
+// ordinary "unidentified developer" prompt, which they can.
+//
+// So: re-sign ad-hoc after packing. This does not make the app notarized or
+// trusted, it just makes it honestly unsigned rather than broken.
+
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+export default async function adhocSignMac(context) {
+    if (context.electronPlatformName !== 'darwin') return;
+
+    const appPath = join(
+        context.appOutDir,
+        `${context.packager.appInfo.productFilename}.app`
+    );
+
+    // --deep is deprecated for distribution signing but remains the supported
+    // way to ad-hoc sign a whole bundle, and the nested Electron helpers and
+    // frameworks must all be re-signed or the outer signature will not verify.
+    execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], {
+        stdio: 'inherit',
+    });
+
+    // Fail the build rather than ship another "damaged" artifact.
+    execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], {
+        stdio: 'inherit',
+    });
+
+    console.log(`  • ad-hoc signed and verified  file=${appPath}`);
+}


### PR DESCRIPTION
Adds macOS support: detecting and launching Deadlock inside a CrossOver bottle, plus a mac packaging target that produces an artifact macOS will actually open.

## Why

Deadlock ships no macOS depot, so the native Steam client can never hold it. On a Mac the game only exists inside a Wine prefix where a Windows Steam installed the Windows depot. Everything here follows from that.

## What changed

**Steam root discovery (`steamRoots.ts`, new).** Three services each carried their own hardcoded per-platform Steam path list (game detection, `loginusers.vdf`, `localconfig.vdf`) and all three were wrong on darwin in the same way. They are collapsed into one module that, on darwin, enumerates CrossOver bottles and ranks bottle Steams ahead of the native location. Windows paths recorded in a bottle's VDF files are mapped back to host paths through the prefix's `dosdevices` links, so a second library on another drive letter resolves instead of being silently wrong.

**Launching (`bottleLaunch.ts`, new).** A `steam://` URL reaches the native client, which lacks the game, so this drives the bottle's own `steam.exe` instead. Process control joins the Linux branch, since the game is a Windows process under a translation layer either way.

**Build target (`electron-builder.yml`, `scripts/adhoc-sign-mac.mjs`).** `mac.identity: null` makes electron-builder skip signing, which is not the same as shipping unsigned: electron-builder rewrites the bundle (app.asar, Info.plist, executable rename), invalidating the linker-signed signature Electron ships with. macOS reports an invalid signature on a quarantined download as "damaged and can't be opened", which users cannot click past. This shipped once in the v1.27.0 mac artifacts. An `afterPack` hook re-signs ad-hoc and verifies, failing the build rather than shipping a broken artifact again. `identity` stays pinned to `null` so the local Apple Development cert is never auto-discovered, since it is not valid for distribution and would fail on every other machine.

**Side effect on Windows:** `steamDetect` and `launchOptions` now inherit the registry lookup that only `deadlock.ts` had, so Steam installed off the `C:` default is handled in all three.

## Testing

All CI gates pass locally on this branch:

| Gate | Result |
| --- | --- |
| `pnpm lint` | pass |
| `tsc -b --noEmit` | pass |
| `pnpm exec vitest run` | 1006 passed / 78 files |
| `pnpm i18n:check` | pass |
| `gen-locale-manifest.mjs --check` | up to date |

New unit coverage: `steamRoots.test.ts` and `bottleLaunch.test.ts` (235 lines).

Verified manually on darwin/arm64:

- `pnpm dev` boots, renderer mounts, catalog sync and conflict detection run.
- `pnpm package:mac` produces `Grimoire-1.27.0-arm64.dmg` and `-mac.zip`.
- `codesign -dv` on the packed bundle reports `Signature=adhoc`; `codesign --verify --deep --strict` reports "valid on disk" and "satisfies its Designated Requirement", which is the behaviour the hook exists to guarantee.
- The packaged `.app` launches, loads the renderer from `app.asar`, and runs renderer-driven IPC. No errors in `~/Library/Logs/grimoire/main.log`.

## Reviewer notes

Two gaps worth knowing about, neither introduced by this branch:

1. **CI will not exercise any of this.** `ci.yml` runs on `ubuntu-latest` only, so the mac target, the signing hook, and the bottle launch path all go green without being run. The pure-logic half is covered by the new unit tests; the packaging half was verified locally as above.
2. **`release.yml` has no macOS runner** (matrix is `ubuntu-latest` + `windows-latest`), so the release workflow will not produce a mac artifact. `pnpm package:mac` is a local-build path for now. Adding a `macos-latest` matrix entry is a deliberate follow-up, not part of this PR.

`docs/macos.md` covers the bottle requirement, root discovery, and how launching differs; `CLAUDE.md` points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
