### PR TITLE
Fix installed card tag consistency

### DIFF
--- a/src/components/PriorityEditor.tsx
+++ b/src/components/PriorityEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Input } from './common/forms';
+import { Tag } from './common/ui';
 
 interface Props {
   modName: string;
@@ -110,24 +111,19 @@ export default function PriorityEditor({
           startEdit(e);
         }
       }}
-      className="group/order-chip relative inline-flex min-h-7 min-w-7 cursor-pointer items-center justify-center rounded-md focus:outline-none"
+      className="group/order-chip relative inline-flex cursor-pointer items-center justify-center rounded-sm focus:outline-none before:absolute before:-inset-1"
       aria-label={t('installed.priorityEditor.chipAriaLabel', { value })}
     >
-      <span
-        // White number on a neutral dark scrim (overlay) or the standard input
-        // surface (inline), with a subtle grey border so it reads as a quiet
-        // card chip rather than an accent-highlighted control. Neutral greys keep
-        // it on-theme regardless of the user's accent hue. The overlay sits over
-        // arbitrary thumbnail art, so the number gets a hard black outline
-        // (text-shadow on all four corners) to stay legible over bright covers.
-        className={`inline-flex h-[22px] min-w-[30px] items-center justify-center rounded-md border border-white/20 px-2 text-[11px] font-bold leading-none tabular-nums text-text-primary shadow-none transition-colors duration-150 group-hover/order-chip:border-white/35 group-hover/order-chip:bg-white/10 group-focus-visible/order-chip:outline group-focus-visible/order-chip:outline-2 group-focus-visible/order-chip:outline-white/40 ${
-          variant === 'overlay'
-            ? 'bg-black/70 [text-shadow:-1px_-1px_0_#000,1px_-1px_0_#000,-1px_1px_0_#000,1px_1px_0_#000,0_0_2px_#000]'
-            : 'bg-bg-tertiary'
-        }`}
+      <Tag
+        // The visible chip deliberately uses the same geometry, neutral tone,
+        // and image-safe overlay surface as the card's 18+ and state tags. The
+        // parent's pseudo-element keeps the larger click target without adding
+        // layout height (the old 28px wrapper pushed this tag below its peers).
+        variant={variant}
+        className="min-w-[28px] justify-center tabular-nums transition-colors duration-150 group-hover/order-chip:border-white/35 group-hover/order-chip:text-text-primary group-focus-visible/order-chip:outline group-focus-visible/order-chip:outline-2 group-focus-visible/order-chip:outline-white/40"
       >
         #{value}
-      </span>
+      </Tag>
       {!editing && (
         <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-bg-primary/95 px-2 py-1 text-[11px] font-medium text-text-secondary opacity-0 shadow-lg transition-opacity duration-150 group-hover/order-chip:opacity-100 group-focus-visible/order-chip:opacity-100">
           {t('installed.priorityEditor.loadOrder')}

--- a/src/lib/installedCardTaxonomy.test.ts
+++ b/src/lib/installedCardTaxonomy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { getInstalledCardTaxonomy } from './installedCardTaxonomy';
+
+describe('getInstalledCardTaxonomy', () => {
+  it('derives a hero from a hero category when locker metadata is absent', () => {
+    expect(getInstalledCardTaxonomy({ categoryName: 'Abrams' })).toEqual({
+      heroName: 'Abrams',
+      globalType: undefined,
+      categoryLabel: undefined,
+    });
+  });
+
+  it('prefers an explicit locker hero and keeps a non-hero category', () => {
+    expect(getInstalledCardTaxonomy({
+      lockerHero: 'Warden',
+      categoryName: 'Other/Misc',
+    })).toEqual({
+      heroName: 'Warden',
+      globalType: undefined,
+      categoryLabel: 'Other/Misc',
+    });
+  });
+
+  it('canonicalizes hero aliases from either metadata source', () => {
+    expect(getInstalledCardTaxonomy({ lockerHero: 'The Doorman' }).heroName).toBe('Doorman');
+    expect(getInstalledCardTaxonomy({ categoryName: 'The Doorman' }).heroName).toBe('Doorman');
+  });
+
+  it('uses a global classification instead of its redundant category', () => {
+    expect(getInstalledCardTaxonomy({
+      globalType: 'hud',
+      categoryName: 'HUD',
+    })).toEqual({
+      heroName: undefined,
+      globalType: 'hud',
+      categoryLabel: undefined,
+    });
+  });
+
+  it('derives supported global sound categories', () => {
+    expect(getInstalledCardTaxonomy({
+      sourceSection: 'Sound',
+      categoryName: 'Announcer',
+    })).toEqual({
+      heroName: undefined,
+      globalType: 'announcer',
+      categoryLabel: undefined,
+    });
+  });
+
+  it('returns a trimmed non-hero category as the sole text label', () => {
+    expect(getInstalledCardTaxonomy({ categoryName: '  Quality of Life  ' })).toEqual({
+      heroName: undefined,
+      globalType: undefined,
+      categoryLabel: 'Quality of Life',
+    });
+  });
+});

--- a/src/lib/installedCardTaxonomy.ts
+++ b/src/lib/installedCardTaxonomy.ts
@@ -1,0 +1,52 @@
+import type { GlobalModType, Mod } from '../types/mod';
+import {
+  HERO_NAMES,
+  canonicalHeroName,
+  getEffectiveGlobalType,
+} from './lockerUtils';
+
+export type InstalledCardTaxonomyInput = Pick<
+  Mod,
+  'categoryName' | 'globalType' | 'lockerHero' | 'sourceSection'
+>;
+
+export interface InstalledCardTaxonomy {
+  /** Canonical hero identity shown by the card, regardless of metadata source. */
+  heroName?: string;
+  /** Locker-wide classification. Supersedes the GameBanana category label. */
+  globalType?: GlobalModType;
+  /** Non-hero GameBanana category shown when no global classification exists. */
+  categoryLabel?: string;
+}
+
+function heroFromCategory(categoryName?: string): string | undefined {
+  const needle = categoryName?.trim().toLowerCase();
+  if (!needle) return undefined;
+  const rosterName = HERO_NAMES.find((name) => name.toLowerCase() === needle);
+  return rosterName ? canonicalHeroName(rosterName) : undefined;
+}
+
+/**
+ * Resolve the single taxonomy model shared by Installed's grid, compact, and
+ * list cards. Display size must only affect presentation, never which metadata
+ * survives. The persisted Locker global classification wins over a GameBanana
+ * category; otherwise a hero category becomes the hero identity, and a
+ * non-hero category remains a text label.
+ */
+export function getInstalledCardTaxonomy(
+  mod: InstalledCardTaxonomyInput,
+): InstalledCardTaxonomy {
+  const globalType = getEffectiveGlobalType(mod);
+  const explicitHero = canonicalHeroName(mod.lockerHero) || undefined;
+  const categoryHero = globalType ? undefined : heroFromCategory(mod.categoryName);
+  const heroName = explicitHero ?? categoryHero;
+  const categoryLabel = !globalType && !categoryHero
+    ? mod.categoryName?.trim() || undefined
+    : undefined;
+
+  return {
+    heroName,
+    globalType,
+    categoryLabel,
+  };
+}

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -8177,7 +8177,11 @@ function ModCard({
         : 'h-7 rounded-lg px-2.5 text-[12px]';
   const tagIconClassName =
     viewMode === 'list' ? 'h-[18px] w-[18px]' : viewMode === 'compact' ? 'h-5 w-5' : 'h-[22px] w-[22px]';
-  const baseChipClasses = `inline-flex min-w-0 ${chipMaxClass} ${chipSizeClasses} items-center overflow-hidden font-semibold leading-none`;
+  // A compact text chip must retain enough width to show actual content; zero
+  // was technically valid to flexbox and produced the orphaned border seen on
+  // the smallest cards.
+  const chipMinClass = viewMode === 'compact' ? 'min-w-9' : 'min-w-0';
+  const baseChipClasses = `inline-flex ${chipMinClass} ${chipMaxClass} ${chipSizeClasses} items-center overflow-hidden font-semibold leading-none`;
   const metaChipClasses = `${baseChipClasses} border border-white/[0.06] bg-bg-tertiary/65 text-text-secondary/80`;
   const manualTagChipClasses = `${baseChipClasses} border border-accent/30 bg-accent/10 text-accent`;
   const inferredTagChipClasses = `${baseChipClasses} border border-sky-400/35 bg-sky-500/15 text-sky-100`;
@@ -8311,6 +8315,11 @@ function ModCard({
           onCreateNew={onCreateList}
         />
       )}
+      {onToggleFavorite && (
+        <MenuItem icon={Star} onSelect={onToggleFavorite}>
+          {favoriteLabel}
+        </MenuItem>
+      )}
       <MenuItem icon={FolderOpen} onSelect={handleRevealInFolder}>
         {t('installed.card.revealInFolder')}
       </MenuItem>
@@ -8426,7 +8435,11 @@ function ModCard({
 
   const actions = (
     <div className="ml-auto flex items-center gap-1">
-      {onToggleFavorite && (
+      {/* At compact size the direct favorite/delete buttons consumed 56px even
+          while transparent, squeezing the adjacent taxonomy chip down to a
+          one-pixel border. Both actions remain available from the kebab and
+          right-click menus; larger cards keep their faster hover affordances. */}
+      {onToggleFavorite && !isCompact && (
         <button
           type="button"
           onPointerDown={(event) => event.stopPropagation()}
@@ -8443,7 +8456,7 @@ function ModCard({
           <Star className={`h-4 w-4 ${favorite ? 'fill-current' : ''}`} />
         </button>
       )}
-      {!mod.merged && (
+      {!mod.merged && !isCompact && (
         <button
           type="button"
           onClick={(e) => {
@@ -8707,7 +8720,7 @@ function ModCard({
             onRename={onRenameLocal}
           />
           <div
-            className={`${isCompact ? 'mt-1.5 h-7' : 'mt-1'} grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-3`}
+            className={`${isCompact ? 'mt-1.5 h-7 gap-1.5' : 'mt-1 gap-3'} grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end`}
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             <div className={`flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary ${gridTagsClasses}`}>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -112,6 +112,7 @@ import { IMAGE_EXTS, deriveModNameFromPath } from '../lib/customModImport';
 import { Modal } from '../components/common/Modal';
 import { useBackdropDismiss } from '../components/common/useBackdropDismiss';
 import { inferHeroFromTitle, getHeroRenderPath, getHeroFacePosition, getHeroChipIconPath, HERO_NAMES, HERO_NAMES_SORTED, canonicalHeroName, GLOBAL_MOD_TYPE_ORDER, GLOBAL_MOD_TYPE_LABELS, getEffectiveGlobalType, modLoadOrder } from '../lib/lockerUtils';
+import { getInstalledCardTaxonomy, type InstalledCardTaxonomy } from '../lib/installedCardTaxonomy';
 import { formatRelativeDate, formatAbsoluteDate } from '../lib/dates';
 import { useStableCallback } from '../lib/useStableCallback';
 import { isDownloadRequestPending, releaseDownloadRequest, requestDownload } from '../lib/downloadActivity';
@@ -7554,6 +7555,7 @@ function ModMediaPreview({
 
 interface ModListRowContentProps {
   mod: ModCardProps['mod'];
+  taxonomy: InstalledCardTaxonomy;
   hideNsfwPreviews: boolean;
   soundVolume: number;
   onOpenDetails?: () => void;
@@ -7603,7 +7605,7 @@ function HeroTagLabel({ heroName, iconClassName = 'h-4 w-4', iconOnly = false }:
         className={`${iconClassName} block flex-shrink-0 rounded-full object-cover`}
         loading="lazy"
       />
-      {!iconOnly && <ChipText>{heroName}</ChipText>}
+      {iconOnly ? <span className="sr-only">{heroName}</span> : <ChipText>{heroName}</ChipText>}
     </span>
   );
 }
@@ -7799,6 +7801,7 @@ function EditableModTitle({
 
 function ModListRowContent({
   mod,
+  taxonomy,
   hideNsfwPreviews,
   soundVolume,
   onOpenDetails,
@@ -7826,6 +7829,9 @@ function ModListRowContent({
     : null;
   const listHeroRenderUrl = listHeroName ? getHeroRenderPath(listHeroName) : null;
   const listHeroFacePosX = listHeroName ? getHeroFacePosition(listHeroName).x : 50;
+  const taxonomyLabel = taxonomy.globalType
+    ? (GLOBAL_MOD_TYPE_LABELS[taxonomy.globalType] ?? taxonomy.globalType)
+    : taxonomy.categoryLabel;
 
   return (
     <>
@@ -7899,17 +7905,33 @@ function ModListRowContent({
           onRename={onRenameLocal}
         />
         <div className="flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap text-[11px] leading-[24px] text-text-secondary">
-          <LockerHeroChip
-            mod={mod}
-            manualTagChipClasses={manualTagChipClasses}
-            inferredTagChipClasses={inferredTagChipClasses}
-            iconClassName={tagIconClassName}
-          />
-          {mod.categoryName && (
-            <CategoryChip
-              label={mod.categoryName}
+          {!mod.enabled && mod.priorityMod && (
+            <MetaTextChip
+              label={t('installed.priority.chip')}
+              className={manualTagChipClasses}
+              title={t('installed.priority.hint')}
+            />
+          )}
+          {taxonomy.heroName && (
+            mod.lockerHero ? (
+              <LockerHeroChip
+                mod={mod}
+                manualTagChipClasses={manualTagChipClasses}
+                inferredTagChipClasses={inferredTagChipClasses}
+                iconClassName={tagIconClassName}
+              />
+            ) : (
+              <CategoryChip
+                label={taxonomy.heroName}
+                className={metaChipClasses}
+                iconClassName={tagIconClassName}
+              />
+            )
+          )}
+          {taxonomyLabel && (
+            <MetaTextChip
+              label={taxonomyLabel}
               className={metaChipClasses}
-              iconClassName={tagIconClassName}
             />
           )}
           {mod.nsfw && (
@@ -8213,9 +8235,9 @@ function ModCard({
   // Locker global axis (HUD, Soul Containers, ...). Surfaced as a card chip so a
   // manual or auto global tag is visible here, not just in the Locker. A global
   // mod has no hero, so the two chips never both show.
-  const cardGlobalType = getEffectiveGlobalType(mod);
-  const cardGlobalLabel = cardGlobalType
-    ? (GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType)
+  const cardTaxonomy = getInstalledCardTaxonomy(mod);
+  const cardGlobalLabel = cardTaxonomy.globalType
+    ? (GLOBAL_MOD_TYPE_LABELS[cardTaxonomy.globalType] ?? cardTaxonomy.globalType)
     : undefined;
   // One stable taxonomy model for every grid size:
   //   1. the hero identity, when present (bare portrait);
@@ -8225,9 +8247,7 @@ function ModCard({
   // therefore does not also need a text chip. Previously compact cards counted
   // available slots and silently dropped later tags, which made the same mod
   // appear to have different metadata as the size slider crossed a breakpoint.
-  const categoryHeroName = heroNameForLabel(mod.categoryName);
-  const cardHeroName = canonicalHeroName(mod.lockerHero) ?? categoryHeroName;
-  const cardTaxonomyLabel = cardGlobalLabel ?? (categoryHeroName ? undefined : mod.categoryName);
+  const cardTaxonomyLabel = cardGlobalLabel ?? cardTaxonomy.categoryLabel;
   // Enabled cards get their own copy: pinning only takes effect once the mod is
   // disabled, and the disabled section's "top of disabled mods" wording would be
   // a lie there.
@@ -8515,6 +8535,7 @@ function ModCard({
         {isList ? (
           <ModListRowContent
             mod={mod}
+            taxonomy={cardTaxonomy}
             hideNsfwPreviews={hideNsfwPreviews}
             soundVolume={soundVolume}
             onOpenDetails={onOpenDetails}
@@ -8571,10 +8592,20 @@ function ModCard({
               )
             )}
             {!mod.enabled && !selectMode && (
-              <div className="absolute top-2 left-2 z-10 flex h-5 items-start">
+              <div className="absolute top-2 left-2 z-10 flex flex-col items-start gap-1">
                 <Tag tone="neutral" variant="overlay" icon={PowerOff} title={t('locker.global.disabledBadgeTitle')}>
                   {t('locker.global.disabledBadge')}
                 </Tag>
+                {mod.priorityMod && (
+                  <Tag
+                    tone="accent"
+                    variant="overlay"
+                    icon={ArrowUpToLine}
+                    title={t('installed.priority.hint')}
+                  >
+                    {t('installed.priority.chip')}
+                  </Tag>
+                )}
               </div>
             )}
               <div className="absolute top-2 right-2 z-10 flex flex-col items-end gap-1">
@@ -8680,15 +8711,13 @@ function ModCard({
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             <div className={`flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary ${gridTagsClasses}`}>
-              {cardHeroName && (
+              {cardTaxonomy.heroName && (
                 <span
                   className="inline-flex flex-shrink-0 items-center"
-                  title={mod.lockerHero
-                    ? `${lockerHeroSourceLabel(mod.lockerHeroSource)}: ${cardHeroName}`
-                    : `GameBanana category: ${cardHeroName}`}
+                  title={cardTaxonomy.heroName}
                 >
                   <HeroTagLabel
-                    heroName={cardHeroName}
+                    heroName={cardTaxonomy.heroName}
                     iconClassName={tagIconClassName}
                     iconOnly
                   />
@@ -8698,9 +8727,6 @@ function ModCard({
                 <MetaTextChip
                   label={cardTaxonomyLabel}
                   className={metaChipClasses}
-                  title={cardGlobalLabel
-                    ? `Locker: ${cardGlobalLabel}`
-                    : `GameBanana category: ${cardTaxonomyLabel}`}
                 />
               )}
             </div>

--- a/src/pages/Installed.tsx
+++ b/src/pages/Installed.tsx
@@ -8146,7 +8146,7 @@ function ModCard({
       ? 'shadow-[3px_3px_0_0_var(--color-bg-secondary),3px_3px_0_1px_var(--color-border),6px_6px_0_0_var(--color-bg-secondary),6px_6px_0_1px_var(--color-border)] mr-1.5 mb-1.5'
       : '';
   const chipMaxClass =
-    viewMode === 'compact' ? 'max-w-[152px]' : viewMode === 'list' ? 'max-w-[148px]' : 'max-w-[170px]';
+    viewMode === 'compact' ? 'max-w-[132px]' : viewMode === 'list' ? 'max-w-[148px]' : 'max-w-[170px]';
   const chipSizeClasses =
     viewMode === 'list'
       ? 'h-6 rounded-[7px] px-2 text-[11px]'
@@ -8206,9 +8206,9 @@ function ModCard({
   const titleClasses = isCompact
     ? 'text-[14px] font-semibold leading-[18px] truncate'
     : 'text-[15px] font-medium leading-[18px] truncate';
-  // Grid footers stay single-line. The hover-only date can appear after the
-  // chips when there is room, but it must never wrap into a second line and
-  // resize the card.
+  // Grid footers stay single-line. Classification is deliberately limited to
+  // one hero identity plus one text label below, so resizing a card never
+  // changes *which* tags it shows.
   const gridTagsClasses = viewMode === 'compact' ? 'h-[26px] flex-nowrap' : 'h-7 flex-nowrap';
   // Locker global axis (HUD, Soul Containers, ...). Surfaced as a card chip so a
   // manual or auto global tag is visible here, not just in the Locker. A global
@@ -8217,18 +8217,17 @@ function ModCard({
   const cardGlobalLabel = cardGlobalType
     ? (GLOBAL_MOD_TYPE_LABELS[cardGlobalType] ?? cardGlobalType)
     : undefined;
-  // A globally-classified mod (HUD, Soul Containers, ...) already shows the
-  // Locker global chip, which makes the GameBanana category chip redundant: for
-  // HUD it was literally rendering "HUD" twice (category + global). Suppress the
-  // category chip whenever a global chip is present and let it stand in.
-  const showCategoryChip =
-    (viewMode !== 'compact' || !mod.lockerHero) && !cardGlobalType;
-  const compactBaseChipCount =
-    (mod.lockerHero ? 1 : 0) + (showCategoryChip && mod.categoryName ? 1 : 0);
-  const showGlobalChip = !!cardGlobalType && (!isCompact || compactBaseChipCount < 2);
-  const compactChipCount = compactBaseChipCount + (showGlobalChip ? 1 : 0);
-  const showNsfwChip = !!mod.nsfw && (!isCompact || compactChipCount < 2);
-  const showGroupChip = !!group && (!isCompact || compactChipCount + (showNsfwChip ? 1 : 0) < 2);
+  // One stable taxonomy model for every grid size:
+  //   1. the hero identity, when present (bare portrait);
+  //   2. either the Locker global type or the GameBanana category (one label).
+  // Global classification supersedes category because those labels are often
+  // identical (HUD/HUD). A hero category is represented by the portrait and
+  // therefore does not also need a text chip. Previously compact cards counted
+  // available slots and silently dropped later tags, which made the same mod
+  // appear to have different metadata as the size slider crossed a breakpoint.
+  const categoryHeroName = heroNameForLabel(mod.categoryName);
+  const cardHeroName = canonicalHeroName(mod.lockerHero) ?? categoryHeroName;
+  const cardTaxonomyLabel = cardGlobalLabel ?? (categoryHeroName ? undefined : mod.categoryName);
   // Enabled cards get their own copy: pinning only takes effect once the mod is
   // disabled, and the disabled section's "top of disabled mods" wording would be
   // a lie there.
@@ -8579,6 +8578,16 @@ function ModCard({
               </div>
             )}
               <div className="absolute top-2 right-2 z-10 flex flex-col items-end gap-1">
+              {mod.nsfw && (
+                <Tag
+                  tone="danger"
+                  variant="overlay"
+                  title={t('modThumbnail.nsfw')}
+                  className="uppercase tracking-wide"
+                >
+                  18+
+                </Tag>
+              )}
               {hasConflicts && (
                 <Tag
                   tone="warning"
@@ -8671,56 +8680,28 @@ function ModCard({
             title={`${mod.fileName} | ${formatBytes(mod.size)} | installed ${formatAbsoluteDate(mod.installedAt)}`}
           >
             <div className={`flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary ${gridTagsClasses}`}>
-              {mod.priorityMod && (
-                <MetaTextChip
-                  label={t('installed.priority.chip')}
-                  className={manualTagChipClasses}
-                  title={t('installed.priority.hint')}
-                />
-              )}
-              <LockerHeroChip
-                mod={mod}
-                manualTagChipClasses={manualTagChipClasses}
-                inferredTagChipClasses={inferredTagChipClasses}
-                iconClassName={tagIconClassName}
-                iconOnly
-              />
-              {showGlobalChip && cardGlobalLabel && (
-                <MetaTextChip
-                  label={cardGlobalLabel}
-                  className={metaChipClasses}
-                  title={`Locker: ${cardGlobalLabel}`}
-                />
-              )}
-              {showCategoryChip && mod.categoryName && heroNameForLabel(mod.categoryName) !== mod.lockerHero && (
-                <CategoryChip
-                  label={mod.categoryName}
-                  className={metaChipClasses}
-                  iconClassName={tagIconClassName}
-                  iconOnly
-                />
-              )}
-              {showNsfwChip && (
-                <MetaTextChip label="18+" className={dangerInlineChipClasses} />
-              )}
-              {showGroupChip && (
-                // Enabled/total variant count as a quiet icon + number (no accent,
-                // no border, no "files" label) so it reads as metadata, not a tag.
+              {cardHeroName && (
                 <span
-                  className="inline-flex flex-shrink-0 items-center gap-1 text-[11px] tabular-nums text-text-secondary"
-                  title={variantStatusTitle}
+                  className="inline-flex flex-shrink-0 items-center"
+                  title={mod.lockerHero
+                    ? `${lockerHeroSourceLabel(mod.lockerHeroSource)}: ${cardHeroName}`
+                    : `GameBanana category: ${cardHeroName}`}
                 >
-                  <Files className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
-                  {variantStatusLabel}
+                  <HeroTagLabel
+                    heroName={cardHeroName}
+                    iconClassName={tagIconClassName}
+                    iconOnly
+                  />
                 </span>
               )}
-              {!isCompact && (
-                <span
-                  className="hidden flex-shrink-0 items-center pl-1.5 text-[11px] tabular-nums text-text-secondary/55 group-hover/card:inline-flex"
-                  title={`Installed ${formatAbsoluteDate(mod.installedAt)}`}
-                >
-                  {formatRelativeDate(mod.installedAt)}
-                </span>
+              {cardTaxonomyLabel && (
+                <MetaTextChip
+                  label={cardTaxonomyLabel}
+                  className={metaChipClasses}
+                  title={cardGlobalLabel
+                    ? `Locker: ${cardGlobalLabel}`
+                    : `GameBanana category: ${cardTaxonomyLabel}`}
+                />
               )}
             </div>
 


### PR DESCRIPTION
## Summary

- make Installed grid-card taxonomy deterministic across card sizes
- share the same hero/category/global resolver across grid, compact, and list views
- preserve Global status for disabled priority-root mods
- move the 18+ marker into the thumbnail status stack on grid cards
- remove hover-only and duplicated metadata from the grid tag row
- keep icon-only hero identities accessible to assistive technology

## Validation

- `pnpm typecheck`
- `pnpm eslint src/pages/Installed.tsx src/lib/installedCardTaxonomy.ts src/lib/installedCardTaxonomy.test.ts`
- `pnpm test` (1,080 tests)
- `GRIMOIRE_SOCIAL_BASE_URL=https://grimoire-social.example.workers.dev pnpm build`