### PR TITLE
fix(installed): preserve Global placement across mod updates

### DIFF
--- a/src/lib/vpkRestore.test.ts
+++ b/src/lib/vpkRestore.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Mod } from '../types/mod';
 import {
   getVpkIndex,
   createEnabledVpkRestoreSnapshot,
+  createGlobalVpkRestoreSnapshot,
+  restoreReplacementVpkState,
   shouldRestoreVpkEnabled,
+  shouldRestoreVpkGlobal,
 } from './vpkRestore';
 
 /** Minimal Mod; the restore logic only reads `vpkIndex` (via getVpkIndex). */
@@ -105,5 +108,64 @@ describe('shouldRestoreVpkEnabled', () => {
     const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
     expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(false);
     expect(shouldRestoreVpkEnabled(fresh[1], fresh, snap)).toBe(true);
+  });
+});
+
+describe('Global placement restore', () => {
+  it('restores Global placement to the matching replacement VPK only', () => {
+    const snap = createGlobalVpkRestoreSnapshot([
+      { priorityMod: true, vpkIndex: 0 },
+      { priorityMod: false, vpkIndex: 1 },
+    ]);
+    const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
+
+    expect(shouldRestoreVpkGlobal(fresh[0], fresh, snap)).toBe(true);
+    expect(shouldRestoreVpkGlobal(fresh[1], fresh, snap)).toBe(false);
+  });
+
+  it('marks a disabled replacement Global without enabling it', async () => {
+    const fresh = [mod({ id: 'replacement', enabled: false })];
+    const setGlobal = vi.fn(async () => {});
+    const enable = vi.fn(async () => {});
+
+    const failures = await restoreReplacementVpkState(
+      fresh,
+      createEnabledVpkRestoreSnapshot([{ enabled: false }]),
+      createGlobalVpkRestoreSnapshot([{ priorityMod: true }]),
+      { setGlobal, enable },
+    );
+
+    expect(setGlobal).toHaveBeenCalledWith('replacement');
+    expect(enable).not.toHaveBeenCalled();
+    expect(failures).toEqual([]);
+  });
+
+  it('restores Global placement before enabling the replacement', async () => {
+    const calls: string[] = [];
+    const fresh = [mod({ id: 'replacement', enabled: false })];
+
+    await restoreReplacementVpkState(
+      fresh,
+      createEnabledVpkRestoreSnapshot([{ enabled: true }]),
+      createGlobalVpkRestoreSnapshot([{ priorityMod: true }]),
+      {
+        setGlobal: async () => { calls.push('global'); },
+        enable: async () => { calls.push('enable'); },
+      },
+    );
+
+    expect(calls).toEqual(['global', 'enable']);
+  });
+
+  it('flags mixed legacy placement as ambiguous instead of promoting ordinary siblings', () => {
+    const snap = createGlobalVpkRestoreSnapshot([
+      { priorityMod: true },
+      { priorityMod: false },
+    ]);
+    const fresh = [mod({ id: 'n0', vpkIndex: 0 }), mod({ id: 'n1', vpkIndex: 1 })];
+
+    expect(snap.ambiguous).toBe(true);
+    expect(shouldRestoreVpkGlobal(fresh[0], fresh, snap)).toBe(false);
+    expect(shouldRestoreVpkGlobal(fresh[1], fresh, snap)).toBe(false);
   });
 });

--- a/src/lib/vpkRestore.ts
+++ b/src/lib/vpkRestore.ts
@@ -13,6 +13,14 @@ export type EnabledVpkRestoreSnapshot = {
   enabledUnindexed: boolean;
 };
 
+export type GlobalVpkRestoreSnapshot = {
+  hadGlobal: boolean;
+  allGlobal: boolean;
+  ambiguous: boolean;
+  globalIndexes: Set<number>;
+  globalUnindexed: boolean;
+};
+
 export function getVpkIndex(mod: Pick<Mod, 'vpkIndex'>): number | undefined {
   return typeof mod.vpkIndex === 'number' && Number.isInteger(mod.vpkIndex) && mod.vpkIndex >= 0
     ? mod.vpkIndex
@@ -58,4 +66,78 @@ export function shouldRestoreVpkEnabled(
     return index === undefined ? snapshot.enabledUnindexed : snapshot.enabledIndexes.has(index);
   }
   return snapshot.enabledIndexes.size === 0 && snapshot.enabledUnindexed;
+}
+
+export function createGlobalVpkRestoreSnapshot(
+  targets: Array<{ priorityMod?: boolean; vpkIndex?: number }>
+): GlobalVpkRestoreSnapshot {
+  const globalIndexes = new Set<number>();
+  let globalUnindexed = false;
+  for (const target of targets) {
+    if (!target.priorityMod) continue;
+    const index = getVpkIndex(target);
+    if (index === undefined) {
+      globalUnindexed = true;
+    } else {
+      globalIndexes.add(index);
+    }
+  }
+  const allGlobal = targets.length > 0 && targets.every((target) => !!target.priorityMod);
+  return {
+    hadGlobal: globalUnindexed || globalIndexes.size > 0,
+    allGlobal,
+    ambiguous: globalUnindexed && !allGlobal,
+    globalIndexes,
+    globalUnindexed,
+  };
+}
+
+export function shouldRestoreVpkGlobal(
+  mod: Mod,
+  candidates: Mod[],
+  snapshot: GlobalVpkRestoreSnapshot
+): boolean {
+  if (!snapshot.hadGlobal) return false;
+  const hasIndexedCandidates = candidates.some((candidate) => getVpkIndex(candidate) !== undefined);
+  const index = getVpkIndex(mod);
+  if (hasIndexedCandidates) {
+    if (snapshot.globalIndexes.size === 0) return snapshot.globalUnindexed && snapshot.allGlobal;
+    return index === undefined ? snapshot.globalUnindexed : snapshot.globalIndexes.has(index);
+  }
+  return snapshot.globalIndexes.size === 0 && snapshot.globalUnindexed && snapshot.allGlobal;
+}
+
+export type ReplacementVpkRestoreFailure = {
+  action: 'global' | 'enable';
+  mod: Mod;
+  error: unknown;
+};
+
+export async function restoreReplacementVpkState(
+  candidates: Mod[],
+  enabledSnapshot: EnabledVpkRestoreSnapshot,
+  globalSnapshot: GlobalVpkRestoreSnapshot,
+  operations: {
+    setGlobal: (modId: string) => Promise<void>;
+    enable: (modId: string) => Promise<void>;
+  }
+): Promise<ReplacementVpkRestoreFailure[]> {
+  const failures: ReplacementVpkRestoreFailure[] = [];
+  for (const mod of candidates) {
+    if (!mod.priorityMod && shouldRestoreVpkGlobal(mod, candidates, globalSnapshot)) {
+      try {
+        await operations.setGlobal(mod.id);
+      } catch (error) {
+        failures.push({ action: 'global', mod, error });
+      }
+    }
+    if (!mod.enabled && shouldRestoreVpkEnabled(mod, candidates, enabledSnapshot)) {
+      try {
+        await operations.enable(mod.id);
+      } catch (error) {
+        failures.push({ action: 'enable', mod, error });
+      }
+    }
+  }
+  return failures;
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1278,6 +1278,8 @@
       "description": "Re-download every mod flagged with an available update. Each one's enabled state will be restored after the install finishes. Downloads run one at a time and may take a while.",
       "receivingUpdates": "Mods receiving updates ({{count}})",
       "dismissError": "Dismiss update error",
+      "restoreStateFailed": "The mod was updated, but its previous state could not be fully restored ({{details}})",
+      "ambiguousGlobalState": "This update was not applied because the old multi-file install has mixed Global placement and no saved variant identities. Make every file Global or remove every file from Global, then try again.",
       "pickReplacement_one": "Pick replacement",
       "pickReplacement_other": "Pick replacements ({{count}})",
       "dismissPickNotice": "Dismiss manual pick notice"

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2208,
+  "totalKeys": 2210,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2208,
+      "translatedKeys": 2210,
       "pct": 100
     },
     {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2190,6 +2190,7 @@ export default function Installed() {
       // Replacement downloads land disabled with fresh metadata. Restore both
       // enabled state and the user's Global priority-root placement after
       // reloading. Match by GB ids because local ids change on reinstall.
+      let restoreFailureMessage: string | null = null;
       if (restoreEnabled.hadEnabled || restoreGlobal.hadGlobal) {
         await loadMods();
         const newMods = useAppStore
@@ -2210,11 +2211,20 @@ export default function Installed() {
           const summary = restoreFailures
             .map((failure) => `${failure.action}: ${String(failure.error)}`)
             .join('; ');
-          throw new Error(t('installed.updateAll.restoreStateFailed', { details: summary }));
+          restoreFailureMessage = t('installed.updateAll.restoreStateFailed', { details: summary });
         }
       }
 
-      closeModDetails();
+      // A restore failure is NOT an update failure: the new file is installed
+      // and only its enabled/Global state is off. Throwing here would report a
+      // succeeded update as a failed one and skip the refresh below, so keep
+      // the overlay open on the explanation instead and always reconcile the
+      // store with what actually landed on disk.
+      if (restoreFailureMessage) {
+        setDetailsError(restoreFailureMessage);
+      } else {
+        closeModDetails();
+      }
       loadMods();
     } catch (err) {
       setDetailsError(String(err));

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -111,7 +111,13 @@ import { useStableCallback } from '../lib/useStableCallback';
 import { formatBytes } from '../lib/formatBytes';
 import { canOpenImageSource, copyImageToClipboard, resolveImageSource } from '../lib/imageActions';
 import { resolveUpdateTarget } from '../lib/updateFileMatch';
-import { createEnabledVpkRestoreSnapshot, shouldRestoreVpkEnabled, type EnabledVpkRestoreSnapshot } from '../lib/vpkRestore';
+import {
+  createEnabledVpkRestoreSnapshot,
+  createGlobalVpkRestoreSnapshot,
+  restoreReplacementVpkState,
+  type EnabledVpkRestoreSnapshot,
+  type GlobalVpkRestoreSnapshot,
+} from '../lib/vpkRestore';
 import { modRestoreKey } from '../lib/soloRestore';
 import { buildCachedModDetails, canUseCachedModDetails } from '../lib/cachedModDetails';
 import {
@@ -2160,6 +2166,10 @@ export default function Installed() {
         );
       }
       const restoreEnabled = createEnabledVpkRestoreSnapshot(replacementTargets);
+      const restoreGlobal = createGlobalVpkRestoreSnapshot(replacementTargets);
+      if (restoreGlobal.ambiguous) {
+        throw new Error(t('installed.updateAll.ambiguousGlobalState'));
+      }
 
       if (replacing && sourceMod) {
         // Snapshot before the destructive delete so the user can roll back,
@@ -2177,21 +2187,30 @@ export default function Installed() {
 
       await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
 
-      // Replacement downloads land disabled, so restore the enabled state after
+      // Replacement downloads land disabled with fresh metadata. Restore both
+      // enabled state and the user's Global priority-root placement after
       // reloading. Match by GB ids because local ids change on reinstall.
-      if (restoreEnabled.hadEnabled) {
+      if (restoreEnabled.hadEnabled || restoreGlobal.hadGlobal) {
         await loadMods();
         const newMods = useAppStore
           .getState()
           .mods.filter((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
-        for (const newMod of newMods) {
-          if (!shouldRestoreVpkEnabled(newMod, newMods, restoreEnabled)) continue;
-          if (newMod.enabled) continue;
-          try {
-            await toggleMod(newMod.id);
-          } catch (err) {
-            console.warn('[Update] failed to re-enable updated mod:', err);
-          }
+        const restoreFailures = await restoreReplacementVpkState(
+          newMods,
+          restoreEnabled,
+          restoreGlobal,
+          {
+            setGlobal: (modId) => setModPriorityFolder(modId, true),
+            enable: async (modId) => {
+              await toggleMod(modId);
+            },
+          },
+        );
+        if (restoreFailures.length > 0) {
+          const summary = restoreFailures
+            .map((failure) => `${failure.action}: ${String(failure.error)}`)
+            .join('; ');
+          throw new Error(t('installed.updateAll.restoreStateFailed', { details: summary }));
         }
       }
 
@@ -2224,6 +2243,7 @@ export default function Installed() {
         section: m.sourceSection ?? 'Mod',
         categoryId: m.categoryId ?? 0,
         wasEnabled: m.enabled,
+        wasGlobal: !!m.priorityMod,
         fileDescription: m.fileDescription,
         sourceFileName: m.sourceFileName,
       }));
@@ -2251,6 +2271,7 @@ export default function Installed() {
       gameBananaId: number;
       gameBananaFileId: number;
       restoreEnabled: EnabledVpkRestoreSnapshot;
+      restoreGlobal: GlobalVpkRestoreSnapshot;
       fileName: string;
     }[] = [];
     let progress = 0;
@@ -2404,6 +2425,21 @@ export default function Installed() {
 
       for (const batch of okBatches.values()) {
         try {
+          const restoreEnabled = createEnabledVpkRestoreSnapshot(
+            batch.snapshots.map((snapshot) => ({
+              enabled: snapshot.wasEnabled,
+              vpkIndex: snapshot.vpkIndex,
+            })),
+          );
+          const restoreGlobal = createGlobalVpkRestoreSnapshot(
+            batch.snapshots.map((snapshot) => ({
+              priorityMod: snapshot.wasGlobal,
+              vpkIndex: snapshot.vpkIndex,
+            })),
+          );
+          if (restoreGlobal.ambiguous) {
+            throw new Error(t('installed.updateAll.ambiguousGlobalState'));
+          }
           for (const snapshot of batch.snapshots) {
             await deleteMod(snapshot.oldId);
           }
@@ -2417,12 +2453,8 @@ export default function Installed() {
           completed.push({
             gameBananaId: batch.gameBananaId,
             gameBananaFileId: batch.fileId,
-            restoreEnabled: createEnabledVpkRestoreSnapshot(
-              batch.snapshots.map((snapshot) => ({
-                enabled: snapshot.wasEnabled,
-                vpkIndex: snapshot.vpkIndex,
-              })),
-            ),
+            restoreEnabled,
+            restoreGlobal,
             fileName: batch.fileName,
           });
         } catch (err) {
@@ -2447,23 +2479,28 @@ export default function Installed() {
     }
 
     // Refresh once so the new installs are in the store with their new ids,
-    // then re-enable anything that was enabled before. Match by GB ids; the
+    // then restore Global placement and enabled state. Match by GB ids; the
     // local mod id changes on reinstall.
     await loadMods();
     const refreshed = useAppStore.getState().mods;
     for (const c of completed) {
-      if (!c.restoreEnabled.hadEnabled) continue;
+      if (!c.restoreEnabled.hadEnabled && !c.restoreGlobal.hadGlobal) continue;
       const newMods = refreshed.filter(
         (m) => m.gameBananaId === c.gameBananaId && m.gameBananaFileId === c.gameBananaFileId,
       );
-      for (const newMod of newMods) {
-        if (!shouldRestoreVpkEnabled(newMod, newMods, c.restoreEnabled)) continue;
-        if (newMod.enabled) continue;
-        try {
-          await toggleMod(newMod.id);
-        } catch (err) {
-          failures.push(`re-enable ${c.fileName}: ${String(err)}`);
-        }
+      const restoreFailures = await restoreReplacementVpkState(
+        newMods,
+        c.restoreEnabled,
+        c.restoreGlobal,
+        {
+          setGlobal: (modId) => setModPriorityFolder(modId, true),
+          enable: async (modId) => {
+            await toggleMod(modId);
+          },
+        },
+      );
+      for (const failure of restoreFailures) {
+        failures.push(`restore ${failure.action} ${c.fileName}: ${String(failure.error)}`);
       }
     }
     setUpdateAllProgress(null);


### PR DESCRIPTION
## Summary

- preserve Global priority-root placement when updating mods through the details modal, grouped updates, or Update All
- restore Global placement before enabled state so enabled replacements return directly to `citadel/grimoire`
- match multi-VPK replacement state by `vpkIndex` and refuse ambiguous legacy mixed-placement updates before deleting the old install
- surface localized restoration errors instead of silently completing with a demoted mod

## Root cause

The update flows snapshotted and restored only enabled state. Updating deletes the old VPK and its metadata, then downloads a replacement into the disabled folder with fresh metadata, so the old `priorityMod` flag was lost.

## User impact

Mods marked **Make Global** remain Global after an update. Existing non-Global mods remain non-Global. Legacy multi-file installs with mixed Global placement and no variant identities are left untouched and receive an actionable error rather than being guessed at.

## Validation

- `pnpm exec vitest run src/lib/vpkRestore.test.ts electron/main/services/priorityFolderMove.test.ts electron/main/services/priorityFolderFailure.test.ts src/lib/updateFileMatch.test.ts` (31 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm i18n:check`
- full `pnpm test`: 989 passed; 7 unrelated Windows-host failures remain in existing CRLF performance-preset and Wine/Bottles tests
