### PR TITLE
ci(macos): ship a macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
             platform: linux
           - os: windows-latest
             platform: win
+          # macos-latest must stay Apple Silicon: vpkmerge publishes a
+          # darwin-arm64 asset only (scripts/fetch-vpkmerge.mjs), and the
+          # CrossOver bottle Deadlock runs in is arm64 in practice. The build
+          # step asserts the arch so an x64 runner fails loudly instead of
+          # silently shipping without mod merging.
+          - os: macos-latest
+            platform: mac
 
     runs-on: ${{ matrix.os }}
 
@@ -89,6 +96,16 @@ jobs:
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             pnpm exec electron-vite build && pnpm exec electron-builder --linux --publish never
+          elif [ "${{ matrix.platform }}" = "mac" ]; then
+            # See the matrix comment: arm64 only. postinstall skips the
+            # vpkmerge fetch with a warning on unsupported platforms, so
+            # without this the .dmg would build fine and just lose merging.
+            ARCH="$(node -p 'process.arch')"
+            if [ "$ARCH" != "arm64" ]; then
+              echo "ERROR: mac runner is $ARCH; expected arm64 (no darwin-$ARCH vpkmerge asset)"
+              exit 1
+            fi
+            pnpm exec electron-vite build && pnpm exec electron-builder --mac --arm64 --publish never
           else
             pnpm exec electron-vite build && pnpm exec electron-builder --win --publish never
           fi
@@ -114,13 +131,20 @@ jobs:
         run: |
           cd release
           # Hash user-facing artifacts only (skip auto-update metadata and blockmaps).
+          # *.zip is the macOS update artifact; win/linux targets produce none.
           shopt -s nullglob
-          files=(*.exe *.AppImage *.deb)
+          files=(*.exe *.AppImage *.deb *.dmg *.zip)
           if [ ${#files[@]} -eq 0 ]; then
             echo "ERROR: no artifact files found to hash"
             exit 1
           fi
-          sha256sum "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          # macOS runners have no sha256sum; shasum ships with the OS and emits
+          # the same "<hash>  <name>" format.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          else
+            shasum -a 256 "${files[@]}" > "SHA256SUMS-${{ matrix.platform }}.txt"
+          fi
           echo "=== SHA256SUMS-${{ matrix.platform }}.txt ==="
           cat "SHA256SUMS-${{ matrix.platform }}.txt"
 
@@ -131,6 +155,8 @@ jobs:
             grimoire/release/*.exe
             grimoire/release/*.AppImage
             grimoire/release/*.deb
+            grimoire/release/*.dmg
+            grimoire/release/*.zip
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Grimoire
 
-Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux shipped; macOS runs from source for development, see `docs/macos.md`).
+Mod manager and companion tool for Deadlock (Valve hero shooter). Electron desktop app (Windows/Linux/macOS shipped; the macOS build is Apple Silicon only, ad-hoc signed, and cannot auto-update, see `docs/macos.md`).
 
 ## What It Does
 
@@ -98,7 +98,7 @@ Design docs and references live in `docs/`:
 - `social-architecture.md` + `social-architecture-decisions.md` - Architecture and ADRs for the planned `grimoire-social` companion service (see below)
 - `ability-vfx-recolor.md` - Hero ability VFX layer extraction + in app recoloring. Read before touching `detectVfxLayer`/`extractVfxLayer` (in `vpk.ts`/`modMerger.ts`) or building the recolor/Locker surface. Covers why particle recolor must use an in place scalar patch, not a KV3 re-encode.
 - `locker-global-mods.md` - "Global" mods: the `citadel/grimoire` priority root that outranks every other mod. Read before touching grimoire-folder handling, the `modLoadOrder` helpers, or the shuffle planner. Covers the deliberate split between `globalType` (classification, labelled "General") and `priorityMod` (placement, labelled "Global").
-- `macos.md` - Why macOS needs a CrossOver bottle, how Steam roots are discovered there, and how launching differs. Read before touching `steamRoots.ts`, `bottleLaunch.ts`, or any per-platform Steam path list. Covers why the three old hardcoded path lists were collapsed into one module.
+- `macos.md` - Why macOS needs a CrossOver bottle, how Steam roots are discovered there, and how launching differs. Read before touching `steamRoots.ts`, `bottleLaunch.ts`, or any per-platform Steam path list. Covers why the three old hardcoded path lists were collapsed into one module, and why the shipped mac build is arm64-only and cannot auto-update.
 - `deadworks-servers.md` - The Deadworks server browser: relay data flow, content provisioning, and (critically) how the deadworks content path is woven into grimoire's canonical `gameinfo.gi` block so Fix Configuration never erases it. Read before touching `deadworksServers.ts`, `ipc/servers.ts`, or the gameinfo handling in `system.ts`/`deadlock.ts`.
 
 ## Companion Service: grimoire-social

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -95,13 +95,13 @@ shipping a build with no mod merging.
   "unidentified developer" prompt on first launch.
 - **Auto-update does not work on macOS.** Squirrel.Mac validates that an update
   carries the same signing identity as the running app, and an ad-hoc signature
-  has none (`TeamIdentifier=not set`). `getInstallSource()` in
-  `services/updater.ts` only special-cases Linux, so macOS is still treated as
-  `'standard'` and the in-app updater is offered even though installing will
-  fail. macOS users have to download each release manually. Fixing this
-  properly needs a paid Developer ID and notarization; short of that, macOS
-  should be routed to a manual-download path the way managed Linux installs
-  are.
+  has none (`TeamIdentifier=not set`), so an in-app update would download and
+  then fail at the install step. `getInstallSource()` reports `'manual'` on
+  darwin to handle this: unlike `'managed'`, which defers the whole lifecycle
+  to a package manager and never checks, `'manual'` still checks and still
+  reports a new version, but `downloadUpdate` and `quitAndInstall` are gated
+  and the UI points at the releases page instead. Users update by downloading
+  each release. Fixing it properly needs a paid Developer ID and notarization.
 - **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only, so a
   Mac-only build break surfaces at release time rather than on the PR. The
   bottle discovery, drive mapping, and launch-argument tests are all

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -77,11 +77,32 @@ Process control (`isDeadlockRunning`, `requestDeadlockStop`) shares the Linux
 branch: the game is a Windows process under a translation layer, so the host
 only ever sees it via the full cmdline, and `pgrep -f` / `pkill -f` are correct.
 
+## Packaging
+
+`release.yml` builds macOS alongside Linux and Windows, producing an arm64
+`.dmg` and `-mac.zip`. Apple Silicon only, for two reasons: vpkmerge publishes
+a `darwin-arm64` asset and no `darwin-x64` one (`scripts/fetch-vpkmerge.mjs`),
+and the CrossOver bottles Deadlock runs in are arm64 in practice. The build
+step asserts the runner arch so an x64 runner fails loudly rather than quietly
+shipping a build with no mod merging.
+
 ## What is not supported
 
-- **No packaged macOS build.** `electron-builder.yml` has no `mac` target and
-  there is no `package:mac` script. Adding one requires decisions about signing
-  and notarization, and the auto-updater expects a signed build.
-- **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only. The bottle
-  discovery, drive mapping, and launch-argument tests are all
+- **The build is ad-hoc signed, not notarized.** There is no Developer ID
+  certificate, so `electron-builder.yml` pins `identity: null` and
+  `scripts/adhoc-sign-mac.mjs` re-signs afterwards (see that file for why an
+  invalid signature is worse than an honest ad-hoc one). Users get the
+  "unidentified developer" prompt on first launch.
+- **Auto-update does not work on macOS.** Squirrel.Mac validates that an update
+  carries the same signing identity as the running app, and an ad-hoc signature
+  has none (`TeamIdentifier=not set`). `getInstallSource()` in
+  `services/updater.ts` only special-cases Linux, so macOS is still treated as
+  `'standard'` and the in-app updater is offered even though installing will
+  fail. macOS users have to download each release manually. Fixing this
+  properly needs a paid Developer ID and notarization; short of that, macOS
+  should be routed to a manual-download path the way managed Linux installs
+  are.
+- **CI does not cover macOS.** `ci.yml` runs `ubuntu-latest` only, so a
+  Mac-only build break surfaces at release time rather than on the PR. The
+  bottle discovery, drive mapping, and launch-argument tests are all
   platform-independent and do run there.

--- a/electron/main/services/launchOptions.test.ts
+++ b/electron/main/services/launchOptions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { isSteamRunning } from './launchOptions';
+
+// Rather than mock child_process, put a fake `pgrep` at the front of PATH that
+// logs its argv and reports a match only for the pattern named in GRIMOIRE_TEST_MATCH.
+// That exercises the real spawn, so a wrong flag or a dropped second probe
+// shows up here instead of at runtime.
+let root: string;
+let argvLog: string;
+let realPath: string | undefined;
+let realPlatform: PropertyDescriptor | undefined;
+
+function setPlatform(value: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+/** Args of every pgrep invocation since the last reset, one per line. */
+function pgrepCalls(): string[] {
+    if (!existsSync(argvLog)) return [];
+    return readFileSync(argvLog, 'utf8').split('\n').filter(Boolean);
+}
+
+beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'grimoire-launchopts-'));
+    argvLog = join(root, 'pgrep-argv.txt');
+
+    const fakePgrep = join(root, 'pgrep');
+    writeFileSync(
+        fakePgrep,
+        [
+            '#!/bin/sh',
+            `printf '%s\\n' "$*" >> "${argvLog}"`,
+            'case "$*" in',
+            '  *"$GRIMOIRE_TEST_MATCH"*) exit 0 ;;',
+            'esac',
+            'exit 1',
+        ].join('\n') + '\n',
+    );
+    chmodSync(fakePgrep, 0o755);
+
+    realPath = process.env.PATH;
+    process.env.PATH = `${root}:${realPath ?? ''}`;
+    realPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+});
+
+afterAll(() => {
+    process.env.PATH = realPath;
+    delete process.env.GRIMOIRE_TEST_MATCH;
+    if (realPlatform) Object.defineProperty(process, 'platform', realPlatform);
+    rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    rmSync(argvLog, { force: true });
+    // A pattern no invocation can contain, so "nothing is running" is the default.
+    process.env.GRIMOIRE_TEST_MATCH = '__no_match__';
+});
+
+describe('isSteamRunning on darwin', () => {
+    beforeEach(() => setPlatform('darwin'));
+
+    it('detects the bottle Steam, which is a Windows steam.exe under Wine', async () => {
+        // The regression this guards: `pgrep -x steam` matches the *native*
+        // client only. With only that probe, a running bottle Steam reads as
+        // "not running" and syncLaunchOptionsToSteam rewrites a localconfig.vdf
+        // Steam is holding open, losing the user's launch options on shutdown.
+        process.env.GRIMOIRE_TEST_MATCH = 'steam\\.exe';
+        expect(await isSteamRunning()).toBe(true);
+    });
+
+    it('still detects a native Steam client', async () => {
+        process.env.GRIMOIRE_TEST_MATCH = '-x steam';
+        expect(await isSteamRunning()).toBe(true);
+    });
+
+    it('reports not running only when neither Steam is up', async () => {
+        expect(await isSteamRunning()).toBe(false);
+    });
+
+    it('probes both the native and the bottled Steam', async () => {
+        await isSteamRunning();
+        const calls = pgrepCalls();
+        expect(calls).toHaveLength(2);
+        expect(calls).toContain('-x steam');
+        expect(calls).toContain('-f steam\\.exe');
+    });
+});
+
+describe('isSteamRunning on linux', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it('matches the client binary by exact name', async () => {
+        process.env.GRIMOIRE_TEST_MATCH = '-x steam';
+        expect(await isSteamRunning()).toBe(true);
+    });
+
+    // -f would match any process with "steam" anywhere in its argv, including
+    // Grimoire itself when a Steam path is on the command line.
+    it('does not fall back to a full-cmdline match', async () => {
+        await isSteamRunning();
+        expect(pgrepCalls()).toEqual(['-x steam']);
+    });
+});

--- a/electron/main/services/launchOptions.ts
+++ b/electron/main/services/launchOptions.ts
@@ -85,10 +85,19 @@ async function findLocalConfigPath(preferredAccountId?: string): Promise<{ path:
     return null;
 }
 
+/** pgrep with the given args. Resolves true when at least one process matches. */
+function pgrepMatches(args: string[]): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const proc = spawn('pgrep', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+        proc.on('close', (code) => resolve(code === 0));
+        proc.on('error', () => resolve(false));
+    });
+}
+
 /** Whether Steam.exe / steam is currently running. Best-effort, platform-aware. */
 export async function isSteamRunning(): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
-        if (process.platform === 'win32') {
+    if (process.platform === 'win32') {
+        return new Promise<boolean>((resolve) => {
             const proc = spawn('tasklist.exe', ['/FI', 'IMAGENAME eq steam.exe', '/NH'], {
                 windowsHide: true,
             });
@@ -96,16 +105,33 @@ export async function isSteamRunning(): Promise<boolean> {
             proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
             proc.on('close', () => resolve(/steam\.exe/i.test(stdout)));
             proc.on('error', () => resolve(false));
-        } else if (process.platform === 'linux' || process.platform === 'darwin') {
-            // pgrep returns 0 if any process matches. We look for the Steam
-            // client binary, not just any "steam" string in argv.
-            const proc = spawn('pgrep', ['-x', 'steam'], { stdio: ['ignore', 'pipe', 'ignore'] });
-            proc.on('close', (code) => resolve(code === 0));
-            proc.on('error', () => resolve(false));
-        } else {
-            resolve(false);
-        }
-    });
+        });
+    }
+
+    if (process.platform === 'linux') {
+        // pgrep returns 0 if any process matches. We look for the Steam
+        // client binary, not just any "steam" string in argv.
+        return pgrepMatches(['-x', 'steam']);
+    }
+
+    if (process.platform === 'darwin') {
+        // The Steam that owns Deadlock here is the bottle's *Windows*
+        // steam.exe running under Wine, which the host only ever sees through
+        // the full cmdline (same reasoning as isDeadlockRunning in launch.ts).
+        // `pgrep -x steam` matches the native client only, so on its own it
+        // reports "not running" while the bottle's Steam has localconfig.vdf
+        // open, and syncLaunchOptionsToSteam would rewrite a file Steam is
+        // about to overwrite from memory, silently dropping the user's launch
+        // options. getSteamRoots returns both kinds of root, so check both and
+        // treat either as running: refusing to write is the safe direction.
+        const [native, bottled] = await Promise.all([
+            pgrepMatches(['-x', 'steam']),
+            pgrepMatches(['-f', 'steam\\.exe']),
+        ]);
+        return native || bottled;
+    }
+
+    return false;
 }
 
 /**

--- a/electron/main/services/updater.ts
+++ b/electron/main/services/updater.ts
@@ -4,12 +4,20 @@ import type { UpdateInfo } from 'electron-updater';
 import { app, BrowserWindow } from 'electron';
 import log from 'electron-log';
 
-export type InstallSource = 'managed' | 'appimage' | 'standard';
+export type InstallSource = 'managed' | 'appimage' | 'standard' | 'manual';
 
 // Detect installs owned by a system package manager (apt/AUR/snap/flatpak).
 // In-app updates would fail on these because /opt and /usr are root-owned, so
 // we route those users to their package manager instead.
 export function getInstallSource(): InstallSource {
+    // The macOS build is ad-hoc signed: there is no Developer ID certificate,
+    // so the bundle carries no signing identity (`TeamIdentifier=not set`).
+    // Squirrel.Mac refuses to swap in an update whose identity does not match
+    // the running app's, so an in-app update would download and then fail at
+    // the install step. Checking still works and is worth doing, so this is a
+    // separate source from 'managed': we tell the user a version exists and
+    // send them to the download page. See docs/macos.md.
+    if (process.platform === 'darwin') return 'manual';
     if (process.platform === 'linux') {
         if (process.env.APPIMAGE) return 'appimage';
         const exec = process.execPath;
@@ -28,7 +36,16 @@ export function getInstallSource(): InstallSource {
 }
 
 const installSource = getInstallSource();
+// 'managed' is fully hands-off: the package manager owns the whole lifecycle,
+// so we do not even check. 'manual' can still check and report a new version,
+// it just cannot apply one in place.
 const updaterDisabled = installSource === 'managed';
+const canInstallInPlace = installSource !== 'managed' && installSource !== 'manual';
+
+/** Whether the in-app updater can actually apply an update on this install. */
+export function canSelfInstall(): boolean {
+    return canInstallInPlace;
+}
 
 // Configure logging
 autoUpdater.logger = log;
@@ -152,7 +169,10 @@ export async function checkForUpdates(): Promise<UpdateInfo | null> {
 }
 
 export async function downloadUpdate(): Promise<void> {
-    if (updaterDisabled) return;
+    // Not just updaterDisabled: downloading on a 'manual' install would hand
+    // Squirrel.Mac a payload it will refuse to install, so stop earlier and
+    // let the UI point at the download page instead.
+    if (!canInstallInPlace) return;
     try {
         await autoUpdater.downloadUpdate();
     } catch (error) {
@@ -162,7 +182,7 @@ export async function downloadUpdate(): Promise<void> {
 }
 
 export function quitAndInstall(): void {
-    if (updaterDisabled) return;
+    if (!canInstallInPlace) return;
     autoUpdater.quitAndInstall(false, true);
 }
 

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -5,7 +5,9 @@ import DOMPurify from 'dompurify';
 import { Button } from './common/ui';
 import { Modal } from './common/Modal';
 
-type InstallSource = 'managed' | 'appimage' | 'standard';
+type InstallSource = 'managed' | 'appimage' | 'standard' | 'manual';
+
+const RELEASES_URL = 'https://github.com/Slush97/grimoire/releases/latest';
 
 interface UpdateInfo {
     version: string;
@@ -33,6 +35,10 @@ export default function UpdateModal({ onClose }: Props) {
     const [status, setStatus] = useState<UpdateStatus | null>(null);
     const [checkedOnce, setCheckedOnce] = useState(false);
     const [installSource, setInstallSource] = useState<InstallSource>('standard');
+    // 'managed' hands the whole lifecycle to the package manager; 'manual'
+    // (ad-hoc signed macOS) can report an update but cannot apply one. Both
+    // hide the download/install actions, but they say different things.
+    const canSelfInstall = installSource !== 'managed' && installSource !== 'manual';
 
     useEffect(() => {
         window.electronAPI.updater.getVersion().then(setAppVersion);
@@ -133,6 +139,24 @@ export default function UpdateModal({ onClose }: Props) {
                         </div>
                     )}
 
+                    {installSource === 'manual' && (
+                        <div className="flex items-start gap-3 p-4 rounded-lg bg-bg-tertiary border border-white/10 mb-4">
+                            <Package className="w-5 h-5 flex-shrink-0 mt-0.5 text-accent" />
+                            <div className="text-sm text-text-secondary space-y-2">
+                                <p className="text-text-primary font-medium">{t('updateModal.manualDownloadRequired')}</p>
+                                <p>{t('updateModal.manualUnsignedExplanation')}</p>
+                                <a
+                                    href={RELEASES_URL}
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                    className="inline-block font-mono text-text-primary underline underline-offset-2 hover:text-accent transition-colors"
+                                >
+                                    {t('updateModal.manualDownloadLink')}
+                                </a>
+                            </div>
+                        </div>
+                    )}
+
                     {status?.error && (
                         <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300 text-sm mb-4">
                             <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -202,7 +226,7 @@ export default function UpdateModal({ onClose }: Props) {
                                 </div>
                             )}
                         </>
-                    ) : installSource !== 'managed' && !status?.available && !status?.checking && (
+                    ) : canSelfInstall && !status?.available && !status?.checking && (
                         <p className="text-sm text-text-secondary">
                             {t('updateModal.deliveredViaGithub')}
                         </p>
@@ -225,11 +249,13 @@ export default function UpdateModal({ onClose }: Props) {
                         <Button onClick={onClose} variant="secondary">
                             {t('common.actions.close')}
                         </Button>
-                        {installSource === 'managed' ? null : status?.downloaded ? (
+                        {/* 'manual' keeps Check (that still works) but never
+                            Download/Install, which Squirrel.Mac would reject. */}
+                        {installSource === 'managed' ? null : canSelfInstall && status?.downloaded ? (
                             <Button onClick={handleInstall} icon={ArrowDownCircle}>
                                 {t('settings.updates.installRestart')}
                             </Button>
-                        ) : status?.available && !status.downloading ? (
+                        ) : canSelfInstall && status?.available && !status.downloading ? (
                             <Button onClick={handleDownload} icon={Download}>
                                 {t('settings.updates.downloadUpdate')}
                             </Button>

--- a/src/components/settings/sections/UpdatesSection.tsx
+++ b/src/components/settings/sections/UpdatesSection.tsx
@@ -47,7 +47,10 @@ export default function UpdatesSection() {
     } | null;
   } | null>(null);
   const [showChangelog, setShowChangelog] = useState(false);
-  const [installSource, setInstallSource] = useState<'managed' | 'appimage' | 'standard'>('standard');
+  const [installSource, setInstallSource] = useState<'managed' | 'appimage' | 'standard' | 'manual'>('standard');
+  // See UpdateModal: 'managed' defers to the package manager, 'manual' (ad-hoc
+  // signed macOS) can check but cannot apply an update in place.
+  const canSelfInstall = installSource !== 'managed' && installSource !== 'manual';
 
   // Derived, not state: a check in flight sets `checking`, so this falls back
   // to false on its own while one runs.
@@ -137,14 +140,14 @@ export default function UpdatesSection() {
               >
                 <Tx k="settings.updates.whatsNew" fallback="What's New" />
               </Button>
-              {installSource === 'managed' ? null : updateStatus?.downloaded ? (
+              {installSource === 'managed' ? null : canSelfInstall && updateStatus?.downloaded ? (
                 <Button
                   onClick={handleInstallUpdate}
                   icon={ArrowDownCircle}
                 >
                   <Tx k="settings.updates.installRestart" fallback="Install & Restart" />
                 </Button>
-              ) : updateStatus?.available && !updateStatus.downloading ? (
+              ) : canSelfInstall && updateStatus?.available && !updateStatus.downloading ? (
                 <Button
                   onClick={handleDownloadUpdate}
                   icon={Download}
@@ -192,6 +195,28 @@ export default function UpdatesSection() {
                   }}
                 />
               </p>
+            </div>
+          )}
+
+          {installSource === 'manual' && (
+            <div className="rounded-lg bg-bg-tertiary border border-white/10 p-3 text-sm text-text-secondary space-y-2">
+              <p className="text-text-primary font-medium">
+                <Tx k="settings.updates.manual" fallback="Updates have to be downloaded manually." />
+              </p>
+              <p>
+                <Tx
+                  k="settings.updates.manualUnsignedExplanation"
+                  fallback="The macOS build is ad-hoc signed rather than notarized, so macOS will not let Grimoire replace itself in place. Grimoire can still tell you when a new version is out."
+                />
+              </p>
+              <a
+                href="https://github.com/Slush97/grimoire/releases/latest"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-block font-mono text-text-primary underline underline-offset-2 hover:text-accent transition-colors"
+              >
+                <Tx k="settings.updates.manualDownloadLink" fallback="Download the latest release" />
+              </a>
             </div>
           )}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -739,7 +739,10 @@
       "downloading": "Downloading update...",
       "whatsNewIn": "What's New in",
       "released": "Released {{date}}",
-      "noReleaseNotes": "No release notes available."
+      "noReleaseNotes": "No release notes available.",
+      "manual": "Updates have to be downloaded manually.",
+      "manualUnsignedExplanation": "The macOS build is ad-hoc signed rather than notarized, so macOS will not let Grimoire replace itself in place. Grimoire can still tell you when a new version is out.",
+      "manualDownloadLink": "Download the latest release"
     },
     "appearance": {
       "accentNamed": "Use {{name}} accent color",
@@ -2614,7 +2617,10 @@
     "whatsNew": "What's new",
     "releasesCount": "({{count}} releases)",
     "noReleaseNotesForThisVersion": "No release notes for this version.",
-    "deliveredViaGithub": "Updates are delivered automatically through GitHub Releases. Click Check for Updates to look now."
+    "deliveredViaGithub": "Updates are delivered automatically through GitHub Releases. Click Check for Updates to look now.",
+    "manualDownloadRequired": "Download updates manually on macOS.",
+    "manualUnsignedExplanation": "The macOS build is ad-hoc signed rather than notarized, so macOS will not let Grimoire replace itself in place. Checking for updates still works.",
+    "manualDownloadLink": "Open the releases page"
   },
   "appUpdateBanner": {
     "readyToInstallVersion": "Grimoire {{version}} is ready to install",

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2208,
+  "totalKeys": 2214,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2208,
+      "translatedKeys": 2214,
       "pct": 100
     },
     {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1114,7 +1114,7 @@ export interface ElectronAPI {
     updater: {
         getVersion: () => Promise<string>;
         getStatus: () => Promise<UpdateStatus>;
-        getInstallSource: () => Promise<'managed' | 'appimage' | 'standard'>;
+        getInstallSource: () => Promise<'managed' | 'appimage' | 'standard' | 'manual'>;
         checkForUpdates: () => Promise<UpdateInfo | null>;
         downloadUpdate: () => Promise<void>;
         installUpdate: () => void;


### PR DESCRIPTION
Supersedes #354, which GitHub auto-closed when its base branch was deleted on merge. Rebased onto `main` (post-v1.27.1) and the two blockers called out there are now fixed.

## 1. macOS in the release matrix

Builds an arm64 `.dmg` and `-mac.zip` alongside Linux and Windows. The packaging side was already in place from #352 (mac target, `package:mac`, ad-hoc signing hook); this wires it into CI.

**Apple Silicon only.** vpkmerge publishes a `darwin-arm64` asset and no `darwin-x64` one, and the CrossOver bottles Deadlock runs in are arm64 in practice. `fetch-vpkmerge.mjs:87` *warns and skips* on an unsupported platform rather than failing, so an x64 runner would have produced a perfectly valid `.dmg` that silently could not merge mods. The build step asserts `process.arch` so that fails loudly instead.

Also `*.dmg`/`*.zip` in the checksum globs and attestation subjects, and a `shasum` fallback since macOS runners have no `sha256sum`.

Verified with a local `pnpm package:mac` on `darwin-arm64`: `better-sqlite3` rebuilds for arm64, the ad-hoc signing hook verifies (`valid on disk`, `satisfies its Designated Requirement`), `vpkmerge-macos-aarch64` lands in `Contents/Resources`, and the checksum step matches exactly the `.dmg` and `.zip` (not the blockmaps or `latest-mac.yml`).

## 2. Launch options could be silently destroyed

`isSteamRunning()` used `pgrep -x steam` on darwin: an exact match on a *host* process name, which can never match the bottle's Wine-hosted `steam.exe`.

This was inert before #352 (the macOS path pointed at a native Steam with no Deadlock). Once `getSteamUserdataRoots()` went through `getSteamRoots()`, `writeLaunchOptions()` started targeting the `localconfig.vdf` that actually governs Deadlock, which made it reachable: with the bottle's Steam running, `syncLaunchOptionsToSteam()` believed Steam was down, backed up and rewrote a multi-MB file Steam held open, and Steam clobbered it on shutdown. The user's launch options vanish.

Now both the native client (`-x steam`) and the bottled one (`-f steam\.exe`) are probed, and either counts as running. Refusing to write is the safe direction.

Tests put a fake `pgrep` at the front of `PATH` rather than mocking `child_process`, matching the approach in `bottleLaunch.test.ts`. **Verified they fail against the old implementation** — `expected false to be true` on a running bottle Steam, and `expected [ '-x steam' ] to have a length of 2`.

## 3. The updater offered updates it cannot install

`codesign -dv` on the built app reports `Signature=adhoc`, `TeamIdentifier=not set`. Squirrel.Mac refuses to swap in an update whose signing identity does not match the running app's, so an in-app update would download and then fail at install. `getInstallSource()` only special-cased Linux, so darwin fell through to `'standard'`.

Adds a `'manual'` install source. Deliberately **not** folded into `'managed'`: `managed` defers the whole lifecycle to the package manager and does not even check, whereas `manual` can still check and report a new version, it just cannot apply one. So mac users keep learning about releases and get pointed at the download page; only `downloadUpdate`/`quitAndInstall` are gated.

`AppUpdateBanner` needs no change: its CTA only opens `UpdateModal`, which now handles `manual`.

Six new `en` keys. They reach translators once this lands on `main`.

## Gates

`tsc -b` clean, `eslint .` clean, 1012 tests across 79 files (6 new), `i18n:check` OK at 1948 referenced keys, locale manifest regenerated.

## Still outstanding

Two lower-severity macOS issues from the same review, not fixed here: `bottleLaunch.ts:74` spawns without an `'error'` listener (a non-executable `GRIMOIRE_WINE` throws uncaught in main), and `deadlock.ts:37` returns a truthy `{}` on drive-map failure, silently dropping every library path. Neither is data-loss; say the word and I'll fold them in.

`ci.yml` still runs `ubuntu-latest` only, so a Mac-only build break surfaces at release time rather than on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)