### PR TITLE
fix(nix): refresh the pnpm-deps hash and guard it in CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,63 @@
+name: Nix
+
+# The from-source Nix package vendors the pnpm store as a fixed-output
+# derivation, so nix/grimoire.nix carries a hash of the whole dependency set.
+# Every pnpm-lock.yaml change invalidates it, and nothing in CI noticed until
+# a downstream build failed with "hash mismatch in fixed-output derivation".
+# This job rebuilds that store on the PR that moves the lockfile, so the hash
+# is bumped in the same change that breaks it.
+#
+# The full `nix build .#grimoire` (electron-vite + electron-builder + a
+# better-sqlite3 rebuild) is deliberately not run here: it costs far more
+# runner time than the failure it would catch, which is Electron API drift
+# rather than lockfile drift.
+
+on:
+  pull_request:
+    paths:
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      # .npmrc and pnpm-workspace.yaml steer resolution, so they can move
+      # the fetched store without the lockfile changing shape.
+      - '.npmrc'
+      - 'pnpm-workspace.yaml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.github/workflows/nix.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      # .npmrc and pnpm-workspace.yaml steer resolution, so they can move
+      # the fetched store without the lockfile changing shape.
+      - '.npmrc'
+      - 'pnpm-workspace.yaml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.github/workflows/nix.yml'
+  workflow_dispatch:
+
+jobs:
+  pnpm-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout grimoire
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      # Catches eval-level rot: a nixpkgs attribute that disappeared
+      # (pnpm_9 and Electron majors both get dropped), a syntax error, or a
+      # devShell that no longer evaluates. No derivation is built.
+      - name: Evaluate flake
+        run: nix flake check --no-build
+
+      # The actual guard. Fails with the correct replacement hash in the
+      # error when nix/grimoire.nix has gone stale.
+      - name: Build vendored pnpm store
+        run: nix build --no-link .#grimoire.pnpmDeps

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "grimoire-social": {
       "flake": false,
       "locked": {
-        "lastModified": 1779261108,
-        "narHash": "sha256-f+wUZOR7dqigxd/IZtay1BrLS5rcSnaDage3NXxqsPE=",
+        "lastModified": 1785648456,
+        "narHash": "sha256-AR2rTNDuge19t+VAqL/I6dmB8f5niIqINmNnRL70k94=",
         "owner": "Slush97",
         "repo": "grimoire-social",
-        "rev": "efffe0b92a49d6cc8d82406d6fc163c2fd3662a5",
+        "rev": "e97a59d7cd55fc1ae1e11a56ca2fde5305de9c4f",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1787070829,
+        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
         "type": "github"
       },
       "original": {

--- a/nix/grimoire.nix
+++ b/nix/grimoire.nix
@@ -58,9 +58,13 @@ stdenv.mkDerivation (finalAttrs: {
     postUnpack = siblingPostUnpack;
     inherit pnpm;
     # The hash changes when pnpm-lock.yaml, the pinned pnpm major,
-    # fetcherVersion, or social-types' package.json change.
+    # fetcherVersion, or social-types' package.json change. Refresh it with
+    #   nix build --no-link .#grimoire.pnpmDeps
+    # and copy the "got:" value from the mismatch. The Nix workflow
+    # (.github/workflows/nix.yml) runs that build on every PR that touches
+    # pnpm-lock.yaml, so a stale hash fails CI instead of downstream users.
     fetcherVersion = 4;
-    hash = "sha256-1KfyeNRXK441zLpScEDi+fXw9+XpZYOyeoExG4nZuwY=";
+    hash = "sha256-crXSQwOoecPtxlgzf+I2i35VPwTB6cEXWz2zx+esvBI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Refresh nix/grimoire.nix dep hash, add .github/workflows/nix.yml so the next pnpm lockfile change fails in CI with the replacement hash instead of failing downstream.