### PR TITLE
ci(macos): add macOS to the release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
             platform: linux
           - os: windows-latest
             platform: win
+          # macos-latest must stay Apple Silicon: vpkmerge publishes a
+          # darwin-arm64 asset only (scripts/fetch-vpkmerge.mjs), and the
+          # CrossOver bottle Deadlock runs in is arm64 in practice. The build
+          # step asserts the arch so an x64 runner fails loudly instead of
+          # silently shipping without mod merging.
+          - os: macos-latest
+            platform: mac
 
     runs-on: ${{ matrix.os }}
 
@@ -89,6 +96,16 @@ jobs:
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             pnpm exec electron-vite build && pnpm exec electron-builder --linux --publish never
+          elif [ "${{ matrix.platform }}" = "mac" ]; then
+            # See the matrix comment: arm64 only. postinstall skips the
+            # vpkmerge fetch with a warning on unsupported platforms, so
+            # without this the .dmg would build fine and just lose merging.
+            ARCH="$(node -p 'process.arch')"
+            if [ "$ARCH" != "arm64" ]; then
+              echo "ERROR: mac runner is $ARCH; expected arm64 (no darwin-$ARCH vpkmerge asset)"
+              exit 1
+            fi
+            pnpm exec electron-vite build && pnpm exec electron-builder --mac --arm64 --publish never
           else
             pnpm exec electron-vite build && pnpm exec electron-builder --win --publish never
           fi
@@ -114,13 +131,20 @@ jobs:
         run: |
           cd release
           # Hash user-facing artifacts only (skip auto-update metadata and blockmaps).
+          # *.zip is the macOS update artifact; win/linux targets produce none.
           shopt -s nullglob
-          files=(*.exe *.AppImage *.deb)
+          files=(*.exe *.AppImage *.deb *.dmg *.zip)
           if [ ${#files[@]} -eq 0 ]; then
             echo "ERROR: no artifact files found to hash"
             exit 1
           fi
-          sha256sum "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          # macOS runners have no sha256sum; shasum ships with the OS and emits
+          # the same "<hash>  <name>" format.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          else
+            shasum -a 256 "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          fi
           echo "=== SHA256SUMS-${{ matrix.platform }}.txt ==="
           cat "SHA256SUMS-${{ matrix.platform }}.txt"
 
@@ -131,6 +155,8 @@ jobs:
             grimoire/release/*.exe
             grimoire/release/*.AppImage
             grimoire/release/*.deb
+            grimoire/release/*.dmg
+            grimoire/release/*.zip
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Grimoire
 
-Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux shipped; macOS runs from source for development, see `docs/macos.md`).
+Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux/macOS shipped; the macOS build is Apple Silicon only, ad-hoc signed, and cannot auto-update, see `docs/macos.md`).
 
 ## What It Does
 
@@ -98,7 +98,7 @@ Design docs and references live in `docs/`:
 - `social-architecture.md` + `social-architecture-decisions.md` - Architecture and ADRs for the planned `grimoire-social` companion service (see below)
 - `ability-vfx-recolor.md` - Hero ability VFX layer extraction + in app recoloring. Read before touching `detectVfxLayer`/`extractVfxLayer` (in `vpk.ts`/`modMerger.ts`) or building the recolor/Locker surface. Covers why particle recolor must use an in place scalar patch, not a KV3 re-encode.
 - `locker-global-mods.md` - "Global" mods: the `citadel/grimoire` priority root that outranks every other mod. Read before touching grimoire-folder handling, the `modLoadOrder` helpers, or the shuffle planner. Covers the deliberate split between `globalType` (classification, labelled "General") and `priorityMod` (placement, labelled "Global").
-- `macos.md` - Why macOS needs a CrossOver bottle, how Steam roots are discovered there, and how launching differs. Read before touching `steamRoots.ts`, `bottleLaunch.ts`, or any per-platform Steam path list. Covers why the three old hardcoded path lists were collapsed into one module.
+- `macos.md` - Why macOS needs a CrossOver bottle, how Steam roots are discovered there, and how launching differs. Read before touching `steamRoots.ts`, `bottleLaunch.ts`, or any per-platform Steam path list. Covers why the three old hardcoded path lists were collapsed into one module, and why the shipped mac build is arm64-only and cannot auto-update.
 - `deadworks-servers.md` - The Deadworks server browser: relay data flow, content provisioning, and (critically) how the deadworks content path is woven into grimoire's canonical `gameinfo.gi` block so Fix Configuration never erases it. Read before touching `deadworksServers.ts`, `ipc/servers.ts`, or the gameinfo handling in `system.ts`/`deadlock.ts`.
 
 ## Companion Service: grimoire-social

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -77,11 +77,32 @@ Process control (`isDeadlockRunning`, `requestDeadlockStop`) shares the Linux
 branch: the game is a Windows process under a translation layer, so the host
 only ever sees it via the full cmdline, and `pgrep -f` / `pkill -f` are correct.
 
+## Packaging
+
+`release.yml` builds macOS alongside Linux and Windows, producing an arm64
+`.dmg` and `-mac.zip`. Apple Silicon only, for two reasons: vpkmerge publishes
+a `darwin-arm64` asset and no `darwin-x64` one (`scripts/fetch-vpkmerge.mjs`),
+and the CrossOver bottles Deadlock runs in are arm64 in practice. The build
+step asserts the runner arch so an x64 runner fails loudly rather than quietly
+shipping a build with no mod merging.
+
 ## What is not supported
 
-- **No packaged macOS build.** `electron-builder.yml` has no `mac` target and
-  there is no `package:mac` script. Adding one requires decisions about signing
-  and notarization, and the auto-updater expects a signed build.
-- **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only. The bottle
-  discovery, drive mapping, and launch-argument tests are all
+- **The build is ad-hoc signed, not notarized.** There is no Developer ID
+  certificate, so `electron-builder.yml` pins `identity: null` and
+  `scripts/adhoc-sign-mac.mjs` re-signs afterwards (see that file for why an
+  invalid signature is worse than an honest ad-hoc one). Users get the
+  "unidentified developer" prompt on first launch.
+- **Auto-update does not work on macOS.** Squirrel.Mac validates that an update
+  carries the same signing identity as the running app, and an ad-hoc signature
+  has none (`TeamIdentifier=not set`). `getInstallSource()` in
+  `services/updater.ts` only special-cases Linux, so macOS is still treated as
+  `'standard'` and the in-app updater is offered even though installing will
+  fail. macOS users have to download each release manually. Fixing this
+  properly needs a paid Developer ID and notarization; short of that, macOS
+  should be routed to a manual-download path the way managed Linux installs
+  are.
+- **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only, so a
+  Mac-only build break surfaces at release time rather than on the PR. The
+  bottle discovery, drive mapping, and launch-argument tests are all
   platform-independent and do run there.


### PR DESCRIPTION
> Stacked on #353 — base is `ci/flatpak-release` so the `release.yml` diff stays readable. Retarget to `main` once that merges.
>
> **Not for 1.27.1.** Two things should land before this ships; see Blockers.

Builds an arm64 `.dmg` and `-mac.zip` alongside Linux and Windows. The packaging side was already in place from #352 (mac target, `package:mac`, ad-hoc signing hook) — this just wires it into CI.

## Apple Silicon only

vpkmerge publishes a `darwin-arm64` asset and no `darwin-x64` one, and the CrossOver bottles Deadlock runs in are arm64 in practice.

`fetch-vpkmerge.mjs:87` *warns and skips* on an unsupported platform rather than failing, so an x64 runner would have produced a perfectly valid `.dmg` that silently could not merge mods. The build step asserts `process.arch` so that fails loudly instead.

## Other changes

- `*.dmg` / `*.zip` added to the checksum globs and the attestation subject paths.
- `command -v sha256sum` fallback to `shasum -a 256`, since macOS runners have no `sha256sum`.

## Verification

Local `pnpm package:mac` on `darwin-arm64`, exit 0:

- `better-sqlite3` rebuilt for arm64
- ad-hoc sign + verify hook ran: `valid on disk`, `satisfies its Designated Requirement`
- `vpkmerge-macos-aarch64` present in `Contents/Resources/vpkmerge/`
- artifacts `Grimoire-1.27.1-arm64.dmg` and `Grimoire-1.27.1-arm64-mac.zip`
- ran the actual checksum snippet against them: matched exactly those two, correctly excluding the blockmaps and `latest-mac.yml`

## Blockers before this ships

**1. Auto-update does not work on macOS.** `codesign -dv` on the built app reports `Signature=adhoc`, `TeamIdentifier=not set`. Squirrel.Mac requires an update to carry the same signing identity as the running app. But `getInstallSource()` in `services/updater.ts:12` only special-cases Linux, so darwin falls through to `'standard'` and the app will offer updates it cannot install. Needs routing to a manual-download path the way managed Linux installs are routed to their package manager — which means new UI copy, so new `en/translation.json` keys that must land on `main` before translators see them.

**2. `launchOptions.ts:102` can eat a user's launch options.** `isSteamRunning()` uses `pgrep -x steam` on darwin, which can never match a bottle's Wine-hosted `steam.exe`, while `getSteamUserdataRoots()` now *does* resolve bottle roots. So `syncLaunchOptionsToSteam()` believes Steam is down and rewrites a `localconfig.vdf` Steam has open, and Steam clobbers it on exit. Inert before #352 (the macOS path pointed at a native Steam with no Deadlock), reachable now, and shipped the moment macOS is in the matrix.

Two lower-severity macOS issues from the same review, worth folding in: `bottleLaunch.ts:74` spawns without an `'error'` listener (a non-executable `GRIMOIRE_WINE` throws uncaught in main), and `deadlock.ts:37` returns a truthy `{}` on drive-map failure, silently dropping every library path.

## Docs

The "No packaged macOS build" bullet in `docs/macos.md` was already stale from #352. Replaced with a Packaging section and the two real remaining limitations. `CLAUDE.md` header updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)