### PR TITLE
chore(release): v1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grimoire",
   "private": true,
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Grimoire - A mod manager for Deadlock",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Version bump for the v1.28.0 release. See the tag for release notes.