### PR TITLE
fix(metadata): an unresolvable game folder must not wipe every mod's identity

### DIFF
--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -17,7 +17,7 @@ import {
     runExclusiveModMutation,
     type Mod,
 } from '../services/mods';
-import { metaKeyFor } from '../services/deadlock';
+import { metaKeyFor, isValidDeadlockPath } from '../services/deadlock';
 import { getModMetadata, setModMetadata, setModMetadataWithHash, removeModMetadata, pruneOrphanMetadata } from '../services/metadata';
 import { inferHeroFromTitle } from '@grimoire/social-types/heroes';
 import { inferHeroFromVpk, classifyGlobalModFromVpk, GLOBAL_CLASSIFIER_VERSION, parseVpkDirectory, parseVpkDirectoriesAsync } from '../services/vpk';
@@ -329,7 +329,23 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     // sandbox starts empty, and pruning against it would wipe every real
     // install's name/thumbnail/gameBananaId from the global metadata sidecar.
     const settings = loadSettings();
-    if (!settings.devMode) {
+    // Same reasoning, for the real install: an empty scan is only evidence that
+    // the user has no mods when it came from a Deadlock folder that is actually
+    // there. A configured path can stop resolving (Steam mid-update after a
+    // reboot, a moved library, a drive that has not come up yet), and the scan
+    // roots are created on demand by getAddonsPath/getGrimoirePath, so the scan
+    // silently fabricates an empty addons tree and reports zero mods rather than
+    // failing. Pruning against that deletes every name, id, thumbnail and hero
+    // assignment the user has, unrecoverably (reported 2026-08-14: 26 mods
+    // reduced to "Pak01".."Pak31" after a PC restart). gameinfo.gi is the
+    // discriminator: Steam ships it and none of our mkdirs create it.
+    const trustworthyScan = isValidDeadlockPath(deadlockPath);
+    if (!trustworthyScan) {
+        console.warn(
+            `[Metadata] Skipping orphan prune: ${deadlockPath} has no game/citadel/gameinfo.gi, so this scan (${mods.length} VPKs) is not evidence of what is installed.`
+        );
+    }
+    if (!settings.devMode && trustworthyScan) {
         // Prune against ALL scanned files (including managed VPKs) so we don't
         // wipe their metadata before filtering them out of the list below.
         pruneOrphanMetadata(new Set(mods.map((m) => m.metaKey)));

--- a/electron/main/ipc/mods.ts
+++ b/electron/main/ipc/mods.ts
@@ -66,6 +66,10 @@ import type { AbilitySoundClassification, AddMergeSourcesResult, MergeSourceRepl
 
 const unknownDetectionControllers = new Map<string, AbortController>();
 
+// Last path we warned about skipping the orphan prune for, so the warning lands
+// once per path instead of once per get-mods.
+let lastUntrustedPathWarned: string | null = null;
+
 interface UnknownCacheBulkRequest {
     modId: string;
     requestId?: string;
@@ -336,11 +340,21 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     // roots are created on demand by getAddonsPath/getGrimoirePath, so the scan
     // silently fabricates an empty addons tree and reports zero mods rather than
     // failing. Pruning against that deletes every name, id, thumbnail and hero
-    // assignment the user has, unrecoverably (reported 2026-08-14: 26 mods
-    // reduced to "Pak01".."Pak31" after a PC restart). gameinfo.gi is the
-    // discriminator: Steam ships it and none of our mkdirs create it.
+    // assignment the user has (reported 2026-08-14: 26 mods reduced to
+    // "Pak01".."Pak31" after a PC restart). gameinfo.gi is the discriminator:
+    // Steam ships it and nothing on the install path writes one.
+    //
+    // The devMode check stays load-bearing rather than redundant: setupDevMode
+    // (services/dev.ts) writes an empty gameinfo.gi into the sandbox, so the
+    // sandbox passes this test and would otherwise prune the real sidecar
+    // against a tree that has never held a mod.
     const trustworthyScan = isValidDeadlockPath(deadlockPath);
-    if (!trustworthyScan) {
+    if (!trustworthyScan && deadlockPath !== lastUntrustedPathWarned) {
+        // Once per path, not once per get-mods: this handler runs on every visit
+        // to Installed, every toggle and every reorder, and a user whose
+        // gameinfo.gi is genuinely missing (antivirus, partial verify) would
+        // otherwise drown their own diagnostic report in this line.
+        lastUntrustedPathWarned = deadlockPath;
         console.warn(
             `[Metadata] Skipping orphan prune: ${deadlockPath} has no game/citadel/gameinfo.gi, so this scan (${mods.length} VPKs) is not evidence of what is installed.`
         );
@@ -348,7 +362,7 @@ ipcMain.handle('get-mods', async (): Promise<Mod[]> => {
     if (!settings.devMode && trustworthyScan) {
         // Prune against ALL scanned files (including managed VPKs) so we don't
         // wipe their metadata before filtering them out of the list below.
-        pruneOrphanMetadata(new Set(mods.map((m) => m.metaKey)));
+        pruneOrphanMetadata(new Set(mods.map((m) => m.metaKey)), deadlockPath);
     }
     // Hide Grimoire-managed Locker VPKs (hero cards + ability sounds). They're
     // driven solely through the Locker pickers and are auto-enabled + pinned to

--- a/electron/main/services/deadlockPathValidity.test.ts
+++ b/electron/main/services/deadlockPathValidity.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Coverage for the discriminator the orphan-prune guard rests on (see the
+ * get-mods handler in ipc/mods.ts).
+ *
+ * The prune may only run against a Deadlock folder that is really there. The
+ * hard part is that Grimoire's own path helpers mkdir their roots on demand, so
+ * a path that has stopped resolving does not fail: it comes back as a clean,
+ * empty, entirely fabricated addons tree, and the scan honestly reports zero
+ * mods. gameinfo.gi is what separates the two, so these tests pin that the
+ * helpers cannot fabricate one, that the looser check would NOT have done the
+ * job, and that the dev sandbox does pass it (which is why the devMode check in
+ * get-mods is load-bearing rather than redundant).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const harness = vi.hoisted(() => ({ devRoot: '' }));
+
+vi.mock('../utils/paths', () => ({
+    getDevDeadlockPath: () => harness.devRoot,
+}));
+vi.mock('./steamRoots', () => ({
+    getSteamRoots: () => [],
+    findBottleForPath: () => null,
+    readBottleDriveMap: () => new Map(),
+    resolveBottleWindowsPath: () => null,
+}));
+
+import {
+    getAddonsPath,
+    getDisabledPath,
+    getGrimoirePath,
+    isValidDeadlockPath,
+    looksLikeDeadlockPath,
+} from './deadlock';
+import { ensureDevDeadlockPath } from './dev';
+
+const created: string[] = [];
+
+function tempRoot(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    created.push(dir);
+    return dir;
+}
+
+afterEach(() => {
+    for (const dir of created.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe('isValidDeadlockPath as the prune guard', () => {
+    it('rejects the empty tree our own path helpers fabricate', () => {
+        // Exactly what scanMods does to a path that no longer resolves: every
+        // root is created on demand, then scanned, then reported as zero mods.
+        const root = tempRoot('deadlock-fabricated-');
+        getAddonsPath(root);
+        getDisabledPath(root);
+        getGrimoirePath(root);
+
+        expect(existsSync(join(root, 'game', 'citadel', 'addons', '.disabled'))).toBe(true);
+        expect(existsSync(join(root, 'game', 'citadel', 'grimoire'))).toBe(true);
+        // The whole tree exists and still does not read as an install.
+        expect(isValidDeadlockPath(root)).toBe(false);
+    });
+
+    it('accepts a real install', () => {
+        const root = tempRoot('deadlock-real-');
+        getAddonsPath(root);
+        writeFileSync(join(root, 'game', 'citadel', 'gameinfo.gi'), '"GameInfo" {}');
+
+        expect(isValidDeadlockPath(root)).toBe(true);
+    });
+
+    it('rejects a path with nothing in it at all', () => {
+        expect(isValidDeadlockPath(tempRoot('deadlock-bare-'))).toBe(false);
+    });
+
+    it('shows why the looser check could not be used here', () => {
+        // looksLikeDeadlockPath exists for the manual path picker, so a user
+        // whose gameinfo.gi was removed can still reach the recovery UI. It
+        // only tests game/citadel, which getAddonsPath creates on the way to
+        // citadel/addons, so it says yes to the fabricated tree above.
+        const root = tempRoot('deadlock-loose-');
+        getAddonsPath(root);
+
+        expect(looksLikeDeadlockPath(root)).toBe(true);
+        expect(isValidDeadlockPath(root)).toBe(false);
+    });
+
+    it('says yes to the dev sandbox, which is why devMode is still checked separately', () => {
+        // ensureDevDeadlockPath writes an empty gameinfo.gi, so the sandbox
+        // passes this guard. get-mods must keep its own !settings.devMode
+        // check, or a dev session would prune every real install's metadata
+        // against a tree that has never held a mod.
+        harness.devRoot = tempRoot('deadlock-devmode-');
+
+        expect(isValidDeadlockPath(ensureDevDeadlockPath())).toBe(true);
+    });
+});

--- a/electron/main/services/metadata.prune.test.ts
+++ b/electron/main/services/metadata.prune.test.ts
@@ -1,17 +1,24 @@
 /**
- * Coverage for pruneOrphanMetadata's refusal to empty a populated sidecar.
+ * Coverage for pruneOrphanMetadata: a metadata row is only dropped when its VPK
+ * is confirmed gone from disk, never because a scan failed to mention it.
  *
  * The prune exists to drop rows whose VPK is gone (issue #26: a dead mod's
  * gameBananaId leaking onto whatever install next lands in its pakNN slot). It
- * runs on every get-mods against whatever the scan returned, and a scan returns
- * nothing whenever the Deadlock folder stops resolving for a moment (Steam
- * mid-update after a reboot, a moved library, a drive that has not come up).
- * The scan roots are created on demand, so that case reads as a clean empty
- * addons folder rather than an error. Reported 2026-08-14: 26 mods reduced to
- * "Pak01".."Pak31", every name, id and thumbnail gone with no way back.
+ * runs on every get-mods against whatever the scan returned, and the scan can
+ * come back short for reasons that say nothing about what the user deleted:
+ *
+ *  - the Deadlock folder stops resolving for a moment (Steam mid-update after a
+ *    reboot, a moved library, a drive that has not come up), and because the
+ *    scan roots are created on demand it reads as a clean empty addons folder
+ *    rather than an error. Reported 2026-08-14: 26 mods reduced to
+ *    "Pak01".."Pak31", every name, id and thumbnail gone with no way back;
+ *  - getAddonFolderPaths falls back to base-only when citadel/ is unreadable,
+ *    dropping every overflow-folder mod from the set at once;
+ *  - scanFolder skips any file whose stat throws, e.g. antivirus holding one
+ *    VPK open.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync } from 'fs';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -27,50 +34,119 @@ import { loadMetadata, pruneOrphanMetadata, saveMetadata } from './metadata';
 const POPULATED = {
     'pak01_dir.vpk': { modName: 'Bikinidicta', gameBananaId: 554012 },
     'pak02_dir.vpk': { modName: 'Ghost Bride Vindicta', gameBananaId: 663268 },
+    'addons1/pak03_dir.vpk': { modName: 'Vatican Vindicta', gameBananaId: 694568 },
     'grimoire/pak05_dir.vpk': { modName: 'Top Bar HUD', gameBananaId: 703330 },
+    'ghost_bride_vindicta_dir.vpk': { modName: 'Ghost Bride (disabled copy)' },
     'locker:cards': { lockerCosmetics: { cards: [], rebuiltAt: '2026-08-14T00:00:00.000Z' } },
 };
 
+/** Every VPK in POPULATED, laid out on disk the way metaKeyFor addresses it:
+ *  bare keys in citadel/addons (or its .disabled parking lot), prefixed keys in
+ *  the priority root and the overflow folders. */
+function createInstall(): string {
+    const root = mkdtempSync(join(tmpdir(), 'metadata-prune-game-'));
+    const citadel = join(root, 'game', 'citadel');
+    for (const folder of ['addons', join('addons', '.disabled'), 'addons1', 'grimoire']) {
+        mkdirSync(join(citadel, folder), { recursive: true });
+    }
+    writeFileSync(join(citadel, 'addons', 'pak01_dir.vpk'), 'vpk');
+    writeFileSync(join(citadel, 'addons', 'pak02_dir.vpk'), 'vpk');
+    writeFileSync(join(citadel, 'addons1', 'pak03_dir.vpk'), 'vpk');
+    writeFileSync(join(citadel, 'grimoire', 'pak05_dir.vpk'), 'vpk');
+    writeFileSync(join(citadel, 'addons', '.disabled', 'ghost_bride_vindicta_dir.vpk'), 'vpk');
+    return root;
+}
+
+const created: string[] = [];
+
 beforeEach(() => {
     harness.userData = mkdtempSync(join(tmpdir(), 'metadata-prune-user-'));
+    created.push(harness.userData);
     saveMetadata({});
 });
 
+afterEach(() => {
+    for (const dir of created.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function install(): string {
+    const root = createInstall();
+    created.push(root);
+    return root;
+}
+
 describe('pruneOrphanMetadata', () => {
     it('refuses to clear the sidecar when the scan found nothing', () => {
+        const game = install();
         saveMetadata({ ...POPULATED });
 
-        pruneOrphanMetadata(new Set());
+        pruneOrphanMetadata(new Set(), game);
 
         expect(loadMetadata()).toEqual(POPULATED);
     });
 
-    it('still drops real orphans when the scan found something', () => {
+    it('refuses even when the whole install has gone missing under it', () => {
+        // Nothing resolves, so every row looks orphaned by the disk check too.
+        // This is the reported failure: a path that stopped resolving.
         saveMetadata({ ...POPULATED });
 
-        pruneOrphanMetadata(new Set(['pak01_dir.vpk', 'grimoire/pak05_dir.vpk']));
+        pruneOrphanMetadata(new Set(), join(tmpdir(), 'metadata-prune-not-here'));
+
+        expect(loadMetadata()).toEqual(POPULATED);
+    });
+
+    it('keeps rows for VPKs the scan missed but disk still has', () => {
+        // citadel/ unreadable => getAddonFolderPaths returns base-only, so every
+        // overflow mod drops out of the scan; and one stat failure drops
+        // pak02. Both files are still there, so both rows must survive.
+        const game = install();
+        saveMetadata({ ...POPULATED });
+
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk', 'grimoire/pak05_dir.vpk']), game);
 
         const after = loadMetadata();
-        expect(Object.keys(after).sort()).toEqual([
-            'grimoire/pak05_dir.vpk',
-            'locker:cards',
-            'pak01_dir.vpk',
-        ]);
-        expect(after['pak02_dir.vpk']).toBeUndefined();
+        expect(after['addons1/pak03_dir.vpk']).toBeDefined();
+        expect(after['pak02_dir.vpk']).toBeDefined();
+        expect(after).toEqual(POPULATED);
+    });
+
+    it('finds a bare key parked in .disabled, not just in addons', () => {
+        const game = install();
+        saveMetadata({ ...POPULATED });
+
+        // A disabled mod is absent from the enabled scan by definition.
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk']), game);
+
+        expect(loadMetadata()['ghost_bride_vindicta_dir.vpk']).toBeDefined();
+    });
+
+    it('still drops a row whose VPK is genuinely gone (the #26 self-heal)', () => {
+        const game = install();
+        saveMetadata({ ...POPULATED, 'pak09_dir.vpk': { modName: 'Deleted Behind Our Back' } });
+
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk']), game);
+
+        const after = loadMetadata();
+        expect(after['pak09_dir.vpk']).toBeUndefined();
+        // and nothing else went with it
+        expect(after).toEqual(POPULATED);
     });
 
     it('never treats a Locker selection set as an orphan', () => {
         // locker:* rows key the Locker-managed VPKs in citadel/grimoire, which
         // are not scanned filenames, so they can never appear in validKeys.
-        saveMetadata({ 'locker:cards': { lockerCosmetics: { cards: [], rebuiltAt: '2026-08-14T00:00:00.000Z' } }, 'pak01_dir.vpk': {} });
+        const game = install();
+        saveMetadata({ ...POPULATED });
 
-        pruneOrphanMetadata(new Set(['pak01_dir.vpk']));
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk']), game);
 
         expect(loadMetadata()['locker:cards']).toBeDefined();
     });
 
     it('leaves an already-empty sidecar alone', () => {
-        pruneOrphanMetadata(new Set());
+        pruneOrphanMetadata(new Set(), install());
 
         expect(loadMetadata()).toEqual({});
     });

--- a/electron/main/services/metadata.prune.test.ts
+++ b/electron/main/services/metadata.prune.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Coverage for pruneOrphanMetadata's refusal to empty a populated sidecar.
+ *
+ * The prune exists to drop rows whose VPK is gone (issue #26: a dead mod's
+ * gameBananaId leaking onto whatever install next lands in its pakNN slot). It
+ * runs on every get-mods against whatever the scan returned, and a scan returns
+ * nothing whenever the Deadlock folder stops resolving for a moment (Steam
+ * mid-update after a reboot, a moved library, a drive that has not come up).
+ * The scan roots are created on demand, so that case reads as a clean empty
+ * addons folder rather than an error. Reported 2026-08-14: 26 mods reduced to
+ * "Pak01".."Pak31", every name, id and thumbnail gone with no way back.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const harness = vi.hoisted(() => ({ userData: '' }));
+
+vi.mock('electron', () => ({ app: { getPath: () => harness.userData } }));
+vi.mock('./vpkIdentity', () => ({
+    resolveVpkIdentity: vi.fn(async () => ({ sha256: 'f'.repeat(64) })),
+}));
+
+import { loadMetadata, pruneOrphanMetadata, saveMetadata } from './metadata';
+
+const POPULATED = {
+    'pak01_dir.vpk': { modName: 'Bikinidicta', gameBananaId: 554012 },
+    'pak02_dir.vpk': { modName: 'Ghost Bride Vindicta', gameBananaId: 663268 },
+    'grimoire/pak05_dir.vpk': { modName: 'Top Bar HUD', gameBananaId: 703330 },
+    'locker:cards': { lockerCosmetics: { cards: [], rebuiltAt: '2026-08-14T00:00:00.000Z' } },
+};
+
+beforeEach(() => {
+    harness.userData = mkdtempSync(join(tmpdir(), 'metadata-prune-user-'));
+    saveMetadata({});
+});
+
+describe('pruneOrphanMetadata', () => {
+    it('refuses to clear the sidecar when the scan found nothing', () => {
+        saveMetadata({ ...POPULATED });
+
+        pruneOrphanMetadata(new Set());
+
+        expect(loadMetadata()).toEqual(POPULATED);
+    });
+
+    it('still drops real orphans when the scan found something', () => {
+        saveMetadata({ ...POPULATED });
+
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk', 'grimoire/pak05_dir.vpk']));
+
+        const after = loadMetadata();
+        expect(Object.keys(after).sort()).toEqual([
+            'grimoire/pak05_dir.vpk',
+            'locker:cards',
+            'pak01_dir.vpk',
+        ]);
+        expect(after['pak02_dir.vpk']).toBeUndefined();
+    });
+
+    it('never treats a Locker selection set as an orphan', () => {
+        // locker:* rows key the Locker-managed VPKs in citadel/grimoire, which
+        // are not scanned filenames, so they can never appear in validKeys.
+        saveMetadata({ 'locker:cards': { lockerCosmetics: { cards: [], rebuiltAt: '2026-08-14T00:00:00.000Z' } }, 'pak01_dir.vpk': {} });
+
+        pruneOrphanMetadata(new Set(['pak01_dir.vpk']));
+
+        expect(loadMetadata()['locker:cards']).toBeDefined();
+    });
+
+    it('leaves an already-empty sidecar alone', () => {
+        pruneOrphanMetadata(new Set());
+
+        expect(loadMetadata()).toEqual({});
+    });
+});

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -396,6 +396,23 @@ export function pruneOrphanMetadata(validKeys: Set<string>): void {
     );
     if (orphans.length === 0) return;
 
+    // A prune that empties a populated sidecar is never a self-heal. Deleting a
+    // mod drops its own row synchronously (deleteMod -> removeModMetadata), so
+    // orphans are always a minority left behind by an older version or an
+    // outside-Grimoire delete. "Nothing on disk matches anything on record"
+    // instead means the scan saw nothing, which is what a Deadlock folder that
+    // briefly stopped resolving looks like. Refuse it: the cost of keeping an
+    // orphan is one stale name on a recycled pakNN slot, the cost of the wipe is
+    // every name, GameBanana id, thumbnail and hero assignment the user has,
+    // with no way back. Callers guard this too (see get-mods); this is the
+    // invariant that holds when a caller forgets.
+    if (validKeys.size === 0) {
+        console.warn(
+            `[Metadata] Refusing to prune ${orphans.length} entries against an empty scan: that would clear the sidecar, and no mod list is worth that.`
+        );
+        return;
+    }
+
     for (const key of orphans) {
         delete metadata[key];
     }

--- a/electron/main/services/metadata.ts
+++ b/electron/main/services/metadata.ts
@@ -171,7 +171,16 @@ export function loadMetadata(): ModMetadataMap {
         metadataCache = { mtimeMs: stat.mtimeMs, size: stat.size, data };
         return data;
     } catch (error) {
+        // Returning {} here means every writer that follows treats "I could not
+        // read the sidecar" as "there is nothing in the sidecar", and the first
+        // one to save (setModMetadata on the next scan, or the startup
+        // backfillMissingMetadataHashes, which mints a hash-only row per VPK)
+        // commits that as fact. Copy the unreadable bytes aside first so the
+        // real content outlives the overwrite: a truncated file after an
+        // unclean shutdown, or a read that lost a race with antivirus, is then
+        // recoverable instead of being the same total loss by a slower route.
         console.warn('[Metadata] Failed to load metadata, returning empty:', error);
+        backupMetadataSidecar('unreadable');
         metadataCache = null;
         return {};
     }
@@ -198,6 +207,14 @@ export function saveMetadata(metadata: ModMetadataMap): void {
         try {
             if (existsSync(tempPath)) unlinkSync(tempPath);
         } catch { /* ignore */ }
+        // Drop the cache, do not leave it. loadMetadata hands its cached map out
+        // by reference and every mutating helper edits that object in place
+        // before calling us, so a failed write leaves the cache holding changes
+        // that never reached disk while its mtime/size still match the
+        // untouched file. The next unrelated save would then write those
+        // half-applied edits over the good file: one denied write during a
+        // prune, and the rows it wanted to drop are gone at the next toggle.
+        metadataCache = null;
         throw error;
     }
 }
@@ -377,6 +394,28 @@ export function removeModMetadata(fileName: string): void {
 export const deleteModMetadata = removeModMetadata;
 
 /**
+ * Every absolute path a metaKey can name, without creating anything.
+ *
+ * Deliberately raw joins: getAddonsPath / getDisabledPath / getGrimoirePath all
+ * mkdir their root on demand, which is exactly how a Deadlock folder that has
+ * stopped resolving comes back as a clean empty tree. A function whose whole
+ * job is to decide whether a file is really gone must not fabricate the folder
+ * it is looking in.
+ *
+ * metaKeyFor produces three shapes: `grimoire/<file>` for the priority root,
+ * `addonsN/<file>` for an overflow root, and a bare `<file>` otherwise, which
+ * can be sitting in either citadel/addons or citadel/addons/.disabled.
+ */
+function resolveMetaKeyPaths(deadlockPath: string, key: string): string[] {
+    const citadel = join(deadlockPath, 'game', 'citadel');
+    const slash = key.indexOf('/');
+    if (slash !== -1) {
+        return [join(citadel, key.slice(0, slash), key.slice(slash + 1))];
+    }
+    return [join(citadel, 'addons', key), join(citadel, 'addons', '.disabled', key)];
+}
+
+/**
  * Drop metadata entries whose VPK no longer exists on disk.
  *
  * Older versions of deleteMod removed the .vpk file but left metadata behind,
@@ -385,27 +424,45 @@ export const deleteModMetadata = removeModMetadata;
  * categoryName, thumbnail, etc. onto the new install (issue #26). Callers
  * pass the current valid set (metaKeys) so users with pre-existing orphans
  * self-heal the next time the mods list is scanned.
+ *
+ * A key missing from that set is a *candidate*, never a verdict. The scan can
+ * come back short for reasons that have nothing to do with the user deleting
+ * anything: getAddonFolderPaths falls back to base-only when citadel/ is
+ * unreadable (so every overflow-folder mod vanishes from the set at once),
+ * scanFolder skips any file whose stat throws (antivirus holding one VPK), and
+ * a path that stopped resolving scans as an empty tree. So confirm each
+ * candidate against disk before deleting its row, and keep the row whenever the
+ * file is there or we cannot tell.
  */
-export function pruneOrphanMetadata(validKeys: Set<string>): void {
+export function pruneOrphanMetadata(validKeys: Set<string>, deadlockPath: string): void {
     const metadata = loadMetadata();
     // Synthetic `locker:*` keys hold the Locker-managed selection sets (cards /
     // sounds), which live in citadel/grimoire and are NOT scanned filenames, so
     // they must never be treated as orphans.
-    const orphans = Object.keys(metadata).filter(
+    const candidates = Object.keys(metadata).filter(
         (key) => !key.startsWith('locker:') && !validKeys.has(key),
     );
+    if (candidates.length === 0) return;
+
+    const orphans = candidates.filter(
+        (key) => !resolveMetaKeyPaths(deadlockPath, key).some((path) => existsSync(path)),
+    );
+    const kept = candidates.length - orphans.length;
+    if (kept > 0) {
+        console.warn(
+            `[Metadata] ${kept} of ${candidates.length} prune candidates are still on disk; the scan missed them. Keeping their metadata.`
+        );
+    }
     if (orphans.length === 0) return;
 
-    // A prune that empties a populated sidecar is never a self-heal. Deleting a
+    // Last line of defence, for the case the check above cannot see: when the
+    // whole install is gone, every path misses and every row looks orphaned. A
+    // prune that empties a populated sidecar is never a self-heal. Deleting a
     // mod drops its own row synchronously (deleteMod -> removeModMetadata), so
     // orphans are always a minority left behind by an older version or an
-    // outside-Grimoire delete. "Nothing on disk matches anything on record"
-    // instead means the scan saw nothing, which is what a Deadlock folder that
-    // briefly stopped resolving looks like. Refuse it: the cost of keeping an
-    // orphan is one stale name on a recycled pakNN slot, the cost of the wipe is
-    // every name, GameBanana id, thumbnail and hero assignment the user has,
-    // with no way back. Callers guard this too (see get-mods); this is the
-    // invariant that holds when a caller forgets.
+    // outside-Grimoire delete. The cost of keeping an orphan is one stale name
+    // on a recycled pakNN slot; the cost of the wipe is every name, GameBanana
+    // id, thumbnail and hero assignment the user has.
     if (validKeys.size === 0) {
         console.warn(
             `[Metadata] Refusing to prune ${orphans.length} entries against an empty scan: that would clear the sidecar, and no mod list is worth that.`
@@ -413,6 +470,10 @@ export function pruneOrphanMetadata(validKeys: Set<string>): void {
         return;
     }
 
+    // Cheap insurance on the one operation here that destroys user data. Runs
+    // only on a real prune, which is rare (orphans are normally zero), and
+    // keeps the last 5.
+    backupMetadataSidecar('pre-prune');
     for (const key of orphans) {
         delete metadata[key];
     }

--- a/electron/main/services/unknownModDetection.ts
+++ b/electron/main/services/unknownModDetection.ts
@@ -270,13 +270,47 @@ async function mapWithConcurrency<T>(
     await Promise.all(runners);
 }
 
+/** Connection-level failure codes. The network dropped, the DNS lookup failed,
+ *  the socket timed out: none of it is a claim about the archive. */
+const TRANSIENT_ERROR_CODES = new Set([
+    'EAI_AGAIN',
+    'ECONNABORTED',
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'EHOSTUNREACH',
+    'ENETDOWN',
+    'ENETUNREACH',
+    'ENOTFOUND',
+    'EPIPE',
+    'ETIMEDOUT',
+    'UND_ERR_BODY_TIMEOUT',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_SOCKET',
+]);
+
 /**
  * A probe failure that says nothing about the archive itself (rate limiting,
- * CDN hiccup). Stamping these `failed` would freeze the file behind the
- * failed-retry window; leaving the row pending lets the next run re-probe.
+ * CDN hiccup, the user's connection going away). Stamping these `failed` would
+ * freeze the file behind the failed-retry window; leaving the row pending lets
+ * the next run re-probe.
+ *
+ * The network arm matters as much as the rate-limit one. undici reports every
+ * connection-level failure as a bare `TypeError: fetch failed` with the real
+ * reason on `.cause`, so a user who goes offline mid-run banks a `failed` row
+ * per candidate: one report had ~100 files stamped in a row, which then made
+ * their retry (the whole point of the feature, and the only recovery from a
+ * lost metadata sidecar) silently check nothing for the next six hours.
  */
-function isTransientProbeError(err: unknown): boolean {
-    return /Archive range request failed: (?:429|5\d\d)\b/.test(errorMessage(err));
+export function isTransientProbeError(err: unknown, depth = 0): boolean {
+    if (/Archive range request failed: (?:408|429|5\d\d)\b/.test(errorMessage(err))) return true;
+    if (!(err instanceof Error) || depth > 4) return false;
+    if (err.name === 'TypeError' && err.message === 'fetch failed') return true;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (typeof code === 'string' && TRANSIENT_ERROR_CODES.has(code)) return true;
+    // Follow the cause chain: undici hangs the real errno off the TypeError,
+    // and our own wrappers can add another layer on top of that.
+    return err.cause === undefined ? false : isTransientProbeError(err.cause, depth + 1);
 }
 
 /**

--- a/electron/main/services/unknownProbeTransient.test.ts
+++ b/electron/main/services/unknownProbeTransient.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Coverage for isTransientProbeError, the predicate that decides whether a
+ * failed archive probe is stamped `failed` in the CRC cache (skipped for the
+ * next FAILED_RETRY_SECONDS) or left `pending` for the next run.
+ *
+ * The bug this guards: undici reports a dropped connection as a bare
+ * `TypeError: fetch failed` with the real errno on `.cause`, which the original
+ * rate-limit-only predicate read as "this archive is unusable". A user whose
+ * network went away mid-run banked ~100 `failed` rows, so their retry checked
+ * nothing for six hours. Over-classifying is the opposite hazard: a genuinely
+ * unparseable archive must still be stamped, or every run re-downloads it.
+ *
+ * Every fs/electron/network dependency is stubbed inert, same pattern as
+ * unknownModEmbedDetect.test.ts.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./archiveCrc', () => ({
+    crc32File: vi.fn(),
+    fetchGameBananaArchiveVpkCrcEntries: vi.fn(),
+}));
+vi.mock('./gamebanana', () => ({
+    fetchModsFilesMetadata: vi.fn(),
+    fetchSubmissions: vi.fn(),
+}));
+vi.mock('./vpk', () => ({
+    parseVpkDirectory: vi.fn(() => []),
+    parseVpkDirectoryCached: vi.fn(() => []),
+}));
+vi.mock('./vpkIdentity', () => ({
+    readEmbeddedAddonInfo: vi.fn(() => null),
+    carryForwardOriginalIdentity: vi.fn(() => null),
+}));
+vi.mock('./modinfoFormat', () => ({ readEmbeddedModinfo: vi.fn(() => null) }));
+vi.mock('./workers', () => ({ fingerprintFilesInWorkers: vi.fn(async () => []) }));
+vi.mock('./unknownCrcCache', () => ({
+    getUnknownCrcEntryCount: vi.fn(() => 0),
+    getUnknownCrcFilesForMods: vi.fn(() => []),
+    lookupUnknownCrcMatch: vi.fn(() => null),
+    lookupUnknownCrcMatches: vi.fn(() => new Map()),
+    replaceUnknownCrcEntries: vi.fn(),
+    updateUnknownCrcFileStatus: vi.fn(),
+    upsertUnknownCrcFiles: vi.fn(),
+    UNKNOWN_CRC_PARSER_VERSION: 1,
+}));
+
+import { isTransientProbeError } from './unknownModDetection';
+
+/** What undici actually throws when the connection fails: the message is
+ *  useless, the errno is one level down on `.cause`. */
+function fetchFailed(cause?: unknown): TypeError {
+    const err = new TypeError('fetch failed');
+    if (cause !== undefined) (err as TypeError & { cause?: unknown }).cause = cause;
+    return err;
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+    const err = new Error(code) as NodeJS.ErrnoException;
+    err.code = code;
+    return err;
+}
+
+describe('isTransientProbeError', () => {
+    it('treats a bare undici "fetch failed" as transient', () => {
+        // The exact shape from the 2026-08-14 report: ~100 of these in a row,
+        // every one of them stamped failed.
+        expect(isTransientProbeError(fetchFailed())).toBe(true);
+    });
+
+    it('follows the cause chain to the errno', () => {
+        expect(isTransientProbeError(fetchFailed(errno('ENOTFOUND')))).toBe(true);
+        expect(isTransientProbeError(fetchFailed(errno('ECONNRESET')))).toBe(true);
+        expect(isTransientProbeError(fetchFailed(errno('UND_ERR_CONNECT_TIMEOUT')))).toBe(true);
+    });
+
+    it('recognises an errno thrown directly, with no wrapper', () => {
+        expect(isTransientProbeError(errno('ETIMEDOUT'))).toBe(true);
+    });
+
+    it('keeps treating rate limits and server errors as transient', () => {
+        expect(isTransientProbeError(new Error('Archive range request failed: 429'))).toBe(true);
+        expect(isTransientProbeError(new Error('Archive range request failed: 503'))).toBe(true);
+        expect(isTransientProbeError(new Error('Archive range request failed: 408'))).toBe(true);
+    });
+
+    it('stamps a genuinely unusable archive, so it is not re-probed forever', () => {
+        expect(isTransientProbeError(new Error('Archive range request failed: 404'))).toBe(false);
+        expect(isTransientProbeError(new Error('Unsupported archive: solid RAR5 block'))).toBe(false);
+        expect(isTransientProbeError(new Error('Central directory not found'))).toBe(false);
+        expect(isTransientProbeError('not an error at all')).toBe(false);
+    });
+
+    it('survives a self-referential cause chain', () => {
+        const err = new Error('boom') as Error & { cause?: unknown };
+        err.cause = err;
+        expect(isTransientProbeError(err)).toBe(false);
+    });
+});


### PR DESCRIPTION
Diagnostic report from a 1.27.1 Windows user: *"whenever I install a new mod, after restarting the PC, all of them become unknown and unnamed"*.

Their `modTrace` dump shows 31 enabled mods, 26 of them reading `local key=pakNN_dir.vpk name="PakNN"`, which is the display fallback for "no sidecar row at all". The log dates the loss to the minute, because the survivors line up exactly with install time:

| Mod that kept its metadata | Installed |
|---|---|
| Needy Girl Overdose (703330) | 08-13 **11:36** |
| Invisible Man Haze FOV FIX (633786) | 08-14 15:22 |
| Blue VDC / Dynamic Scope (695938) | 08-14 15:27 |
| Vatican Vindicta (694568) | 08-14 15:27 |
| Colored VFX + Tracers (686119) | 08-14 18:07 |

Everything installed before 08-13 11:36 lost its metadata, everything after kept it. The session that starts at 11:33 is the first launch after a PC restart:

```
11:33:24  logger ready
11:33:25  [detectConflicts] enabled=0 took=108ms (trivial)   <- the scan saw ZERO mods
11:33:26  [DiscordRPC] connected                             <- so settings.json was intact
11:34:59  [detectDeadlockPath] FOUND via manifest: ...\Deadlock
11:34:59  [detectConflicts] enabled=28                       <- the 28 VPKs were there all along
```

The files never went anywhere. Only their identity did.

## What happens

`get-mods` prunes metadata rows whose VPK is no longer on disk (issue #26: a dead mod's `gameBananaId` leaking onto whatever install next lands in its recycled `pakNN` slot). It prunes against whatever `scanMods` returned, guarded only against a null path.

But an empty scan is not evidence that the user has no mods:

- `scanFolder` returns `[]` for a folder that is not there, so a fresh install with no `.disabled` scans clean.
- `getAddonsPath` / `getDisabledPath` / `getGrimoirePath` `mkdir` their roots on demand, so a path that has stopped resolving does not fail either. Grimoire recreates the tree and scans it empty.

So a Deadlock folder that is briefly not there (Steam mid-update after a reboot, a moved library, a drive that has not come up yet, a stale path aimed at a second Steam install, and this reporter's log lists two) produces a clean, quiet, zero-mod scan. The prune then clears `mod-metadata.json`: every name, GameBanana id, thumbnail, hero assignment, `lastPriority`, merge record. There is no backup and no way back.

The `devMode` skip already anticipated this exact failure for the dev sandbox. The real install just never got the same courtesy.

## The fix

Two guards, because this one earns the belt and braces.

**`get-mods` only prunes when the path holds a `game/citadel/gameinfo.gi`.** Steam ships that file and none of our `mkdir`s create it, so it separates a real install from a tree we invented moments ago. A user whose `gameinfo.gi` was removed (antivirus, partial verify, the case `looksLikeDeadlockPath` exists for) keeps their metadata and loses only the self-heal, which is the right way round.

**`pruneOrphanMetadata` refuses to empty a populated sidecar**, whatever a caller passes. Deleting a mod drops its own row synchronously (`deleteMod` -> `removeModMetadata`), so real orphans are always a minority left by an older version or an outside-Grimoire delete. "Nothing on disk matches anything on record" only ever means the scan saw nothing. The cost of keeping an orphan is one stale name on a recycled slot. The cost of the wipe is everything.

Both log why they skipped, so the next diagnostic report says so out loud.

## Second commit: the recovery path failed too

Fix Unknown Mods is how a user rebuilds identity after this. In the same report, all ~100 archive probes failed with `fetch failed` because their connection was down at the time.

`isTransientProbeError` only recognised `Archive range request failed: 429|5xx`, so all ~100 got stamped `failed` in the CRC cache, and `shouldProbeArchive` skips a failed file for `FAILED_RETRY_SECONDS` (6 hours). The retry a user runs the moment their network is back silently checks nothing and reports no matches, which reads as "the feature is broken" rather than "come back later".

undici reports every connection-level failure as a bare `TypeError: fetch failed` with the real errno on `.cause`, so match that shape and walk the cause chain for the transient errnos. Kept deliberately narrow in the other direction: a genuinely unusable archive must still be stamped, or every run re-downloads it.

## Testing

Three new test files, 18 cases in total. `metadata.prune.test.ts` pins the refusal, the per-key disk verification (scan-missed rows kept, `.disabled` parking lot searched), that a genuine orphan is still dropped (the #26 self-heal), and that `locker:*` rows are never orphans. Verified non-vacuous twice: with the empty-scan refusal disabled the populated sidecar collapses to the single `locker:` key, and with the disk check stubbed to always report orphaned, exactly the three verification cases fail. `unknownProbeTransient.test.ts` pins both directions of the probe predicate. `deadlockPathValidity.test.ts` pins the discriminator itself: the tree our own helpers fabricate reads false, a real install reads true, `looksLikeDeadlockPath` says yes to that same fabricated tree (which is why the loose check could not be used here), and the dev sandbox reads true (which is why the `devMode` check beside it is load-bearing).

Full suite 1055 passing, typecheck and lint clean.

## Second pass, after review

A review found the first pass still had three routes to losing rows, all the same shape: something other than the user deleting a mod makes the scan come back short, and the prune reads that gap as a verdict. `getAddonFolderPaths` falls back to base-only when `citadel/` is unreadable, so every overflow folder's mods leave the scan set at once; `scanFolder` skips any file whose `stat` throws (one VPK held open by antivirus on Windows); and a path aimed at a second complete Steam install prunes every row describing the first. All three pass both of the original guards.

So the prune no longer infers absence at all. A key missing from the scan set is a *candidate*; it is confirmed against disk (raw joins, never the mkdir-on-demand path helpers) and the row is kept whenever the file is there. That is N `existsSync` calls where N is normally zero, and it covers all three cases plus metaKey case drift on NTFS, which `backfillMissingMetadataHashes` already concedes happens. The empty-scan refusal stays as the last line of defence for what the disk check cannot see: when the whole install is gone, every path misses and every row looks orphaned. A `backupMetadataSidecar('pre-prune')` now precedes any real prune.

Three more fixes from the same review:

- **`saveMetadata`'s catch left the cache poisoned.** `loadMetadata` hands its cached map out by reference and every mutating helper edits it in place before saving, so a failed write left the cache holding changes that never reached disk while its mtime/size still matched the untouched file. One denied write during a prune (antivirus, a full disk) and the next unrelated save committed the loss. The cache is now dropped on failure.
- **`loadMetadata` returning `{}` on an unreadable file is its own total-loss route**, and neither guard here touches it: the startup `backfillMissingMetadataHashes` then mints a hash-only row per VPK and saves, which renders as exactly the reported `PakNN` symptom. It now copies the unreadable bytes aside first, so they outlive the overwrite. (My earlier claim that the refusal made this unreachable was wrong: the refusal lives in `pruneOrphanMetadata`, which is not on that path.)
- **The `devMode` check is load-bearing, not redundant.** `dev.ts` writes an empty `gameinfo.gi`, so the sandbox passes `isValidDeadlockPath`. The comment said the opposite, which is how the next person deletes the check.

Also: the skip warning fired on every `get-mods` (every Installed visit, every toggle, every reorder) and is now once per path, so a user whose `gameinfo.gi` is genuinely missing does not drown their own diagnostic report in it.

## Known trade-offs and follow-ups

- **`mod-metadata.json` is still written temp+rename with no `fsync`.** Not what caused this, and the sidecar backups plus the copy-aside above make the failure recoverable rather than silent, but the durability gap is real. Follow-up.
- **A permanently broken connection now re-probes forever** instead of being bounded by the 6-hour `failed` window. Each run is still capped by `MAX_LIVE_SEARCH_PAGES`, and for a user whose network is genuinely down the old behaviour was worse (their retry silently checked nothing), but there is no ceiling across runs. A proper fix needs an attempt counter in the CRC cache schema. Follow-up.
- **Repointing at a different complete install still prunes**, since those files really are absent from the configured path and the sidecar is global rather than per-install. Now backed up first.

Does not touch `replayFolder.ts` / `system.ts` / `ipc/launch.ts`, so it stays clear of #358. That report's `Could not link the replays folder: ENOENT ...\citadel\replays` is the dangling-junction variant of the ELOOP #358 already repairs, so this is a second data point for it, from a Windows user.
