### PR TITLE
chore(release): v1.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Patch bump for the 9 commits since `v1.27.0`.

## Gates

All green on this branch: `tsc -b` clean, `eslint .` clean, 1006 tests across 78 files, `i18n:check` OK (1942 referenced keys all present), locale manifest up to date.

## Review notes

A review of `v1.27.0..HEAD` turned up five issues, none blocking. Three are macOS-only and cannot reach a 1.27.1 artifact, since macOS is not in the release matrix (see #354, deliberately held back). The two that do ship:

- **`download.ts:615`** — after a filecache redirect hands off to `downloadTransfer`, the original `request` keeps its `'error'` handler. A late socket error nulls the `localAbort` cancel handler and rejects the outer promise while the transfer keeps writing to `destPath`. `finalize` is `settled`-guarded so there is no double-settle; the damage is the early rejection orphaning a live transfer. Needs a socket error on an already-drained 302, so the window is narrow.
- **`DownloadQueueIndicator.tsx:116`** — `downloadTransfer.ts:331` resets `startingOffset = 0` on restart, so `downloaded` goes backwards on a mirror failover and the speed/ETA readout blanks. It self-heals once `downloaded` re-passes `anchor.bytes` (via the `prev <= 0 ? rate` branch), so this is cosmetic rather than sticky.

Both are worth a follow-up patch, neither justifies holding the tag.

## Sequencing

#353 must merge before this is tagged, or the `flatpak-publish` job will not be on the tagged commit and will not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)