### PR TITLE
Fix live update and variant download state in mod popups

### DIFF
--- a/electron/main/ipc/gamebanana.ts
+++ b/electron/main/ipc/gamebanana.ts
@@ -20,7 +20,7 @@ import {
     type GameBananaCollection,
     type GameBananaCollectionItemsResponse,
 } from '../services/gamebanana';
-import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, cancelActiveDownload, resolveSuspiciousFileDecision, resolveMultiVpkPick, type DownloadModArgs } from '../services/download';
+import { downloadMod, getDownloadQueue, getCurrentDownload, removeFromQueue, cancelActiveDownload, cancelDownloadTarget, resolveSuspiciousFileDecision, resolveMultiVpkPick, type DownloadModArgs } from '../services/download';
 import { getMainWindow } from '../index';
 import type {
     BrowseModsArgs,
@@ -89,13 +89,18 @@ ipcMain.handle('get-current-download', () => {
 });
 
 // remove-from-queue (cancel a queued download)
-ipcMain.handle('remove-from-queue', (_, modId: number): boolean => {
-    return removeFromQueue(modId);
+ipcMain.handle('remove-from-queue', (_, modId: number, fileId?: number): boolean => {
+    return removeFromQueue(modId, fileId);
 });
 
 // cancel-active-download (abort the currently-running download)
 ipcMain.handle('cancel-active-download', (): boolean => {
     return cancelActiveDownload();
+});
+
+// cancel-download-target (exact optimistic/queued/active target)
+ipcMain.handle('cancel-download-target', (_, modId: number, fileId: number): boolean => {
+    return cancelDownloadTarget(modId, fileId);
 });
 
 // one-click-suspicious-response (renderer relays user's modal decision)

--- a/electron/main/services/download.ts
+++ b/electron/main/services/download.ts
@@ -206,10 +206,13 @@ export function getCurrentDownload(): DownloadQueueItem | null {
 }
 
 /**
- * Remove a mod from the queue (cancel before download starts)
+ * Remove one queued target (cancel before download starts). fileId remains
+ * optional for older callers that intentionally cancel the first row by mod.
  */
-export function removeFromQueue(modId: number): boolean {
-    const index = downloadQueue.findIndex(item => item.args.modId === modId);
+export function removeFromQueue(modId: number, fileId?: number): boolean {
+    const index = downloadQueue.findIndex(item =>
+        item.args.modId === modId && (fileId === undefined || item.args.fileId === fileId)
+    );
     if (index !== -1) {
         const removed = downloadQueue.splice(index, 1)[0];
         removed.reject(new Error('Cancelled by user'));
@@ -217,6 +220,14 @@ export function removeFromQueue(modId: number): boolean {
         return true;
     }
     return false;
+}
+
+/** Cancel one exact target regardless of whether it is queued or active. */
+export function cancelDownloadTarget(modId: number, fileId: number): boolean {
+    if (currentDownloadInfo?.modId === modId && currentDownloadInfo.fileId === fileId) {
+        return cancelActiveDownload();
+    }
+    return removeFromQueue(modId, fileId);
 }
 
 /**

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -459,8 +459,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Download Queue
     getDownloadQueue: () => ipcRenderer.invoke('get-download-queue'),
     getCurrentDownload: () => ipcRenderer.invoke('get-current-download'),
-    removeFromQueue: (modId: number) => ipcRenderer.invoke('remove-from-queue', modId),
+    removeFromQueue: (modId: number, fileId?: number) =>
+        ipcRenderer.invoke('remove-from-queue', modId, fileId),
     cancelActiveDownload: () => ipcRenderer.invoke('cancel-active-download'),
+    cancelDownloadTarget: (modId: number, fileId: number) =>
+        ipcRenderer.invoke('cancel-download-target', modId, fileId),
     onDownloadQueueUpdated: (callback: (data: DownloadQueueData) => void) => {
         const handler = (_event: Electron.IpcRendererEvent, data: DownloadQueueData) => callback(data);
         ipcRenderer.on('download-queue-updated', handler);

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -9,7 +9,11 @@ import type {
 import { formatBytes } from '../lib/formatBytes';
 import { rollPreparingSuffix } from '../lib/easterEggs';
 import Tx from './translation/Tx';
-import { getVisibleDownloadQueue, useDownloadActivity } from '../lib/downloadActivity';
+import {
+    cancelDownloadRequest,
+    getVisibleDownloadQueue,
+    useDownloadActivity,
+} from '../lib/downloadActivity';
 
 interface DownloadQueueIndicatorProps {
     className?: string;
@@ -102,12 +106,16 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
         : null;
     const currentSpeed = speedState.target === currentTarget ? speedState.value : 0;
 
-    const handleCancelQueued = async (modId: number) => {
-        await window.electronAPI.removeFromQueue(modId);
+    const handleCancelQueued = async (modId: number, fileId: number) => {
+        cancelDownloadRequest(modId, fileId);
+        await window.electronAPI.cancelDownloadTarget(modId, fileId);
     };
 
     const handleCancelActive = async () => {
-        await window.electronAPI.cancelActiveDownload();
+        const current = queueState.currentDownload;
+        if (!current) return;
+        cancelDownloadRequest(current.modId, current.fileId);
+        await window.electronAPI.cancelDownloadTarget(current.modId, current.fileId);
     };
 
     const totalItems = queueState.queue.length + (queueState.currentDownload ? 1 : 0);
@@ -317,7 +325,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                             type="button"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                void handleCancelQueued(item.modId);
+                                                void handleCancelQueued(item.modId, item.fileId);
                                             }}
                                             className="rounded-md p-1 text-text-secondary opacity-0 transition-opacity hover:text-state-danger group-hover:opacity-100 cursor-pointer"
                                             title={t('downloadQueue.removeFromQueue')}

--- a/src/components/DownloadQueueIndicator.tsx
+++ b/src/components/DownloadQueueIndicator.tsx
@@ -3,25 +3,20 @@ import { Download, Loader2, X, ChevronUp, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type {
-    DownloadQueueItem,
     DownloadProgressData,
     DownloadServerStatusData,
 } from '../types/electron';
 import { formatBytes } from '../lib/formatBytes';
 import { rollPreparingSuffix } from '../lib/easterEggs';
 import Tx from './translation/Tx';
+import { getVisibleDownloadQueue, useDownloadActivity } from '../lib/downloadActivity';
 
 interface DownloadQueueIndicatorProps {
     className?: string;
 }
 
-interface QueueState {
-    queue: DownloadQueueItem[];
-    currentDownload: DownloadQueueItem | null;
-    progress: { downloaded: number; total: number } | null;
-}
-
 interface SpeedSample {
+    target: string;
     time: number;
     bytes: number;
 }
@@ -43,11 +38,13 @@ function formatEta(seconds: number, t: TFunction): string {
 
 export default function DownloadQueueIndicator({ className = '' }: DownloadQueueIndicatorProps) {
     const { t } = useTranslation();
-    const [queueState, setQueueState] = useState<QueueState>({
-        queue: [],
-        currentDownload: null,
-        progress: null,
-    });
+    const downloadActivity = useDownloadActivity();
+    const visibleDownloads = getVisibleDownloadQueue(downloadActivity);
+    const queueState = {
+        queue: visibleDownloads.queue,
+        currentDownload: visibleDownloads.current,
+        progress: downloadActivity.current ? downloadActivity.progress : null,
+    };
     const [isExpanded, setIsExpanded] = useState(false);
     const [serverStatus, setServerStatus] = useState<DownloadServerStatusData | null>(null);
 
@@ -56,72 +53,54 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
     // changes so we report average throughput for this file rather than
     // bleeding speed from the previous one.
     const sampleRef = useRef<SpeedSample | null>(null);
-    const [speed, setSpeed] = useState(0);
+    const [speedState, setSpeedState] = useState<{ target: string | null; value: number }>({
+        target: null,
+        value: 0,
+    });
     const [preparingSuffix] = useState(rollPreparingSuffix);
 
     useEffect(() => {
-        Promise.all([
-            window.electronAPI.getDownloadQueue(),
-            window.electronAPI.getCurrentDownload(),
-        ]).then(([queue, currentDownload]) => {
-            setQueueState((prev) => ({ ...prev, queue, currentDownload }));
-        });
-
-        const queueUnsub = window.electronAPI.onDownloadQueueUpdated((data) => {
-            setQueueState((prev) => {
-                const nextCurrent = data.currentDownload;
-                const switched =
-                    prev.currentDownload?.modId !== nextCurrent?.modId ||
-                    prev.currentDownload?.fileId !== nextCurrent?.fileId;
-                if (switched) {
-                    sampleRef.current = null;
-                    setSpeed(0);
-                    setServerStatus(null);
-                }
-                return {
-                    ...prev,
-                    queue: data.queue,
-                    currentDownload: nextCurrent,
-                    progress: switched ? null : prev.progress,
-                };
-            });
-        });
-
         const progressUnsub = window.electronAPI.onDownloadProgress((data: DownloadProgressData) => {
             const now = Date.now();
+            const target = `${data.modId}:${data.fileId}`;
             const anchor = sampleRef.current;
-            if (!anchor) {
-                sampleRef.current = { time: now, bytes: data.downloaded };
+            if (!anchor || anchor.target !== target) {
+                sampleRef.current = { target, time: now, bytes: data.downloaded };
+                setSpeedState({ target, value: 0 });
             } else {
                 const dt = (now - anchor.time) / 1000;
                 if (dt > 0.25) {
                     const rate = (data.downloaded - anchor.bytes) / dt;
                     // Light smoothing so the readout doesn't twitch every tick.
-                    setSpeed((prev) => (prev <= 0 ? rate : prev * 0.7 + rate * 0.3));
+                    setSpeedState((prev) => ({
+                        target,
+                        value: prev.target !== target || prev.value <= 0
+                            ? rate
+                            : prev.value * 0.7 + rate * 0.3,
+                    }));
                 }
             }
-            setQueueState((prev) => ({
-                ...prev,
-                progress: { downloaded: data.downloaded, total: data.total },
-            }));
         });
 
         const completeUnsub = window.electronAPI.onDownloadComplete(() => {
             sampleRef.current = null;
-            setSpeed(0);
+            setSpeedState({ target: null, value: 0 });
             setServerStatus(null);
-            setQueueState((prev) => ({ ...prev, progress: null }));
         });
 
         const serverStatusUnsub = window.electronAPI.onDownloadServerStatus(setServerStatus);
 
         return () => {
-            queueUnsub();
             progressUnsub();
             completeUnsub();
             serverStatusUnsub();
         };
     }, []);
+
+    const currentTarget = queueState.currentDownload
+        ? `${queueState.currentDownload.modId}:${queueState.currentDownload.fileId}`
+        : null;
+    const currentSpeed = speedState.target === currentTarget ? speedState.value : 0;
 
     const handleCancelQueued = async (modId: number) => {
         await window.electronAPI.removeFromQueue(modId);
@@ -139,10 +118,10 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
     const progressPercentRounded = Math.round(progressPercent);
 
     const etaSeconds = useMemo(() => {
-        if (!queueState.progress || speed <= 0) return 0;
+        if (!queueState.progress || currentSpeed <= 0) return 0;
         const remaining = queueState.progress.total - queueState.progress.downloaded;
-        return remaining / speed;
-    }, [queueState.progress, speed]);
+        return remaining / currentSpeed;
+    }, [queueState.progress, currentSpeed]);
 
     if (totalItems === 0) return null;
 
@@ -191,10 +170,10 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                             </div>
                             <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary">
                                 <span className="tabular-nums">{progressPercentRounded}%</span>
-                                {speed > 0 && (
+                                {currentSpeed > 0 && (
                                     <>
                                         <span className="opacity-50">·</span>
-                                        <span className="tabular-nums">{formatSpeed(speed)}</span>
+                                        <span className="tabular-nums">{formatSpeed(currentSpeed)}</span>
                                     </>
                                 )}
                                 {totalItems > 1 && (
@@ -298,7 +277,7 @@ export default function DownloadQueueIndicator({ className = '' }: DownloadQueue
                                         : '—'}
                                 </span>
                                 <span className="flex items-center gap-2">
-                                    {speed > 0 && <span>{formatSpeed(speed)}</span>}
+                                    {currentSpeed > 0 && <span>{formatSpeed(currentSpeed)}</span>}
                                     {etaSeconds > 0 && (
                                         <>
                                             <span className="opacity-50">·</span>

--- a/src/components/ModDetailsModal.tsx
+++ b/src/components/ModDetailsModal.tsx
@@ -45,6 +45,7 @@ import { ArchivedTag, Button, IconButton } from './common/ui';
 import ImageContextMenu from './ImageContextMenu';
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from './common/menu';
 import { showToast } from '../stores/toastStore';
+import { selectFileDownloadActivity, useDownloadActivity } from '../lib/downloadActivity';
 
 type ModDetailsNavigationDirection = 'previous' | 'next';
 
@@ -64,13 +65,6 @@ interface ModDetailsModalProps {
   /** Handler invoked when the user clicks the inline "Enable" pill. Receives
    *  the local mod id of the disabled install. */
   onEnableFile?: (modId: string) => void;
-  downloadingFileId: number | null;
-  /** GameBanana file ids for this mod that are queued behind the active
-   *  download. Their rows show a "Queued" state but other rows stay clickable,
-   *  so the user can line up several variants at once. */
-  queuedFileIds?: Set<number>;
-  extracting: boolean;
-  progress: { downloaded: number; total: number } | null;
   hideNsfwPreviews: boolean;
   dateAdded?: number;
   dateModified?: number;
@@ -82,6 +76,10 @@ interface ModDetailsModalProps {
   navigationDirection?: ModDetailsNavigationDirection;
   navigationLabel?: string;
   updateAvailable?: boolean;
+  /** Current file rows that are actual replacement destinations. Keeping this
+   *  separate from the mod-level badge prevents alternate variants from all
+   *  being mislabeled as updates. */
+  updateFileIds?: Set<number>;
   /** When provided, render a toggle next to the Update/Installed badge that
    *  flips the underlying mod's ignoreUpdates flag. Only meaningful in the
    *  installed-mod path; Browse leaves both undefined. */
@@ -128,10 +126,6 @@ function ModDetailsModal({
   activeFileIds = new Set<number>(),
   installedFileStates,
   onEnableFile,
-  downloadingFileId,
-  queuedFileIds = new Set<number>(),
-  extracting,
-  progress,
   hideNsfwPreviews,
   dateAdded,
   dateModified,
@@ -140,6 +134,7 @@ function ModDetailsModal({
   navigationDirection = 'next',
   navigationLabel,
   updateAvailable,
+  updateFileIds = new Set<number>(),
   ignoreUpdates,
   onToggleIgnoreUpdates,
   onClose,
@@ -156,6 +151,10 @@ function ModDetailsModal({
   onOpenGameBananaItem,
 }: ModDetailsModalProps) {
   const { t } = useTranslation();
+  // One app-wide queue snapshot drives every host of this popup. This keeps
+  // Browse, Installed, and downloads started elsewhere in sync without each
+  // page trying to reconstruct active/queued/progress state independently.
+  const downloadActivity = useDownloadActivity();
   // Canonical GameBanana page for this submission. WiPs live under /wips, Sounds
   // under /sounds, etc., which section.toLowerCase()+'s' already yields.
   const gbUrl = `https://gamebanana.com/${section.toLowerCase()}s/${mod.id}`;
@@ -457,8 +456,8 @@ function ModDetailsModal({
     // "Update". Archived files are never update targets (they're the old ones).
     // Both hosts set updateAvailable, so a file the author replaced reads the
     // same way whether you reach it from Installed or from Browse.
+    if (updateFileIds.has(fileId) && !archived) return t('profiles.actions.update');
     if (installedFileIds.has(fileId)) return t('modDetails.actions.reinstall');
-    if (updateAvailable && !archived) return t('profiles.actions.update');
     return t('modDetails.actions.install');
   };
 
@@ -553,26 +552,31 @@ function ModDetailsModal({
 
   const renderFileRow = (file: GameBananaFile, archived = false) => {
     const isInstalled = installedFileIds.has(file.id);
-    // Highlight the update *target* (the new, not-yet-installed current file),
-    // not the superseded file the user currently has, so the accent points at
-    // the row they should click to update. Archived files are never targets.
-    const isUpdate = !!updateAvailable && !isInstalled && !archived;
-    const isActive = activeFileIds.has(file.id);
-    const isDownloadingThis = downloadingFileId === file.id;
-    const isQueuedThis = queuedFileIds.has(file.id);
+    // Highlight the actual replacement target, not every uninstalled sibling.
+    // A target can already be installed: in that case Update promotes it and
+    // removes the stale predecessor without downloading a duplicate.
+    const isUpdate = updateFileIds.has(file.id) && !archived;
+    const installedFileState = installedFileStates?.get(file.id);
+    const isActive = activeFileIds.has(file.id) || installedFileState?.enabled === true;
+    const fileDownload = selectFileDownloadActivity(downloadActivity, mod.id, file.id);
+    const isDownloadingThis =
+      fileDownload.phase === 'starting' ||
+      fileDownload.phase === 'downloading' ||
+      fileDownload.phase === 'extracting';
+    const isQueuedThis = fileDownload.phase === 'queued';
     // Only this row's own download/queue state should lock its buttons. A
     // download in progress on a *different* file must leave this row clickable
     // so the user can queue several variants in one go.
     const isBusyThis = isDownloadingThis || isQueuedThis;
-    const installedFileState = installedFileStates?.get(file.id);
     const showEnablePill =
       !!installedFileState &&
       !installedFileState.enabled &&
       !!onEnableFile &&
       !isBusyThis;
     const showDeleteButton = !!installedFileState && !!onDeleteFile;
-    const pct = progress && progress.total > 0
-      ? Math.round((progress.downloaded / progress.total) * 100)
+    const fileProgress = 'progress' in fileDownload ? fileDownload.progress : null;
+    const pct = fileProgress && fileProgress.total > 0
+      ? Math.round((fileProgress.downloaded / fileProgress.total) * 100)
       : null;
 
     return (
@@ -676,12 +680,18 @@ function ModDetailsModal({
             {isDownloadingThis ? (
               <>
                 <Loader2 className="w-4 h-4 animate-spin" />
-                {extracting ? t('modDetails.status.extracting') : pct !== null ? `${pct}%` : t('modDetails.status.starting')}
+                {fileDownload.phase === 'extracting'
+                  ? t('modDetails.status.extracting')
+                  : pct !== null
+                    ? `${pct}%`
+                    : t('modDetails.status.starting')}
               </>
             ) : isQueuedThis ? (
               <>
                 <Clock className="w-4 h-4" />
-                {t('modDetails.status.queued')}
+                {fileDownload.phase === 'queued'
+                  ? `${t('modDetails.status.queued')} #${fileDownload.position}`
+                  : t('modDetails.status.queued')}
               </>
             ) : (
               <>
@@ -937,7 +947,7 @@ function ModDetailsModal({
             {updateAvailable && (
               <span className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent border border-accent/40">
                 <Download className="w-2.5 h-2.5" />
-                Update
+                {t('profiles.actions.update')}
               </span>
             )}
             {installed && !updateAvailable && (

--- a/src/index.css
+++ b/src/index.css
@@ -480,6 +480,58 @@ body {
   stroke-width: 2;
 }
 
+/* Smooth card-download orbit. Two simple borders keep the animation on the
+   compositor and stay crisp at the 12–20px sizes used by Browse cards. */
+.browse-download-spinner {
+  position: relative;
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  min-width: 12px;
+  min-height: 12px;
+  flex: 0 0 auto;
+  border-radius: 9999px;
+  color: currentColor;
+}
+
+.browse-download-spinner::before,
+.browse-download-spinner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: max(1.5px, 0.1em) solid currentColor;
+}
+
+.browse-download-spinner::before {
+  opacity: 0.18;
+}
+
+.browse-download-spinner::after {
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  animation: browseDownloadOrbit 720ms linear infinite;
+  backface-visibility: hidden;
+  transform: translateZ(0) rotate(0deg);
+  will-change: transform;
+}
+
+.browse-download-spinner--large {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.browse-action-button-icon .browse-download-spinner {
+  width: clamp(12px, 4.8cqw, 15px);
+  height: clamp(12px, 4.8cqw, 15px);
+}
+
+.browse-download-badge {
+  box-shadow:
+    0 6px 18px rgba(0, 0, 0, 0.28),
+    0 0 0 1px color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
 .browse-action-button-label {
   display: inline-flex;
   align-items: center;
@@ -695,6 +747,12 @@ body {
   100% {
     opacity: 0;
     transform: translateX(120%) skewX(-18deg);
+  }
+}
+
+@keyframes browseDownloadOrbit {
+  to {
+    transform: translateZ(0) rotate(360deg);
   }
 }
 
@@ -1506,6 +1564,7 @@ body {
   .mod-details-body--loading-previous .mod-details-navigation-skeleton,
   .skeleton-shimmer,
   .browse-action-button--downloading::after,
+  .browse-download-spinner::after,
   .browse-action-button--complete-pop,
   .browse-action-button--complete-pop::before,
   .browse-action-button-queue-value,

--- a/src/lib/downloadActivity.test.ts
+++ b/src/lib/downloadActivity.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { getVisibleDownloadQueue, isModDownloadPending, selectFileDownloadActivity, type DownloadActivitySnapshot } from './downloadActivity';
+import {
+  applyDownloadExtracting,
+  applyDownloadProgress,
+  cancelDownloadRequest,
+  getVisibleDownloadQueue,
+  isDownloadRequestPending,
+  isModDownloadPending,
+  requestDownload,
+  selectFileDownloadActivity,
+  type DownloadActivitySnapshot,
+} from './downloadActivity';
 
 const item = (modId: number, fileId: number) => ({ modId, fileId, fileName: `${fileId}.zip` });
 const state = (over: Partial<DownloadActivitySnapshot> = {}): DownloadActivitySnapshot => ({
@@ -42,5 +52,38 @@ describe('download activity selectors', () => {
     expect(isModDownloadPending(snapshot, 7)).toBe(true);
     expect(isModDownloadPending(snapshot, 8)).toBe(false);
     expect(selectFileDownloadActivity(snapshot, 8, 10).phase).toBe('idle');
+  });
+
+  it('ignores progress and extracting events until the current target is known', () => {
+    const unknown = state();
+    expect(applyDownloadProgress(unknown, {
+      modId: 7,
+      fileId: 10,
+      downloaded: 25,
+      total: 100,
+    })).toBe(unknown);
+    expect(applyDownloadExtracting(unknown, { modId: 7, fileId: 10 })).toBe(unknown);
+
+    const active = state({ current: item(7, 10) });
+    expect(applyDownloadProgress(active, {
+      modId: 8,
+      fileId: 10,
+      downloaded: 50,
+      total: 100,
+    })).toBe(active);
+    expect(applyDownloadProgress(active, {
+      modId: 7,
+      fileId: 10,
+      downloaded: 50,
+      total: 100,
+    }).progress).toEqual({ downloaded: 50, total: 100 });
+  });
+
+  it('cancels an optimistic request before it crosses IPC', () => {
+    expect(requestDownload(item(9, 20))).toBe(true);
+    expect(isDownloadRequestPending(9, 20)).toBe(true);
+    expect(cancelDownloadRequest(9, 20)).toBe(true);
+    expect(isDownloadRequestPending(9, 20)).toBe(false);
+    expect(cancelDownloadRequest(9, 20)).toBe(false);
   });
 });

--- a/src/lib/downloadActivity.test.ts
+++ b/src/lib/downloadActivity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getVisibleDownloadQueue, isModDownloadPending, selectFileDownloadActivity, type DownloadActivitySnapshot } from './downloadActivity';
+
+const item = (modId: number, fileId: number) => ({ modId, fileId, fileName: `${fileId}.zip` });
+const state = (over: Partial<DownloadActivitySnapshot> = {}): DownloadActivitySnapshot => ({
+  current: null,
+  queue: [],
+  requested: [],
+  progress: null,
+  extracting: false,
+  ...over,
+});
+
+describe('download activity selectors', () => {
+  it('distinguishes active, queued, and unrelated variants of one mod', () => {
+    const snapshot = state({
+      current: item(7, 10),
+      queue: [item(7, 11)],
+      progress: { downloaded: 25, total: 100 },
+    });
+
+    expect(selectFileDownloadActivity(snapshot, 7, 10)).toEqual({
+      phase: 'downloading',
+      progress: { downloaded: 25, total: 100 },
+    });
+    expect(selectFileDownloadActivity(snapshot, 7, 11)).toEqual({ phase: 'queued', position: 1 });
+    expect(selectFileDownloadActivity(snapshot, 7, 12)).toEqual({ phase: 'idle' });
+  });
+
+  it('shows an optimistic first click as starting and later clicks as queued', () => {
+    const snapshot = state({ requested: [item(7, 10), item(7, 11)] });
+    expect(selectFileDownloadActivity(snapshot, 7, 10).phase).toBe('starting');
+    expect(selectFileDownloadActivity(snapshot, 7, 11)).toEqual({ phase: 'queued', position: 2 });
+    expect(getVisibleDownloadQueue(snapshot)).toEqual({
+      current: item(7, 10),
+      queue: [item(7, 11)],
+    });
+  });
+
+  it('tracks pending state by mod without confusing identical file ids from another mod', () => {
+    const snapshot = state({ current: item(7, 10) });
+    expect(isModDownloadPending(snapshot, 7)).toBe(true);
+    expect(isModDownloadPending(snapshot, 8)).toBe(false);
+    expect(selectFileDownloadActivity(snapshot, 8, 10).phase).toBe('idle');
+  });
+});

--- a/src/lib/downloadActivity.ts
+++ b/src/lib/downloadActivity.ts
@@ -9,6 +9,12 @@ export interface DownloadActivitySnapshot {
   extracting: boolean;
 }
 
+/** Queue membership only, excluding high-frequency byte progress. */
+export type DownloadQueueActivitySnapshot = Pick<
+  DownloadActivitySnapshot,
+  'current' | 'queue' | 'requested'
+>;
+
 export type FileDownloadActivity =
   | { phase: 'idle' }
   | { phase: 'starting'; progress: null }
@@ -25,8 +31,16 @@ const EMPTY_SNAPSHOT: DownloadActivitySnapshot = {
 };
 
 let snapshot = EMPTY_SNAPSHOT;
+let queueSnapshot: DownloadQueueActivitySnapshot = {
+  current: snapshot.current,
+  queue: snapshot.queue,
+  requested: snapshot.requested,
+};
 let subscribers = 0;
-let revision = 0;
+// Only backend lifecycle events invalidate an in-flight hydration read.
+// Progress/extracting ticks update presentation state but say nothing about
+// whether the queue/current IPC response is stale.
+let backendRevision = 0;
 let stopListening: (() => void) | null = null;
 const listeners = new Set<() => void>();
 
@@ -35,34 +49,73 @@ const itemKey = (item: Pick<DownloadQueueItem, 'modId' | 'fileId'>) =>
   targetKey(item.modId, item.fileId);
 
 function publish(next: DownloadActivitySnapshot) {
+  if (
+    next.current !== snapshot.current ||
+    next.queue !== snapshot.queue ||
+    next.requested !== snapshot.requested
+  ) {
+    queueSnapshot = {
+      current: next.current,
+      queue: next.queue,
+      requested: next.requested,
+    };
+  }
   snapshot = next;
-  revision += 1;
   for (const listener of listeners) listener();
+}
+
+export function applyDownloadProgress(
+  state: DownloadActivitySnapshot,
+  data: { modId: number; fileId: number; downloaded: number; total: number },
+): DownloadActivitySnapshot {
+  if (!state.current || itemKey(state.current) !== targetKey(data.modId, data.fileId)) return state;
+  return {
+    ...state,
+    progress: { downloaded: data.downloaded, total: data.total },
+    extracting: false,
+  };
+}
+
+export function applyDownloadExtracting(
+  state: DownloadActivitySnapshot,
+  data: { modId: number; fileId: number },
+): DownloadActivitySnapshot {
+  if (!state.current || itemKey(state.current) !== targetKey(data.modId, data.fileId)) return state;
+  return { ...state, extracting: true };
 }
 
 function beginListening() {
   if (stopListening || typeof window === 'undefined') return;
 
-  const hydrationRevision = revision;
+  const hydrationRevision = backendRevision;
   void Promise.all([
     window.electronAPI.getDownloadQueue(),
     window.electronAPI.getCurrentDownload(),
   ]).then(([queue, current]) => {
     // An event that arrived while these IPC reads were in flight is newer than
     // the hydration response and must win.
-    if (revision !== hydrationRevision) return;
-    const backendKeys = new Set([...queue, ...(current ? [current] : [])].map(itemKey));
+    if (backendRevision !== hydrationRevision) return;
+    const currentKey = current ? itemKey(current) : null;
+    // The two IPC reads are concurrent, so the queue read can observe an item
+    // just before it is shifted while the current read observes it just after.
+    const hydratedQueue = currentKey ? queue.filter((item) => itemKey(item) !== currentKey) : queue;
+    const backendKeys = new Set([...hydratedQueue, ...(current ? [current] : [])].map(itemKey));
+    const switched = itemKey(snapshot.current ?? { modId: 0, fileId: 0 }) !==
+      itemKey(current ?? { modId: 0, fileId: 0 });
     publish({
       ...snapshot,
-      queue,
+      queue: hydratedQueue,
       current,
       requested: snapshot.requested.filter((item) => !backendKeys.has(itemKey(item))),
+      progress: switched ? null : snapshot.progress,
+      extracting: switched ? false : snapshot.extracting,
     });
   }).catch((error) => {
     console.error('[DownloadActivity] Failed to hydrate queue state:', error);
   });
 
   const queueUnsub = window.electronAPI.onDownloadQueueUpdated((data) => {
+    backendRevision += 1;
     const backendKeys = new Set(
       [...data.queue, ...(data.currentDownload ? [data.currentDownload] : [])].map(itemKey),
     );
@@ -78,20 +131,17 @@ function beginListening() {
   });
 
   const progressUnsub = window.electronAPI.onDownloadProgress((data) => {
-    if (snapshot.current && itemKey(snapshot.current) !== targetKey(data.modId, data.fileId)) return;
-    publish({
-      ...snapshot,
-      progress: { downloaded: data.downloaded, total: data.total },
-      extracting: false,
-    });
+    const next = applyDownloadProgress(snapshot, data);
+    if (next !== snapshot) publish(next);
   });
 
   const extractingUnsub = window.electronAPI.onDownloadExtracting((data) => {
-    if (snapshot.current && itemKey(snapshot.current) !== targetKey(data.modId, data.fileId)) return;
-    publish({ ...snapshot, extracting: true });
+    const next = applyDownloadExtracting(snapshot, data);
+    if (next !== snapshot) publish(next);
   });
 
   const settle = (modId: number, fileId: number) => {
+    backendRevision += 1;
     const key = targetKey(modId, fileId);
     publish({
       ...snapshot,
@@ -129,6 +179,14 @@ export function useDownloadActivity(): DownloadActivitySnapshot {
 }
 
 /**
+ * Subscribe to active/queued targets without redrawing the caller for every
+ * byte-progress tick. File-level progress UI should use useDownloadActivity.
+ */
+export function useDownloadQueueActivity(): DownloadQueueActivitySnapshot {
+  return useSyncExternalStore(subscribe, () => queueSnapshot, () => EMPTY_SNAPSHOT);
+}
+
+/**
  * Optimistically marks a click before the backend queue event crosses IPC.
  * Returns false for a duplicate target, providing a synchronous double-click
  * and cross-page re-entry guard.
@@ -150,6 +208,23 @@ export function releaseDownloadRequest(modId: number, fileId: number) {
     ...snapshot,
     requested: snapshot.requested.filter((item) => itemKey(item) !== key),
   });
+}
+
+/** Removes a request that has not crossed IPC yet. */
+export function cancelDownloadRequest(modId: number, fileId: number): boolean {
+  const key = targetKey(modId, fileId);
+  if (!snapshot.requested.some((item) => itemKey(item) === key)) return false;
+  publish({
+    ...snapshot,
+    requested: snapshot.requested.filter((item) => itemKey(item) !== key),
+  });
+  return true;
+}
+
+/** True only during the optimistic pre-IPC phase. */
+export function isDownloadRequestPending(modId: number, fileId: number): boolean {
+  const key = targetKey(modId, fileId);
+  return snapshot.requested.some((item) => itemKey(item) === key);
 }
 
 export function selectFileDownloadActivity(
@@ -175,7 +250,7 @@ export function selectFileDownloadActivity(
 }
 
 /** Backend queue plus clicks that have not crossed IPC yet, de-duplicated. */
-export function getVisibleDownloadQueue(state: DownloadActivitySnapshot): {
+export function getVisibleDownloadQueue(state: DownloadQueueActivitySnapshot): {
   current: DownloadQueueItem | null;
   queue: DownloadQueueItem[];
 } {
@@ -194,7 +269,7 @@ export function getVisibleDownloadQueue(state: DownloadActivitySnapshot): {
   return { current, queue };
 }
 
-export function isModDownloadPending(state: DownloadActivitySnapshot, modId: number): boolean {
+export function isModDownloadPending(state: DownloadQueueActivitySnapshot, modId: number): boolean {
   return state.current?.modId === modId ||
     state.queue.some((item) => item.modId === modId) ||
     state.requested.some((item) => item.modId === modId);

--- a/src/lib/downloadActivity.ts
+++ b/src/lib/downloadActivity.ts
@@ -1,0 +1,201 @@
+import { useSyncExternalStore } from 'react';
+import type { DownloadQueueItem } from '../types/electron';
+
+export interface DownloadActivitySnapshot {
+  current: DownloadQueueItem | null;
+  queue: DownloadQueueItem[];
+  requested: DownloadQueueItem[];
+  progress: { downloaded: number; total: number } | null;
+  extracting: boolean;
+}
+
+export type FileDownloadActivity =
+  | { phase: 'idle' }
+  | { phase: 'starting'; progress: null }
+  | { phase: 'downloading'; progress: { downloaded: number; total: number } | null }
+  | { phase: 'extracting'; progress: { downloaded: number; total: number } | null }
+  | { phase: 'queued'; position: number };
+
+const EMPTY_SNAPSHOT: DownloadActivitySnapshot = {
+  current: null,
+  queue: [],
+  requested: [],
+  progress: null,
+  extracting: false,
+};
+
+let snapshot = EMPTY_SNAPSHOT;
+let subscribers = 0;
+let revision = 0;
+let stopListening: (() => void) | null = null;
+const listeners = new Set<() => void>();
+
+const targetKey = (modId: number, fileId: number) => `${modId}:${fileId}`;
+const itemKey = (item: Pick<DownloadQueueItem, 'modId' | 'fileId'>) =>
+  targetKey(item.modId, item.fileId);
+
+function publish(next: DownloadActivitySnapshot) {
+  snapshot = next;
+  revision += 1;
+  for (const listener of listeners) listener();
+}
+
+function beginListening() {
+  if (stopListening || typeof window === 'undefined') return;
+
+  const hydrationRevision = revision;
+  void Promise.all([
+    window.electronAPI.getDownloadQueue(),
+    window.electronAPI.getCurrentDownload(),
+  ]).then(([queue, current]) => {
+    // An event that arrived while these IPC reads were in flight is newer than
+    // the hydration response and must win.
+    if (revision !== hydrationRevision) return;
+    const backendKeys = new Set([...queue, ...(current ? [current] : [])].map(itemKey));
+    publish({
+      ...snapshot,
+      queue,
+      current,
+      requested: snapshot.requested.filter((item) => !backendKeys.has(itemKey(item))),
+    });
+  }).catch((error) => {
+    console.error('[DownloadActivity] Failed to hydrate queue state:', error);
+  });
+
+  const queueUnsub = window.electronAPI.onDownloadQueueUpdated((data) => {
+    const backendKeys = new Set(
+      [...data.queue, ...(data.currentDownload ? [data.currentDownload] : [])].map(itemKey),
+    );
+    const switched = itemKey(snapshot.current ?? { modId: 0, fileId: 0 }) !==
+      itemKey(data.currentDownload ?? { modId: 0, fileId: 0 });
+    publish({
+      current: data.currentDownload,
+      queue: data.queue,
+      requested: snapshot.requested.filter((item) => !backendKeys.has(itemKey(item))),
+      progress: switched ? null : snapshot.progress,
+      extracting: switched ? false : snapshot.extracting,
+    });
+  });
+
+  const progressUnsub = window.electronAPI.onDownloadProgress((data) => {
+    if (snapshot.current && itemKey(snapshot.current) !== targetKey(data.modId, data.fileId)) return;
+    publish({
+      ...snapshot,
+      progress: { downloaded: data.downloaded, total: data.total },
+      extracting: false,
+    });
+  });
+
+  const extractingUnsub = window.electronAPI.onDownloadExtracting((data) => {
+    if (snapshot.current && itemKey(snapshot.current) !== targetKey(data.modId, data.fileId)) return;
+    publish({ ...snapshot, extracting: true });
+  });
+
+  const settle = (modId: number, fileId: number) => {
+    const key = targetKey(modId, fileId);
+    publish({
+      ...snapshot,
+      requested: snapshot.requested.filter((item) => itemKey(item) !== key),
+      progress: snapshot.current && itemKey(snapshot.current) === key ? null : snapshot.progress,
+      extracting: snapshot.current && itemKey(snapshot.current) === key ? false : snapshot.extracting,
+    });
+  };
+  const completeUnsub = window.electronAPI.onDownloadComplete(({ modId, fileId }) => settle(modId, fileId));
+  const errorUnsub = window.electronAPI.onDownloadError(({ modId, fileId }) => settle(modId, fileId));
+
+  stopListening = () => {
+    queueUnsub();
+    progressUnsub();
+    extractingUnsub();
+    completeUnsub();
+    errorUnsub();
+    stopListening = null;
+  };
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  subscribers += 1;
+  beginListening();
+  return () => {
+    listeners.delete(listener);
+    subscribers -= 1;
+    if (subscribers === 0) stopListening?.();
+  };
+}
+
+export function useDownloadActivity(): DownloadActivitySnapshot {
+  return useSyncExternalStore(subscribe, () => snapshot, () => EMPTY_SNAPSHOT);
+}
+
+/**
+ * Optimistically marks a click before the backend queue event crosses IPC.
+ * Returns false for a duplicate target, providing a synchronous double-click
+ * and cross-page re-entry guard.
+ */
+export function requestDownload(item: DownloadQueueItem): boolean {
+  const key = itemKey(item);
+  if (snapshot.current && itemKey(snapshot.current) === key) return false;
+  if (snapshot.queue.some((queued) => itemKey(queued) === key)) return false;
+  if (snapshot.requested.some((requested) => itemKey(requested) === key)) return false;
+  publish({ ...snapshot, requested: [...snapshot.requested, item] });
+  return true;
+}
+
+/** Clears an optimistic request when work fails before it reaches the backend. */
+export function releaseDownloadRequest(modId: number, fileId: number) {
+  const key = targetKey(modId, fileId);
+  if (!snapshot.requested.some((item) => itemKey(item) === key)) return;
+  publish({
+    ...snapshot,
+    requested: snapshot.requested.filter((item) => itemKey(item) !== key),
+  });
+}
+
+export function selectFileDownloadActivity(
+  state: DownloadActivitySnapshot,
+  modId: number,
+  fileId: number,
+): FileDownloadActivity {
+  const key = targetKey(modId, fileId);
+  if (state.current && itemKey(state.current) === key) {
+    if (state.extracting) return { phase: 'extracting', progress: state.progress };
+    return { phase: 'downloading', progress: state.progress };
+  }
+  const queueIndex = state.queue.findIndex((item) => itemKey(item) === key);
+  if (queueIndex >= 0) return { phase: 'queued', position: queueIndex + 1 };
+  const requestIndex = state.requested.findIndex((item) => itemKey(item) === key);
+  if (requestIndex >= 0) {
+    if (!state.current && state.queue.length === 0 && requestIndex === 0) {
+      return { phase: 'starting', progress: null };
+    }
+    return { phase: 'queued', position: state.queue.length + requestIndex + 1 };
+  }
+  return { phase: 'idle' };
+}
+
+/** Backend queue plus clicks that have not crossed IPC yet, de-duplicated. */
+export function getVisibleDownloadQueue(state: DownloadActivitySnapshot): {
+  current: DownloadQueueItem | null;
+  queue: DownloadQueueItem[];
+} {
+  const optimisticCurrent =
+    !state.current && state.queue.length === 0 ? state.requested[0] ?? null : null;
+  const current = state.current ?? optimisticCurrent;
+  const currentKey = current ? itemKey(current) : null;
+  const seen = new Set(state.queue.map(itemKey));
+  const queue = [...state.queue];
+  for (const requested of state.requested) {
+    const key = itemKey(requested);
+    if (key === currentKey || seen.has(key)) continue;
+    seen.add(key);
+    queue.push(requested);
+  }
+  return { current, queue };
+}
+
+export function isModDownloadPending(state: DownloadActivitySnapshot, modId: number): boolean {
+  return state.current?.modId === modId ||
+    state.queue.some((item) => item.modId === modId) ||
+    state.requested.some((item) => item.modId === modId);
+}

--- a/src/lib/replacementCleanup.test.ts
+++ b/src/lib/replacementCleanup.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { findReplacementTargetIdsAfterInstall } from './replacementCleanup';
+
+describe('findReplacementTargetIdsAfterInstall', () => {
+  it('deletes only the original ids when reinstalling the same file', () => {
+    expect(findReplacementTargetIdsAfterInstall(
+      [
+        { id: 'old', gameBananaId: 7, gameBananaFileId: 10 },
+        { id: 'fresh', gameBananaId: 7, gameBananaFileId: 10 },
+      ],
+      [{ id: 'old', gameBananaId: 7, gameBananaFileId: 10 }],
+      10,
+    )).toEqual(['old']);
+  });
+
+  it('follows stale update sources whose local ids changed during auto-disable', () => {
+    expect(findReplacementTargetIdsAfterInstall(
+      [
+        { id: 'moved-old-a', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'moved-old-b', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'fresh', gameBananaId: 7, gameBananaFileId: 10 },
+      ],
+      [
+        { id: 'old-a', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'old-b', gameBananaId: 7, gameBananaFileId: 9 },
+      ],
+      10,
+    )).toEqual(['moved-old-a', 'moved-old-b']);
+  });
+});

--- a/src/lib/replacementCleanup.test.ts
+++ b/src/lib/replacementCleanup.test.ts
@@ -16,15 +16,54 @@ describe('findReplacementTargetIdsAfterInstall', () => {
   it('follows stale update sources whose local ids changed during auto-disable', () => {
     expect(findReplacementTargetIdsAfterInstall(
       [
-        { id: 'moved-old-a', gameBananaId: 7, gameBananaFileId: 9 },
-        { id: 'moved-old-b', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'moved-old-a', gameBananaId: 7, gameBananaFileId: 9, vpkIndex: 0 },
+        { id: 'moved-old-b', gameBananaId: 7, gameBananaFileId: 9, vpkIndex: 1 },
         { id: 'fresh', gameBananaId: 7, gameBananaFileId: 10 },
+      ],
+      [
+        { id: 'old-a', gameBananaId: 7, gameBananaFileId: 9, vpkIndex: 0 },
+        { id: 'old-b', gameBananaId: 7, gameBananaFileId: 9, vpkIndex: 1 },
+      ],
+      10,
+    )).toEqual(['moved-old-a', 'moved-old-b']);
+  });
+
+  it('preserves untargeted siblings from the same GameBanana file', () => {
+    expect(findReplacementTargetIdsAfterInstall(
+      [
+        { id: 'moved-target', gameBananaId: 7, gameBananaFileId: 9, sha256: 'target-hash' },
+        { id: 'ignored-sibling', gameBananaId: 7, gameBananaFileId: 9, sha256: 'ignored-hash' },
+        { id: 'fresh', gameBananaId: 7, gameBananaFileId: 10, sha256: 'fresh-hash' },
+      ],
+      [
+        { id: 'old-target', gameBananaId: 7, gameBananaFileId: 9, sha256: 'target-hash' },
+      ],
+      10,
+    )).toEqual(['moved-target']);
+  });
+
+  it('does not guess between legacy siblings when only one was targeted', () => {
+    expect(findReplacementTargetIdsAfterInstall(
+      [
+        { id: 'moved-target', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'ignored-sibling', gameBananaId: 7, gameBananaFileId: 9 },
+      ],
+      [{ id: 'old-target', gameBananaId: 7, gameBananaFileId: 9 }],
+      10,
+    )).toEqual([]);
+  });
+
+  it('cleans a complete legacy provenance group when every sibling was targeted', () => {
+    expect(findReplacementTargetIdsAfterInstall(
+      [
+        { id: 'moved-a', gameBananaId: 7, gameBananaFileId: 9 },
+        { id: 'moved-b', gameBananaId: 7, gameBananaFileId: 9 },
       ],
       [
         { id: 'old-a', gameBananaId: 7, gameBananaFileId: 9 },
         { id: 'old-b', gameBananaId: 7, gameBananaFileId: 9 },
       ],
       10,
-    )).toEqual(['moved-old-a', 'moved-old-b']);
+    )).toEqual(['moved-a', 'moved-b']);
   });
 });

--- a/src/lib/replacementCleanup.ts
+++ b/src/lib/replacementCleanup.ts
@@ -1,6 +1,12 @@
 import type { Mod } from '../types/mod';
 
-type ReplacementIdentity = Pick<Mod, 'id' | 'gameBananaId' | 'gameBananaFileId'>;
+type ReplacementIdentity = Pick<
+  Mod,
+  'id' | 'gameBananaId' | 'gameBananaFileId' | 'vpkIndex' | 'sha256'
+>;
+
+const provenanceKey = (mod: ReplacementIdentity) =>
+  `${mod.gameBananaId ?? 'unknown'}:${mod.gameBananaFileId ?? 'unknown'}`;
 
 /**
  * Resolve the local ids that existed before a successful replacement install.
@@ -8,7 +14,9 @@ type ReplacementIdentity = Pick<Mod, 'id' | 'gameBananaId' | 'gameBananaFileId'>
  * Reinstalling the same GameBanana file leaves the old ids stable, so matching
  * by id prevents the fresh copy from being deleted too. Updating to a different
  * file can auto-disable the stale sibling during installation, which changes
- * its local id; in that case its old GameBanana file id is the stable identity.
+ * its local id. In that case vpkIndex and sha256 identify the exact VPK inside
+ * the old GameBanana file; provenance alone is safe only when every remaining
+ * candidate from that file was targeted.
  */
 export function findReplacementTargetIdsAfterInstall(
   installed: readonly ReplacementIdentity[],
@@ -16,6 +24,13 @@ export function findReplacementTargetIdsAfterInstall(
   destinationFileId: number,
 ): string[] {
   const ids = new Set<string>();
+  const targetsByProvenance = new Map<string, ReplacementIdentity[]>();
+  for (const target of targets) {
+    const key = provenanceKey(target);
+    const group = targetsByProvenance.get(key) ?? [];
+    group.push(target);
+    targetsByProvenance.set(key, group);
+  }
 
   for (const target of targets) {
     if (target.gameBananaFileId === destinationFileId) {
@@ -23,13 +38,39 @@ export function findReplacementTargetIdsAfterInstall(
       continue;
     }
 
-    for (const candidate of installed) {
-      if (
+    const candidates = installed.filter(
+      (candidate) =>
         candidate.gameBananaId === target.gameBananaId &&
-        candidate.gameBananaFileId === target.gameBananaFileId
-      ) {
-        ids.add(candidate.id);
-      }
+        candidate.gameBananaFileId === target.gameBananaFileId,
+    );
+    const exactId = candidates.find((candidate) => candidate.id === target.id);
+    if (exactId) {
+      ids.add(exactId.id);
+      continue;
+    }
+
+    const indexed = typeof target.vpkIndex === 'number'
+      ? candidates.filter((candidate) => candidate.vpkIndex === target.vpkIndex)
+      : [];
+    if (indexed.length === 1) {
+      ids.add(indexed[0].id);
+      continue;
+    }
+
+    const hashed = target.sha256
+      ? candidates.filter((candidate) => candidate.sha256 === target.sha256)
+      : [];
+    if (hashed.length === 1) {
+      ids.add(hashed[0].id);
+      continue;
+    }
+
+    // Legacy installs may have neither vpkIndex nor sha256. Preserve them when
+    // only part of their provenance group was selected; deleting the wrong VPK
+    // is worse than leaving a stale copy for the user to resolve manually.
+    const targetGroup = targetsByProvenance.get(provenanceKey(target)) ?? [];
+    if (candidates.length === targetGroup.length) {
+      for (const candidate of candidates) ids.add(candidate.id);
     }
   }
 

--- a/src/lib/replacementCleanup.ts
+++ b/src/lib/replacementCleanup.ts
@@ -1,0 +1,37 @@
+import type { Mod } from '../types/mod';
+
+type ReplacementIdentity = Pick<Mod, 'id' | 'gameBananaId' | 'gameBananaFileId'>;
+
+/**
+ * Resolve the local ids that existed before a successful replacement install.
+ *
+ * Reinstalling the same GameBanana file leaves the old ids stable, so matching
+ * by id prevents the fresh copy from being deleted too. Updating to a different
+ * file can auto-disable the stale sibling during installation, which changes
+ * its local id; in that case its old GameBanana file id is the stable identity.
+ */
+export function findReplacementTargetIdsAfterInstall(
+  installed: readonly ReplacementIdentity[],
+  targets: readonly ReplacementIdentity[],
+  destinationFileId: number,
+): string[] {
+  const ids = new Set<string>();
+
+  for (const target of targets) {
+    if (target.gameBananaFileId === destinationFileId) {
+      if (installed.some((candidate) => candidate.id === target.id)) ids.add(target.id);
+      continue;
+    }
+
+    for (const candidate of installed) {
+      if (
+        candidate.gameBananaId === target.gameBananaId &&
+        candidate.gameBananaFileId === target.gameBananaFileId
+      ) {
+        ids.add(candidate.id);
+      }
+    }
+  }
+
+  return [...ids];
+}

--- a/src/lib/updateFileMatch.test.ts
+++ b/src/lib/updateFileMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hasPendingUpdate } from './updateFileMatch';
+import { hasPendingUpdate, planFileUpdates } from './updateFileMatch';
 import type { GameBananaFile } from '../types/gamebanana';
 
 const file = (id: number, fileName: string, isArchived = false): GameBananaFile => ({
@@ -83,5 +83,62 @@ describe('hasPendingUpdate', () => {
   it('treats an unloaded or fully archived file list as "unknown", not "outdated"', () => {
     expect(hasPendingUpdate(650634, [], [variant(1)])).toBe(false);
     expect(hasPendingUpdate(650634, [file(2, 'old.zip', true)], [variant(1)])).toBe(false);
+  });
+});
+
+describe('planFileUpdates', () => {
+  it('promotes an already-installed sole replacement for a stale sibling', () => {
+    const files = [file(1774719, 'freaky_hidout.zip')];
+    const installed = [
+      {
+        id: 'feet-v4',
+        gameBananaId: 677044,
+        gameBananaFileId: 1723227,
+        installedFileId: 1723227,
+        fileDescription: 'Feet in hub V4',
+        sourceFileName: 'feetinhubv4',
+      },
+      {
+        id: 'feet-v5',
+        gameBananaId: 677044,
+        gameBananaFileId: 1774719,
+        installedFileId: 1774719,
+      },
+    ];
+
+    const plan = planFileUpdates(677044, files, installed);
+    expect(plan.sourcesByTargetFileId.get(1774719)).toEqual(['feet-v4']);
+    expect(plan.unresolvedSourceIds).toEqual([]);
+  });
+
+  it('leaves a multi-file replacement unresolved when no candidate is confident', () => {
+    const files = [file(2, 'gold.zip'), file(3, 'silver.zip')];
+    const plan = planFileUpdates(10, files, [{
+      id: 'old',
+      gameBananaId: 10,
+      gameBananaFileId: 1,
+      installedFileId: 1,
+      sourceFileName: 'unrelated.zip',
+    }]);
+
+    expect(plan.sourcesByTargetFileId.size).toBe(0);
+    expect(plan.unresolvedSourceIds).toEqual(['old']);
+  });
+
+  it('marks only the matching replacement as an update, not alternate live variants', () => {
+    const files = [
+      { ...file(2, 'gold-v2.zip'), description: 'Gold' },
+      { ...file(3, 'silver-v2.zip'), description: 'Silver' },
+    ];
+    const plan = planFileUpdates(10, files, [{
+      id: 'old-gold',
+      gameBananaId: 10,
+      gameBananaFileId: 1,
+      installedFileId: 1,
+      fileDescription: 'Gold',
+    }]);
+
+    expect([...plan.sourcesByTargetFileId.keys()]).toEqual([2]);
+    expect(plan.sourcesByTargetFileId.has(3)).toBe(false);
   });
 });

--- a/src/lib/updateFileMatch.test.ts
+++ b/src/lib/updateFileMatch.test.ts
@@ -141,4 +141,31 @@ describe('planFileUpdates', () => {
     expect([...plan.sourcesByTargetFileId.keys()]).toEqual([2]);
     expect(plan.sourcesByTargetFileId.has(3)).toBe(false);
   });
+
+  it('keeps confident matches separate when another stale variant is unresolved', () => {
+    const files = [
+      { ...file(2, 'gold-v2.zip'), description: 'Gold' },
+      { ...file(3, 'silver-v2.zip'), description: 'Silver' },
+    ];
+    const plan = planFileUpdates(10, files, [
+      {
+        id: 'old-gold',
+        gameBananaId: 10,
+        gameBananaFileId: 1,
+        installedFileId: 1,
+        fileDescription: 'Gold',
+      },
+      {
+        id: 'unknown',
+        gameBananaId: 10,
+        gameBananaFileId: 4,
+        installedFileId: 4,
+        sourceFileName: 'unrelated.zip',
+      },
+    ]);
+
+    expect(plan.sourcesByTargetFileId.get(2)).toEqual(['old-gold']);
+    expect(plan.sourcesByTargetFileId.has(3)).toBe(false);
+    expect(plan.unresolvedSourceIds).toEqual(['unknown']);
+  });
 });

--- a/src/lib/updateFileMatch.ts
+++ b/src/lib/updateFileMatch.ts
@@ -23,6 +23,17 @@ export interface InstalledVariantUpdateState {
   ignoreUpdates?: boolean;
 }
 
+export interface InstalledFileUpdateCandidate extends InstalledVariantUpdateState, UpdateMatchSignals {
+  id: string;
+}
+
+export interface FileUpdatePlan {
+  /** Current GameBanana file id -> stale local mod ids it supersedes. */
+  sourcesByTargetFileId: Map<number, string[]>;
+  /** Stale local mods whose replacement is ambiguous and needs user choice. */
+  unresolvedSourceIds: string[];
+}
+
 /**
  * True when any installed variant of `gameBananaId` points at a file id that is
  * no longer live on the mod page. An author who re-uploads a file gets a new
@@ -120,6 +131,74 @@ export function resolveUpdateTarget(
     return best.file;
   }
   return null;
+}
+
+/**
+ * Plan the per-file update actions shown in ModDetailsModal. Existing current
+ * siblings are valid destinations (updating can promote one without another
+ * download), while uninstalled targets are claimed once so unrelated stale
+ * variants are never silently collapsed into the same replacement.
+ */
+export function planFileUpdates(
+  gameBananaId: number,
+  files: GameBananaFile[],
+  installed: readonly InstalledFileUpdateCandidate[],
+): FileUpdatePlan {
+  const liveFiles = files.filter((file) => !file.isArchived);
+  const liveIds = new Set(liveFiles.map((file) => file.id));
+  const installedLiveIds = new Set(
+    installed
+      .filter(
+        (mod) =>
+          mod.gameBananaId === gameBananaId &&
+          typeof mod.gameBananaFileId === 'number' &&
+          liveIds.has(mod.gameBananaFileId),
+      )
+      .map((mod) => mod.gameBananaFileId!),
+  );
+  const stale = installed.filter(
+    (mod) =>
+      mod.gameBananaId === gameBananaId &&
+      typeof mod.gameBananaFileId === 'number' &&
+      mod.gameBananaFileId > 0 &&
+      !mod.ignoreUpdates &&
+      !liveIds.has(mod.gameBananaFileId),
+  );
+
+  const sourcesByTargetFileId = new Map<number, string[]>();
+  const unresolvedSourceIds: string[] = [];
+  const claimedUninstalledIds = new Set<number>();
+  const resolvedByOldFileId = new Map<number, number>();
+
+  for (const source of stale) {
+    const oldFileId = source.gameBananaFileId!;
+    let targetId = resolvedByOldFileId.get(oldFileId);
+    if (targetId === undefined) {
+      const match = resolveUpdateTarget(source, files, claimedUninstalledIds);
+      if (match) {
+        targetId = match.id;
+      } else if (
+        liveFiles.length === 1 &&
+        (installedLiveIds.has(liveFiles[0].id) || !claimedUninstalledIds.has(liveFiles[0].id))
+      ) {
+        targetId = liveFiles[0].id;
+      }
+      if (targetId !== undefined) {
+        resolvedByOldFileId.set(oldFileId, targetId);
+        if (!installedLiveIds.has(targetId)) claimedUninstalledIds.add(targetId);
+      }
+    }
+
+    if (targetId === undefined) {
+      unresolvedSourceIds.push(source.id);
+      continue;
+    }
+    const sources = sourcesByTargetFileId.get(targetId) ?? [];
+    sources.push(source.id);
+    sourcesByTargetFileId.set(targetId, sources);
+  }
+
+  return { sourcesByTargetFileId, unresolvedSourceIds };
 }
 
 /** Lowercase, strip punctuation, collapse whitespace. "Current/Max Health"

--- a/src/lib/vpkRestore.test.ts
+++ b/src/lib/vpkRestore.test.ts
@@ -100,6 +100,12 @@ describe('shouldRestoreVpkEnabled', () => {
     expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(true);
   });
 
+  it('restores a sole replacement when the new archive no longer has the old index', () => {
+    const snap = createEnabledVpkRestoreSnapshot([{ enabled: true, vpkIndex: 1 }]);
+    const fresh = [mod({ id: 'n' })];
+    expect(shouldRestoreVpkEnabled(fresh[0], fresh, snap)).toBe(true);
+  });
+
   it('does not restore an indexed sibling that was off, even when another was on', () => {
     const snap = createEnabledVpkRestoreSnapshot([
       { enabled: true, vpkIndex: 1 },
@@ -155,6 +161,13 @@ describe('Global placement restore', () => {
     );
 
     expect(calls).toEqual(['global', 'enable']);
+  });
+
+  it('restores Global placement to a sole replacement after archive topology changes', () => {
+    const snap = createGlobalVpkRestoreSnapshot([{ priorityMod: true, vpkIndex: 1 }]);
+    const fresh = [mod({ id: 'replacement' })];
+
+    expect(shouldRestoreVpkGlobal(fresh[0], fresh, snap)).toBe(true);
   });
 
   it('flags mixed legacy placement as ambiguous instead of promoting ordinary siblings', () => {

--- a/src/lib/vpkRestore.ts
+++ b/src/lib/vpkRestore.ts
@@ -54,6 +54,11 @@ export function shouldRestoreVpkEnabled(
   snapshot: EnabledVpkRestoreSnapshot
 ): boolean {
   if (!snapshot.hadEnabled) return false;
+  // An update can change archive topology (for example, V4 shipped several
+  // indexed VPKs while V5 consolidates them into one unindexed VPK). With only
+  // one possible replacement there is no ambiguity: preserve the coarse fact
+  // that the old install was enabled even when its old index cannot match.
+  if (candidates.length === 1) return true;
   const hasIndexedCandidates = candidates.some((candidate) => getVpkIndex(candidate) !== undefined);
   const index = getVpkIndex(mod);
   if (hasIndexedCandidates) {
@@ -98,6 +103,9 @@ export function shouldRestoreVpkGlobal(
   snapshot: GlobalVpkRestoreSnapshot
 ): boolean {
   if (!snapshot.hadGlobal) return false;
+  // As with enabled state, a sole replacement is the unambiguous destination
+  // even if the author's new archive no longer carries the old VPK index.
+  if (candidates.length === 1) return !snapshot.ambiguous;
   const hasIndexedCandidates = candidates.some((candidate) => getVpkIndex(candidate) !== undefined);
   const index = getVpkIndex(mod);
   if (hasIndexedCandidates) {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -67,9 +67,17 @@ import {
   getGamebananaSections,
   getGamebananaCategories,
   backfillGameBananaFileId,
+  createSnapshot,
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { useStableCallback } from '../lib/useStableCallback';
+import {
+  isModDownloadPending,
+  getVisibleDownloadQueue,
+  releaseDownloadRequest,
+  requestDownload,
+  useDownloadActivity,
+} from '../lib/downloadActivity';
 import type {
   GameBananaMod,
   GameBananaModDetails,
@@ -102,7 +110,12 @@ import ImportCollectionModal from '../components/ImportCollectionModal';
 import ImportProfileDialog from '../components/profiles/ImportProfileDialog';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, findCategoryByName } from '../lib/lockerUtils';
 import { formatAbsoluteDate, formatRelativeDate } from '../lib/dates';
-import { hasPendingUpdate } from '../lib/updateFileMatch';
+import { hasPendingUpdate, planFileUpdates } from '../lib/updateFileMatch';
+import {
+  createEnabledVpkRestoreSnapshot,
+  createGlobalVpkRestoreSnapshot,
+  restoreReplacementVpkState,
+} from '../lib/vpkRestore';
 import { showToast } from '../stores/toastStore';
 
 const DEFAULT_PER_PAGE = 36;
@@ -1104,6 +1117,8 @@ export default function Browse() {
   const saveSettings = useAppStore((s) => s.saveSettings);
   const loadMods = useAppStore((s) => s.loadMods);
   const deleteMod = useAppStore((s) => s.deleteMod);
+  const toggleMod = useAppStore((s) => s.toggleMod);
+  const setModPriorityFolder = useAppStore((s) => s.setModPriorityFolder);
   const installedMods = useAppStore((s) => s.mods);
   const soundVolume = useAppStore((s) => s.soundVolume);
   const setSoundVolume = useAppStore((s) => s.setSoundVolume);
@@ -1111,6 +1126,7 @@ export default function Browse() {
   const setBrowseUi = useAppStore((s) => s.setBrowseUi);
   const browseSession = useAppStore((s) => s.browseSession);
   const setBrowseSession = useAppStore((s) => s.setBrowseSession);
+  const downloadActivity = useDownloadActivity();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const hiddenCreators = useMemo(() => settings?.hiddenCreators ?? [], [settings?.hiddenCreators]);
   const hiddenCreatorIds = useMemo(() => hiddenCreators.map((creator) => creator.id), [hiddenCreators]);
@@ -1190,9 +1206,6 @@ export default function Browse() {
   const [selectedModDates, setSelectedModDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   const [modalNavigation, setModalNavigation] = useState<{ direction: ModDetailsNavigationDirection; label: string } | null>(null);
   const modalNavigationRequestRef = useRef(0);
-  const [downloading, setDownloading] = useState<{ modId: number; fileId: number } | null>(null);
-  const [downloadProgress, setDownloadProgress] = useState<{ downloaded: number; total: number } | null>(null);
-  const [extracting, setExtracting] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(() => initialCache?.hasMore ?? true);
   // A page>1 (or stale-results) fetch failure routes here instead of `error`
@@ -1248,7 +1261,6 @@ export default function Browse() {
   const [localSearchFailed, setLocalSearchFailed] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [downloadQueue, setDownloadQueue] = useState<Array<{ modId: number; fileId: number; fileName: string }>>([]);
   // Multi-file quick-install picker anchored to a card's Install button (#209).
   const [filePicker, setFilePicker] = useState<{
     details: GameBananaModDetails;
@@ -1256,6 +1268,18 @@ export default function Browse() {
     anchor: HTMLElement;
     dates: { dateAdded: number; dateModified: number };
   } | null>(null);
+  // Card chrome and the compact picker consume the same app-wide queue state as
+  // ModDetailsModal. The first optimistic request occupies the active slot
+  // until the backend publishes its queue event; later requests are queued.
+  const visibleDownloads = useMemo(
+    () => getVisibleDownloadQueue(downloadActivity),
+    [downloadActivity],
+  );
+  const currentDownload = visibleDownloads.current;
+  const downloading = currentDownload
+    ? { modId: currentDownload.modId, fileId: currentDownload.fileId }
+    : null;
+  const downloadQueue = visibleDownloads.queue;
   const [playingModId, setPlayingModId] = useState<number | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -1447,25 +1471,6 @@ export default function Browse() {
       unsub();
     };
   }, [refreshLocalCacheState]);
-
-  // Fetch initial download queue state on mount
-  useEffect(() => {
-    const fetchInitialQueueState = async () => {
-      try {
-        const [queue, currentDownload] = await Promise.all([
-          window.electronAPI.getDownloadQueue(),
-          window.electronAPI.getCurrentDownload(),
-        ]);
-        setDownloadQueue(queue);
-        if (currentDownload) {
-          setDownloading({ modId: currentDownload.modId, fileId: currentDownload.fileId });
-        }
-      } catch (err) {
-        console.error('Failed to fetch initial queue state:', err);
-      }
-    };
-    fetchInitialQueueState();
-  }, []);
 
   // 'none' = client-side post-filter for Sound mods without a hero in the
   // title. The fetch path sees it as "no category filter" so the API doesn't
@@ -2274,78 +2279,19 @@ export default function Browse() {
   }, [activeDeadlockPath, loadMods]);
 
   useEffect(() => {
-    const progressUnsub = window.electronAPI.onDownloadProgress((data) => {
-      if (
-        downloading &&
-        data.modId === downloading.modId &&
-        data.fileId === downloading.fileId
-      ) {
-        setDownloadProgress({
-          downloaded: data.downloaded,
-          total: data.total,
-        });
-      }
-    });
-
-    const extractingUnsub = window.electronAPI.onDownloadExtracting((data) => {
-      if (
-        downloading &&
-        data.modId === downloading.modId &&
-        data.fileId === downloading.fileId
-      ) {
-        setExtracting(true);
-      }
-    });
-
-    const completeUnsub = window.electronAPI.onDownloadComplete((data) => {
-      if (
-        downloading &&
-        data.modId === downloading.modId &&
-        data.fileId === downloading.fileId
-      ) {
-        setDownloading(null);
-        setDownloadProgress(null);
-        setExtracting(false);
-        loadMods(); // Refresh installed mods
-      }
-    });
-
-    const errorUnsub = window.electronAPI.onDownloadError((data) => {
-      if (
-        downloading &&
-        data.modId === downloading.modId &&
-        data.fileId === downloading.fileId
-      ) {
-        setDownloading(null);
-        setDownloadProgress(null);
-        setExtracting(false);
-        const fullMessage =
-          data.helpUrl && !data.message.includes(data.helpUrl)
-            ? `${data.message} ${data.helpUrl}`
-            : data.message;
-        setError(fullMessage);
-      }
-    });
-
-    const queueUnsub = window.electronAPI.onDownloadQueueUpdated((data) => {
-      setDownloadQueue(data.queue);
-      // Sync local downloading state with backend - this is the source of truth
-      if (data.currentDownload) {
-        setDownloading({ modId: data.currentDownload.modId, fileId: data.currentDownload.fileId });
-      } else {
-        // Only clear if we don't have a current download from backend
-        // Don't clear during race conditions - let the complete event handle that
-      }
+    const completeUnsub = window.electronAPI.onDownloadComplete(() => {
+      // Refresh unconditionally, not only for downloads this page started.
+      // 1-Click protocol installs, collection/profile imports and the
+      // DeadlockForge bridge all complete with ids Browse never tracked, and
+      // an open details overlay would otherwise keep offering "Install" for a
+      // mod that is now on disk.
+      loadMods();
     });
 
     return () => {
-      progressUnsub();
-      extractingUnsub();
       completeUnsub();
-      errorUnsub();
-      queueUnsub();
     };
-  }, [downloading, loadMods]);
+  }, [loadMods]);
 
   // Infinite scroll observer
   // Infinite scroll observer
@@ -2435,7 +2381,7 @@ export default function Browse() {
       pendingPageResetStampRef.current = null;
       setRefreshKey(k => k + 1);
     } catch (err) {
-      setError(String(err));
+      showToast(String(err), { tone: 'error', duration: 7000 });
     } finally {
       setSyncing(false);
     }
@@ -2573,45 +2519,86 @@ export default function Browse() {
   // virtualizer range change while the docked sidebar is open).
   const handleDownload = useStableCallback(async (fileId: number, fileName: string) => {
     if (!selectedMod || !activeDeadlockPath) return;
-
-    // The first file claims the active slot (shows progress); additional clicks
-    // queue behind it. The backend's download-queue-updated event is the source
-    // of truth for what's queued, so don't clobber the active progress UI here.
-    if (!downloading) {
-      setDownloading({ modId: selectedMod.id, fileId });
-      setDownloadProgress({ downloaded: 0, total: 0 });
-      setExtracting(false);
-    }
+    if (!requestDownload({ modId: selectedMod.id, fileId, fileName, modName: selectedMod.name })) return;
 
     try {
-      await downloadMod(selectedMod.id, fileId, fileName, selectedDetailsSection, effectiveCategoryId);
+      const updateSourceIds = selectedUpdateSourcesByTargetFileId.get(fileId) ?? [];
+      const replacementTargets = updateSourceIds.length > 0
+        ? installedMods.filter((mod) => updateSourceIds.includes(mod.id))
+        : installedMods.filter(
+            (mod) => mod.gameBananaId === selectedMod.id && mod.gameBananaFileId === fileId,
+          );
+      const restoreEnabled = createEnabledVpkRestoreSnapshot(replacementTargets);
+      const restoreGlobal = createGlobalVpkRestoreSnapshot(replacementTargets);
+      if (restoreGlobal.ambiguous) {
+        throw new Error(t('installed.updateAll.ambiguousGlobalState'));
+      }
+
+      if (replacementTargets.length > 0) {
+        try {
+          await createSnapshot('pre-update');
+        } catch (error) {
+          console.warn('[Browse download] Failed to capture replacement snapshot:', error);
+        }
+      }
+
+      const replacementAlreadyInstalled =
+        updateSourceIds.length > 0 &&
+        installedMods.some(
+          (mod) =>
+            mod.gameBananaId === selectedMod.id &&
+            mod.gameBananaFileId === fileId &&
+            !updateSourceIds.includes(mod.id),
+        );
+      for (const target of replacementTargets) await deleteMod(target.id);
+
+      if (!replacementAlreadyInstalled) {
+        await downloadMod(selectedMod.id, fileId, fileName, selectedDetailsSection, effectiveCategoryId);
+      }
+      await loadMods();
+
+      if (restoreEnabled.hadEnabled || restoreGlobal.hadGlobal) {
+        const replacements = useAppStore
+          .getState()
+          .mods.filter(
+            (mod) => mod.gameBananaId === selectedMod.id && mod.gameBananaFileId === fileId,
+          );
+        const failures = await restoreReplacementVpkState(
+          replacements,
+          restoreEnabled,
+          restoreGlobal,
+          {
+            setGlobal: (modId) => setModPriorityFolder(modId, true),
+            enable: async (modId) => { await toggleMod(modId); },
+          },
+        );
+        if (failures.length > 0) {
+          showToast(
+            t('installed.updateAll.restoreStateFailed', {
+              details: failures.map((failure) => `${failure.action}: ${String(failure.error)}`).join('; '),
+            }),
+            { tone: 'warning', duration: 7000 },
+          );
+          await loadMods();
+        }
+      }
     } catch (err) {
       setError(String(err));
-      // Reset the active UI only if the file that failed is the active one.
-      // Functional update reads fresh state, not this closure's snapshot.
-      setDownloading((cur) =>
-        cur && cur.modId === selectedMod.id && cur.fileId === fileId ? null : cur
-      );
+    } finally {
+      releaseDownloadRequest(selectedMod.id, fileId);
     }
   });
 
   // Kick off the actual download of one specific file. Shared by the single-file
   // quick install and the multi-file picker so both behave identically.
   const runDownload = async (modId: number, file: GameBananaFile) => {
-    if (!downloading) {
-      setDownloading({ modId, fileId: file.id });
-      setDownloadProgress({ downloaded: 0, total: 0 });
-      setExtracting(false);
-    }
+    if (!requestDownload({ modId, fileId: file.id, fileName: file.fileName })) return;
     try {
       await downloadMod(modId, file.id, file.fileName, section, effectiveCategoryId);
     } catch (err) {
       setError(String(err));
-      if (downloading?.modId === modId) {
-        setDownloading(null);
-        setDownloadProgress(null);
-        setExtracting(false);
-      }
+    } finally {
+      releaseDownloadRequest(modId, file.id);
     }
   };
 
@@ -2619,8 +2606,7 @@ export default function Browse() {
     if (!activeDeadlockPath) return;
 
     // Check if already downloading or in queue
-    if (downloading?.modId === mod.id) return;
-    if (downloadQueue.some(q => q.modId === mod.id)) return;
+    if (isModDownloadPending(downloadActivity, mod.id)) return;
 
     try {
       // Fetch mod details to get the first file. Include the submitter up front
@@ -2657,12 +2643,6 @@ export default function Browse() {
       await runDownload(mod.id, getPrimaryFile(installable));
     } catch (err) {
       setError(String(err));
-      // Only clear downloading state if this was the active download
-      if (downloading?.modId === mod.id) {
-        setDownloading(null);
-        setDownloadProgress(null);
-        setExtracting(false);
-      }
     }
   };
 
@@ -2730,8 +2710,6 @@ export default function Browse() {
     return map;
   }, [installedMods]);
 
-  const toggleMod = useAppStore((state) => state.toggleMod);
-
   // Track installed file IDs for per-file "Reinstall" button state
   const installedFileIds = useMemo(() => {
     const ids = new Set<number>();
@@ -2768,6 +2746,53 @@ export default function Browse() {
     () => (selectedMod ? hasPendingUpdate(selectedMod.id, selectedMod.files ?? [], installedMods) : false),
     [selectedMod, installedMods]
   );
+  const selectedUpdatePlan = useMemo(() => {
+    if (!selectedMod) {
+      return { sourcesByTargetFileId: new Map<number, string[]>(), unresolvedSourceIds: [] };
+    }
+    return planFileUpdates(
+      selectedMod.id,
+      selectedMod.files ?? [],
+      installedMods
+        .filter(
+          (mod) =>
+            mod.gameBananaId === selectedMod.id &&
+            typeof mod.gameBananaFileId === 'number',
+        )
+        .map((mod) => ({
+          id: mod.id,
+          gameBananaId: mod.gameBananaId,
+          gameBananaFileId: mod.gameBananaFileId,
+          ignoreUpdates: mod.ignoreUpdates,
+          installedFileId: mod.gameBananaFileId!,
+          fileDescription: mod.fileDescription,
+          sourceFileName: mod.sourceFileName,
+        })),
+    );
+  }, [selectedMod, installedMods]);
+  const selectedUpdateSourcesByTargetFileId = useMemo(() => {
+    const sources = new Map(selectedUpdatePlan.sourcesByTargetFileId);
+    if (!selectedMod || selectedUpdatePlan.unresolvedSourceIds.length === 0) return sources;
+
+    // If every unresolved local VPK came from the same old GameBanana file,
+    // the ambiguity is only "which new variant does the user want?". Let every
+    // current row be an explicit Update choice. Distinct stale file ids remain
+    // unlabelled because collapsing several variants into one would be unsafe.
+    const unresolved = installedMods.filter((mod) =>
+      selectedUpdatePlan.unresolvedSourceIds.includes(mod.id),
+    );
+    const oldFileIds = new Set(unresolved.map((mod) => mod.gameBananaFileId));
+    if (oldFileIds.size === 1) {
+      for (const file of selectedMod.files ?? []) {
+        if (!file.isArchived) sources.set(file.id, [...selectedUpdatePlan.unresolvedSourceIds]);
+      }
+    }
+    return sources;
+  }, [selectedMod, selectedUpdatePlan, installedMods]);
+  const selectedUpdateFileIds = useMemo(
+    () => new Set(selectedUpdateSourcesByTargetFileId.keys()),
+    [selectedUpdateSourcesByTargetFileId],
+  );
 
   const queuedByModId = useMemo(() => {
     const map = new Map<number, QueuedDownloadState>();
@@ -2776,15 +2801,6 @@ export default function Browse() {
     });
     return map;
   }, [downloadQueue]);
-
-  const selectedQueuedFileIds = useMemo(() => {
-    if (!selectedMod) return new Set<number>();
-    const ids = new Set<number>();
-    for (const queued of downloadQueue) {
-      if (queued.modId === selectedMod.id) ids.add(queued.fileId);
-    }
-    return ids;
-  }, [downloadQueue, selectedMod]);
 
   const queuedModIds = useMemo(
     () => new Set(downloadQueue.map((queued) => queued.modId)),
@@ -3119,13 +3135,10 @@ export default function Browse() {
         section={selectedDetailsSection}
         installed={installedIds.has(selectedMod.id)}
         updateAvailable={selectedModUpdateAvailable}
+        updateFileIds={selectedUpdateFileIds}
         installedFileIds={installedFileIds}
         installedFileStates={installedFileStates}
         onEnableFile={toggleMod}
-        downloadingFileId={downloading && downloading.modId === selectedMod.id ? downloading.fileId : null}
-        queuedFileIds={selectedQueuedFileIds}
-        extracting={extracting}
-        progress={downloadProgress}
         hideNsfwPreviews={browseBlurNsfwPreviews}
         dateAdded={selectedModDates?.dateAdded}
         dateModified={selectedModDates?.dateModified}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -68,15 +68,17 @@ import {
   getGamebananaCategories,
   backfillGameBananaFileId,
   createSnapshot,
+  deleteMod as deleteModApi,
 } from '../lib/api';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { useStableCallback } from '../lib/useStableCallback';
 import {
   isModDownloadPending,
   getVisibleDownloadQueue,
+  isDownloadRequestPending,
   releaseDownloadRequest,
   requestDownload,
-  useDownloadActivity,
+  useDownloadQueueActivity,
 } from '../lib/downloadActivity';
 import type {
   GameBananaMod,
@@ -116,6 +118,7 @@ import {
   createGlobalVpkRestoreSnapshot,
   restoreReplacementVpkState,
 } from '../lib/vpkRestore';
+import { findReplacementTargetIdsAfterInstall } from '../lib/replacementCleanup';
 import { showToast } from '../stores/toastStore';
 
 const DEFAULT_PER_PAGE = 36;
@@ -852,6 +855,26 @@ function BrowseSoundPlaceholder({ title }: { title: string }) {
   );
 }
 
+/**
+ * Compositor-only download indicator for cards. The old stroked SVG spinner
+ * could look stepped at these tiny sizes; this keeps a quiet track underneath
+ * a continuous orbit and never depends on React progress renders to move.
+ */
+function BrowseDownloadSpinner({
+  className = '',
+  size = 'default',
+}: {
+  className?: string;
+  size?: 'default' | 'large';
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`browse-download-spinner ${size === 'large' ? 'browse-download-spinner--large' : ''} ${className}`}
+    />
+  );
+}
+
 function BrowseReadableAction({
   modName,
   installed,
@@ -955,9 +978,7 @@ function BrowseReadableAction({
     queueShift ? 'browse-action-button--queue-shift' : '',
   ].filter(Boolean).join(' ');
   const icon =
-    action === 'downloading'
-      ? Loader2
-      : action === 'installed'
+    action === 'installed'
         ? Check
         : action === 'enable'
           ? Power
@@ -967,12 +988,16 @@ function BrowseReadableAction({
   const content = (
     iconOnly ? (
       <span className={`browse-action-button-icon browse-action-button-icon--${action}`}>
-        {React.createElement(icon, { 'aria-hidden': true, className: action === 'downloading' ? 'animate-spin' : undefined })}
+        {action === 'downloading'
+          ? <BrowseDownloadSpinner />
+          : React.createElement(icon, { 'aria-hidden': true })}
       </span>
     ) : (
       <>
         <span className={`browse-action-button-icon browse-action-button-icon--${action}`}>
-          {React.createElement(icon, { 'aria-hidden': true, className: action === 'downloading' ? 'animate-spin' : undefined })}
+          {action === 'downloading'
+            ? <BrowseDownloadSpinner />
+            : React.createElement(icon, { 'aria-hidden': true })}
         </span>
         <span className="browse-action-button-label">
           {action === 'queued' ? (
@@ -1126,7 +1151,10 @@ export default function Browse() {
   const setBrowseUi = useAppStore((s) => s.setBrowseUi);
   const browseSession = useAppStore((s) => s.browseSession);
   const setBrowseSession = useAppStore((s) => s.setBrowseSession);
-  const downloadActivity = useDownloadActivity();
+  // Browse only needs queue membership. Byte-progress ticks belong to the
+  // details popup and queue indicator; subscribing the whole catalog to them
+  // redrew every visible card throughout an install/reinstall.
+  const downloadActivity = useDownloadQueueActivity();
   const activeDeadlockPath = getActiveDeadlockPath(settings);
   const hiddenCreators = useMemo(() => settings?.hiddenCreators ?? [], [settings?.hiddenCreators]);
   const hiddenCreatorIds = useMemo(() => hiddenCreators.map((creator) => creator.id), [hiddenCreators]);
@@ -2550,10 +2578,23 @@ export default function Browse() {
             mod.gameBananaFileId === fileId &&
             !updateSourceIds.includes(mod.id),
         );
-      for (const target of replacementTargets) await deleteMod(target.id);
 
       if (!replacementAlreadyInstalled) {
+        // Snapshot capture can leave an optimistic row on screen long enough
+        // for the user to cancel it. Do not cross IPC after that cancellation.
+        if (!isDownloadRequestPending(selectedMod.id, fileId)) return;
         await downloadMod(selectedMod.id, fileId, fileName, selectedDetailsSection, effectiveCategoryId);
+        await loadMods();
+        const installedAfterDownload = useAppStore.getState().mods;
+        const targetIds = findReplacementTargetIdsAfterInstall(
+          installedAfterDownload,
+          replacementTargets,
+          fileId,
+        );
+        for (const targetId of targetIds) await deleteModApi(targetId);
+      } else {
+        if (!isDownloadRequestPending(selectedMod.id, fileId)) return;
+        for (const target of replacementTargets) await deleteModApi(target.id);
       }
       await loadMods();
 
@@ -2569,7 +2610,9 @@ export default function Browse() {
           restoreGlobal,
           {
             setGlobal: (modId) => setModPriorityFolder(modId, true),
-            enable: async (modId) => { await toggleMod(modId); },
+            enable: async (modId) => {
+              if (!await toggleMod(modId)) throw new Error('Failed to enable replacement mod');
+            },
           },
         );
         if (failures.length > 0) {
@@ -2772,7 +2815,11 @@ export default function Browse() {
   }, [selectedMod, installedMods]);
   const selectedUpdateSourcesByTargetFileId = useMemo(() => {
     const sources = new Map(selectedUpdatePlan.sourcesByTargetFileId);
-    if (!selectedMod || selectedUpdatePlan.unresolvedSourceIds.length === 0) return sources;
+    if (
+      !selectedMod ||
+      sources.size > 0 ||
+      selectedUpdatePlan.unresolvedSourceIds.length === 0
+    ) return sources;
 
     // If every unresolved local VPK came from the same old GameBanana file,
     // the ambiguity is only "which new variant does the user want?". Let every
@@ -4520,7 +4567,7 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
               </Tag>
             ) : downloading ? (
               <span className="flex-shrink-0 flex items-center justify-center w-7 h-7 bg-bg-primary/80 rounded-full">
-                <Loader2 className="w-4 h-4 animate-spin text-accent" />
+                <BrowseDownloadSpinner className="text-accent" />
               </span>
             ) : (
               <button
@@ -4898,8 +4945,8 @@ function ModCard({ mod, installed, installedDisabled, downloading, queuePosition
             ✓
           </span>
         ) : downloading ? (
-          <div className={`flex items-center justify-center rounded-full bg-bg-primary/85 backdrop-blur-sm ring-1 ring-border shadow-md ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`} title={t('browse.card.downloading')}>
-            <Loader2 className={`animate-spin text-accent ${isCompact ? 'w-4 h-4' : 'w-5 h-5'}`} />
+          <div className={`browse-download-badge flex items-center justify-center rounded-full bg-bg-primary/85 backdrop-blur-sm ring-1 ring-border shadow-md ${isCompact ? 'w-7 h-7' : 'w-8 h-8'}`} title={t('browse.card.downloading')}>
+            <BrowseDownloadSpinner className="text-accent" size={isCompact ? 'default' : 'large'} />
           </div>
         ) : queuePosition ? (
           <div

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -2596,7 +2596,7 @@ export default function Browse() {
         if (!isDownloadRequestPending(selectedMod.id, fileId)) return;
         for (const target of replacementTargets) await deleteModApi(target.id);
       }
-      await loadMods();
+      await loadMods({ force: true });
 
       if (restoreEnabled.hadEnabled || restoreGlobal.hadGlobal) {
         const replacements = useAppStore
@@ -2622,7 +2622,7 @@ export default function Browse() {
             }),
             { tone: 'warning', duration: 7000 },
           );
-          await loadMods();
+          await loadMods({ force: true });
         }
       }
     } catch (err) {

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2282,7 +2282,7 @@ export default function Installed() {
         for (const mod of replacementTargets) await deleteModApi(mod.id);
       }
 
-      await loadMods();
+      await loadMods({ force: true });
 
       // Replacement downloads land disabled with fresh metadata. Restore both
       // enabled state and the user's Global priority-root placement after
@@ -2313,7 +2313,7 @@ export default function Installed() {
 
       // Always reconcile the store with what actually landed on disk, even when
       // the state restore below failed.
-      await loadMods();
+      await loadMods({ force: true });
 
       // A restore failure is NOT an update failure: the new file is installed
       // and only its enabled/Global state is off. Throwing here would report a
@@ -2363,6 +2363,7 @@ export default function Installed() {
         gameBananaFileId: m.gameBananaFileId!,
         fileName: m.fileName,
         vpkIndex: m.vpkIndex,
+        sha256: m.sha256,
         section: m.sourceSection ?? 'Mod',
         categoryId: m.categoryId ?? 0,
         wasEnabled: m.enabled,
@@ -2573,6 +2574,8 @@ export default function Installed() {
             id: snapshot.oldId,
             gameBananaId: snapshot.gameBananaId,
             gameBananaFileId: snapshot.gameBananaFileId,
+            vpkIndex: snapshot.vpkIndex,
+            sha256: snapshot.sha256,
           }));
           const targetIds = findReplacementTargetIdsAfterInstall(
             installedAfterDownload,
@@ -2611,7 +2614,7 @@ export default function Installed() {
     // Refresh once so the new installs are in the store with their new ids,
     // then restore Global placement and enabled state. Match by GB ids; the
     // local mod id changes on reinstall.
-    await loadMods();
+    await loadMods({ force: true });
     const refreshed = useAppStore.getState().mods;
     for (const c of completed) {
       if (!c.restoreEnabled.hadEnabled && !c.restoreGlobal.hadGlobal) continue;

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -89,7 +89,7 @@ import { showToast } from '../stores/toastStore';
 import { useAppStore, type BrowseArtistRef } from '../stores/appStore';
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { isImprintPending } from '../lib/imprintPending';
-import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, addMergeSources, replaceMergeSources, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder, dmmMigrateScan, dmmMigrateExecute, imprintAllInstalled, onImprintAllInstalledProgress, imprintPreflight, readImprintDetails, launchModded } from '../lib/api';
+import { getConflicts, openModsFolder, readImageDataUrl, showOpenDialog, getModDetails, getModFileList, downloadMod, createSnapshot, deleteMod as deleteModApi, detectUnknownModFilters, detectUnknownModCacheBulk, cancelUnknownModDetection, onUnknownModDetectionProgress, applyUnknownModMatch, applyUnknownCustomMod, associateUnknownMod, listUnknownModFiles, browseMods, mergeMods, unmergeMod, extractMergeSource, addMergeSources, replaceMergeSources, reorderMods as apiReorderMods, setModIgnoreUpdates, getLockerOverview, revealModInFolder, dmmMigrateScan, dmmMigrateExecute, imprintAllInstalled, onImprintAllInstalledProgress, imprintPreflight, readImprintDetails, launchModded } from '../lib/api';
 import type { UnmergeModResult, ImprintAllInstalledResult, ImprintInstalledProgress, ImprintPreflightResult, ImprintDetails } from '../lib/api';
 import type { ModConflict } from '../lib/api';
 import type { Mod, GlobalModType, UnknownModDetectionProgress, UnknownModFilterGuess, MergedModSource, MergeSourceReplacement, AssociateUnknownModArgs, ImprintAnomalousMod, ImprintSkippedMod, ImprintFailedMod } from '../types/mod';
@@ -114,7 +114,7 @@ import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType, modLoadOrder } from '../lib/lockerUtils';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
-import { releaseDownloadRequest, requestDownload } from '../lib/downloadActivity';
+import { isDownloadRequestPending, releaseDownloadRequest, requestDownload } from '../lib/downloadActivity';
 import { formatBytes } from '../lib/formatBytes';
 import { canOpenImageSource, copyImageToClipboard, resolveImageSource } from '../lib/imageActions';
 import { planFileUpdates } from '../lib/updateFileMatch';
@@ -126,6 +126,7 @@ import {
   type GlobalVpkRestoreSnapshot,
 } from '../lib/vpkRestore';
 import { modRestoreKey } from '../lib/soloRestore';
+import { findReplacementTargetIdsAfterInstall } from '../lib/replacementCleanup';
 import { buildCachedModDetails, canUseCachedModDetails } from '../lib/cachedModDetails';
 import {
   createDisabledEntryComparator,
@@ -1417,9 +1418,8 @@ export default function Installed() {
   // "Install" and the row never picked up its Installed/Active styling.
   const [detailsGameBananaId, setDetailsGameBananaId] = useState<number | null>(null);
   const [detailsDates, setDetailsDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
-  // Local id of the installed mod that triggered the overlay. On download we
-  // delete this entry first so Update/Reinstall replaces the old VPK instead
-  // of installing a second copy alongside it.
+  // Local id of the installed mod that triggered the overlay. A successful
+  // Update/Reinstall removes this predecessor after the replacement lands.
   const [detailsSourceModId, setDetailsSourceModId] = useState<string | null>(null);
   // Monotonic guard so a slower linked-item fetch can't clobber a newer one.
   const detailsRequestIdRef = useRef(0);
@@ -1667,19 +1667,19 @@ export default function Installed() {
     setDetailsSection(item.section);
     setDetailsCategoryId(0);
 
-    // A linked item has no clicked entry, so anchor the overlay on the first
-    // installed sibling (if any). The file sets and update pulse follow from
-    // that plus the live mod list.
-    let sourceModId: string | null = null;
-    let ignoreUpdates = false;
-    for (const candidate of mods) {
-      if (candidate.gameBananaId !== item.id) continue;
-      if (!sourceModId) sourceModId = candidate.id;
-      if (candidate.ignoreUpdates) ignoreUpdates = true;
-    }
+    // A linked item has no clicked entry, so choose an installed sibling as
+    // its anchor. The file sets and update pulse follow from that anchor plus
+    // the live mod list.
+    const linkedCandidates = mods.filter((candidate) => candidate.gameBananaId === item.id);
+    // Prefer the sibling that actually carries the update pulse. Choosing the
+    // first installed sibling could anchor on a current variant and suppress
+    // both the badge and the stale variant's replacement plan.
+    const source = linkedCandidates.find((candidate) => updatesAvailable.has(candidate.id))
+      ?? linkedCandidates[0]
+      ?? null;
     setDetailsGameBananaId(item.id);
-    setDetailsSourceModId(sourceModId);
-    setDetailsIgnoreUpdates(ignoreUpdates);
+    setDetailsSourceModId(source?.id ?? null);
+    setDetailsIgnoreUpdates(!!source?.ignoreUpdates);
     setDetailsDates(null);
 
     const cachedPromise = window.electronAPI.getCachedMod(item.id).catch(() => null);
@@ -2260,9 +2260,6 @@ export default function Installed() {
           console.warn('[Update] failed to capture pre-update snapshot:', err);
         }
       }
-      for (const mod of replacementTargets) {
-        await deleteMod(mod.id);
-      }
 
       const replacementAlreadyInstalled = mods.some(
         (mod) =>
@@ -2270,16 +2267,28 @@ export default function Installed() {
           mod.gameBananaFileId === fileId &&
           !replacementTargets.some((target) => target.id === mod.id),
       );
+      if (!isDownloadRequestPending(detailsMod.id, fileId)) return;
       if (!replacementAlreadyInstalled) {
         await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
+        await loadMods();
+        const installedAfterDownload = useAppStore.getState().mods;
+        const targetIds = findReplacementTargetIdsAfterInstall(
+          installedAfterDownload,
+          replacementTargets,
+          fileId,
+        );
+        for (const targetId of targetIds) await deleteModApi(targetId);
+      } else {
+        for (const mod of replacementTargets) await deleteModApi(mod.id);
       }
+
+      await loadMods();
 
       // Replacement downloads land disabled with fresh metadata. Restore both
       // enabled state and the user's Global priority-root placement after
       // reloading. Match by GB ids because local ids change on reinstall.
       let restoreFailureMessage: string | null = null;
       if (restoreEnabled.hadEnabled || restoreGlobal.hadGlobal) {
-        await loadMods();
         const newMods = useAppStore
           .getState()
           .mods.filter((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
@@ -2290,7 +2299,7 @@ export default function Installed() {
           {
             setGlobal: (modId) => setModPriorityFolder(modId, true),
             enable: async (modId) => {
-              await toggleMod(modId);
+              if (!await toggleMod(modId)) throw new Error('Failed to enable replacement mod');
             },
           },
         );
@@ -2310,7 +2319,7 @@ export default function Installed() {
       // and only its enabled/Global state is off. Throwing here would report a
       // succeeded update as a failed one, so surface it in the overlay instead.
       if (restoreFailureMessage) {
-        setDetailsError(restoreFailureMessage);
+        showToast(restoreFailureMessage, { tone: 'warning', duration: 7000 });
       }
 
       // Keep the overlay open on the freshly installed file so the row flips to
@@ -2321,7 +2330,10 @@ export default function Installed() {
       const installed = useAppStore
         .getState()
         .mods.find((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
-      if (installed) setDetailsSourceModId(installed.id);
+      if (installed) {
+        setDetailsSourceModId(installed.id);
+        setDetailsIgnoreUpdates(!!installed.ignoreUpdates);
+      }
     } catch (err) {
       // The error dialog below only renders when no mod is loaded, and the
       // overlay now stays open through the install, so a failure has to be
@@ -2546,9 +2558,6 @@ export default function Installed() {
               mod.gameBananaFileId === batch.fileId &&
               !batch.snapshots.some((snapshot) => snapshot.oldId === mod.id),
           );
-          for (const snapshot of batch.snapshots) {
-            await deleteMod(snapshot.oldId);
-          }
           if (!replacementAlreadyInstalled) {
             await downloadMod(
               batch.gameBananaId,
@@ -2558,6 +2567,19 @@ export default function Installed() {
               batch.categoryId,
             );
           }
+          await loadMods();
+          const installedAfterDownload = useAppStore.getState().mods;
+          const cleanupTargets = batch.snapshots.map((snapshot) => ({
+            id: snapshot.oldId,
+            gameBananaId: snapshot.gameBananaId,
+            gameBananaFileId: snapshot.gameBananaFileId,
+          }));
+          const targetIds = findReplacementTargetIdsAfterInstall(
+            installedAfterDownload,
+            cleanupTargets,
+            batch.fileId,
+          );
+          for (const targetId of targetIds) await deleteModApi(targetId);
           completed.push({
             gameBananaId: batch.gameBananaId,
             gameBananaFileId: batch.fileId,
@@ -2603,7 +2625,7 @@ export default function Installed() {
         {
           setGlobal: (modId) => setModPriorityFolder(modId, true),
           enable: async (modId) => {
-            await toggleMod(modId);
+            if (!await toggleMod(modId)) throw new Error('Failed to enable replacement mod');
           },
         },
       );

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -2343,15 +2343,19 @@ export default function Installed() {
         | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };
       const resolutions: Resolution[] = [];
       const resolvedByOldFileId = new Map<number, { fileId: number; fileName: string }>();
-      // Seed claims with live files already installed as siblings outside this
-      // run, so neither the fuzzy match nor the single-file fallback
-      // re-downloads a variant the user already has.
+      // Track live files already installed as siblings outside this run. They
+      // are valid update destinations: if V5 is already installed beside the
+      // stale V4, updating V4 should remove it and transfer its enabled/Global
+      // state to V5 instead of silently refusing to act. Only uninstalled live
+      // files are "claimed" to prevent two unrelated stale variants from both
+      // being mapped to the same new download.
       const groupOldIds = new Set(group.map((s) => s.oldId));
+      const installedLiveIds = new Set<number>();
       const claimedIds = new Set<number>();
       for (const m of mods) {
         if (m.gameBananaId !== group[0].gameBananaId || groupOldIds.has(m.id)) continue;
         if (typeof m.gameBananaFileId === 'number' && liveFileIds.has(m.gameBananaFileId)) {
-          claimedIds.add(m.gameBananaFileId);
+          installedLiveIds.add(m.gameBananaFileId);
         }
       }
       for (const s of group) {
@@ -2384,11 +2388,14 @@ export default function Installed() {
         if (match) {
           resolutions.push({ ok: true, snapshot: s, fileId: match.id, fileName: match.fileName });
           resolvedByOldFileId.set(s.gameBananaFileId, { fileId: match.id, fileName: match.fileName });
-          claimedIds.add(match.id);
-        } else if (liveFiles.length === 1 && !claimedIds.has(liveFiles[0].id)) {
+          if (!installedLiveIds.has(match.id)) claimedIds.add(match.id);
+        } else if (
+          liveFiles.length === 1 &&
+          (installedLiveIds.has(liveFiles[0].id) || !claimedIds.has(liveFiles[0].id))
+        ) {
           resolutions.push({ ok: true, snapshot: s, fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
           resolvedByOldFileId.set(s.gameBananaFileId, { fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
-          claimedIds.add(liveFiles[0].id);
+          if (!installedLiveIds.has(liveFiles[0].id)) claimedIds.add(liveFiles[0].id);
         } else {
           resolutions.push({
             ok: false,
@@ -2465,16 +2472,29 @@ export default function Installed() {
           if (restoreGlobal.ambiguous) {
             throw new Error(t('installed.updateAll.ambiguousGlobalState'));
           }
+          // The replacement may already be installed as a disabled sibling
+          // (for example the user installed V5 from Browse while V4 remained
+          // enabled). In that case the update is a promotion, not another
+          // download: delete the stale install and restore its state onto the
+          // existing current file.
+          const replacementAlreadyInstalled = mods.some(
+            (mod) =>
+              mod.gameBananaId === batch.gameBananaId &&
+              mod.gameBananaFileId === batch.fileId &&
+              !batch.snapshots.some((snapshot) => snapshot.oldId === mod.id),
+          );
           for (const snapshot of batch.snapshots) {
             await deleteMod(snapshot.oldId);
           }
-          await downloadMod(
-            batch.gameBananaId,
-            batch.fileId,
-            batch.fileName,
-            batch.section,
-            batch.categoryId,
-          );
+          if (!replacementAlreadyInstalled) {
+            await downloadMod(
+              batch.gameBananaId,
+              batch.fileId,
+              batch.fileName,
+              batch.section,
+              batch.categoryId,
+            );
+          }
           completed.push({
             gameBananaId: batch.gameBananaId,
             gameBananaFileId: batch.fileId,

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -114,9 +114,10 @@ import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType, modLoadOrder } from '../lib/lockerUtils';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
+import { releaseDownloadRequest, requestDownload } from '../lib/downloadActivity';
 import { formatBytes } from '../lib/formatBytes';
 import { canOpenImageSource, copyImageToClipboard, resolveImageSource } from '../lib/imageActions';
-import { resolveUpdateTarget } from '../lib/updateFileMatch';
+import { planFileUpdates } from '../lib/updateFileMatch';
 import {
   createEnabledVpkRestoreSnapshot,
   createGlobalVpkRestoreSnapshot,
@@ -1408,12 +1409,13 @@ export default function Installed() {
   // True when the overlay is showing cached-catalog data because the live
   // GameBanana fetch failed; drives the offline banner in the modal.
   const [detailsOffline, setDetailsOffline] = useState(false);
-  const [detailsUpdateAvailable, setDetailsUpdateAvailable] = useState(false);
   const [detailsIgnoreUpdates, setDetailsIgnoreUpdates] = useState(false);
-  const [detailsInstalledFileIds, setDetailsInstalledFileIds] = useState<Set<number>>(new Set());
-  // GameBanana fileIds of enabled files in the group. Drives the "Active"
-  // badges in the details modal when multiple files are enabled together.
-  const [detailsActiveFileIds, setDetailsActiveFileIds] = useState<Set<number>>(new Set());
+  // GameBanana id the overlay is showing. Every installed-state value below is
+  // derived live from the store off this id rather than snapshotted when the
+  // overlay opens: a snapshot went stale the moment the user installed a
+  // variant or an update from inside the overlay, so the button stayed on
+  // "Install" and the row never picked up its Installed/Active styling.
+  const [detailsGameBananaId, setDetailsGameBananaId] = useState<number | null>(null);
   const [detailsDates, setDetailsDates] = useState<{ dateAdded: number; dateModified: number } | null>(null);
   // Local id of the installed mod that triggered the overlay. On download we
   // delete this entry first so Update/Reinstall replaces the old VPK instead
@@ -1421,7 +1423,6 @@ export default function Installed() {
   const [detailsSourceModId, setDetailsSourceModId] = useState<string | null>(null);
   // Monotonic guard so a slower linked-item fetch can't clobber a newer one.
   const detailsRequestIdRef = useRef(0);
-
   // Map of mod id → true if a newer version exists on GameBanana.
   const [updatesAvailable, setUpdatesAvailable] = useState<Set<string>>(new Set());
   // Merged mod id -> fileNames of its absorbed sources whose GameBanana file is
@@ -1430,6 +1431,78 @@ export default function Installed() {
   const [mergedSourceUpdates, setMergedSourceUpdates] = useState<Map<string, Set<string>>>(
     new Map(),
   );
+
+  // Installed/enabled GameBanana fileIds for the mod the details overlay is
+  // showing, aggregated across every sibling that shares the GB id (not just
+  // the clicked file) so multi-variant groups flag every owned row. Derived
+  // from `mods` so an install, delete or toggle performed while the overlay is
+  // open updates it on the spot, the way Browse feeds the same modal.
+  const { detailsInstalledFileIds, detailsActiveFileIds } = useMemo(() => {
+    const installedFileIds = new Set<number>();
+    const activeFileIds = new Set<number>();
+    if (detailsGameBananaId !== null) {
+      for (const candidate of mods) {
+        if (candidate.gameBananaId !== detailsGameBananaId) continue;
+        if (typeof candidate.gameBananaFileId !== 'number') continue;
+        installedFileIds.add(candidate.gameBananaFileId);
+        if (candidate.enabled) activeFileIds.add(candidate.gameBananaFileId);
+      }
+    }
+    return { detailsInstalledFileIds: installedFileIds, detailsActiveFileIds: activeFileIds };
+  }, [mods, detailsGameBananaId]);
+
+  // Update pulse for the overlay. Keyed off the entry that opened it, matching
+  // the per-file update check: a sibling variant having an update must not
+  // relabel this file's button as "Update", which would make the download
+  // handler treat the pick as a version replacement and delete the source.
+  const detailsUpdateAvailable = useMemo(
+    () => (detailsSourceModId ? updatesAvailable.has(detailsSourceModId) : false),
+    [detailsSourceModId, updatesAvailable],
+  );
+
+  const detailsUpdatePlan = useMemo(() => {
+    if (!detailsMod || !detailsSourceModId || !detailsUpdateAvailable) {
+      return { sourcesByTargetFileId: new Map<number, string[]>(), unresolvedSourceIds: [] };
+    }
+    const source = mods.find((mod) => mod.id === detailsSourceModId);
+    if (!source || typeof source.gameBananaFileId !== 'number') {
+      return { sourcesByTargetFileId: new Map<number, string[]>(), unresolvedSourceIds: [] };
+    }
+    const liveIds = new Set(
+      (detailsMod.files ?? []).filter((file) => !file.isArchived).map((file) => file.id),
+    );
+    const candidates = mods.filter(
+      (mod) =>
+        mod.gameBananaId === detailsMod.id &&
+        (mod.gameBananaFileId === source.gameBananaFileId ||
+          (typeof mod.gameBananaFileId === 'number' && liveIds.has(mod.gameBananaFileId))),
+    );
+    return planFileUpdates(
+      detailsMod.id,
+      detailsMod.files ?? [],
+      candidates.map((mod) => ({
+        id: mod.id,
+        gameBananaId: mod.gameBananaId,
+        gameBananaFileId: mod.gameBananaFileId,
+        ignoreUpdates: mod.ignoreUpdates,
+        installedFileId: mod.gameBananaFileId!,
+        fileDescription: mod.fileDescription,
+        sourceFileName: mod.sourceFileName,
+      })),
+    );
+  }, [detailsMod, detailsSourceModId, detailsUpdateAvailable, mods]);
+
+  const detailsUpdateFileIds = useMemo(() => {
+    const planned = new Set(detailsUpdatePlan.sourcesByTargetFileId.keys());
+    if (planned.size > 0 || detailsUpdatePlan.unresolvedSourceIds.length === 0) return planned;
+    // No automatic match: every current file is a user-selectable replacement.
+    // They are intentionally labelled Update because the Installed handler
+    // will replace the stale source, not add an ordinary sibling variant.
+    for (const file of detailsMod?.files ?? []) {
+      if (!file.isArchived) planned.add(file.id);
+    }
+    return planned;
+  }, [detailsMod, detailsUpdatePlan]);
 
   // "Update all" confirm + progress. Progress is null when idle, otherwise
   // { done, total } so the button can render "Updating 2/5…" and stay disabled
@@ -1502,23 +1575,9 @@ export default function Installed() {
     setDetailsSection(section);
     setDetailsCategoryId(categoryId);
     setDetailsSourceModId(m.id);
-    // Build the installed-file set from every sibling sharing this GB id,
-    // not just the clicked file. Otherwise the modal flags only one row
-    // as "Reinstall" when multiple files of the same mod are present -
-    // diverging from Browse, which already aggregates correctly.
-    const siblingFileIds = new Set<number>();
-    const activeFileIds = new Set<number>();
-    for (const candidate of mods) {
-      if (candidate.gameBananaId !== m.gameBananaId) continue;
-      if (typeof candidate.gameBananaFileId !== 'number') continue;
-      siblingFileIds.add(candidate.gameBananaFileId);
-      if (candidate.enabled) {
-        activeFileIds.add(candidate.gameBananaFileId);
-      }
-    }
-    setDetailsInstalledFileIds(siblingFileIds);
-    setDetailsActiveFileIds(activeFileIds);
-    setDetailsUpdateAvailable(updatesAvailable.has(m.id));
+    // Installed/active file sets and the update pulse are derived from this id
+    // against the live mod list, so nothing to snapshot here.
+    setDetailsGameBananaId(m.gameBananaId);
     setDetailsIgnoreUpdates(!!m.ignoreUpdates);
     setDetailsDates(null);
     setDetailsOffline(false);
@@ -1575,10 +1634,9 @@ export default function Installed() {
     setDetailsMod(null);
     setDetailsError(null);
     setDetailsOffline(false);
-    setDetailsUpdateAvailable(false);
     setDetailsIgnoreUpdates(false);
     setDetailsSourceModId(null);
-    setDetailsActiveFileIds(new Set());
+    setDetailsGameBananaId(null);
     setDetailsDates(null);
   });
 
@@ -1609,25 +1667,19 @@ export default function Installed() {
     setDetailsSection(item.section);
     setDetailsCategoryId(0);
 
-    const siblingFileIds = new Set<number>();
-    const activeFileIds = new Set<number>();
+    // A linked item has no clicked entry, so anchor the overlay on the first
+    // installed sibling (if any). The file sets and update pulse follow from
+    // that plus the live mod list.
     let sourceModId: string | null = null;
     let ignoreUpdates = false;
-    let updateAvailable = false;
     for (const candidate of mods) {
       if (candidate.gameBananaId !== item.id) continue;
       if (!sourceModId) sourceModId = candidate.id;
       if (candidate.ignoreUpdates) ignoreUpdates = true;
-      if (updatesAvailable.has(candidate.id)) updateAvailable = true;
-      if (typeof candidate.gameBananaFileId !== 'number') continue;
-      siblingFileIds.add(candidate.gameBananaFileId);
-      if (candidate.enabled) activeFileIds.add(candidate.gameBananaFileId);
     }
-    setDetailsInstalledFileIds(siblingFileIds);
-    setDetailsActiveFileIds(activeFileIds);
+    setDetailsGameBananaId(item.id);
     setDetailsSourceModId(sourceModId);
     setDetailsIgnoreUpdates(ignoreUpdates);
-    setDetailsUpdateAvailable(updateAvailable);
     setDetailsDates(null);
 
     const cachedPromise = window.electronAPI.getCachedMod(item.id).catch(() => null);
@@ -2145,6 +2197,10 @@ export default function Installed() {
 
   const handleDetailsDownload = useStableCallback(async (fileId: number, fileName: string) => {
     if (!detailsMod) return;
+    // Synchronous app-wide guard: covers double clicks and the same target
+    // being requested from Browse before React or the backend queue can render.
+    if (!requestDownload({ modId: detailsMod.id, fileId, fileName, modName: detailsMod.name })) return;
+    setDetailsError(null);
     try {
       // Decide whether this pick replaces the source install or adds a sibling:
       //  - same-file pick = a true reinstall -> replace.
@@ -2162,14 +2218,22 @@ export default function Installed() {
       // *different* file the user already owns (a second variant) reinstalls it
       // rather than deleting the source; guard on !archived so picking an old
       // file from the archived list never replaces a newer install.
+      const plannedUpdateSourceIds = detailsUpdatePlan.sourcesByTargetFileId.get(fileId);
+      const isPlannedUpdate = !!plannedUpdateSourceIds && plannedUpdateSourceIds.length > 0;
+      const isManualUpdate =
+        detailsUpdatePlan.unresolvedSourceIds.includes(sourceMod?.id ?? '') &&
+        detailsUpdateFileIds.has(fileId);
       const isUpdate =
         !!sourceMod &&
         detailsUpdateAvailable &&
-        !detailsInstalledFileIds.has(fileId) &&
-        !pickedIsArchived;
+        !pickedIsArchived &&
+        (isPlannedUpdate || isManualUpdate);
       const replacing = isReinstall || isUpdate;
       let replacementTargets: typeof mods = [];
-      if (replacing && sourceMod) {
+      if (isPlannedUpdate) {
+        const sourceIds = new Set(plannedUpdateSourceIds);
+        replacementTargets = mods.filter((mod) => sourceIds.has(mod.id));
+      } else if (replacing && sourceMod) {
         replacementTargets = mods.filter(
           (mod) =>
             mod.gameBananaId === sourceMod.gameBananaId &&
@@ -2200,7 +2264,15 @@ export default function Installed() {
         await deleteMod(mod.id);
       }
 
-      await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
+      const replacementAlreadyInstalled = mods.some(
+        (mod) =>
+          mod.gameBananaId === detailsMod.id &&
+          mod.gameBananaFileId === fileId &&
+          !replacementTargets.some((target) => target.id === mod.id),
+      );
+      if (!replacementAlreadyInstalled) {
+        await downloadMod(detailsMod.id, fileId, fileName, detailsSection, detailsCategoryId);
+      }
 
       // Replacement downloads land disabled with fresh metadata. Restore both
       // enabled state and the user's Global priority-root placement after
@@ -2230,19 +2302,33 @@ export default function Installed() {
         }
       }
 
+      // Always reconcile the store with what actually landed on disk, even when
+      // the state restore below failed.
+      await loadMods();
+
       // A restore failure is NOT an update failure: the new file is installed
       // and only its enabled/Global state is off. Throwing here would report a
-      // succeeded update as a failed one and skip the refresh below, so keep
-      // the overlay open on the explanation instead and always reconcile the
-      // store with what actually landed on disk.
+      // succeeded update as a failed one, so surface it in the overlay instead.
       if (restoreFailureMessage) {
         setDetailsError(restoreFailureMessage);
-      } else {
-        closeModDetails();
       }
-      loadMods();
+
+      // Keep the overlay open on the freshly installed file so the row flips to
+      // Installed/Active and the button to "Reinstall" in place. Re-anchor the
+      // source entry first: an update or reinstall deletes the old local id, and
+      // leaving it dangling would break the ignore-updates toggle and make a
+      // follow-up pick look like a variant add rather than a replacement.
+      const installed = useAppStore
+        .getState()
+        .mods.find((m) => m.gameBananaId === detailsMod.id && m.gameBananaFileId === fileId);
+      if (installed) setDetailsSourceModId(installed.id);
     } catch (err) {
-      setDetailsError(String(err));
+      // The error dialog below only renders when no mod is loaded, and the
+      // overlay now stays open through the install, so a failure has to be
+      // surfaced as a toast or it would be swallowed entirely.
+      showToast(String(err), { tone: 'error', duration: 6000 });
+    } finally {
+      releaseDownloadRequest(detailsMod.id, fileId);
     }
   });
 
@@ -2326,84 +2412,61 @@ export default function Installed() {
       const liveFiles = (details.files ?? []).filter((f) => !f.isArchived);
       const liveFileIds = new Set(liveFiles.map((f) => f.id));
 
-      // Resolve every snapshot to a target file *before* any delete/download
-      // runs, so an unrecoverable row keeps its existing install rather than
-      // getting deleted into a failed re-download.
-      //
-      // Pass 1: rows whose stored fileId is still a current file on GameBanana
-      // (genuine multi-file mods stay 1:1).
-      // Pass 2: rows whose fileId is gone or archived. First try to identify
-      // the replacement by the author's per-file description and filename
-      // token overlap (resolveUpdateTarget); then fall back to a single-file
-      // consolidation when the mod now ships exactly one current file. Rows
-      // with no confident match go to the manual-pick queue instead of being
-      // guessed at.
+      // Use the same per-file planner as the Installed and Browse detail
+      // popups, so Update-all cannot disagree with the row labelled Update.
+      // Resolve everything before any delete/download runs; unresolved rows
+      // keep their existing install and go to the manual-pick queue.
       type Resolution =
         | { ok: true; snapshot: (typeof snapshots)[number]; fileId: number; fileName: string }
         | { ok: false; snapshot: (typeof snapshots)[number]; reason: string };
-      const resolutions: Resolution[] = [];
-      const resolvedByOldFileId = new Map<number, { fileId: number; fileName: string }>();
-      // Track live files already installed as siblings outside this run. They
-      // are valid update destinations: if V5 is already installed beside the
-      // stale V4, updating V4 should remove it and transfer its enabled/Global
-      // state to V5 instead of silently refusing to act. Only uninstalled live
-      // files are "claimed" to prevent two unrelated stale variants from both
-      // being mapped to the same new download.
       const groupOldIds = new Set(group.map((s) => s.oldId));
-      const installedLiveIds = new Set<number>();
-      const claimedIds = new Set<number>();
-      for (const m of mods) {
-        if (m.gameBananaId !== group[0].gameBananaId || groupOldIds.has(m.id)) continue;
-        if (typeof m.gameBananaFileId === 'number' && liveFileIds.has(m.gameBananaFileId)) {
-          installedLiveIds.add(m.gameBananaFileId);
-        }
+      const plan = planFileUpdates(
+        group[0].gameBananaId,
+        details.files ?? [],
+        [
+          ...group.map((snapshot) => ({
+            id: snapshot.oldId,
+            gameBananaId: snapshot.gameBananaId,
+            gameBananaFileId: snapshot.gameBananaFileId,
+            installedFileId: snapshot.gameBananaFileId,
+            fileDescription: snapshot.fileDescription,
+            sourceFileName: snapshot.sourceFileName,
+          })),
+          ...mods
+            .filter(
+              (mod) =>
+                mod.gameBananaId === group[0].gameBananaId &&
+                !groupOldIds.has(mod.id) &&
+                typeof mod.gameBananaFileId === 'number' &&
+                liveFileIds.has(mod.gameBananaFileId),
+            )
+            .map((mod) => ({
+              id: mod.id,
+              gameBananaId: mod.gameBananaId,
+              gameBananaFileId: mod.gameBananaFileId,
+              installedFileId: mod.gameBananaFileId!,
+              fileDescription: mod.fileDescription,
+              sourceFileName: mod.sourceFileName,
+            })),
+        ],
+      );
+      const targetBySourceId = new Map<string, number>();
+      for (const [fileId, sourceIds] of plan.sourcesByTargetFileId) {
+        for (const sourceId of sourceIds) targetBySourceId.set(sourceId, fileId);
       }
-      for (const s of group) {
-        if (liveFileIds.has(s.gameBananaFileId)) {
-          resolutions.push({ ok: true, snapshot: s, fileId: s.gameBananaFileId, fileName: s.fileName });
-          claimedIds.add(s.gameBananaFileId);
-        }
-      }
-      for (const s of group) {
-        if (liveFileIds.has(s.gameBananaFileId)) continue;
-        const existingResolution = resolvedByOldFileId.get(s.gameBananaFileId);
-        if (existingResolution) {
-          resolutions.push({
-            ok: true,
-            snapshot: s,
-            fileId: existingResolution.fileId,
-            fileName: existingResolution.fileName,
-          });
-          continue;
-        }
-        const match = resolveUpdateTarget(
-          {
-            installedFileId: s.gameBananaFileId,
-            fileDescription: s.fileDescription,
-            sourceFileName: s.sourceFileName,
-          },
-          details.files ?? [],
-          claimedIds,
-        );
-        if (match) {
-          resolutions.push({ ok: true, snapshot: s, fileId: match.id, fileName: match.fileName });
-          resolvedByOldFileId.set(s.gameBananaFileId, { fileId: match.id, fileName: match.fileName });
-          if (!installedLiveIds.has(match.id)) claimedIds.add(match.id);
-        } else if (
-          liveFiles.length === 1 &&
-          (installedLiveIds.has(liveFiles[0].id) || !claimedIds.has(liveFiles[0].id))
-        ) {
-          resolutions.push({ ok: true, snapshot: s, fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
-          resolvedByOldFileId.set(s.gameBananaFileId, { fileId: liveFiles[0].id, fileName: liveFiles[0].fileName });
-          if (!installedLiveIds.has(liveFiles[0].id)) claimedIds.add(liveFiles[0].id);
-        } else {
-          resolutions.push({
-            ok: false,
-            snapshot: s,
-            reason: 'stored file is no longer current on GameBanana and no clear replacement match exists',
-          });
-        }
-      }
+      const resolutions: Resolution[] = group.map((snapshot) => {
+        const fileId = liveFileIds.has(snapshot.gameBananaFileId)
+          ? snapshot.gameBananaFileId
+          : targetBySourceId.get(snapshot.oldId);
+        const file = fileId === undefined ? undefined : liveFiles.find((candidate) => candidate.id === fileId);
+        return file
+          ? { ok: true, snapshot, fileId: file.id, fileName: file.fileName }
+          : {
+              ok: false,
+              snapshot,
+              reason: 'stored file is no longer current on GameBanana and no clear replacement match exists',
+            };
+      });
 
       // Capture a recovery snapshot before any delete runs in this group.
       // We only snapshot once per runUpdate invocation (guarded by the
@@ -4989,14 +5052,12 @@ export default function Installed() {
           installed={detailsInstalledFileIds.size > 0}
           installedFileIds={detailsInstalledFileIds}
           activeFileIds={detailsActiveFileIds}
-          downloadingFileId={null}
-          extracting={false}
-          progress={null}
           hideNsfwPreviews={installedHideNsfwPreviews}
           dateAdded={detailsDates?.dateAdded}
           dateModified={detailsDates?.dateModified}
           offline={detailsOffline}
           updateAvailable={detailsUpdateAvailable}
+          updateFileIds={detailsUpdateFileIds}
           ignoreUpdates={detailsIgnoreUpdates}
           onToggleIgnoreUpdates={
             detailsSourceModId ? handleToggleIgnoreUpdates : undefined

--- a/src/stores/appStore.loadMods.test.ts
+++ b/src/stores/appStore.loadMods.test.ts
@@ -66,4 +66,23 @@ describe('appStore loadMods refreshes', () => {
     expect(useAppStore.getState().modsLoading).toBe(false);
     expect(publications).toBe(0);
   });
+
+  it('starts a fresh generation when a post-mutation reload is forced', async () => {
+    let resolveFirst!: (mods: Mod[]) => void;
+    let resolveSecond!: (mods: Mod[]) => void;
+    getMods
+      .mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockReturnValueOnce(new Promise((resolve) => { resolveSecond = resolve; }));
+
+    const first = useAppStore.getState().loadMods();
+    const forced = useAppStore.getState().loadMods({ force: true });
+    expect(getMods).toHaveBeenCalledTimes(2);
+
+    resolveSecond([mod('after-mutation')]);
+    await forced;
+    resolveFirst([mod('stale')]);
+    await first;
+
+    expect(useAppStore.getState().mods.map((entry) => entry.id)).toEqual(['after-mutation']);
+  });
 });

--- a/src/stores/appStore.loadMods.test.ts
+++ b/src/stores/appStore.loadMods.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mod } from '../types/mod';
+import * as api from '../lib/api';
+import { useAppStore } from './appStore';
+
+vi.mock('../i18n', () => ({
+  default: { t: (key: string) => key },
+  applyLanguagePreference: vi.fn(),
+}));
+
+vi.mock('../lib/api', () => ({
+  getMods: vi.fn(),
+}));
+
+const getMods = vi.mocked(api.getMods);
+
+function mod(id: string): Mod {
+  return {
+    id,
+    name: id,
+    fileName: `${id}.vpk`,
+    path: `/addons/${id}.vpk`,
+    metaKey: `${id}.vpk`,
+    enabled: false,
+    priority: 1,
+    size: 0,
+    installedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('appStore loadMods refreshes', () => {
+  beforeEach(() => {
+    getMods.mockReset();
+    useAppStore.setState({
+      mods: [],
+      modsLoaded: false,
+      modsLoading: false,
+      modsError: null,
+    });
+  });
+
+  it('shares overlapping scans requested for the same generation', async () => {
+    let resolveScan!: (mods: Mod[]) => void;
+    getMods.mockReturnValueOnce(new Promise((resolve) => { resolveScan = resolve; }));
+
+    const first = useAppStore.getState().loadMods();
+    const second = useAppStore.getState().loadMods();
+    expect(getMods).toHaveBeenCalledTimes(1);
+
+    resolveScan([mod('one')]);
+    await Promise.all([first, second]);
+    expect(useAppStore.getState().mods.map((entry) => entry.id)).toEqual(['one']);
+  });
+
+  it('does not publish or enter loading state for an unchanged loaded library', async () => {
+    const existing = mod('one');
+    useAppStore.setState({ mods: [existing], modsLoaded: true });
+    getMods.mockResolvedValueOnce([{ ...existing }]);
+    let publications = 0;
+    const unsubscribe = useAppStore.subscribe(() => { publications += 1; });
+
+    await useAppStore.getState().loadMods();
+
+    unsubscribe();
+    expect(useAppStore.getState().mods).toEqual([existing]);
+    expect(useAppStore.getState().modsLoading).toBe(false);
+    expect(publications).toBe(0);
+  });
+});

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -36,6 +36,13 @@ const DOWNLOAD_COUNTS_TTL = 60 * 60 * 1000;
 // (the "added a custom mod but can't act on it until I refresh" bug).
 let modsGeneration = 0;
 
+// A download completion event and the renderer action that awaited that same
+// download can both request a rescan in the same instant. Share the scan while
+// it is current so one install does not publish the same library state twice.
+// Mutations bump modsGeneration, which deliberately makes an older in-flight
+// scan ineligible for reuse.
+let modsLoadInFlight: { generation: number; promise: Promise<void> } | null = null;
+
 // Serialize mod enable/disable toggles. A mod's id is its filename, which the
 // main process renames on every enable/disable, so two toggles fired in the same
 // tick (rapid Locker clicking, the exact repro in #bugs "disabled a lot of them
@@ -298,7 +305,9 @@ interface AppState {
   /** Reload the installed-mods list from the main process.
    *  Pass `{ silent: true }` to refresh without toggling `modsLoading`,
    *  so background refreshes (e.g. on window focus) don't replace the
-   *  page with the loading skeleton. */
+   *  page with the loading skeleton. Refreshes are silent by default once a
+   *  library has loaded; pass `{ silent: false }` only for an explicit blocking
+   *  reload. */
   loadMods: (opts?: { silent?: boolean }) => Promise<void>;
   /** Returns false when the toggle was blocked (e.g. the 99-enabled cap), so
    *  batch callers can stop early. */
@@ -596,27 +605,51 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Load mods from backend.
   // Silent refreshes (window focus, etc.) skip the loading flag so the UI
   // doesn't flash the skeleton over already-rendered content.
-  loadMods: async (opts) => {
-    const silent = !!opts?.silent;
+  loadMods: (opts) => {
+    const existing = modsLoadInFlight;
+    if (existing && existing.generation === modsGeneration) {
+      return existing.promise;
+    }
+
+    const silent = opts?.silent ?? get().modsLoaded;
     const gen = ++modsGeneration;
     if (!silent) set({ modsLoading: true, modsError: null });
-    try {
-      const scanned = await api.getMods();
-      if (gen === modsGeneration) {
-        const mods = reconcileMods(get().mods, scanned);
-        set(silent ? { mods, modsLoaded: true, modsError: null } : { mods, modsLoaded: true, modsLoading: false });
-      } else if (!silent) {
-        // Superseded by a newer load/mutation: drop the stale list, but still
-        // clear our own spinner so the page doesn't hang on it.
-        set({ modsLoading: false });
+    const promise = (async () => {
+      try {
+        const scanned = await api.getMods();
+        if (gen === modsGeneration) {
+          const state = get();
+          const mods = reconcileMods(state.mods, scanned);
+          if (silent) {
+            // Zustand notifies whole-store subscribers on every set(), even if
+            // every field value is unchanged. Avoid that no-op publication:
+            // it used to redraw the Installed grid after every duplicate
+            // completion/focus refresh.
+            if (mods !== state.mods || !state.modsLoaded || state.modsError !== null) {
+              set({ mods, modsLoaded: true, modsError: null });
+            }
+          } else {
+            set({ mods, modsLoaded: true, modsLoading: false });
+          }
+        } else if (!silent) {
+          // Superseded by a newer load/mutation: drop the stale list, but still
+          // clear our own spinner so the page doesn't hang on it.
+          set({ modsLoading: false });
+        }
+      } catch (err) {
+        if (gen === modsGeneration) {
+          set(silent ? { modsError: String(err) } : { modsError: String(err), modsLoading: false });
+        } else if (!silent) {
+          set({ modsLoading: false });
+        }
       }
-    } catch (err) {
-      if (gen === modsGeneration) {
-        set(silent ? { modsError: String(err) } : { modsError: String(err), modsLoading: false });
-      } else if (!silent) {
-        set({ modsLoading: false });
-      }
-    }
+    })();
+
+    modsLoadInFlight = { generation: gen, promise };
+    void promise.finally(() => {
+      if (modsLoadInFlight?.promise === promise) modsLoadInFlight = null;
+    });
+    return promise;
   },
 
   // Toggle mod enabled/disabled. Runs through enqueueToggle so concurrent

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -307,8 +307,9 @@ interface AppState {
    *  so background refreshes (e.g. on window focus) don't replace the
    *  page with the loading skeleton. Refreshes are silent by default once a
    *  library has loaded; pass `{ silent: false }` only for an explicit blocking
-   *  reload. */
-  loadMods: (opts?: { silent?: boolean }) => Promise<void>;
+   *  reload. Pass `{ force: true }` after a filesystem mutation so an older
+   *  in-flight scan cannot be reused. */
+  loadMods: (opts?: { silent?: boolean; force?: boolean }) => Promise<void>;
   /** Returns false when the toggle was blocked (e.g. the 99-enabled cap), so
    *  batch callers can stop early. */
   toggleMod: (modId: string) => Promise<boolean>;
@@ -453,7 +454,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ settings, settingsLoading: false });
       // Reload mods if path changed
       if (getActiveDeadlockPath(settings)) {
-        get().loadMods();
+        get().loadMods({ force: true });
       }
     } catch (err) {
       // A failed write deliberately leaves `settings` untouched, so the control
@@ -604,10 +605,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Load mods from backend.
   // Silent refreshes (window focus, etc.) skip the loading flag so the UI
-  // doesn't flash the skeleton over already-rendered content.
+  // doesn't flash the skeleton over already-rendered content. A forced refresh
+  // supersedes an older scan when a mutation or path change makes reuse unsafe.
   loadMods: (opts) => {
     const existing = modsLoadInFlight;
-    if (existing && existing.generation === modsGeneration) {
+    if (!opts?.force && existing && existing.generation === modsGeneration) {
       return existing.promise;
     }
 
@@ -684,7 +686,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       // found". The desired state is whatever the folder already reflects, so
       // resync silently instead of dropping the whole page to the error screen.
       if (/Mod not found/.test(String(err))) {
-        get().loadMods({ silent: true });
+        get().loadMods({ silent: true, force: true });
         return false;
       }
       set({ modsError: String(err) });
@@ -753,7 +755,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
-      get().loadMods();
+      get().loadMods({ force: true });
     }
   },
 
@@ -818,7 +820,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       } catch (err) {
         if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
         else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
-        get().loadMods();
+        get().loadMods({ force: true });
         return { failures: plan.enableIds.length + plan.disableIds.length };
       }
     });
@@ -844,7 +846,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
-      get().loadMods();
+      get().loadMods({ force: true });
       // The game-running lock is swallowed silently everywhere else (background
       // toggles), but a solo *launch* that does nothing needs a reason, so the
       // caller can surface it. Enable-cap already auto-toasts via modsNotice and
@@ -872,7 +874,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (err) {
       if (isEnableCapError(err)) { set({ modsNotice: ENABLE_CAP_NOTICE }); }
       else if (!isGameRunningModLockError(err)) { set({ modsError: String(err) }); }
-      get().loadMods();
+      get().loadMods({ force: true });
       return { failures: enable.length + disable.length };
     }
   }),
@@ -913,7 +915,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         // Reconcile any partial batch progress, then preserve the rejection for
         // the initiating surface. The picker and card menus own contextual
         // errors; swallowing here made them close as if a failed move worked.
-        await get().loadMods({ silent: true });
+        await get().loadMods({ silent: true, force: true });
         throw err;
       }
     });

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1004,8 +1004,9 @@ export interface ElectronAPI {
     // Download Queue
     getDownloadQueue: () => Promise<DownloadQueueItem[]>;
     getCurrentDownload: () => Promise<DownloadQueueItem | null>;
-    removeFromQueue: (modId: number) => Promise<boolean>;
+    removeFromQueue: (modId: number, fileId?: number) => Promise<boolean>;
     cancelActiveDownload: () => Promise<boolean>;
+    cancelDownloadTarget: (modId: number, fileId: number) => Promise<boolean>;
     onDownloadQueueUpdated: (callback: (data: DownloadQueueData) => void) => () => void;
 
     // GameBanana 1-Click protocol handler


### PR DESCRIPTION
## Summary

- promote an already-installed current replacement when updating a stale mod instead of leaving the update button inert
- centralize download activity for Browse, Installed, mod detail popups, and the global queue indicator
- show per-file Starting, Downloading, Extracting, and queued-position states while keeping sibling variants queueable
- plan update targets per file so alternate variants remain Install actions and only true replacements are labeled Update
- make Browse and Installed perform the same replace/reinstall flow, preserving enabled and Global placement state
- keep popup install state live after downloads, external one-click installs, toggles, and variant changes

## Verification

- `pnpm test` (85 files, 1063 tests)
- `pnpm typecheck`
- ESLint on all changed TypeScript/TSX files
- `pnpm build` with the required `GRIMOIRE_SOCIAL_BASE_URL` supplied
- pre-push i18n/locale manifest check