### PR TITLE
feat: add OLED mode

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, shell, session, protocol, nativeTheme, screen } from 'electron';
+import { windowBackgroundColor } from '../../src/lib/oledMode';
 import { join, resolve } from 'path';
 import { pathToFileURL } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -254,6 +255,7 @@ function resolveInitialBounds(): {
 
 function createWindow(): void {
     const initial = resolveInitialBounds();
+    const oledMode = loadSettings().oledMode;
     mainWindow = new BrowserWindow({
         width: initial.width,
         height: initial.height,
@@ -264,7 +266,7 @@ function createWindow(): void {
         minHeight: MIN_WINDOW_HEIGHT,
         title: 'Grimoire',
         show: false, // Don't show until ready to prevent white flash
-        backgroundColor: '#0f0f0f', // Dark background matching app theme
+        backgroundColor: windowBackgroundColor(oledMode),
         autoHideMenuBar: true,
         // Standard native frame on every platform. themeSource is forced to
         // 'dark' above, so Windows draws its title bar dark; the previous

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -103,7 +103,7 @@ import './ipc/forge';
 
 import { initUpdater, checkForUpdates, getInstallSource } from './services/updater';
 import { runStartupRecovery } from './ipc/launch';
-import { loadSettings, saveSettings } from './services/settings';
+import { loadSettings, saveSettings, type AppSettings } from './services/settings';
 import {
     configureForgeBridge,
     requestForgeEnable,
@@ -215,14 +215,13 @@ const MIN_WINDOW_HEIGHT = 600;
  * would strand the window offscreen. When the saved spot is gone (or nothing
  * was saved yet) we omit x/y so Electron centers on the primary display.
  */
-function resolveInitialBounds(): {
+function resolveInitialBounds(saved: AppSettings['windowBounds']): {
     width: number;
     height: number;
     x?: number;
     y?: number;
     isMaximized: boolean;
 } {
-    const saved = loadSettings().windowBounds;
     if (!saved) {
         return { width: DEFAULT_WINDOW_WIDTH, height: DEFAULT_WINDOW_HEIGHT, isMaximized: false };
     }
@@ -254,8 +253,8 @@ function resolveInitialBounds(): {
 }
 
 function createWindow(): void {
-    const initial = resolveInitialBounds();
-    const oledMode = loadSettings().oledMode;
+    const settings = loadSettings();
+    const initial = resolveInitialBounds(settings.windowBounds);
     mainWindow = new BrowserWindow({
         width: initial.width,
         height: initial.height,
@@ -266,7 +265,7 @@ function createWindow(): void {
         minHeight: MIN_WINDOW_HEIGHT,
         title: 'Grimoire',
         show: false, // Don't show until ready to prevent white flash
-        backgroundColor: windowBackgroundColor(oledMode),
+        backgroundColor: windowBackgroundColor(settings.oledMode),
         autoHideMenuBar: true,
         // Standard native frame on every platform. themeSource is forced to
         // 'dark' above, so Windows draws its title bar dark; the previous
@@ -278,6 +277,10 @@ function createWindow(): void {
             contextIsolation: true,
             nodeIntegration: false,
             sandbox: true,
+            // Lets the renderer apply the OLED theme before its first paint,
+            // instead of waiting on the async settings IPC (which flashed the
+            // default grey canvas). Read in the preload via process.argv.
+            additionalArguments: settings.oledMode ? ['--grimoire-oled'] : [],
         },
     });
 

--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -1,5 +1,6 @@
-import { ipcMain } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 import { loadSettings, saveSettings, type AppSettings } from '../services/settings';
+import { windowBackgroundColor } from '../../../src/lib/oledMode';
 import { detectDeadlockPath, looksLikeDeadlockPath } from '../services/deadlock';
 import { ensureDevDeadlockPath } from '../services/dev';
 import { syncForgeBridgeWithSettings } from '../services/forgeBridge';
@@ -29,6 +30,9 @@ ipcMain.handle('get-settings', (): AppSettings => {
 // set-settings
 ipcMain.handle('set-settings', (_, settings: AppSettings): void => {
     saveSettings(settings);
+    for (const window of BrowserWindow.getAllWindows()) {
+        window.setBackgroundColor(windowBackgroundColor(settings.oledMode));
+    }
     // Bring the DeadlockForge bridge up or down to match. Toggling it off must
     // actually close the socket, not just start refusing requests on it.
     void syncForgeBridgeWithSettings();

--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -1,6 +1,6 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 import { loadSettings, saveSettings, type AppSettings } from '../services/settings';
-import { windowBackgroundColor } from '../../../src/lib/oledMode';
+import { syncWindowBackgroundWithSettings } from '../services/windowBackground';
 import { detectDeadlockPath, looksLikeDeadlockPath } from '../services/deadlock';
 import { ensureDevDeadlockPath } from '../services/dev';
 import { syncForgeBridgeWithSettings } from '../services/forgeBridge';
@@ -30,9 +30,7 @@ ipcMain.handle('get-settings', (): AppSettings => {
 // set-settings
 ipcMain.handle('set-settings', (_, settings: AppSettings): void => {
     saveSettings(settings);
-    for (const window of BrowserWindow.getAllWindows()) {
-        window.setBackgroundColor(windowBackgroundColor(settings.oledMode));
-    }
+    syncWindowBackgroundWithSettings();
     // Bring the DeadlockForge bridge up or down to match. Toggling it off must
     // actually close the socket, not just start refusing requests on it.
     void syncForgeBridgeWithSettings();

--- a/electron/main/services/settings.ts
+++ b/electron/main/services/settings.ts
@@ -35,6 +35,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     ignoredConflictFilesGlobal: [],
     ignoredConflictMods: [],
     accentColor: '#f97316',
+    oledMode: false,
     sidebarHeroHighlight: 'Abrams',
     dateFormat: 'MM/DD/YYYY',
     language: null,

--- a/electron/main/services/settingsMigration.test.ts
+++ b/electron/main/services/settingsMigration.test.ts
@@ -95,3 +95,17 @@ describe('loadSettings hidden creator normalization', () => {
     expect(loadSettings().hiddenCreators).toEqual([{ id: 12, name: 'Valid' }]);
   });
 });
+
+describe('loadSettings OLED mode', () => {
+  it('defaults OLED mode to off for existing settings', () => {
+    writeFileSync(settingsPath(), JSON.stringify({}));
+
+    expect(loadSettings().oledMode).toBe(false);
+  });
+
+  it('keeps an enabled OLED mode from saved settings', () => {
+    writeFileSync(settingsPath(), JSON.stringify({ oledMode: true }));
+
+    expect(loadSettings().oledMode).toBe(true);
+  });
+});

--- a/electron/main/services/windowBackground.ts
+++ b/electron/main/services/windowBackground.ts
@@ -1,0 +1,15 @@
+import { BrowserWindow } from 'electron';
+import { loadSettings } from './settings';
+import { windowBackgroundColor } from '../../../src/lib/oledMode';
+
+/**
+ * Repaint every window's native background to match the saved OLED setting.
+ * Called after any settings save, like syncForgeBridgeWithSettings; new
+ * windows get the color at construction via windowBackgroundColor.
+ */
+export function syncWindowBackgroundWithSettings(): void {
+    const color = windowBackgroundColor(loadSettings().oledMode);
+    for (const window of BrowserWindow.getAllWindows()) {
+        window.setBackgroundColor(color);
+    }
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -87,6 +87,10 @@ import type {
 contextBridge.exposeInMainWorld('electronAPI', {
     platform: process.platform,
 
+    // Saved OLED setting, forwarded by main via additionalArguments so the
+    // renderer can theme itself before the settings IPC round-trip resolves.
+    initialOledMode: process.argv.includes('--grimoire-oled'),
+
     // Settings
     detectDeadlock: () => ipcRenderer.invoke('detect-deadlock'),
     validateDeadlockPath: (path: string) => ipcRenderer.invoke('validate-deadlock-path', path),

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import { getSettings, setSettings, getGameinfoStatus, fixGameinfo } from '../lib
 import { getActiveDeadlockPath } from '../lib/appSettings';
 import { applyAccentColor } from '../lib/accentColor';
 import { applyBackgroundGradient } from '../lib/backgroundGradient';
+import { applyOledMode } from '../lib/applyOledMode';
 import { useAppStore } from '../stores/appStore';
 import type {
   OneClickSuspiciousFilesData,
@@ -59,6 +60,7 @@ export default function Layout() {
   // even when the user has picked a different accent.
   const accentColor = useAppStore((s) => s.settings?.accentColor);
   const backgroundGradient = useAppStore((s) => s.settings?.backgroundGradient);
+  const oledMode = useAppStore((s) => s.settings?.oledMode);
   const loadStoreSettings = useAppStore((s) => s.loadSettings);
   const loadAppearanceImages = useAppStore((s) => s.loadAppearanceImages);
 
@@ -79,6 +81,9 @@ export default function Layout() {
   useEffect(() => {
     applyBackgroundGradient(backgroundGradient);
   }, [backgroundGradient]);
+  useEffect(() => {
+    applyOledMode(oledMode);
+  }, [oledMode]);
 
   useEffect(() => {
     const checkFirstRun = async () => {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -81,7 +81,11 @@ export default function Layout() {
   useEffect(() => {
     applyBackgroundGradient(backgroundGradient);
   }, [backgroundGradient]);
+  // main.tsx seeds the OLED attribute from the preload before first paint, so
+  // hold off until settings actually arrive: applying the undefined value here
+  // would strip the seed and reintroduce the startup flash.
   useEffect(() => {
+    if (oledMode === undefined) return;
     applyOledMode(oledMode);
   }, [oledMode]);
 

--- a/src/components/settings/BackgroundGradientPicker.tsx
+++ b/src/components/settings/BackgroundGradientPicker.tsx
@@ -5,7 +5,6 @@ import { Ban, Check, Pipette } from 'lucide-react';
 import { HexColorPicker, HexColorInput } from 'react-colorful';
 import { useAppStore } from '../../stores/appStore';
 import {
-  BACKGROUND_BASE,
   BACKGROUND_GRADIENT_PRESETS,
   applyBackgroundGradient,
   backgroundGradientPreviewCss,
@@ -45,7 +44,7 @@ function GradientTile({
       aria-label={label}
       aria-pressed={active}
       className={`${TILE_BASE} ${active ? 'border-accent/70' : 'border-white/10 hover:border-white/30'}`}
-      style={{ background: gradient ? backgroundGradientPreviewCss(gradient) : BACKGROUND_BASE }}
+      style={{ background: gradient ? backgroundGradientPreviewCss(gradient) : 'var(--color-bg-primary)' }}
     >
       {children}
       {/* Ringed badge: it is accent-colored and the swatch under it can be any

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -1,7 +1,7 @@
 import { Languages, Palette } from 'lucide-react';
 import { useAppStore } from '../../../stores/appStore';
 import { formatDateParts } from '../../../lib/dateFormat';
-import { Card } from '../../common/ui';
+import { Card, Toggle } from '../../common/ui';
 import Tx from '../../translation/Tx';
 import AccentColorPicker from '../AccentColorPicker';
 import BackgroundGradientPicker from '../BackgroundGradientPicker';
@@ -29,6 +29,14 @@ export default function AppearanceSection() {
   return (
     <>
       <Card title={<Tx k="settings.sections.appearance" fallback="Appearance" />} icon={Palette}>
+        <Toggle
+          checked={settings?.oledMode ?? false}
+          onChange={(checked) => settings && void saveSettings({ ...settings, oledMode: checked })}
+          label={<Tx k="settings.appearance.oled.title" fallback="OLED mode" />}
+        />
+
+        <div className="my-5 h-px bg-border" />
+
         <AccentColorPicker />
 
         <div className="my-5 h-px bg-white/5" />

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -35,7 +35,7 @@ export default function AppearanceSection() {
           label={<Tx k="settings.appearance.oled.title" fallback="OLED mode" />}
         />
 
-        <div className="my-5 h-px bg-border" />
+        <div className="my-5 h-px bg-white/5" />
 
         <AccentColorPicker />
 

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,19 @@
   --font-mod-title: 'Reaver', serif;
 }
 
+/* OLED mode keeps the existing dark-theme contrast model while moving the
+   largest surfaces to true black. Raised and recessed surfaces remain subtly
+   separated so cards, inputs, and popovers do not collapse into one plane. */
+:root[data-oled='true'] {
+  color-scheme: dark;
+  --color-bg-primary: #000000;
+  --color-bg-secondary: #080808;
+  --color-bg-tertiary: #141414;
+  --color-bg-sunken: #030303;
+  --color-bg-glass: #020304;
+  --color-border: #242424;
+}
+
 /* Bottom-up dark scrim for art/thumbnail overlays so foreground chrome stays
    legible over any underlying image. Pairs with `absolute inset-0`. Replaces
    the gradient that was copy-pasted across the Locker/Installed surfaces. */

--- a/src/index.css
+++ b/src/index.css
@@ -130,11 +130,17 @@
   --font-mod-title: 'Reaver', serif;
 }
 
+/* The app is permanently dark. Declaring it here (not per-theme) keeps
+   UA-drawn widgets (select popups, checkboxes, date-picker calendars)
+   rendering dark regardless of the OLED toggle. */
+:root {
+  color-scheme: dark;
+}
+
 /* OLED mode keeps the existing dark-theme contrast model while moving the
    largest surfaces to true black. Raised and recessed surfaces remain subtly
    separated so cards, inputs, and popovers do not collapse into one plane. */
 :root[data-oled='true'] {
-  color-scheme: dark;
   --color-bg-primary: #000000;
   --color-bg-secondary: #080808;
   --color-bg-tertiary: #141414;
@@ -149,9 +155,9 @@
 @utility scrim-bottom {
   background-image: linear-gradient(
     to bottom,
-    rgb(15 15 15 / 0.45),
-    rgb(15 15 15 / 0.65),
-    rgb(15 15 15 / 0.88)
+    rgb(from var(--color-bg-primary) r g b / 0.45),
+    rgb(from var(--color-bg-primary) r g b / 0.65),
+    rgb(from var(--color-bg-primary) r g b / 0.88)
   );
 }
 

--- a/src/lib/applyOledMode.ts
+++ b/src/lib/applyOledMode.ts
@@ -1,0 +1,8 @@
+export function applyOledMode(enabled: boolean | null | undefined): void {
+  const root = document.documentElement;
+  if (enabled) {
+    root.dataset.oled = 'true';
+  } else {
+    delete root.dataset.oled;
+  }
+}

--- a/src/lib/applyOledMode.ts
+++ b/src/lib/applyOledMode.ts
@@ -1,3 +1,6 @@
+// Split from oledMode.ts deliberately: that module is imported by the main
+// process (no DOM lib in tsconfig.node), so the document-touching half lives
+// in this renderer-only file.
 export function applyOledMode(enabled: boolean | null | undefined): void {
   const root = document.documentElement;
   if (enabled) {

--- a/src/lib/backgroundGradient.ts
+++ b/src/lib/backgroundGradient.ts
@@ -5,6 +5,8 @@
 // custom pick is the same shape as a preset, and one renderer covers both the
 // real layer and the little preview tiles in Settings.
 
+import { BACKGROUND_BASE } from './oledMode';
+
 export interface BackgroundGradient {
   /** Color of the glow entering from the top-left corner. */
   from: string;
@@ -33,9 +35,6 @@ export const BACKGROUND_GRADIENT_PRESETS: BackgroundGradientPreset[] = [
 /** Peak alpha at each corner. Low enough that body text over the glow keeps
  *  its contrast, high enough to read as deliberate on a #0f0f0f base. */
 const GLOW_ALPHA = 0.3;
-
-/** The app's base background, painted under the glow in preview tiles. */
-export const BACKGROUND_BASE = '#0f0f0f';
 
 /** Hex (3- or 6-digit, with or without `#`) to an rgba() string. Anything else
  *  resolves to fully transparent: settings.json is user-editable and the color
@@ -85,9 +84,10 @@ export function backgroundGradientCss(gradient: BackgroundGradient): string {
   return glowLayers(gradient, LAYER);
 }
 
-/** Swatch background: the bolder preview glow over the app's own base color. */
+/** Swatch background: the bolder preview glow over the app's current base
+ *  color (the token, so swatches stay honest when OLED remaps it to black). */
 export function backgroundGradientPreviewCss(gradient: BackgroundGradient): string {
-  return `${glowLayers(gradient, SWATCH)}, ${BACKGROUND_BASE}`;
+  return `${glowLayers(gradient, SWATCH)}, var(--color-bg-primary, ${BACKGROUND_BASE})`;
 }
 
 /** True when both corners match, ignoring hex case. */

--- a/src/lib/oledMode.test.ts
+++ b/src/lib/oledMode.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyOledMode } from './applyOledMode';
+import { windowBackgroundColor } from './oledMode';
+
+describe('applyOledMode', () => {
+  beforeEach(() => {
+    delete document.documentElement.dataset.oled;
+  });
+
+  it('marks the document as OLED themed while the mode is enabled', () => {
+    applyOledMode(true);
+
+    expect(document.documentElement.dataset.oled).toBe('true');
+  });
+
+  it('removes the OLED theme marker when the mode is disabled', () => {
+    document.documentElement.dataset.oled = 'true';
+
+    applyOledMode(false);
+
+    expect(document.documentElement.dataset.oled).toBeUndefined();
+  });
+
+  it('uses true black for the Electron window in OLED mode', () => {
+    expect(windowBackgroundColor(true)).toBe('#000000');
+    expect(windowBackgroundColor(false)).toBe('#0f0f0f');
+  });
+});

--- a/src/lib/oledMode.ts
+++ b/src/lib/oledMode.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_WINDOW_BACKGROUND = '#0f0f0f';
+export const OLED_WINDOW_BACKGROUND = '#000000';
+
+export function windowBackgroundColor(enabled: boolean | null | undefined): string {
+  return enabled ? OLED_WINDOW_BACKGROUND : DEFAULT_WINDOW_BACKGROUND;
+}

--- a/src/lib/oledMode.ts
+++ b/src/lib/oledMode.ts
@@ -1,6 +1,13 @@
-export const DEFAULT_WINDOW_BACKGROUND = '#0f0f0f';
-export const OLED_WINDOW_BACKGROUND = '#000000';
+// This module is imported by the main process, whose tsconfig has no DOM lib,
+// so it must stay document-free; the DOM half of the OLED toggle lives in
+// applyOledMode.ts.
 
+/** The app's base background (--color-bg-primary in index.css), painted under
+ *  the glow in preview tiles and behind the native window. */
+export const BACKGROUND_BASE = '#0f0f0f';
+
+/** Native window background (pre-paint flash, resize gutters) matching the
+ *  painted canvas: true black in OLED mode, the app base color otherwise. */
 export function windowBackgroundColor(enabled: boolean | null | undefined): string {
-  return enabled ? OLED_WINDOW_BACKGROUND : DEFAULT_WINDOW_BACKGROUND;
+  return enabled ? '#000000' : BACKGROUND_BASE;
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -751,6 +751,9 @@
       "customAccentColor": "Custom accent color",
       "selectedColorPreview": "Selected color preview",
       "customAccent": "Custom Accent",
+      "oled": {
+        "title": "OLED mode"
+      },
       "launchButtons": {
         "combine": "Combine launch buttons",
         "combineDescription": "Use a single launch button and switch between Modded and Vanilla with the swap icon or right-click, instead of two stacked buttons."

--- a/src/locales/manifest.json
+++ b/src/locales/manifest.json
@@ -1,6 +1,6 @@
 {
   "sourceLanguage": "en",
-  "totalKeys": 2346,
+  "totalKeys": 2347,
   "languages": [
     {
       "code": "bg",
@@ -11,7 +11,7 @@
     {
       "code": "en",
       "name": "English",
-      "translatedKeys": 2346,
+      "translatedKeys": 2347,
       "pct": 100
     },
     {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,14 @@ import './index.css'
 import { hydrateDownloadedLocales } from './i18n'
 import App from './App.tsx'
 import { initAutoHideScrollbars } from './lib/autoHideScrollbars'
+import { applyOledMode } from './lib/applyOledMode'
 
 initAutoHideScrollbars()
+
+// Seed the OLED theme before first paint. Main passes the saved setting
+// through the preload's argv, so an OLED user never sees the default grey
+// canvas while settings load over IPC.
+applyOledMode(window.electronAPI.initialOledMode)
 
 // Register any downloaded language packs before first paint so a non-English
 // user lands on their language without a flash. Best-effort: if it fails or is

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -775,6 +775,10 @@ export interface ElectronAPI {
     // bar strip (the native frame is hidden on Windows only).
     platform: string;
 
+    // Saved OLED setting at window creation, forwarded through the preload's
+    // argv so the theme can apply before the settings IPC round-trip.
+    initialOledMode: boolean;
+
     // Settings
     detectDeadlock: () => Promise<string | null>;
     validateDeadlockPath: (path: string) => Promise<boolean>;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -1149,6 +1149,8 @@ export interface AppSettings {
   /** UI accent color (hex, e.g. "#f97316"). Used to theme buttons, links, and
    *  focus rings throughout the app. */
   accentColor: string;
+  /** Use true black for the app canvas and near-black neutral surfaces. */
+  oledMode: boolean;
   /** Hero render used as the active sidebar highlight background.
    *  @deprecated Superseded by `appearanceBackgrounds.activeTab`. Kept as a
    *  legacy compat read so existing installs keep their chosen highlight; the


### PR DESCRIPTION
## Summary

- add a persisted OLED mode toggle in Settings > Appearance
- switch the app canvas to true black while retaining near-black elevated surfaces
- keep the Electron window backing color in sync to avoid gray flashes

Closes #371

## Validation

- manually verified in the Windows Electron app
- `pnpm vitest run src/lib/oledMode.test.ts electron/main/services/settingsMigration.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm i18n:check`
- `pnpm build`
- `pnpm test` (101 files and 1,275 tests passed; 12 unrelated existing Windows platform/CRLF assertions failed in steamRoots, bottleLaunch, launchOptions, and performanceConfig)